### PR TITLE
Re-enable ERC page headers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ permalink: /:slug
 defaults:
   -
     scope:
-      path: "EIPS"
+      path: "ERCS"
     values:
       layout: "eip"
 


### PR DESCRIPTION
During the transition from the EIPs repo to the ERCs repo, the jekyll config was not updated to use the `eip.html` layout for ERC pages. As a result, all ERCs on the ERC website lack author and status information in the page header (example: https://ercs.ethereum.org/ERCS/erc-6551).

This PR re-enables headers for all ERCs in this repo.