### PR TITLE
Update ERC-7579: Update erc-7579 interface param names

### DIFF
--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -157,7 +157,7 @@ interface IModuleConfig {
 
     /**
      * @dev Installs a Module of a certain type on the smart account
-     * @param moduleType the module type ID according to the ERC-7579 spec
+     * @param moduleTypeId the module type ID according to the ERC-7579 spec
      * @param module the module address
      * @param initData arbitrary data that may be required on the module during `onInstall`
      * initialization.
@@ -167,11 +167,11 @@ interface IModuleConfig {
      * MUST emit ModuleInstalled event
      * MUST revert if the module is already installed or the initialization on the module failed
      */
-    function installModule(uint256 moduleType, address module, bytes calldata initData) external payable;
+    function installModule(uint256 moduleTypeId, address module, bytes calldata initData) external payable;
 
     /**
      * @dev Uninstalls a Module of a certain type on the smart account
-     * @param moduleType the module type ID according the ERC-7579 spec
+     * @param moduleTypeId the module type ID according the ERC-7579 spec
      * @param module the module address
      * @param deInitData arbitrary data that may be required on the module during `onInstall`
      * initialization.
@@ -181,17 +181,17 @@ interface IModuleConfig {
      * MUST emit ModuleUninstalled event
      * MUST revert if the module is not installed or the deInitialization on the module failed
      */
-    function uninstallModule(uint256 moduleType, address module, bytes calldata deInitData) external payable;
+    function uninstallModule(uint256 moduleTypeId, address module, bytes calldata deInitData) external payable;
 
     /**
      * @dev Returns whether a module is installed on the smart account
-     * @param moduleType the module type ID according the ERC-7579 spec
+     * @param moduleTypeId the module type ID according the ERC-7579 spec
      * @param module the module address
      * @param additionalContext arbitrary data that may be required to determine if the module is installed
      *
      * MUST return true if the module is installed and false otherwise
      */
-    function isModuleInstalled(uint256 moduleType, address module, bytes calldata additionalContext) external view returns (bool);
+    function isModuleInstalled(uint256 moduleTypeId, address module, bytes calldata additionalContext) external view returns (bool);
 }
 ```
 


### PR DESCRIPTION
Fixes typo, rename `moduleType` to `moduleTypeId`

This change can be verified from the reference implementation - https://github.com/erc7579/erc7579-implementation/blob/main/src/MSAAdvanced.sol#L249