### PR TITLE
Update ERC-7254: fix broken links

### DIFF
--- a/ERCS/erc-7254.md
+++ b/ERCS/erc-7254.md
@@ -12,9 +12,9 @@ created: 2023-06-29
 
 ## Abstract
 
-With the aspiration of bringing forth unique functionality and enhancing value for holders of [ERC-20](./erc-20.md) tokens, our project aims to effortlessly reward token holders without necessitating users to lock, stake, or farm their tokens. Whenever the project generates profits, these profits can be distributed to the token holders.
+With the aspiration of bringing forth unique functionality and enhancing value for holders of [ERC-20](./eip-20.md) tokens, our project aims to effortlessly reward token holders without necessitating users to lock, stake, or farm their tokens. Whenever the project generates profits, these profits can be distributed to the token holders.
 
-Revenue Sharing is an extended version of [ERC-20](./erc-20.md). It proposes an additional payment method for token holders. 
+Revenue Sharing is an extended version of [ERC-20](./eip-20.md). It proposes an additional payment method for token holders. 
 
 This standard includes updating rewards for holders and allowing token holders to withdraw rewards.
 
@@ -121,8 +121,8 @@ TBD
 
 ## Reference Implementation
 
-* [ERC-7254](../assets/erc-7254/ERC7254.sol)
-* [IERC-7254](../assets/erc-7254/IERC7254.sol)
+* [ERC-7254](../assets/eip-7254/ERC7254.sol)
+* [IERC-7254](../assets/eip-7254/IERC7254.sol)
 
 ## Security Considerations
 


### PR DESCRIPTION
Per #8, we're still using `eip` in links because of the joint build occurring in `ethereum/EIPs`.