### PR TITLE
Update ERC-7531: Fix typo in IERC7531

### DIFF
--- a/ERCS/erc-7531.md
+++ b/ERCS/erc-7531.md
@@ -69,7 +69,7 @@ interface IERC7531 {
    *
    * @param tokenAddress The address of the ERC-721 contract.
    * @param tokenId The ID of the token.
-   * @param rights The type of rights held by the holder.
+   * @param right The type of right held by the holder.
    * @return The address of the entity with rights over the token.
    */
   function rightsHolderOf(


### PR DESCRIPTION
Fixing a typo @param right (it was rights, which was wrong)