### PR TITLE
Update ERC-1363: Add missing return statement

### DIFF
--- a/ERCS/erc-1363.md
+++ b/ERCS/erc-1363.md
@@ -99,6 +99,7 @@ interface ERC1363 /* is ERC20, ERC165 */ {
    * and then call `onApprovalReceived` on spender.
    * @param spender address The address which will spend the funds
    * @param value uint256 The amount of tokens to be spent
+   * @return true unless throwing
    */
   function approveAndCall(address spender, uint256 value) external returns (bool);
 
@@ -108,6 +109,7 @@ interface ERC1363 /* is ERC20, ERC165 */ {
    * @param spender address The address which will spend the funds
    * @param value uint256 The amount of tokens to be spent
    * @param data bytes Additional data with no specified format, sent in call to `spender`
+   * @return true unless throwing
    */
   function approveAndCall(address spender, uint256 value, bytes memory data) external returns (bool);
 }


### PR DESCRIPTION
Just adding an explicit return value docs as it was missing for no reason.

The `approveAndCall` methods are aligned with the `transferAndCall` and `transferFromAndCall` methods.
