### PR TITLE
Update ERC-6900: Fix incorrect `dependencies` type in `installPlugin`

### DIFF
--- a/ERCS/erc-6900.md
+++ b/ERCS/erc-6900.md
@@ -143,7 +143,7 @@ interface IPluginManager {
         address plugin,
         bytes32 manifestHash,
         bytes calldata pluginInitData,
-        address[] calldata dependencies,
+        FunctionReference[] calldata dependencies,
         InjectedHook[] calldata injectedHooks
     ) external;
 


### PR DESCRIPTION
This was missed in a prior spec update.