### PR TITLE
Update ERC-5564: update schemeID

### DIFF
--- a/ERCS/erc-5564.md
+++ b/ERCS/erc-5564.md
@@ -260,7 +260,7 @@ This ERC is fully backward compatible.
 
 ## Reference Implementation
 
-You can find an implementation of this standard in TBD.
+You can find the implementation of the ERC above in the Specification section.
 
 ## Security Considerations
 

--- a/assets/erc-5564/scheme_ids.md
+++ b/assets/erc-5564/scheme_ids.md
@@ -1,8 +1,8 @@
 # EIP-5564 - Scheme Id Mapping
 
 
-Last edited 07.02.2023
+Last edited 18.12.2023
 
 | ID | Scheme | EIP | Added |
 |---|---|---|---|
-| 0 | SECP256k1, with view tags. | [EIP-5564](https://eips.ethereum.org/EIPS/eip-5564) | 07.02.2023 |
+| 1 | SECP256k1, with view tags. | [EIP-5564](https://eips.ethereum.org/EIPS/eip-5564) | 07.02.2023 |


### PR DESCRIPTION
- Update the scheme ID for the SECP256k1 implementation from 0 to 1.
- Add content to the implementation section