### PR TITLE
Update ERC-6900: Add missing `pluginMetadata()` method

### DIFF
--- a/ERCS/erc-6900.md
+++ b/ERCS/erc-6900.md
@@ -380,6 +380,11 @@ interface IPlugin {
     /// @dev The manifest MUST stay constant over time.
     /// @return A manifest describing the contents and intended configuration of the plugin.
     function pluginManifest() external pure returns (PluginManifest memory);
+
+    /// @notice Describe the metadata of the plugin.
+    /// @dev This metadata MUST stay constant over time.
+    /// @return A metadata struct describing the plugin.
+    function pluginMetadata() external pure returns (PluginMetadata memory);
 }
 ```
 


### PR DESCRIPTION
This change was introduced in the latest spec update, but the function was accidentally left out of the `IPlugin` interface. The struct has already been added, so just adding in the function in the interface here.