### PR TITLE
Update ERC-6982: Clarifying description

### DIFF
--- a/ERCS/erc-6982.md
+++ b/ERCS/erc-6982.md
@@ -32,9 +32,10 @@ interface IERC6982 {
   // This event MUST be emitted upon deployment of the contract, establishing 
   // the default lock status for any tokens that will be minted in the future.
   // If the default lock status changes for any reason, this event 
-  // MUST be re-emitted to update the default status for all tokens.
-  // Note that emitting a new DefaultLocked event does not affect the lock 
-  // status of any tokens for which a Locked event has previously been emitted.
+  // MUST be re-emitted to update the default status for all tokens, including the
+  // ones already minted.  However, emitting a new DefaultLocked event does not 
+  // affect the lock status of any tokens for which a Locked event has previously 
+  // been emitted.
   event DefaultLocked(bool locked);
 
   // This event MUST be emitted whenever the lock status of a specific token 
@@ -70,7 +71,7 @@ The `locked` function gives the current lock status of a particular token, furth
 
 Bear in mind that a token being designated as "locked" doesn't necessarily imply that it is entirely non-transferable. There might be certain conditions under which a token can still be transferred despite its locked status. Primarily, the locked status relates to a token's transferability on marketplaces and external exchanges.
 
-To illustrate, let's consider the Cruna protocol. In this system, an NFT owner has the ability to activate what is termed an 'initiator'. This is essentially a secondary wallet with the unique privilege of initiating key transactions. Upon setting an initiator, the token's status is rendered 'locked'. However, this does not impede the token's transferability if the initiation for the transfer comes from the designated initiator. 
+To illustrate, let's consider the Cruna protocol. In this system, an NFT owner has the ability to activate what is termed an 'protector'. This is essentially a secondary wallet with the unique privilege of initiating key transactions. Upon setting an initiator, the token's status is rendered 'locked'. However, this does not impede the token's transferability if the initiation for the transfer comes from the designated protector. 
 
 ## Backwards Compatibility
 

--- a/ERCS/erc-6982.md
+++ b/ERCS/erc-6982.md
@@ -31,11 +31,10 @@ The interface is defined as follows:
 interface IERC6982 {
   // This event MUST be emitted upon deployment of the contract, establishing 
   // the default lock status for any tokens that will be minted in the future.
-  // If the default lock status changes for any reason, this event 
-  // MUST be re-emitted to update the default status for all tokens, including the
-  // ones already minted.  However, emitting a new DefaultLocked event does not 
-  // affect the lock status of any tokens for which a Locked event has previously 
-  // been emitted.
+  // If the default lock status changes for any reason, this event  MUST be 
+  // re-emitted to update the default status for all tokens, including the ones 
+  // already minted.  However, emitting a new DefaultLocked event does not affect 
+  // the lock status of any tokens for which a Locked event has been emitted.
   event DefaultLocked(bool locked);
 
   // This event MUST be emitted whenever the lock status of a specific token 


### PR DESCRIPTION
This clarifies the description of the DefaultLocked event, to make it clear that the emission of a new DefaultLocked event establishes the default behavior of all the tokens, including the ones already minted.
It also fixes an error referring to Cruna protocol, where protectors where mistakenly called initiators.