### PR TITLE
Readding ERC-7531

### DIFF
--- a/ERCS/erc-7531.md
+++ b/ERCS/erc-7531.md
@@ -1,0 +1,73 @@
+---
+eip: 7531
+title: Getting Staked ERC-721 Ownership Recognition
+description: Recognizing NFT ownership when staked into other contracts.
+author: Francesco Sullo (@sullof)
+discussions-to: https://ethereum-magicians.org/t/eip-7531-resolving-staked-erc-721-ownership-recognition/15967
+status: Draft
+type: Standards Track
+category: ERC
+created: 2023-10-01
+requires: 165, 721
+---
+
+## Abstract
+
+The ownership of [ERC-721](./eip-721.md) tokens when staked in a pool presents challenges, particularly when it involves older, non-lockable NFTs like, for example, Crypto Punks or Bored Ape Yacht Club (BAYC) tokens. This proposal introduces an interface to address these challenges by allowing staked NFTs to be recognized by their original owners, even after they've been staked.
+
+## Motivation
+
+Recent solutions involve retaining NFT ownership while "locking" the token when staked. However, this requires the NFT contract to implement lockable functionality. Many early vintage NFTs like CryptoPunks or Bored Ape Yacht Club were not originally designed as lockable.
+
+When these non-lockable NFTs are staked, ownership transfers fully to the staking pool contract. This prevents the original owner from accessing valuable privileges and benefits associated with their NFTs.
+
+For example:
+
+A BAYC holder would lose access to the BAYC Yacht Club and member events when staked.
+A CryptoPunks holder may miss out on special airdrops or displays only available to verified owners.
+Owners of other early NFTs like EtherRocks would lose the social status of provable ownership when staked.
+By maintaining a record of the original owner, the proposed interface allows these original perks to remain accessible even when the NFT is staked elsewhere. This compatibility is critical for vintage NFT projects lacking native locking mechanisms.
+
+The interface provides a simple, elegant way to extend staking compatibility to legacy NFTs without affecting their core functionality or benefits of ownership.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+The interface is defined as follows:
+
+```solidity
+interface IERC7531 {
+  // It MUST revert if the token is not staked
+  function holderOfRightsFor(
+    address tokenAddress,
+    uint256 tokenId
+  ) external view returns (address);
+}
+```
+
+The function name could have been simply `ownerOf` but nothing stops a standard [ERC-721](./eip-721.md) from staking another [ERC-721](./eip-721.md), and in that case the function's name would conflict with the standard `ownerOf` function, forcing the caller of the second to specify the signature to distinguish between the two functions. That may break existing apps that expect that an [ERC-721](./eip-721.md) contract has only one `ownerOf` function.
+
+Also, the name `holderOfRightsFor` is more descriptive of the function's purpose and is also more generic, as it could be used for other rights, not only ownership. For example, a staking pool may allow Bob to stake a token that can be later unstaked by Alice. In this case, the function should most likely return Alice's address.
+
+## Rationale
+
+This approach provides a workaround for the challenges posed by non-lockable NFTs. By maintaining a record of the original owner and exposing this through the `holderOfRightsFor` method, we ensure that staking does not hinder the utility or privileges tied to certain NFTs.
+
+## Backwards Compatibility
+
+This standard is fully backwards compatible with existing [ERC-721](./eip-721.md) contracts. It can seamlessly integrate with existing upgradeable staking pools, provided they choose to adopt it. It does not require changes to the [ERC-721](./eip-721.md) standard but acts as an enhancement for staking pools.
+
+## Security Considerations
+
+A potential risk is that a staking pool could improperly assign ownership to a different wallet through this interface. This would allow that wallet to potentially access privileges associated with the NFT.
+
+However, this is a much lower risk than transferring full legal ownership of the NFT to the staking pool initially. The interface only enables recognizing the staker, not replacing the actual owner on-chain.
+
+Overall, improper use of this interface poses some risk of inaccurate ownership records. But this is an inherent issue with any staking arrangement, and is reduced by the owner retaining custody rather than transferring ownership.
+
+As with any privilege granting NFT, consumers should evaluate staking providers carefully for signs of mismanagement or fraud. The interface itself does not enable any new manipulation capabilities, but prudent caution is always warranted.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-7531.md
+++ b/ERCS/erc-7531.md
@@ -13,7 +13,7 @@ requires: 165, 721
 
 ## Abstract
 
-The ownership of [ERC-721](./eip-721.md) tokens when staked in a pool presents challenges, particularly when it involves older, non-lockable NFTs like, for example, Crypto Punks or Bored Ape Yacht Club (BAYC) tokens. This proposal introduces an interface to address these challenges by allowing staked NFTs to be recognized by their original owners, even after they've been staked.
+The ownership of [ERC-721](./erc-721.md) tokens when staked in a pool presents challenges, particularly when it involves older, non-lockable NFTs like, for example, Crypto Punks or Bored Ape Yacht Club (BAYC) tokens. This proposal introduces an interface to address these challenges by allowing staked NFTs to be recognized by their original owners, even after they've been staked.
 
 ## Motivation
 
@@ -46,7 +46,7 @@ interface IERC7531 {
 }
 ```
 
-The function name could have been simply `ownerOf` but nothing stops a standard [ERC-721](./eip-721.md) from staking another [ERC-721](./eip-721.md), and in that case the function's name would conflict with the standard `ownerOf` function, forcing the caller of the second to specify the signature to distinguish between the two functions. That may break existing apps that expect that an [ERC-721](./eip-721.md) contract has only one `ownerOf` function.
+The function name could have been simply `ownerOf` but nothing stops a standard [ERC-721](./erc-721.md) from staking another [ERC-721](./erc-721.md), and in that case the function's name would conflict with the standard `ownerOf` function, forcing the caller of the second to specify the signature to distinguish between the two functions. That may break existing apps that expect that an [ERC-721](./erc-721.md) contract has only one `ownerOf` function.
 
 Also, the name `holderOfRightsFor` is more descriptive of the function's purpose and is also more generic, as it could be used for other rights, not only ownership. For example, a staking pool may allow Bob to stake a token that can be later unstaked by Alice. In this case, the function should most likely return Alice's address.
 
@@ -56,7 +56,7 @@ This approach provides a workaround for the challenges posed by non-lockable NFT
 
 ## Backwards Compatibility
 
-This standard is fully backwards compatible with existing [ERC-721](./eip-721.md) contracts. It can seamlessly integrate with existing upgradeable staking pools, provided they choose to adopt it. It does not require changes to the [ERC-721](./eip-721.md) standard but acts as an enhancement for staking pools.
+This standard is fully backwards compatible with existing [ERC-721](./erc-721.md) contracts. It can seamlessly integrate with existing upgradeable staking pools, provided they choose to adopt it. It does not require changes to the [ERC-721](./erc-721.md) standard but acts as an enhancement for staking pools.
 
 ## Security Considerations
 


### PR DESCRIPTION
A previous PR has been closed on EIPs (https://github.com/ethereum/EIPs/pull/7817).

----

The ownership of ERC721 tokens when staked in a pool presents challenges, particularly when it involves older, non-lockable NFTs like, for example, Crypto Punks or Bored Ape Yacht Club (BAYC) tokens. This proposal introduces an interface to address these challenges by allowing staked NFTs to be recognized by their original owners, even after they've been staked.

Recent solutions involve retaining NFT ownership while "locking" the token when staked. However, this requires the NFT contract to implement lockable functionality. Many early vintage NFTs like CryptoPunks or Bored Ape Yacht Club were not originally designed as lockable.

When these non-lockable NFTs are staked, ownership transfers fully to the staking pool contract. This prevents the original owner from accessing valuable privileges and benefits associated with their NFTs.

For example:

A BAYC holder would lose access to the BAYC Yacht Club and member events when staked.
A CryptoPunks holder may miss out on special airdrops or displays only available to verified owners.
Owners of other early NFTs like EtherRocks would lose the social status of provable ownership when staked.
By maintaining a record of the original owner, the proposed interface allows these original perks to remain accessible even when the NFT is staked elsewhere. This compatibility is critical for vintage NFT projects lacking native locking mechanisms.

The interface provides a simple, elegant way to extend staking compatibility to legacy NFTs without affecting their core functionality or benefits of ownership.