### PR TITLE
Add ERC: ERC-5189 Operation Receipts

### DIFF
--- a/ERCS/erc-7655.md
+++ b/ERCS/erc-7655.md
@@ -1,0 +1,113 @@
+---
+eip: 7655
+title: ERC-5189 Operation Receipts
+description: A general interface for the detection of ERC-5189 operation receipts.
+author: William Hua (@attente), Agustín Aguilar (@agusx1211)
+discussions-to: https://ethereum-magicians.org/t/erc-7655-erc-5189-operation-receipts/19187
+status: Draft
+type: Standards Track
+category: ERC
+created: 2024-03-12
+requires: 5189
+---
+
+## Abstract
+
+This ERC is intended to address the issue of obtaining operation receipts in [ERC-5189](./eip-5189.md), which is an application layer account abstraction proposal that maintains compatibility with existing smart contract wallets.
+
+## Motivation
+
+Native Ethereum is capable of issuing receipts for block-included transactions, indexed by transaction hash.
+For an account abstraction design to behave on par with the consensus-layer protocol, it must similarly be able to inform interested parties when operations are included on-chain.
+A common theme among account abstraction proposals is that multiple operations can be executed in a single transaction and ERC-5189 is no different.
+These operations can target different entrypoints with no restrictions or commonality in their behaviour.
+In addition, because ERC-5189 describes a shared mempool where any arbitrary participant is able to bundle and execute any arbitrary operation, there is no guarantee that an interested party has a direct line of communication with the bundler that sends any specific operation to the network, and therefore cannot assume ready access to the transaction where it was executed.
+
+Therefore, we require a general framework to determine:
+1. Which transaction executed any specific operation.
+2. If the operation succeeded.
+3. What logs were emitted during execution of the operation.
+4. How much gas was used to execute the operation.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+Endorsers as described in ERC-5189 SHOULD implement the following interface:
+
+```solidity
+interface ReceiptProvider {
+
+  /// @notice Returns an event log filter that can be used to detect transactions that execute a given operation.
+  /// @dev The filter is intended for eth_newFilter and eth_getLogs JSON-RPC requests.
+  /// @dev Empty arrays returned in the topics array must be replaced with `null`.
+  /// @param operation The operation to search for.
+  /// @return _address The contract address to filter logs on.
+  /// @return topics The event topics to filter logs on.
+  function operationFilter(
+    Endorser.Operation calldata operation
+  ) external view returns (
+    address _address,
+    bytes32[][] memory topics
+  );
+
+  /// @notice Operation status
+  enum Status {
+    Unknown,
+    Succeeded,
+    Failed
+  }
+
+  /// @notice Event log
+  struct Log {
+    address _address;
+    bytes32[] topics;
+    bytes data;
+  }
+
+  /// @notice Returns an operation receipt derived from the event logs of a transaction that executes it.
+  /// @param operation The operation to derive a receipt for.
+  /// @param transactionLogs The logs of a transaction that executes the operation.
+  /// @return status Whether the operation succeeded or failed.
+  /// @return operationLogs The logs emitted specifically due to this operation.
+  /// @return gasUsed The gas used specifically due to this operation.
+  function operationReceipt(
+    Endorser.Operation calldata operation,
+    Log[] calldata transactionLogs
+  ) external view returns (
+    Status status,
+    Log[] memory operationLogs,
+    uint256 gasUsed
+  );
+
+}
+```
+
+When `operationFilter` is called with an operation that the endorser recognizes, the endorser SHOULD return an origin address and an array of possible topics for that position in a matching log's topics, as described in the JSON-RPC API documentation for the `eth_getLogs` and `eth_newFilter` methods, with the exception that an empty array in a position behaves equivalently to the `null` value.
+
+When `operationReceipt` is called with an operation that the endorser recognizes and the logs of the transaction where the operation was executed, the endorser SHOULD return the success status of the operation, a subsequence of logs that were emitted during the execution of the operation, and the amount of gas used during execution of the operation.
+
+## Rationale
+
+`operationFilter` addresses the first requirement for detecting when an operation is mined without any knowledge of the bundler that executed the operation on-chain.
+Users can use the result of this function to issue an `eth_getLogs` request to a JSON-RPC node to find potential transactions where the operation was executed.
+
+`operationReceipt` addresses the other requirements of determining if the operation succeeded, identifying which logs of the encompassing transaction were executed in the context of the operation in question, as well as how much gas was consumed during the operation's execution.
+Users can use the result of this function to filter a transaction receipt's logs into those logs specifically emitted due to the operation, as well as determine the status and gas usage of the operation.
+
+## Backwards Compatibility
+
+This ERC specifies the ideal behaviour of an endorser, but recognizes that some features might not be possible to implement for existing smart contract wallets.
+If it is not possible to infer the gas consumed during an operation's execution, `operationReceipt` MUST return 0 for `gasUsed`.
+If it is not possible to infer exactly those logs that were emitted specifically due to the operation, `operationReceipt` MUST return an empty array for `operationLogs`.
+If it is not possible to infer the success status of the operation, `operationReceipt` MUST return `Status.Unknown` for `status`.
+Finally, if it is not even possible to implement `operationFilter`, `operationFilter` MUST return the zero address and an empty array of topics.
+
+## Security Considerations
+
+Users can evaluate the correctness of an endorser based on its history, adoption, and stake in the endorser registry as described in ERC-5189.
+If an endorser implements this ERC incorrectly, whether accidentally or intentionally, users can immediately conclude that the endorser is not to be relied upon and a correct endorser will need to be registered and used instead.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
This ERC is intended to address the issue of obtaining operation receipts in ERC-5189, which is an application layer account abstraction proposal that maintains compatibility with existing smart contract wallets.