### PR TITLE
Add ERC: Metadata Management for NFTs

### DIFF
--- a/ERCS/erc-7646.md
+++ b/ERCS/erc-7646.md
@@ -13,7 +13,7 @@ requires: 721, 1155
 
 ## Abstract
 
-The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the [ERC-721](./erc-721.md) or [ERC-1155](./erc-1155.md) standard.
+The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the [ERC-721](./eip-721.md) or [ERC-1155](./eip-1155.md) standard.
 
 ## Motivation
 
@@ -36,7 +36,7 @@ The rationale behind this proposal is to provide a decentralized method for the 
 
 ## Backwards Compatibility
 
-This proposal is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the [ERC-721](./erc-721.md) or [ERC-1155](./erc-1155.md) standard.
+This proposal is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the [ERC-721](./eip-721.md) or [ERC-1155](./eip-1155.md) standard.
 
 ## Test Cases
 

--- a/ERCS/erc-7646.md
+++ b/ERCS/erc-7646.md
@@ -13,7 +13,7 @@ requires: 721, 1155
 
 ## Abstract
 
-The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the [ERC-721](https://ercs.ethereum.org/ERCS/erc-721) or [ERC-1155](https://ercs.ethereum.org/ERCS/erc-1155) standard.
+The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the [ERC-721](./erc-721.md) or [ERC-1155](./erc-1155.md) standard.
 
 ## Motivation
 
@@ -36,7 +36,7 @@ The rationale behind this proposal is to provide a decentralized method for the 
 
 ## Backwards Compatibility
 
-This proposal is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the [ERC-721](https://ercs.ethereum.org/ERCS/erc-721) or [ERC-1155](https://ercs.ethereum.org/ERCS/erc-1155) standard.
+This proposal is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the [ERC-721](./erc-721.md) or [ERC-1155](./erc-1155.md) standard.
 
 ## Test Cases
 

--- a/ERCS/erc-7646.md
+++ b/ERCS/erc-7646.md
@@ -32,11 +32,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Rationale
 
-The rationale behind [ERC-7646](./erc-7647.md) is to provide a decentralized method for the management of NFT metadata, allowing updates post-mint, as well as the ability for the owner to assign metadata editing permissions.
+The rationale behind this proposal is to provide a decentralized method for the management of NFT metadata, allowing updates post-mint, as well as the ability for the owner to assign metadata editing permissions.
 
 ## Backwards Compatibility
 
-[ERC-7646](./erc-7647.md) is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the [ERC-721](./erc-721.md) or [ERC-1155](./erc-1155.md) standard.
+This proposal is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the [ERC-721](./erc-721.md) or [ERC-1155](./erc-1155.md) standard.
 
 ## Test Cases
 

--- a/ERCS/erc-7646.md
+++ b/ERCS/erc-7646.md
@@ -13,7 +13,7 @@ requires: 721, 1155
 
 ## Abstract
 
-The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the [ERC-721](./erc-721.md) or [ERC-1155](./erc-1155.md) standard.
+The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the [ERC-721](https://ercs.ethereum.org/ERCS/erc-721) or [ERC-1155](https://ercs.ethereum.org/ERCS/erc-1155) standard.
 
 ## Motivation
 
@@ -36,7 +36,7 @@ The rationale behind this proposal is to provide a decentralized method for the 
 
 ## Backwards Compatibility
 
-This proposal is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the [ERC-721](./erc-721.md) or [ERC-1155](./erc-1155.md) standard.
+This proposal is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the [ERC-721](https://ercs.ethereum.org/ERCS/erc-721) or [ERC-1155](https://ercs.ethereum.org/ERCS/erc-1155) standard.
 
 ## Test Cases
 

--- a/ERCS/erc-7646.md
+++ b/ERCS/erc-7646.md
@@ -13,7 +13,7 @@ requires: 721, 1155
 
 ## Abstract
 
-The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the ERC-721 or ERC-1155 standard.
+The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the [ERC-721](./erc-721.md) or [ERC-1155](./erc-1155.md) standard.
 
 ## Motivation
 
@@ -32,11 +32,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Rationale
 
-The rationale behind ERC-7646 is to provide a decentralized method for the management of NFT metadata, allowing updates post-mint, as well as the ability for the owner to assign metadata editing permissions.
+The rationale behind [ERC-7646](./erc-7647.md) is to provide a decentralized method for the management of NFT metadata, allowing updates post-mint, as well as the ability for the owner to assign metadata editing permissions.
 
 ## Backwards Compatibility
 
-ERC-7646 is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the ERC-721 or ERC-1155 standard.
+[ERC-7646](./erc-7647.md) is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the [ERC-721](./erc-721.md) or [ERC-1155](./erc-1155.md) standard.
 
 ## Test Cases
 

--- a/ERCS/erc-7646.md
+++ b/ERCS/erc-7646.md
@@ -1,7 +1,7 @@
 ---
 eip: 7646
 title: Metadata Management for NFTs
-description: This ERC proposes a standard for managing metadata of NFTs that allows owners and authorized addresses to update the metadata of their tokens.
+description: This ERC allows NFT owners and authorized addresses to update their token metadata.
 author: Alexey Kureev (@Kureev) <a.g.kureev@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/erc-7646-metadata-management-for-nfts/19027
 status: Draft
@@ -13,7 +13,7 @@ requires: 721, 1155
 
 ## Abstract
 
-The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the ERC721 or ERC1155 standard.
+The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the ERC-721 or ERC-1155 standard.
 
 ## Motivation
 
@@ -32,11 +32,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Rationale
 
-This ERC provides a flexible and decentralized way to manage the metadata of NFTs. It allows the metadata of an NFT to be updated after it has been minted, and it allows the owner of an NFT to delegate the ability to update the metadata to other addresses.
+The rationale behind ERC-7646 is to provide a decentralized method for the management of NFT metadata, allowing updates post-mint, as well as the ability for the owner to assign metadata editing permissions.
 
 ## Backwards Compatibility
 
-This ERC is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the ERC721 or ERC1155 standard.
+ERC-7646 is fully backwards compatible with existing NFT standards. It can be used in conjunction with any NFT contract that implements the ERC-721 or ERC-1155 standard.
 
 ## Test Cases
 

--- a/ERCS/erc-7646.md
+++ b/ERCS/erc-7646.md
@@ -3,7 +3,7 @@ eip: 7646
 title: Metadata Management for NFTs
 description: This ERC proposes a standard for managing metadata of NFTs that allows owners and authorized addresses to update the metadata of their tokens.
 author: Alexey Kureev (@Kureev) <a.g.kureev@gmail.com>
-discussions-to:
+discussions-to: https://ethereum-magicians.org/t/erc-7646-metadata-management-for-nfts/19027
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc_draft_metadata_management_for_nfts.md
+++ b/ERCS/erc_draft_metadata_management_for_nfts.md
@@ -1,4 +1,5 @@
 ---
+eip: 7646
 title: Metadata Management for NFTs
 description: This ERC proposes a standard for managing metadata of NFTs that allows owners and authorized addresses to update the metadata of their tokens.
 author: Alexey Kureev (@Kureev) <a.g.kureev@gmail.com>


### PR DESCRIPTION
Draft ERC to discuss the Metadata Manager concept.

The MetadataManager contract provides a mapping for storing metadata of NFTs. It also provides a mechanism for authorizing other addresses to update the metadata of a token. This contract can be used in conjunction with any NFT contract that implements the [ERC-721](https://ercs.ethereum.org/ERCS/erc-721) or [ERC-1155](https://ercs.ethereum.org/ERCS/erc-1155) standard.

UPD: [Link to the Ethereum Magicians forum](https://ethereum-magicians.org/t/erc-tbd-metadata-management-for-nfts/19027)