### PR TITLE
Update ERC-5189: ERC5189 - Scaling factor and untrusted environments

### DIFF
--- a/ERCS/erc-5189.md
+++ b/ERCS/erc-5189.md
@@ -49,6 +49,7 @@ To avoid Ethereum consensus changes, we do not attempt to create new transaction
 | endorserGasLimit  | uint64  | amount of gas that should be passed to the endorser when validating the `operation`.                                                                        |
 | maxFeePerGas      | uint256 | max amount of basefee that the `operation` execution is expected to pay. _(Similar to [EIP-1559](./eip-1559.md) `max_fee_per_gas`)_.                        |
 | priorityFeePerGas | uint256 | fixed amount of fees that the `operation` execution is expected to pay to the bundler. _(Similar to [EIP-1559](./eip-1559.md) `max_priority_fee_per_gas`)_. |
+| hasUntrustedContext | bool  | If `true`, the operation *may* have untrusted code paths. These should be treated differently by the bundler (see untrusted environment). |
 
 These `Operation` objects can be sent to a dedicated operations mempool. A specialized class of actors called bundlers (either block producers running special-purpose code, or just users that can relay transactions to block producers) listen for operations on the mempool and execute these transactions.
 
@@ -90,7 +91,8 @@ interface Endorser {
     uint256 _gasLimit,
     uint256 _maxFeePerGas,
     uint256 _maxPriorityFeePerGas,
-    address _feeToken
+    address _feeToken,
+    bool _hasUntrustedContext
   ) external returns (
     bool readiness,
     BlockDependency memory blockDependency,
@@ -107,7 +109,11 @@ When the `isOperationReady` method is called, the endorser must return this info
 * **blockDependency:** maximum values for block values; once the block reaches these values, the `readiness` result MUST be re-evaluated.
 * **dependencies:** a comprehensive list of addresses and storage slots that must be monitored; any state change in these dependencies MUST trigger a re-evaluation of the operation's readiness.
 
-The information provided by the endorser helps the mempool operator maintain a pool of "good" AA transactions that behave correctly; it DOES NOT guarantee that such transactions will be able to be executed correctly. Bundlers must always simulate the result of the execution before including a transaction in a block. They can alternatively monitor the dependencies for changes induced by other transactions in the mempool.
+The information provided by the endorser helps the mempool operator maintain a pool of "good" AA transactions that behave correctly; but it only provides a soft guarantee that the transaction will be executed correctly. Bundlers must always simulate the result of the execution before including a transaction in a block.
+
+If the result of the last simulation fails, but the endorser still returns `readiness == true`, then the endorser can not be trusted and it must be banned by the mempool operator.
+
+The dependency list serves as a shortcut for the bundler to know which operations are fully independent from each other. This shortcut is useful for (a) clearing the mempool from operations that are no longer valid, and (b) for bundlers to know which operations can be included in the same block.
 
 For efficiency, additional information CAN be provided to the endorser with `_endorserCallData`.
 If used, the endorser MUST validate that the provided `_endorserCallData` is valid and relevant to the other values provided.
@@ -153,7 +159,7 @@ The `endorser` should prefer to use `constraints` over `slots`, and `slots` over
 | minValue | bytes32 | Minimum value (inclusive) of `slot` that `readiness` applies to.            |
 | maxValue | bytes32 | Maximum value (inclusive) of `slot` that `readiness` applies to.            |
 
-The `endorser` can use the `minValue` and `maxValue` fields to limit the validity of the `readiness` result. This allows the bundler to avoid re-evaluating the `operation` for some slot changes.
+The `endorser` can use the `minValue` and `maxValue` fields to limit the validity of the `readiness` result. This allows the endorser to fully validate an operation, even when this operation depends on storage values that are not directly accessible by the endorser.
 
 When an exact value is required, `minValue` and `maxValue` should be set to the same value.
 
@@ -174,7 +180,26 @@ If, when simulating the final inclusion of the operation, the bundler discovers 
 
 After an `endorser` is banned, the mempool operator should drop all `operations` related to such endorser.
 
-> Notice: The mempool operator could call one last time `isOperationReady` to determine if the `endorser` should be banned because `(1)` or `(2)`, but this step is not strictly necessary since both scenarios lead to the `endoser` being banned.
+### Untrusted environment
+
+In some scenarios, the endorser may not be able to fully validate the operation but may be able to infer that a given code path *should* be safe. In these cases, the endorser can mark a section of the operation as `untrusted`. Any storage slots (balance, code, nonce, or specific slots) accessed in this untrusted context should be automatically considered as dependencies.
+
+```sol
+interface Endorser {
+  event UntrustedStarted();
+  event UntrustedEnded();
+}
+```
+
+The endorser can use the `UntrustedStarted` and `UntrustedEnded` events to signal the start and end of an untrusted context. The bundler should listen to these events and extend the dependencies list accordingly.
+
+Only the top-level endorser can signal an untrusted context; any other events with the same signature but emitted by a different contract should be ignored.
+
+If multiple events are emitted, the bundler should count the number of `UntrustedStarted` and `UntrustedEnded` events and only consider the untrusted context as ended when the number of `UntrustedEnded` events is equal to the number of `UntrustedStarted` events.
+
+Untrusted contexts can be opened and closed multiple times and can be nested.
+
+If `hasUntrustedContext` is set to `false`, the bundler should ignore any `UntrustedStarted` and `UntrustedEnded` events.
 
 ### Bundler behavior upon receiving an operation
 
@@ -189,7 +214,7 @@ When a bundler receives an `operation`, it SHOULD perform these sanity checks:
 * The `maxFeePerGas` and `priorityPerGas` are above a configurable minimum value the bundler is willing to accept.
 * If another operation exists in the mempool with the exact same dependency set AND the same endorser address, the `maxFeePerGas` and `priorityFeePerGas` of the newly received operation MUST be 12% higher than the one on the mempool to replace it. (Similar with how EOA with same nonce work)
 
-If the `operation` passes these checks, then the bundler MUST call `isOperationReady()` on the `endorser`. If the endorser considers the operation ready, then the client MUST add the operation to the mempool. Otherwise, the operation MUST be dropped.
+If the `operation` passes these checks, then the bundler MUST call `isOperationReady()` on the `endorser`. If the endorser considers the operation ready, and the constraints are within bounds, then the client MUST add the operation to the mempool. Otherwise, the operation MUST be dropped.
 
 The `endorser` result SHOULD be invalidated and its readiness SHOULD be re-evaluated if any of the values of the provided dependencies change. If the operation readiness changes to `false`, the operation MUST be discarded.
 

--- a/ERCS/erc-5189.md
+++ b/ERCS/erc-5189.md
@@ -49,6 +49,8 @@ To avoid Ethereum consensus changes, we do not attempt to create new transaction
 | endorserGasLimit  | uint64  | amount of gas that should be passed to the endorser when validating the `operation`.                                                                        |
 | maxFeePerGas      | uint256 | max amount of basefee that the `operation` execution is expected to pay. _(Similar to [EIP-1559](./eip-1559.md) `max_fee_per_gas`)_.                        |
 | priorityFeePerGas | uint256 | fixed amount of fees that the `operation` execution is expected to pay to the bundler. _(Similar to [EIP-1559](./eip-1559.md) `max_priority_fee_per_gas`)_. |
+| baseFeeScalingFactory | uint256 | Scaling factor to convert `block.basefee` into the `feeToken` unit. |
+| baseFeeNormalizationFactor | uint256 | Normalization factor to convert `block.basefee` into the `feeToken` unit. |
 | hasUntrustedContext | bool  | If `true`, the operation *may* have untrusted code paths. These should be treated differently by the bundler (see untrusted environment). |
 
 These `Operation` objects can be sent to a dedicated operations mempool. A specialized class of actors called bundlers (either block producers running special-purpose code, or just users that can relay transactions to block producers) listen for operations on the mempool and execute these transactions.
@@ -92,6 +94,8 @@ interface Endorser {
     uint256 _maxFeePerGas,
     uint256 _maxPriorityFeePerGas,
     address _feeToken,
+    uint256 _baseFeeScalingFactor,
+    uint256 _baseFeeNormalizationFactor,
     bool _hasUntrustedContext
   ) external returns (
     bool readiness,
@@ -149,7 +153,7 @@ Note that `allSlots`, `constraints` and `slots` are mutually exclusive. If `allS
 If a slot is listed in `constraints`, it must not be listed in `slots`.
 The `endorser` should prefer to use `constraints` over `slots`, and `slots` over `allSlots` whenever possible.
 
-> E.g. A wallet may pay fees using funds stored as WETH. During `isValidOperation()`, the endorser contract may call the `balanceOf` method of the `WETH` contract to determine if the wallet has enough `WETH` balance. Even though the ETH balance of the WETH contract and the code of the WETH contract are being accessed, the endorser only cares about the user's WETH balance for this operation and hence does not include these as dependencies.
+> E.g. A wallet may pay fees using funds stored as WETH. During `isOperationReady()`, the endorser contract may call the `balanceOf` method of the `WETH` contract to determine if the wallet has enough `WETH` balance. Even though the ETH balance of the WETH contract and the code of the WETH contract are being accessed, the endorser only cares about the user's WETH balance for this operation and hence does not include these as dependencies.
 
 #### Constraints
 
@@ -200,6 +204,22 @@ If multiple events are emitted, the bundler should count the number of `Untruste
 Untrusted contexts can be opened and closed multiple times and can be nested.
 
 If `hasUntrustedContext` is set to `false`, the bundler should ignore any `UntrustedStarted` and `UntrustedEnded` events.
+
+### Fee payment
+
+The operation is expected to pay at least `gasUsed * effectiveGasPrice` to `tx.origin`, the `gasUsed` includes both the execution cost of the operation and the cost of its calldata.
+
+The payment is always made in the `feeToken`.
+
+The `maxFeePerGas` and `priorityFeePerGas` are expressed in the unit of the `feeToken`.
+
+The effective gas price is calculated as follows:
+
+```
+effectiveGasPrice = Min(maxFeePerGas, ((block.baseFee * _baseFeeScalingFactor) / _baseFeeNormalizationFactor) + priorityFeePerGas)
+```
+
+`block.baseFee` is the base fee of the block in the native token unit, and `_baseFeeScalingFactor` and `_baseFeeNormalizationFactor` are used to convert the base fee into the `feeToken` unit.
 
 ### Bundler behavior upon receiving an operation
 


### PR DESCRIPTION
It adds two additional features to the ERC:

- `block.basefee` scaling factor, it allows the bundler and the endorser to agree on a common exchange rate for the `block.basefee`; avoiding the need to infer it from 3rd sources.
- Untrusted environments, it allows the endorser to add unknown execution paths into the list of dependencies.