### PR TITLE
Update ERC-5216: ERC-5216 global update

### DIFF
--- a/ERCS/erc-5216.md
+++ b/ERCS/erc-5216.md
@@ -1,7 +1,7 @@
 ---
 eip: 5216
-title: EIP-1155 Approval By Amount Extension
-description: Extension for EIP-1155 secure approvals
+title: ERC-1155 Allowance Extension
+description: Extension for ERC-1155 secure approvals
 author: Iván Mañús (@ivanmmurciaua), Juan Carlos Cantó (@EscuelaCryptoES)
 discussions-to: https://ethereum-magicians.org/t/eip-erc1155-approval-by-amount/9898
 status: Last Call
@@ -14,38 +14,38 @@ requires: 20, 165, 1155
 
 ## Abstract
 
-This EIP defines standard functions for granular approval of [EIP-1155](./eip-1155.md) tokens by both `id` and `amount`. This EIP extends [EIP-1155](./eip-1155.md).
+This ERC defines standard functions for granular approval of [ERC-1155](./erc-1155.md) tokens by both `id` and `amount`. This ERC extends [ERC-1155](./erc-1155.md).
 
 ## Motivation
 
-[EIP-1155](./eip-1155.md)'s popularity means that multi-token management transactions occur on a daily basis. Although it can be used as a more comprehensive alternative to [EIP-721](./eip-721.md), EIP-1155 is most commonly used as intended: creating multiple `id`s, each with multiple tokens. While many projects interface with these semi-fungible tokens, by far the most common interactions are with NFT marketplaces.
+[ERC-1155](./erc-1155.md)'s popularity means that multi-token management transactions occur on a daily basis. Although it can be used as a more comprehensive alternative to [ERC-721](./erc-721.md), ERC-1155 is most commonly used as intended: creating multiple `id`s, each with multiple tokens. While many projects interface with these semi-fungible tokens, by far the most common interactions are with NFT marketplaces.
 
-Due to the nature of the blockchain, programming errors or malicious operators can cause permanent loss of funds. It is therefore essential that transactions are as trustless as possible. EIP-1155 uses the `setApprovalForAll` function, which approves ALL tokens with a specific `id`. This system has obvious minimum required trust flaws. This EIP combines ideas from [EIP-20](./eip-20.md) and [EIP-721](./eip-721.md) in order to create a trust mechanism where an owner can allow a third party, such as a marketplace, to approve a limited (instead of unlimited) number of tokens of one `id`.
+Due to the nature of the blockchain, programming errors or malicious operators can cause permanent loss of funds. It is therefore essential that transactions are as trustless as possible. ERC-1155 uses the `setApprovalForAll` function, which approves ALL tokens with a specific `id`. This system has obvious minimum required trust flaws. This ERC combines ideas from [ERC-20](./erc-20.md) and [ERC-721](./erc-721.md) in order to create a trust mechanism where an owner can allow a third party, such as a marketplace, to approve a limited (instead of unlimited) number of tokens of one `id`.
 
 ## Specification
 
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-Contracts using this EIP MUST implement the `IERC1155ApprovalByAmount` interface.
+Contracts using this ERC MUST implement the `IERC5216` interface.
 
 ### Interface implementation
 
 ```solidity
 /**
- * @title ERC-1155 Approval By Amount Extension
+ * @title ERC-1155 Allowance Extension
  * Note: the ERC-165 identifier for this interface is 0x1be07d74
  */
-interface IERC1155ApprovalByAmount is IERC1155 {
+interface IERC5216 is IERC1155 {
 
     /**
      * @notice Emitted when `account` grants or revokes permission to `operator` to transfer their tokens, according to
      * `id` and with an amount: `amount`.
      */
-    event ApprovalByAmount(address indexed account, address indexed operator, uint256 id, uint256 amount);
+    event Approval(address indexed account, address indexed operator, uint256 id, uint256 amount);
 
     /**
      * @notice Grants permission to `operator` to transfer the caller's tokens, according to `id`, and an amount: `amount`.
-     * Emits an {ApprovalByAmount} event.
+     * Emits an {Approval} event.
      *
      * Requirements:
      * - `operator` cannot be the caller.
@@ -63,7 +63,7 @@ The `approve(address operator, uint256 id, uint256 amount)` function MUST be eit
 
 The `allowance(address account, address operator, uint256 id)` function MUST be either `public` or `external` and MUST be `view`.
 
-The `safeTrasferFrom` function (as defined by EIP-1155) MUST:
+The `safeTrasferFrom` function (as defined by ERC-1155) MUST:
 
 - Not revert if the user has approved `msg.sender` with a sufficient `amount`
 - Subtract the transferred amount of tokens from the approved amount if `msg.sender` is not approved with `setApprovalForAll`
@@ -72,32 +72,32 @@ In addition, the `safeBatchTransferFrom` MUST:
 
 - Add an extra condition that checks if the `allowance` of all `ids` have the approved `amounts` (See `_checkApprovalForBatch` function reference implementation)
 
-The `ApprovalByAmount` event MUST be emitted when a certain number of tokens are approved.
+The `Approval` event MUST be emitted when a certain number of tokens are approved.
 
 The `supportsInterface` method MUST return `true` when called with `0x1be07d74`.
 
 ## Rationale
 
-The name "EIP-1155 Approval By Amount Extension" was chosen because it is a succinct description of this EIP. Users can approve their tokens by `id` and `amount` to `operator`s.
+The name "ERC-1155 Allowance Extension" was chosen because it is a succinct description of this ERC. Users can approve their tokens by `id` and `amount` to `operator`s.
 
-By having a way to approve and revoke in a manner similar to [EIP-20](./eip-20.md), the trust level can be more directly managed by users:
+By having a way to approve and revoke in a manner similar to [ERC-20](./erc-20.md), the trust level can be more directly managed by users:
 
 - Using the `approve` function, users can approve an operator to spend an `amount` of tokens for each `id`.
 - Using the `allowance` function, users can see the approval that an operator has for each `id`.
 
-The [EIP-20](./eip-20.md) name patterns were used due to similarities with [EIP-20](./eip-20.md) approvals.
+The [ERC-20](./erc-20.md) name patterns were used due to similarities with [ERC-20](./erc-20.md) approvals.
 
 ## Backwards Compatibility
 
-This standard is compatible with [EIP-1155](./eip-1155.md).
+This standard is compatible with [ERC-1155](./erc-1155.md).
 
 ## Reference Implementation
 
-The reference implementation can be found [here](../assets/eip-5216/ERC1155ApprovalByAmount.sol).
+The reference implementation can be found [here](../assets/erc-5216/ERC5216.sol).
 
 ## Security Considerations
 
-Users of this EIP must thoroughly consider the amount of tokens they give permission to `operators`, and should revoke unused authorizations.
+Users of this ERC must thoroughly consider the amount of tokens they give permission to `operators`, and should revoke unused authorizations.
 
 ## Copyright
 

--- a/ERCS/erc-5216.md
+++ b/ERCS/erc-5216.md
@@ -93,7 +93,7 @@ This standard is compatible with [ERC-1155](./eip-1155.md).
 
 ## Reference Implementation
 
-The reference implementation can be found [here](../assets/eip-5216/ERC1155ApprovalByAmount.sol).
+The reference implementation can be found [here](../assets/eip-5216/ERC5216.sol).
 
 ## Security Considerations
 

--- a/ERCS/erc-5216.md
+++ b/ERCS/erc-5216.md
@@ -14,13 +14,13 @@ requires: 20, 165, 1155
 
 ## Abstract
 
-This ERC defines standard functions for granular approval of [ERC-1155](./erc-1155.md) tokens by both `id` and `amount`. This ERC extends [ERC-1155](./erc-1155.md).
+This ERC defines standard functions for granular approval of [ERC-1155](./eip-1155.md) tokens by both `id` and `amount`. This ERC extends [ERC-1155](./eip-1155.md).
 
 ## Motivation
 
-[ERC-1155](./erc-1155.md)'s popularity means that multi-token management transactions occur on a daily basis. Although it can be used as a more comprehensive alternative to [ERC-721](./erc-721.md), ERC-1155 is most commonly used as intended: creating multiple `id`s, each with multiple tokens. While many projects interface with these semi-fungible tokens, by far the most common interactions are with NFT marketplaces.
+[ERC-1155](./eip-1155.md)'s popularity means that multi-token management transactions occur on a daily basis. Although it can be used as a more comprehensive alternative to [ERC-721](./eip-721.md), ERC-1155 is most commonly used as intended: creating multiple `id`s, each with multiple tokens. While many projects interface with these semi-fungible tokens, by far the most common interactions are with NFT marketplaces.
 
-Due to the nature of the blockchain, programming errors or malicious operators can cause permanent loss of funds. It is therefore essential that transactions are as trustless as possible. ERC-1155 uses the `setApprovalForAll` function, which approves ALL tokens with a specific `id`. This system has obvious minimum required trust flaws. This ERC combines ideas from [ERC-20](./erc-20.md) and [ERC-721](./erc-721.md) in order to create a trust mechanism where an owner can allow a third party, such as a marketplace, to approve a limited (instead of unlimited) number of tokens of one `id`.
+Due to the nature of the blockchain, programming errors or malicious operators can cause permanent loss of funds. It is therefore essential that transactions are as trustless as possible. ERC-1155 uses the `setApprovalForAll` function, which approves ALL tokens with a specific `id`. This system has obvious minimum required trust flaws. This ERC combines ideas from [ERC-20](./eip-20.md) and [ERC-721](./eip-721.md) in order to create a trust mechanism where an owner can allow a third party, such as a marketplace, to approve a limited (instead of unlimited) number of tokens of one `id`.
 
 ## Specification
 
@@ -80,20 +80,20 @@ The `supportsInterface` method MUST return `true` when called with `0x1be07d74`.
 
 The name "ERC-1155 Allowance Extension" was chosen because it is a succinct description of this ERC. Users can approve their tokens by `id` and `amount` to `operator`s.
 
-By having a way to approve and revoke in a manner similar to [ERC-20](./erc-20.md), the trust level can be more directly managed by users:
+By having a way to approve and revoke in a manner similar to [ERC-20](./eip-20.md), the trust level can be more directly managed by users:
 
 - Using the `approve` function, users can approve an operator to spend an `amount` of tokens for each `id`.
 - Using the `allowance` function, users can see the approval that an operator has for each `id`.
 
-The [ERC-20](./erc-20.md) name patterns were used due to similarities with [ERC-20](./erc-20.md) approvals.
+The [ERC-20](./eip-20.md) name patterns were used due to similarities with [ERC-20](./eip-20.md) approvals.
 
 ## Backwards Compatibility
 
-This standard is compatible with [ERC-1155](./erc-1155.md).
+This standard is compatible with [ERC-1155](./eip-1155.md).
 
 ## Reference Implementation
 
-The reference implementation can be found [here](../assets/erc-5216/ERC5216.sol).
+The reference implementation can be found [here](../assets/eip-5216/ERC1155ApprovalByAmount.sol).
 
 ## Security Considerations
 

--- a/assets/erc-5216/ERC5216.sol
+++ b/assets/erc-5216/ERC5216.sol
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.21;
 
 import "IERC1155.sol";
 import "ERC1155.sol";
 
 /**
- * @title ERC-1155 Approval By Amount Extension
+ * @title ERC-1155 Allowance Extension
  * Note: the ERC-165 identifier for this interface is 0x1be07d74
  */
-interface IERC1155ApprovalByAmount is IERC1155 {
+interface IERC5216 is IERC1155 {
 
     /**
      * @notice Emitted when `account` grants or revokes permission to `operator` to transfer their tokens, according to
      * `id` and with an amount: `amount`.
      */
-    event ApprovalByAmount(address indexed account, address indexed operator, uint256 id, uint256 amount);
+    event Approval(address indexed account, address indexed operator, uint256 id, uint256 amount);
 
     /**
      * @notice Grants permission to `operator` to transfer the caller's tokens, according to `id`, and an amount: `amount`.
-     * Emits an {ApprovalByAmount} event.
+     * Emits an {Approval} event.
      *
      * Requirements:
      * - `operator` cannot be the caller.
@@ -29,33 +29,32 @@ interface IERC1155ApprovalByAmount is IERC1155 {
      * @notice Returns the amount allocated to `operator` approved to transfer `account`'s tokens, according to `id`.
      */
     function allowance(address account, address operator, uint256 id) external view returns (uint256);
-    
 }
 
 /**
  * @dev Extension of {ERC1155} that allows you to approve your tokens by amount and id.
  */
-abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
+abstract contract ERC5216 is ERC1155, IERC5216 {
 
     // Mapping from account to operator approvals by id and amount.
     mapping(address => mapping(address => mapping(uint256 => uint256))) internal _allowances;
 
     /**
-     * @dev See {IERC1155ApprovalByAmount}
+     * @dev See {IERC5216}
      */
     function approve(address operator, uint256 id, uint256 amount) public virtual {
         _approve(msg.sender, operator, id, amount);
     }
 
     /**
-     * @dev See {IERC1155ApprovalByAmount}
+     * @dev See {IERC5216}
      */
     function allowance(address account, address operator, uint256 id) public view virtual returns (uint256) {
         return _allowances[account][operator][id];
     }
 
     /**
-     * @dev safeTransferFrom implementation for using ApprovalByAmount extension
+     * @dev safeTransferFrom implementation for using allowance extension
      */
     function safeTransferFrom(
         address from,
@@ -75,7 +74,7 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
     }
 
     /**
-     * @dev safeBatchTransferFrom implementation for using ApprovalByAmount extension
+     * @dev safeBatchTransferFrom implementation for using allowance extension
      */
     function safeBatchTransferFrom(
         address from,
@@ -106,9 +105,9 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
         uint256 idsLength = ids.length;
         uint256 amountsLength = amounts.length;
 
-        require(idsLength == amountsLength, "ERC1155ApprovalByAmount: ids and amounts length mismatch");
+        require(idsLength == amountsLength, "ERC5216: ids and amounts length mismatch");
         for (uint256 i = 0; i < idsLength;) {
-            require(allowance(from, to, ids[i]) >= amounts[i], "ERC1155ApprovalByAmount: operator is not approved for that id or amount");
+            require(allowance(from, to, ids[i]) >= amounts[i], "ERC5216: operator is not approved for that id or amount");
             unchecked { 
                 _allowances[from][to][ids[i]] -= amounts[i];
                 ++i; 
@@ -119,7 +118,7 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
 
     /**
      * @dev Approve `operator` to operate on all of `owner` tokens by id and amount.
-     * Emits a {ApprovalByAmount} event.
+     * Emits a {Approval} event.
      */
     function _approve(
         address owner,
@@ -127,13 +126,13 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
         uint256 id,
         uint256 amount
     ) internal virtual {
-        require(owner != operator, "ERC1155ApprovalByAmount: setting approval status for self");
+        require(owner != operator, "ERC5216: setting approval status for self");
         _allowances[owner][operator][id] = amount;
-        emit ApprovalByAmount(owner, operator, id, amount);
+        emit Approval(owner, operator, id, amount);
     }
 }
 
-contract ExampleToken is ERC1155ApprovalByAmount {
+contract ExampleToken is ERC5216 {
     constructor() ERC1155("") {}
 
     function mint(address account, uint256 id, uint256 amount, bytes memory data) public {


### PR DESCRIPTION
Hey,

I'm updating this ERC due to a several reasons:

- Rename all "EIP" for "ERC".
- Change internal links to continue working with the new repository structure.
- Rename the title from "ERC-1155 Approval by Amount Extension" to "ERC-1155 Allowance Extension", suggested by https://ethereum-magicians.org/t/last-call-eip-5216-erc1155-approval-by-amount/9898/9 with the approval of both creators.
-  Changed and updated Solidity code to keep it simple and working.

In addition, I would like to pose a question to the editors and maintainers. Given the deadline date, what about the status of this ERC? Still in last call?

Thanks in advance