### PR TITLE
jekyll: ignore erc-template.md

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,7 +61,7 @@ exclude:
   - vendor/cache/
   - vendor/gems/
   - vendor/ruby/
-  - eip-template.md
+  - erc-template.md
   - ISSUE_TEMPLATE.md
   - PULL_REQUEST_TEMPLATE.md
   - README.md


### PR DESCRIPTION
Fixes the issue first noted in #5.