### PR TITLE
Remove external links and useless references

### DIFF
--- a/ERCS/erc-1363.md
+++ b/ERCS/erc-1363.md
@@ -195,14 +195,16 @@ interface ERC1363Spender {
 The choice to use `transferAndCall`, `transferFromAndCall` and `approveAndCall` derives from the [ERC-20](./eip-20.md) naming. They want to highlight that they have the same behaviours of `transfer`, `transferFrom` and `approve` with the addition of a callback on receiver or spender.
 
 ## Backwards Compatibility
-This proposal has been inspired also by [ERC-223](https://github.com/ethereum/EIPs/issues/223) and [ERC-677](https://github.com/ethereum/EIPs/issues/677) but it uses the [ERC-721](./eip-721.md) approach, so it doesn't override the [ERC-20](./eip-20.md) `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining the [ERC-20](./eip-20.md) backwards compatibility.  
+
+Unlike other ERC-20 extension proposals, ERC-1363 doesn't override the ERC-20 `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining backward compatibility with ERC-20.
 
 ## Security Considerations
-The `approveAndCall` and `transferFromAndCall` methods can be affected by the same issue of the standard [ERC-20](./eip-20.md) `approve` and `transferFrom` method.
-  
+
+The `approveAndCall` and `transferFromAndCall` methods can be affected by the same issue of the standard ERC-20 `approve` and `transferFrom` method.
 Changing an allowance with the `approveAndCall` methods brings the risk that someone may use both the old and the new allowance by unfortunate transaction ordering.
 
-One possible solution to mitigate this race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards ([EIP-20#issuecomment-263524729](https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729)).
+One possible solution to mitigate this race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards.
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
This PR is part of some changes I would like to make on ERC1363 to follow the modern EIP1 recommendation.

This PR:

* Remove external links and useless references to other eips

Note that this PR will not pass the CI, because of many changes required by validator and that are not addressed here but will be addressed in other PR.

I.g. external links, broken link, new line after h1, etc.

Other PR will address other sections of ERC1363