### PR TITLE
Update ERC-5189: ERC5189 Structure and Fee changes

### DIFF
--- a/ERCS/erc-5189.md
+++ b/ERCS/erc-5189.md
@@ -42,6 +42,7 @@ To avoid Ethereum consensus changes, we do not attempt to create new transaction
 | -------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | entrypoint                 | address | Contract address that must be called with `callData` to execute the `operation`.                                                                            |
 | callData                   | bytes   | Data that must be passed to the `entrypoint` call to execute the `operation`.                                                                               |
+| fixedGas                   | uint64  | Amount of gas that the operation will pay for, regardless execution costs, and independent from `gasLimit`.                                                 |
 | gasLimit                   | uint64  | Minimum gasLimit that must be passed when executing the `operation`.                                                                                        |
 | feeToken                   | address | Contract address of the [ERC-20](./eip-20.md) token used to repay the bundler. _(`address(0)` for the native token)_.                                       |
 | endorser                   | address | Address of the endorser contract that should be used to validate the `operation`.                                                                           |
@@ -49,10 +50,10 @@ To avoid Ethereum consensus changes, we do not attempt to create new transaction
 | endorserGasLimit           | uint64  | Amount of gas that should be passed to the endorser when validating the `operation`.                                                                        |
 | maxFeePerGas               | uint256 | Max amount of basefee that the `operation` execution is expected to pay. _(Similar to [EIP-1559](./eip-1559.md) `max_fee_per_gas`)_.                        |
 | priorityFeePerGas          | uint256 | Fixed amount of fees that the `operation` execution is expected to pay to the bundler. _(Similar to [EIP-1559](./eip-1559.md) `max_priority_fee_per_gas`)_. |
-| baseFeeScalingFactor       | uint256 | Scaling factor to convert `block.basefee` into the `feeToken` unit.                                                                                         |
-| baseFeeNormalizationFactor | uint256 | Normalization factor to convert `block.basefee` into the `feeToken` unit.                                                                                   |
+| feeScalingFactor           | uint256 | Scaling factor to convert the computed fee into the `feeToken` unit.                                                                                        |
+| feeNormalizationFactor     | uint256 | Normalization factor to convert the computed fee into the `feeToken` unit.                                                                                  |
 | hasUntrustedContext        | bool    | If `true`, the operation _may_ have untrusted code paths. These should be treated differently by the bundler (see untrusted environment).                   |
-| chainId                    | uint256 | Chain ID of the network where the `operation` is intended to be executed.                                                                                    |
+| chainId                    | uint256 | Chain ID of the network where the `operation` is intended to be executed.                                                                                   |
 
 These `Operation` objects can be sent to a dedicated operations mempool. A specialized class of actors called bundlers (either block producers running special-purpose code, or just users that can relay transactions to block producers) listen for operations on the mempool and execute these transactions.
 
@@ -100,6 +101,7 @@ interface Endorser {
   struct Operation {
     address entrypoint;
     bytes callData;
+    uint256 fixedGas,
     uint256 gasLimit;
     address endorser;
     bytes endorserCallData;
@@ -107,8 +109,8 @@ interface Endorser {
     uint256 maxFeePerGas;
     uint256 priorityFeePerGas;
     address feeToken;
-    uint256 baseFeeScalingFactor;
-    uint256 baseFeeNormalizationFactor;
+    uint256 feeScalingFactor;
+    uint256 feeNormalizationFactor;
     bool hasUntrustedContext;
   }
 
@@ -299,21 +301,21 @@ It is recommended to use untrusted environments only when necessary, like when a
 
 ### Fee payment
 
-The operation is expected to repay spend gas to `tx.origin`. The `gasUsed` is the total gas consumed by the operation, including the execution cost and the calldata cost.
+The operation is expected to repay spent gas to `tx.origin`.
 
-The payment is always made in the `feeToken`, which can be any ERC-20 token. If `feeToken` is `address(0)` then payment is made in the native currency.
+The payment is always made in the `feeToken`, which can be any ERC-20 token. If `feeToken` is `address(0)`, then payment is made in the native currency.
 
-The `maxFeePerGas` and `priorityFeePerGas` are expressed in the unit of the `feeToken`, and they represent the maximum gas price that the user is willing to pay.
+All units are expressed in the native token unit. The result of the fee calculation is then converted to the `feeToken` unit using the `feeScalingFactor` and `feeNormalizationFactor`.
 
 The gas price is calculated as follows:
 
 ```
-effectiveGasPrice = Min(maxFeePerGas, block.baseFee + priorityFeePerGas)
-totalFee = gasUsed * effectiveGasPrice * _baseFeeScalingFactor / _baseFeeNormalizationFactor
+gasUsed = fixedGas + (0:gasLimit)
+feePerGas = Min(maxFeePerGas, block.baseFee + priorityFeePerGas)
+totalFee = (gasUsed * feePerGas * _feeScalingFactor) / _feeNormalizationFactor
 ```
 
-`block.baseFee` is the base fee of the block in the native token unit, and `_baseFeeScalingFactor` and `_baseFeeNormalizationFactor` are used to convert the base fee into the `feeToken` unit.
-When `feeToken` is `address(0)`, `_baseFeeScalingFactor` and `_baseFeeNormalizationFactor` MUST be equal to `1`.
+When `feeToken` is `address(0)`, `_feeScalingFactor` and `_feeNormalizationFactor` MUST be equal to `1`.
 
 ### Operation identification
 

--- a/ERCS/erc-5189.md
+++ b/ERCS/erc-5189.md
@@ -97,17 +97,23 @@ interface Endorser {
     Constraint[] constraints;
   }
 
+  struct Operation {
+    address entrypoint;
+    bytes callData;
+    uint256 gasLimit;
+    address endorser;
+    bytes endorserCallData;
+    uint256 endorserGasLimit;
+    uint256 maxFeePerGas;
+    uint256 priorityFeePerGas;
+    address feeToken;
+    uint256 baseFeeScalingFactor;
+    uint256 baseFeeNormalizationFactor;
+    bool hasUntrustedContext;
+  }
+
   function isOperationReady(
-    address _entrypoint,
-    bytes calldata _data,
-    bytes calldata _endorserCallData,
-    uint256 _gasLimit,
-    uint256 _maxFeePerGas,
-    uint256 _maxPriorityFeePerGas,
-    address _feeToken,
-    uint256 _baseFeeScalingFactor,
-    uint256 _baseFeeNormalizationFactor,
-    bool _hasUntrustedContext
+    Operation calldata _operation,
   ) external returns (
     bool readiness,
     GlobalDependency memory globalDependency,


### PR DESCRIPTION
- Use the `Operation` struct for `isOperationReady`, leads to cleaner endorsers
- Apply fee scaling at the end of the fee formula
- Add `fixedGas`