### PR TITLE
Update ERC-7508: Improvements on ERC7508.

### DIFF
--- a/ERCS/erc-7508.md
+++ b/ERCS/erc-7508.md
@@ -57,23 +57,23 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 ```solidity
 /// @title ERC-7508 Public On-Chain NFT Attributes Repository
 /// @dev See https://eips.ethereum.org/EIPS/eip-7508
-/// @dev Note: the ERC-165 identifier for this interface is 0x07cd44c7.
+/// @dev Note: the ERC-165 identifier for this interface is 0x212206a8.
 
 pragma solidity ^0.8.21;
 
 interface IERC7508 is IERC165 {
     /**
      * @notice A list of supported access types.
-     * @return The `Issuer` type, where only the issuer can manage the parameter.
+     * @return The `Owner` type, where only the owner can manage the parameter.
      * @return The `Collaborator` type, where only the collaborators can manage the parameter.
-     * @return The `IssuerOrCollaborator` type, where only the issuer or collaborators can manage the parameter.
+     * @return The `OwnerOrCollaborator` type, where only the owner or collaborators can manage the parameter.
      * @return The `TokenOwner` type, where only the token owner can manage the parameters of their tokens.
      * @return The `SpecificAddress` type, where only specific addresses can manage the parameter.
      */
     enum AccessType {
-        Issuer,
+        Owner,
         Collaborator,
-        IssuerOrCollaborator,
+        OwnerOrCollaborator,
         TokenOwner,
         SpecificAddress
     }
@@ -141,14 +141,14 @@ interface IERC7508 is IERC165 {
     /**
      * @notice Used to notify listeners that a new collection has been registered to use the repository.
      * @param collection Address of the collection
-     * @param issuer Address of the issuer of the collection; the addess authorized to manage the access control
+     * @param owner Address of the owner of the collection; the addess authorized to manage the access control
      * @param registeringAddress Address that registered the collection
      * @param useOwnable A boolean value indicating whether the collection uses the Ownable extension to verify the
-     *  issuer (`true`) or not (`false`)
+     *  owner (`true`) or not (`false`)
      */
     event AccessControlRegistration(
         address indexed collection,
-        address indexed issuer,
+        address indexed owner,
         address indexed registeringAddress,
         bool useOwnable
     );
@@ -308,25 +308,25 @@ interface IERC7508 is IERC165 {
      * @dev  If the collection does not implement the Ownable interface, the `useOwnable` value must be set to `false`.
      * @dev Emits an {AccessControlRegistration} event.
      * @param collection The address of the collection that will use the RMRK token attributes repository.
-     * @param issuer The address of the issuer of the collection.
+     * @param owner The address of the owner of the collection.
      * @param useOwnable The boolean value to indicate if the collection implements the Ownable interface and whether it
-     *  should be used to validate that the caller is the issuer (`true`) or to use the manually set issuer address
+     *  should be used to validate that the caller is the owner (`true`) or to use the manually set owner address
      *  (`false`).
      */
     function registerAccessControl(
         address collection,
-        address issuer,
+        address owner,
         bool useOwnable
     ) external;
 
     /**
      * @notice Used to manage the access control settings for a specific parameter.
-     * @dev Only the `issuer` of the collection can call this function.
+     * @dev Only the `owner` of the collection can call this function.
      * @dev The possible `accessType` values are:
      *  [
-     *      Issuer,
+     *      Owner,
      *      Collaborator,
-     *      IssuerOrCollaborator,
+     *      OwnerOrCollaborator,
      *      TokenOwner,
      *      SpecificAddress,
      *  ]
@@ -366,7 +366,7 @@ interface IERC7508 is IERC165 {
      * @param collection Address of the collection
      * @return attributesMetadataURI The URI of the attributes metadata
      */
-    function getAttributesMetadataURI(
+    function getAttributesMetadataURIForCollection(
         address collection
     ) external view returns (string memory attributesMetadataURI);
 
@@ -376,7 +376,7 @@ interface IERC7508 is IERC165 {
      * @param collection Address of the collection
      * @param attributesMetadataURI The URI of the attributes metadata
      */
-    function setAttributesMetadataURI(
+    function setAttributesMetadataURIForCollection(
         address collection,
         string memory attributesMetadataURI
     ) external;
@@ -565,38 +565,38 @@ interface IERC7508 is IERC165 {
      *  ]
      * @param collection The collection address
      * @param tokenId The token ID
+     * @param addressKeys An array of address type attribute keys to retrieve
+     * @param boolKeys An array of bool type attribute keys to retrieve
+     * @param bytesKeys An array of bytes type attribute keys to retrieve
+     * @param intKeys An array of int type attribute keys to retrieve
      * @param stringKeys An array of string type attribute keys to retrieve
      * @param uintKeys An array of uint type attribute keys to retrieve
-     * @param intKeys An array of int type attribute keys to retrieve
-     * @param boolKeys An array of bool type attribute keys to retrieve
-     * @param addressKeys An array of address type attribute keys to retrieve
-     * @param bytesKeys An array of bytes type attribute keys to retrieve
+     * @return addressAttributes An array of addresses, in the same order as the addressKeys
+     * @return boolAttributes An array of bools, in the same order as the boolKeys
+     * @return bytesAttributes An array of bytes, in the same order as the bytesKeys
+     * @return intAttributes An array of ints, in the same order as the intKeys
      * @return stringAttributes An array of strings, in the same order as the stringKeys
      * @return uintAttributes An array of uints, in the same order as the uintKeys
-     * @return intAttributes An array of ints, in the same order as the intKeys
-     * @return boolAttributes An array of bools, in the same order as the boolKeys
-     * @return addressAttributes An array of addresses, in the same order as the addressKeys
-     * @return bytesAttributes An array of bytes, in the same order as the bytesKeys
      */
     function getAttributes(
         address collection,
         uint256 tokenId,
-        string[] memory stringKeys,
-        string[] memory uintKeys,
-        string[] memory intKeys,
-        string[] memory boolKeys,
         string[] memory addressKeys,
-        string[] memory bytesKeys
+        string[] memory boolKeys,
+        string[] memory bytesKeys,
+        string[] memory intKeys,
+        string[] memory stringKeys,
+        string[] memory uintKeys
     )
         external
         view
         returns (
-            string[] memory stringAttributes,
-            uint256[] memory uintAttributes,
-            int256[] memory intAttributes,
-            bool[] memory boolAttributes,
             address[] memory addressAttributes,
-            bytes[] memory bytesAttributes
+            bool[] memory boolAttributes,
+            bytes[] memory bytesAttributes,
+            int256[] memory intAttributes,
+            string[] memory stringAttributes,
+            uint256[] memory uintAttributes
         );
 
     // ------------------- PREPARE PRESIGNED MESSAGES -------------------
@@ -910,22 +910,22 @@ interface IERC7508 is IERC165 {
      *  ]
      * @param collection The address of the collection
      * @param tokenId The token ID
+     * @param addressAttributes An array of `AddressAttribute` structs containing address attributes to set
+     * @param boolAttributes An array of `BoolAttribute` structs containing bool attributes to set
+     * @param bytesAttributes An array of `BytesAttribute` structs containing bytes attributes to set
+     * @param intAttributes An array of `IntAttribute` structs containing int attributes to set
      * @param stringAttributes An array of `StringAttribute` structs containing string attributes to set
      * @param uintAttributes An array of `UintAttribute` structs containing uint attributes to set
-     * @param intAttributes An array of `IntAttribute` structs containing int attributes to set
-     * @param boolAttributes An array of `BoolAttribute` structs containing bool attributes to set
-     * @param addressAttributes An array of `AddressAttribute` structs containing address attributes to set
-     * @param bytesAttributes An array of `BytesAttribute` structs containing bytes attributes to set
      */
     function setAttributes(
         address collection,
         uint256 tokenId,
-        StringAttribute[] memory stringAttributes,
-        UintAttribute[] memory uintAttributes,
-        IntAttribute[] memory intAttributes,
-        BoolAttribute[] memory boolAttributes,
         AddressAttribute[] memory addressAttributes,
-        BytesAttribute[] memory bytesAttributes
+        BoolAttribute[] memory boolAttributes,
+        BytesAttribute[] memory bytesAttributes,
+        IntAttribute[] memory intAttributes,
+        StringAttribute[] memory stringAttributes,
+        UintAttribute[] memory uintAttributes
     ) external;
 
     // ------------------- PRESIGNED SETTERS -------------------

--- a/assets/erc-7508/contracts/IERC7508.sol
+++ b/assets/erc-7508/contracts/IERC7508.sol
@@ -12,16 +12,16 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 interface IERC7508 is IERC165 {
     /**
      * @notice A list of supported access types.
-     * @return The `Issuer` type, where only the issuer can manage the parameter.
+     * @return The `Owner` type, where only the owner can manage the parameter.
      * @return The `Collaborator` type, where only the collaborators can manage the parameter.
-     * @return The `IssuerOrCollaborator` type, where only the issuer or collaborators can manage the parameter.
+     * @return The `OwnerOrCollaborator` type, where only the owner or collaborators can manage the parameter.
      * @return The `TokenOwner` type, where only the token owner can manage the parameters of their tokens.
      * @return The `SpecificAddress` type, where only specific addresses can manage the parameter.
      */
     enum AccessType {
-        Issuer,
+        Owner,
         Collaborator,
-        IssuerOrCollaborator,
+        OwnerOrCollaborator,
         TokenOwner,
         SpecificAddress
     }
@@ -89,14 +89,14 @@ interface IERC7508 is IERC165 {
     /**
      * @notice Used to notify listeners that a new collection has been registered to use the repository.
      * @param collection Address of the collection
-     * @param issuer Address of the issuer of the collection; the addess authorized to manage the access control
+     * @param owner Address of the owner of the collection; the addess authorized to manage the access control
      * @param registeringAddress Address that registered the collection
      * @param useOwnable A boolean value indicating whether the collection uses the Ownable extension to verify the
-     *  issuer (`true`) or not (`false`)
+     *  owner (`true`) or not (`false`)
      */
     event AccessControlRegistration(
         address indexed collection,
-        address indexed issuer,
+        address indexed owner,
         address indexed registeringAddress,
         bool useOwnable
     );
@@ -256,25 +256,25 @@ interface IERC7508 is IERC165 {
      * @dev  If the collection does not implement the Ownable interface, the `useOwnable` value must be set to `false`.
      * @dev Emits an {AccessControlRegistration} event.
      * @param collection The address of the collection that will use the RMRK token attributes repository.
-     * @param issuer The address of the issuer of the collection.
+     * @param owner The address of the owner of the collection.
      * @param useOwnable The boolean value to indicate if the collection implements the Ownable interface and whether it
-     *  should be used to validate that the caller is the issuer (`true`) or to use the manually set issuer address
+     *  should be used to validate that the caller is the owner (`true`) or to use the manually set owner address
      *  (`false`).
      */
     function registerAccessControl(
         address collection,
-        address issuer,
+        address owner,
         bool useOwnable
     ) external;
 
     /**
      * @notice Used to manage the access control settings for a specific parameter.
-     * @dev Only the `issuer` of the collection can call this function.
+     * @dev Only the `owner` of the collection can call this function.
      * @dev The possible `accessType` values are:
      *  [
-     *      Issuer,
+     *      Owner,
      *      Collaborator,
-     *      IssuerOrCollaborator,
+     *      OwnerOrCollaborator,
      *      TokenOwner,
      *      SpecificAddress,
      *  ]
@@ -314,7 +314,7 @@ interface IERC7508 is IERC165 {
      * @param collection Address of the collection
      * @return attributesMetadataURI The URI of the attributes metadata
      */
-    function getAttributesMetadataURI(
+    function getAttributesMetadataURIForCollection(
         address collection
     ) external view returns (string memory attributesMetadataURI);
 
@@ -324,7 +324,7 @@ interface IERC7508 is IERC165 {
      * @param collection Address of the collection
      * @param attributesMetadataURI The URI of the attributes metadata
      */
-    function setAttributesMetadataURI(
+    function setAttributesMetadataURIForCollection(
         address collection,
         string memory attributesMetadataURI
     ) external;


### PR DESCRIPTION
- Renames Issuer for Owner in token attributes.
- Renames methods to set and get collection attributes metadata to make it explicit they are per collection. Adds full test coverage for token attributes.
- Sorts methods on RMRKTokenAttributesRepository.
- Updates interfaceId.