### PR TITLE
Update ERC-223: Remove `standard` function

### DIFF
--- a/ERCS/erc-223.md
+++ b/ERCS/erc-223.md
@@ -70,16 +70,6 @@ Returns the number of decimals of the token. The functionality of this method is
 
 OPTIONAL - This method can be used to improve usability, but interfaces and other contracts MUST NOT expect these values to be present. 
 
-##### `standard`
-
-```solidity
-function standard() view returns (string memory)  
-```
-
-Returns the identifier of the standard. If the token is [ERC-223](./eip-20.md) then it must return `"223"`.
-
-OPTIONAL - This method can be used to improve usability, but interfaces and other contracts MUST NOT expect these values to be present.
-
 ##### `balanceOf`
 
 ```solidity


### PR DESCRIPTION
Migration from https://github.com/ethereum/EIPs/pull/7856