### PR TITLE
Update ERC-165: Clarify misleading usage of `pure` attribute

### DIFF
--- a/ERCS/erc-165.md
+++ b/ERCS/erc-165.md
@@ -198,7 +198,7 @@ contract Lisa is ERC165MappingImplementation, Simpson {
 }
 ```
 
-Following is a `pure` function implementation of `supportsInterface`. The worst-case execution cost is 236 gas, but increases linearly with a higher number of supported interfaces.
+Following is an implementation of `supportsInterface` that doesn't read from storage. The worst-case execution cost is 236 gas, but increases linearly with a higher number of supported interfaces.
 
 ```solidity
 pragma solidity ^0.4.20;


### PR DESCRIPTION
The example provided after the phrase still uses `view` attribute. Either the example or the description before that should change.

If the example is changed, it would be ambiguous whether the ERC-165 imposes restriction on the usage of `view` or `pure` for the `supportsInterface` function.