### PR TITLE
Update ERC-5573: ERC-5573 typos

### DIFF
--- a/ERCS/erc-5573.md
+++ b/ERCS/erc-5573.md
@@ -85,7 +85,7 @@ A ReCap Capability is identified by their ReCap URI that resolves to a ReCap Det
 
 ##### ReCap URI Scheme
 
-A ReCap URI starts with `urn:recap:` followed by `:` and the unpadded base64url-encoded payload of the ReCap Details Object. Note, the term base64url is defined in RFC4648 - Base 64 Encoding with URL and Filename Safe Alphabet. If present, a Recap URI MUST occupy the final entry of the SIWE resource list.
+A ReCap URI starts with `urn:recap:` followed by the unpadded base64url-encoded payload of the ReCap Details Object. Note, the term base64url is defined in RFC4648 - Base 64 Encoding with URL and Filename Safe Alphabet. If present, a Recap URI MUST occupy the final entry of the SIWE resource list.
 
 The following is a non-normative example of a ReCap Capability:
 

--- a/ERCS/erc-5573.md
+++ b/ERCS/erc-5573.md
@@ -151,7 +151,7 @@ Objects in the `att` field (including nested objects) MUST NOT contain duplicate
 1. Sort by byte value.
 2. If a string starts with another, the shorter string comes first (e.g. `msg/send` comes before `msg/send-to`)
 
-This is the same as the `Array.sort()` method in Javascript. In the example below, `crud/delete` must appear before `crud/update` and `other/action`, similarly `msg/receive` must appear before `msg/send`.
+This is the same as the `Array.sort()` method in JavaScript. In the example below, `crud/delete` must appear before `crud/update` and `other/action`, similarly `msg/receive` must appear before `msg/send`.
 
 The following is a non-normative example of a ReCap Capability Object with `att` and `prf`:
 
@@ -175,14 +175,14 @@ The following is a non-normative example of a ReCap Capability Object with `att`
 }
 ```
 
-In the example above, the Relying Party is authorized to perform the actions `crud/update`, `crud/delete` and `other/action` on resource `https://example.com/pictures` without limitations for any. Additionally the Relying Party is authorized to perform actions `msg/send` and `msg/recieve` on resource `mailto:username@example.com`, where `msg/send` is limited to sending to `someone@email.com` or `joe@email.com` and `msg/recieve` is limited to a maximum of 5 and templates `newsletter` or `marketing`. Note, the Relying Party can invoke each action individually and independently from each other in the RS. Additionally the ReCap Capability Object contains some additional information that the RS will need during verification. The responsibility for defining the structure and semantics of this data lies with the RS. These action and restriction semantics are examples not intended to be universally understood. The Nota Bene objects appearing in the array associated with ability strings represent restrictions on use of an ability. An empty object implies that the action can be performed with no restrictions, but an empty array with no objects implies that there is no way to use this ability in a valid way.
+In the example above, the Relying Party is authorized to perform the actions `crud/update`, `crud/delete` and `other/action` on resource `https://example.com/pictures/` without limitations for any. Additionally the Relying Party is authorized to perform actions `msg/send` and `msg/recieve` on resource `mailto:username@example.com`, where `msg/send` is limited to sending to `someone@email.com` or `joe@email.com` and `msg/recieve` is limited to a maximum of 5 and templates `newsletter` or `marketing`. Note, the Relying Party can invoke each action individually and independently from each other in the RS. Additionally the ReCap Capability Object contains some additional information that the RS will need during verification. The responsibility for defining the structure and semantics of this data lies with the RS. These action and restriction semantics are examples not intended to be universally understood. The Nota Bene objects appearing in the array associated with ability strings represent restrictions on use of an ability. An empty object implies that the action can be performed with no restrictions, but an empty array with no objects implies that there is no way to use this ability in a valid way.
 
 It is expected that RS implementers define which resources they want to expose through ReCap Details Objects and which actions they want to allow users to invoke on them.
 
 This example is expected to transform into the following `recap-transformed-statement` (for `URI` of `https://example.com`):
 
 ```text
-I further authorize the stated URI to perform the following actions on my behalf: (1) 'crud': 'delete', 'update' for 'https://example.com/pictures'. (2) 'other': 'action' for 'https://example.com/pictures'. (3) 'msg': 'recieve', 'send' for 'mailto:username@example.com'.
+I further authorize the stated URI to perform the following actions on my behalf: (1) 'crud': 'delete', 'update' for 'https://example.com/pictures/'. (2) 'other': 'action' for 'https://example.com/pictures/'. (3) 'msg': 'receive', 'send' for 'mailto:username@example.com'.
 ```
 
 This example is also expected to transform into the following `recap-uri`:


### PR DESCRIPTION
Fixes some details:
- Missing trailing slashes in some URIs; test cases didn't match
- Duplicate `:` in ReCaps URI spec
- Javascript -> JavaScript
- Misspelling of receive