### PR TITLE
Update ERC-4337: fix debug_bundler_dumpreputation status type

### DIFF
--- a/ERCS/erc-4337.md
+++ b/ERCS/erc-4337.md
@@ -966,7 +966,7 @@ An array of reputation entries with the fields:
 * `address` - The address to set the reputation for.
 * `opsSeen` - number of times a user operations with that entity was seen and added to the mempool
 * `opsIncluded` - number of times a user operations that uses this entity was included on-chain
-* `status` - (string) The status of the address in the bundler 'ok' | 'throttled' | 'banned'.
+* `status` - (number) The status of the address in the bundler 0 = 'ok' | 1 = 'throttled' | 2 = 'banned'.
 
 ```json=
 # Request
@@ -985,7 +985,7 @@ An array of reputation entries with the fields:
     { "address": "0x7A0A0d159218E6a2f407B99173A2b12A6DDfC2a6",
       "opsSeen": 20,
       "opsIncluded": 19,
-      "status": "ok"
+      "status": "0x0"
     }
   ]
 }


### PR DESCRIPTION
Changed `debug_bundler_dumpreputation` response to `number` instead of `string` as per [spec-tests](https://github.com/eth-infinitism/bundler-spec-tests/blob/master/tests/single/reputation/test_reputation.py#L20-L23)
