### PR TITLE
ERC-2333: schedule for review

### DIFF
--- a/ERCS/erc-2333.md
+++ b/ERCS/erc-2333.md
@@ -1,9 +1,9 @@
 ---
 eip: 2333
 title: BLS12-381 Key Generation
-author: Carl Beekhuizen <carl@ethereum.org>
-discussions-to: https://github.com/ethereum/EIPs/issues/2337
-status: Stagnant
+author: Carl Beekhuizen <carl@ethereum.org>, Mamy Ratsimbazafy <mamy@numforge.co>
+discussions-to: https://ethereum-magicians.org/t/erc-2333-erc-2334-erc-2335-bls12-381-key-generation-deterministic-account-hierarchy-keystore/19566
+status: Review
 type: Standards Track
 category: ERC
 created: 2019-09-30


### PR DESCRIPTION
See discussion at https://ethereum-magicians.org/t/erc-2333-erc-2334-erc-2335-bls12-381-key-generation-deterministic-account-hierarchy-keystore/19566

ERC-2333 is a defacto standard, required for staking tools and implemented in all consensus client.

Ideally this is fast-tracked to `Final`