### PR TITLE
Update ERC-5573: require single recap in resources

### DIFF
--- a/ERCS/erc-5573.md
+++ b/ERCS/erc-5573.md
@@ -85,7 +85,7 @@ A ReCap Capability is identified by their ReCap URI that resolves to a ReCap Det
 
 ##### ReCap URI Scheme
 
-A ReCap URI starts with `urn:recap:` followed by the unpadded base64url-encoded payload of the ReCap Details Object. Note, the term base64url is defined in RFC4648 - Base 64 Encoding with URL and Filename Safe Alphabet. There MUST be at most one ReCap URI in the SIWE resource list and if present, it MUST occupy the final entry.
+A ReCap URI starts with `urn:recap:` followed by the unpadded base64url-encoded payload of the ReCap Details Object. Note, the term base64url is defined in RFC4648 - Base 64 Encoding with URL and Filename Safe Alphabet. There MUST be at most one ReCap URI in the SIWE resource list and, if present, it MUST occupy the final entry.
 
 The following is a non-normative example of a ReCap Capability:
 

--- a/ERCS/erc-5573.md
+++ b/ERCS/erc-5573.md
@@ -85,7 +85,7 @@ A ReCap Capability is identified by their ReCap URI that resolves to a ReCap Det
 
 ##### ReCap URI Scheme
 
-A ReCap URI starts with `urn:recap:` followed by the unpadded base64url-encoded payload of the ReCap Details Object. Note, the term base64url is defined in RFC4648 - Base 64 Encoding with URL and Filename Safe Alphabet. If present, a Recap URI MUST occupy the final entry of the SIWE resource list.
+A ReCap URI starts with `urn:recap:` followed by the unpadded base64url-encoded payload of the ReCap Details Object. Note, the term base64url is defined in RFC4648 - Base 64 Encoding with URL and Filename Safe Alphabet. There MUST be at most one ReCap URI in the SIWE resource list and if present, it MUST occupy the final entry.
 
 The following is a non-normative example of a ReCap Capability:
 
@@ -193,7 +193,7 @@ urn:recap:eyJhdHQiOnsiaHR0cHM6Ly9leGFtcGxlLmNvbS9waWN0dXJlcy8iOnsiY3J1ZC9kZWxldG
 
 ##### Merging Capability Objects
 
-Any two Recap objects can be merged together by recursive concatenation of their field elements as long as the ordering rules of the field contents is followed. For example, two recap objects:
+Any two ReCap objects can be merged together by recursive concatenation of their field elements as long as the ordering rules of the field contents is followed. For example, two recap objects:
 
 ```jsonc
 {

--- a/ERCS/erc-5573.md
+++ b/ERCS/erc-5573.md
@@ -193,7 +193,7 @@ urn:recap:eyJhdHQiOnsiaHR0cHM6Ly9leGFtcGxlLmNvbS9waWN0dXJlcy8iOnsiY3J1ZC9kZWxldG
 
 ##### Merging Capability Objects
 
-Any two ReCap objects can be merged together by recursive concatenation of their field elements as long as the ordering rules of the field contents is followed. For example, two recap objects:
+Any two ReCap objects can be merged together by recursive concatenation of their field elements as long as the ordering rules of the field contents is followed. For example, two ReCap objects:
 
 ```jsonc
 {
@@ -297,7 +297,7 @@ Inputs:
 Algorithm:
 - Perform ERC-4361 signature verification with `recap-siwe` and `siwe-signature` as inputs.
 - Let `uri` be the uri field of `recap-siwe`.
-- Let `recap-uri` be a recap URI taken from the last entry of the resources field of `recap-siwe`.
+- Let `recap-uri` be a ReCap URI taken from the last entry of the resources field of `recap-siwe`.
 - Let `recap-transformed-statement` be the result of performing the above `ReCap Translation Algorithm` with `uri` and `recap-uri` as input.
 - Assert that the statement field of `recap-siwe` ends with `recap-transformed-statement`.
 

--- a/ERCS/erc-5573.md
+++ b/ERCS/erc-5573.md
@@ -157,21 +157,21 @@ The following is a non-normative example of a ReCap Capability Object with `att`
 
 ```jsonc
 {
-   "att":{
-      "https://example.com/pictures/":{
-         "crud/delete": [{}],
-         "crud/update": [{}],
-         "other/action": [{}]
-      },
-      "mailto:username@example.com":{
-          "msg/receive": [{
-              "max_count": 5,
-              "templates": ["newsletter", "marketing"]
-          }],
-          "msg/send": [{ "to": "someone@email.com" }, { "to": "joe@email.com" }]
-      }
-   },
-   "prf":["bafybeigk7ly3pog6uupxku3b6bubirr434ib6tfaymvox6gotaaaaaaaaa"]
+  "att": {
+    "https://example.com/pictures/": {
+      "crud/delete": [{}],
+      "crud/update": [{}],
+      "other/action": [{}]
+    },
+    "mailto:username@example.com": {
+      "msg/receive": [{
+        "max_count": 5,
+        "templates": ["newsletter", "marketing"]
+      }],
+      "msg/send": [{ "to": "someone@email.com" }, { "to": "joe@email.com" }]
+    }
+  },
+  "prf": ["bafybeigk7ly3pog6uupxku3b6bubirr434ib6tfaymvox6gotaaaaaaaaa"]
 }
 ```
 


### PR DESCRIPTION
"a Recap URI MUST occupy the final entry of the SIWE resource list" is somewhat ambiguous as to if there can be more (implied ignored) `urn:recap` URIs elsewhere in the resource list. Making this more explicit that there must be a single `urn:recap` URI.

Also adjust spacing and indent to be consistent with elsewhere in the spec & fix some caps typos.