### PR TITLE
Update ERC-5559: Move to Draft

### DIFF
--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -2,7 +2,7 @@
 eip: 5559
 title: "Cross-chain Write Deferral Protocol"
 description: The cross-chain write deferral protocol provides a mechanism to replace L1 storage with L2 and databases through off-chain handlers
-author: Avneet Singh (@sshmatrix), 0xc0de4c0ffee (@0xc0de4c0ffee), Nick Johnson (@arachnid), (@0xpaulio)
+author: Avneet Singh (@sshmatrix), 0xc0de4c0ffee (@0xc0de4c0ffee), Nick Johnson (@arachnid), Paul Gauvreau (@0xpaulio)
 discussions-to: https://ethereum-magicians.org/t/erc-5559-cross-chain-write-deferral-protocol/19664
 status: Draft
 type: Standards Track
@@ -12,14 +12,14 @@ requires: 155
 ---
 
 ## Abstract
-The cross-chain write deferral protocol, aka CCIP-Write, facilitates replacing Ethereum L1 storage with L2 chains and/or centralised databases with an aim to cut gas costs and further privacy while retaining the secure aspects of on-chain storage. Methods in this document specifically target security and cost-effectiveness of write deferrals. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](https://eips.ethereum.org/EIPS/eip-3668)-compliant contracts completing the cross-chain data life cycle. This document, alongside [EIP-3668](https://eips.ethereum.org/EIPS/eip-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
+The cross-chain write deferral protocol, aka CCIP-Write, facilitates replacing Ethereum L1 storage with L2 chains and/or centralised databases with an aim to cut gas costs and further privacy while retaining the secure aspects of on-chain storage. Methods in this document specifically target security and cost-effectiveness of write deferrals. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](./erc-3668)-compliant contracts completing the cross-chain data life cycle. This document, alongside [EIP-3668](./erc-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
 
-## Motivation
-[EIP-3668](https://eips.ethereum.org/EIPS/eip-3668), aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum. 
+## Rationale
+[EIP-3668](./erc-3668), aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum. 
 
-Cross-chain data retrieval through [EIP-3668](https://eips.ethereum.org/EIPS/eip-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and centralised databases (or decentralised storages, although they are not covered by this draft). On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage.
+Cross-chain data retrieval through [EIP-3668](./erc-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and centralised databases (or decentralised storages, although they are not covered by this draft). On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage.
 
-[EIP-5559](https://eips.ethereum.org/EIPS/eip-5559) is the first step toward such a tolerant CCIP-Write protocol which outlines how secure write deferrals can be made to L2s and centralised databases. The cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
+[EIP-5559](./erc-5559) is the first step toward such a tolerant CCIP-Write protocol which outlines how secure write deferrals can be made to L2s and centralised databases. The cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
 
 ## Specification
 ### Overview
@@ -225,7 +225,7 @@ Requesting Signature To Approve Data Signer\n\nOrigin: ${username}\nApproved Sig
 where `dataSigner` must be checksummed.
 
 #### 4. Post CCIP-Read Compatible Payload
-The final [EIP-3668](https://eips.ethereum.org/EIPS/eip-3668)-compatible `data` payload in the off-chain data file must then follow the format
+The final [EIP-3668](./erc-3668)-compatible `data` payload in the off-chain data file must then follow the format
 
 ```solidity
 bytes encodedData = abi.encode(['bytes'], [dataValue])
@@ -430,7 +430,7 @@ await fetch(gatewayUrl, {
 ```
 
 ## Backwards Compatibility
-`StorageHandledByDatabase()` method in this document is NOT compatible with the previous [EIP-5559](https://eips.ethereum.org/EIPS/eip-5559) specification.
+`StorageHandledByDatabase()` method in this document is NOT compatible with the previous [EIP-5559](./erc-5559) specification.
 
 ## Security Considerations
 1. Clients must purge the derived signer private keys from local storage immediately after signing the off-chain data.

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -144,7 +144,7 @@ function keygen(
 This `keygen()` function requires three variables: `username`, `password` and `sigKeygen`. Their definitions are given below.
 
 ##### `username`
-CAIP-10 identifier `username` is auto-derived from the connected wallet's checksummed address `wallet` and `chainId`.
+CAIP-10 identifier `username` is auto-derived from the connected wallet's checksummed address `wallet` and `chainId` using [EIP-155](./eip-155).
 
 ```js
 /* CAIP-10 identifier */

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -14,13 +14,6 @@ requires: 155
 ## Abstract
 The cross-chain write deferral protocol, aka CCIP-Write, facilitates replacing Ethereum L1 storage with L2 chains and/or centralised databases with an aim to cut gas costs and further privacy while retaining the secure aspects of on-chain storage. Methods in this document specifically target security and cost-effectiveness of write deferrals. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](./erc-3668)-compliant contracts completing the cross-chain data life cycle. This document, alongside [EIP-3668](./erc-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
 
-## Rationale
-[EIP-3668](./erc-3668), aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum. 
-
-Cross-chain data retrieval through [EIP-3668](./erc-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and centralised databases (or decentralised storages, although they are not covered by this draft). On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage.
-
-[EIP-5559](./erc-5559) is the first step toward such a tolerant CCIP-Write protocol which outlines how secure write deferrals can be made to L2s and centralised databases. The cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
-
 ## Specification
 ### Overview
 The following specification revolves around the structure and description of a cross-chain storage handler tasked with the responsibility of writing to an L2 or database storage. This draft introduces `StorageHandledByL2()` and `StorageHandledByDatabase()` storage handlers, and proposes that new `StorageHandledBy__()` reverts be allowed through new EIPs that sufficiently detail their interfaces and designs. Some foreseen examples of new storage handlers include `StorageHandledBySolana()` for Solana, `StorageHandledByFilecoin()` for Filecoin, `StorageHandledByIPFS()` for IPFS, `StorageHandledByIPNS()` for IPNS, `StorageHandledByArweave()` for Arweave, `StorageHandledByArNS()` for ArNS, `StorageHandledBySwarm()` for Swarm etc.
@@ -428,6 +421,13 @@ await fetch(gatewayUrl, {
   body: JSON.stringify(post)
 });
 ```
+
+## Rationale
+[EIP-3668](./erc-3668), aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum. 
+
+Cross-chain data retrieval through [EIP-3668](./erc-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and centralised databases (or decentralised storages, although they are not covered by this draft). On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage.
+
+[EIP-5559](./erc-5559) is the first step toward such a tolerant CCIP-Write protocol which outlines how secure write deferrals can be made to L2s and centralised databases. The cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
 
 ## Backwards Compatibility
 `StorageHandledByDatabase()` method in this document is NOT compatible with the previous [EIP-5559](./erc-5559) specification.

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -433,7 +433,7 @@ await fetch(gatewayUrl, {
 ```
 
 ## Rationale
-Technically, the cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification. Methods in this document perform these precise tasks when deferring write operations to external handlers. In addition, methods such as signing data with a derived signer (for databases) allows for significant UX improvement by fixing the number of signature prompts in wallets to 2, irrespective of the number of data instances to sign per node or the total number of nodes to update. This improvement comes at no additional cost to the user or allows services to perform batch updates.
+Technically, the cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification. Methods in this document perform these precise tasks when deferring write operations to external handlers. In addition, methods such as signing data with a derived signer (for databases) allow for significant UX improvement by fixing the number of signature prompts in wallets to 2, irrespective of the number of data instances to sign per node or the total number of nodes to update. This improvement comes at no additional cost to the user and allows services to perform batch updates.
 
 ## Backwards Compatibility
 None.

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -1,471 +1,447 @@
 ---
 eip: 5559
-title: "Cross Chain Write Deferral Protocol"
-description: The cross chain write deferral protocol provides a mechanism to defer the storage & resolution of mutations to off-chain handlers
-author: Paul Gauvreau (@0xpaulio), Nick Johnson (@arachnid)
+title: "Cross-chain Write Deferral Protocol"
+description: The cross-chain write deferral protocol provides a mechanism to replace L1 storage with L2 and databases through off-chain handlers
+author: (@sshmatrix), (@0xc0de4c0ffee), (@arachnid), (@0xpaulio)
 discussions-to: https://ethereum-magicians.org/t/eip-cross-chain-write-deferral-protocol/10576
-status: Stagnant
+status: Draft
 type: Standards Track
 category: ERC
-created: 2022-06-23
+created: 2024-04-16
 requires: 712
 ---
 
 ## Abstract
-The following standard provides a mechanism in which smart contracts can request various tasks to be resolved by an external handler. This provides a mechanism in which protocols can reduce the gas fees associated with storing data on mainnet by deferring the handling of it to another system/network. These external handlers act as an extension to the core L1 contract.
-
-This standard outlines a set of handler types that can be used for managing the execution and storage of mutations (tasks), as well as their corresponding tradeoffs. Each handler type has associated operational costs, finality guarantees, and levels of decentralization. By further specifying the type of handler that the mutation is deferred to, the protocol can better define how to permission and secure their system. 
-
-This standard can be implemented in conjunction with [EIP-3668](./eip-3668) to provide a mechanism in which protocols can reside on and be interfaced through an L1 contract on mainnet, while being able to resolve and mutate data stored in external systems.
+The cross-chain write deferral protocol, aka CCIP-Write, facilitates replacing Ethereum L1 storage with L2 chains and/or centralised databases with an aim to cut gas costs and further privacy while retaining the secure aspects of on-chain storage. Methods in this document specifically target security and cost-effectiveness of write deferrals. The cross-chain data written with these methods can be retrieved by generic EIP-3668-compliant contracts completing the cross-chain data life cycle. This document, alongside EIP-3668, is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
 
 ## Motivation
-[EIP-3668](./eip-3668) provides a mechanism by which off-chain lookups can be defined inside smart contracts in a transparent manner. In addition, it provides a scheme in which the resolved data can be verified on-chain. However, there lacks a standard by which mutations can be requested through the native contract, to be performed on the off-chain data. Furthermore, with the increase in L2 solutions, smart contract engineers have additional tools that can be used to reduce the storage and transaction costs of performing mutations on the Ethereum mainnet. 
+EIP-3668, aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum. 
 
-A specification that allows smart contracts to defer the storage and resolution of data to external handlers facilitates writing clients agnostic to the storage solution being used, enabling new applications that can operate without knowledge of the underlying handlers associated with the contracts they interact with.
+Cross-chain data retrieval through EIP-3668 is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and centralised databases (or decentralised storages, although they are not covered by this draft). On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage.
 
-Examples of this include:
- - Allowing the management of ENS domains externally resolved on an L2 solution or off-chain database as if they were native L1 tokens.
- - Allowing the management of digital identities stored on external handlers as if they were in the stored in the native L1 smart contract. 
+EIP-5559 is the first step toward such a tolerant CCIP-Write protocol which outlines how secure write deferrals can be made to L2s and centralised databases. The cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
 
 ## Specification
 ### Overview
-There are two main handler classifications: L2 Contract and Off-Chain Database. These are determined based off of where the handler is deployed. The handler classifications are used to better define the different security guarantees and requirements associated with its deployment. 
+The following specification revolves around the structure and description of a cross-chain storage handler tasked with the responsibility of writing to an L2 or database storage. This draft introduces `StorageHandledByL2()` and `StorageHandledByDatabase()` storage handlers, and proposes that new `StorageHandledBy__()` reverts be allowed through new EIPs that sufficiently detail their interfaces and designs. Some foreseen examples of new storage handlers include `StorageHandledBySolana()` for Solana, `StorageHandledByFilecoin()` for Filecoin, `StorageHandledByIPFS()` for IPFS, `StorageHandledByIPNS()` for IPNS, `StorageHandledByArweave()` for Arweave, `StorageHandledByArNS()` for ArNS, `StorageHandledBySwarm()` for Swarm etc.
 
-From a high level:
-- Handlers hosted on an L2 solution are EVM compatible and can use attributes native to the Ethereum ecosystem (such as address) to permission access. 
-- Handlers hosted on an Off-Chain Database require additional parameters and signatures to correctly enforce the authenticity and check the validity of a request.  
+![](https://raw.githubusercontent.com/namesys-eth/namesys-ccip-write/main/images/schematic.png)
 
-A deferred mutation can be handled in as little as two steps. However, in some cases the mutation might be deferred multiple times.
-
-1. Querying or sending a transaction to the contract
-2. Querying or sending a transaction to the handler using the parameters provided in step 1
-
-In step 1, a standard blockchain call operation is made to the contract. The contract either performs the operation as intended or reverts with an error that specifies the type of handler that the mutation is being deferred to and the corresponding parameters required to perform the subsequent mutation. There are two types of errors that the contract can revert with, but more may be defined in other EIPs:
-
-- `StorageHandledByL2(chainId, contractAddress)`
-- `StorageHandledByOffChainDatabase(sender, url, data)`
-
-In step 2, the client builds and performs a new request based off of the type of error received in (1). These handshakes are outlined in the sections below:
-
-- [StorageHandledByL2](#data-stored-in-an-l2)
-- [StorageHandledByOffChainDatabase](#data-stored-in-an-off-chain-database) 
-
-In some cases, the mutation may be deferred multiple times
-- [Storage Deferred Twice L1 > L2 > Off-Chain](#data-stored-in-an-l2--an-off-chain-database) 
-
-### Data Stored in an L1
-```
-┌──────┐                ┌───────────┐ 
-│Client│                │L1 Contract│ 
-└──┬───┘                └─────┬─────┘ 
-   │                          │       
-   │ somefunc(...)            │       
-   ├─────────────────────────►│       
-   │                          │       
-   │ response                 │       
-   │◄─────────────────────────┤       
-   │                          │       
-```
-
-In the case in which no reversion occurs, data is stored in the L1 contract when the transaction is executed.
-
-### Data Stored in an L2
-
-```
-┌──────┐                                           ┌───────────┐  ┌─────────────┐
-│Client│                                           │L1 Contract│  │ L2 Contract │
-└──┬───┘                                           └─────┬─────┘  └──────┬──────┘
-   │                                                     │               │       
-   │ somefunc(...)                                       │               │       
-   ├────────────────────────────────────────────────────►│               │       
-   │                                                     │               │       
-   │ revert StorageHandledByL2(chainId, contractAddress) │               │       
-   │◄────────────────────────────────────────────────────┤               │       
-   │                                                     │               │       
-   │ Execute Tx [chainId] [contractAddress] [callData]   │               │       
-   ├─────────────────────────────────────────────────────┼──────────────►│       
-   │                                                     │               │       
-   │ response                                            │               │       
-   │◄────────────────────────────────────────────────────┼───────────────┤       
-   │                                                     │               │       
-```
-
-The call or transaction to the L1 contract reverts with the `StorageHandledByL2(chainId, contractAddress)` error.
-
-In this case, the client builds a new transaction for `contractAddress` with the original `callData` and sends it to a RPC of their choice for the corresponding `chainId`. The `chainId` parameter corresponds to an L2 Solution that is EVM compatible.
-
-#### Example
-
-Suppose a contract has the following method:
+### L2 Handler: `StorageHandledByL2()`
+A minimal L2 handler only requires the list of `chainId` values and the corresponding `contract` addresses, while the clients must ensure that the calldata is invariant under routing to L2. One example implementation of an L2 handler in an L1 contract is shown below.
 
 ```solidity
-function setAddr(bytes32 node, address a) external;
-```
+// Define revert event
+error StorageHandledByL2(
+    address contractL2, 
+    uint256 chainId
+);
 
-Data for this mutations is stored and tracked on an EVM compatible L2. The contract author wants to reduce the gas fees associated with the contract, while maintaining the interoperability and decentralization of the protocol. Therefore, the mutation is deferred to a off-chain handler by reverting with the `StorageHandledByL2(chainId, contractAddress)` error.
-
-One example of a valid implementation of `setAddr` would be:
-
-```solidity
-function setAddr(bytes32 node, address a) external {
-   revert StorageHandledByL2(
-      10,
-      _l2HandlerContractAddress
-   ); 
-}
-```
-
-For example, if a contract returns the following data in an `StorageHandledByL2`:
-
-```text
-chainId = 10
-contractAddress = 0x0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff
-```
-
-The user, receiving this error, creates a new transaction for the corresponding `chainId`, and builds a transaction with the original `callData` to send to `contractAddress`. The user will have to choose an RPC of their choice to send the transaction to for the corresponding `chainId`.
-
-### Data Stored in an Off-Chain Database
-```
-┌──────┐                                           ┌───────────┐  ┌────────────────────┐
-│Client│                                           │L1 Contract│  │ Off-Chain Database │
-└──┬───┘                                           └─────┬─────┘  └──────────┬─────────┘
-   │                                                     │                   │ 
-   │ somefunc(...)                                       │                   │ 
-   ├────────────────────────────────────────────────────►│                   │ 
-   │                                                     │                   │ 
-   │ revert StorageHandledByOffChainDatabase(sender,     |                   │ 
-   │                               urls, requestParams)  │                   │ 
-   │◄────────────────────────────────────────────────────┤                   │ 
-   │                                                     │                   │ 
-   │ HTTP Request [requestParams, signature]             │                   │ 
-   ├─────────────────────────────────────────────────────┼──────────────────►│ 
-   │                                                     │                   │ 
-   │ response                                            │                   │ 
-   │◄────────────────────────────────────────────────────┼───────────────────┤ 
-   │                                                     │                   │ 
-```
-
-The call or transaction to the L1 contract reverts with the `StorageHandledByOffChainDatabase(sender, url, data)` error.
-
-In this case, the client performs a HTTP POST request to the gateway service. The gateway service is defined by `url`. The body attached to the request is a JSON object that includes `sender`, `data`, and a signed copy of `data` denoted `signature`. The signature is generated according to a [EIP-712](./eip-712), in which a typed data signature is generated using domain definition, `sender`, and the message context, `data`.
-
-`sender` ia an ABI-encoded struct defined as:
-
-```solidity
-/**
-* @notice Struct used to define the domain of the typed data signature, defined in EIP-712.
-* @param name The user friendly name of the contract that the signature corresponds to.
-* @param version The version of domain object being used.
-* @param chainId The ID of the chain that the signature corresponds to (ie Ethereum mainnet: 1, Goerli testnet: 5, ...). 
-* @param verifyingContract The address of the contract that the signature pertains to.
-*/
-struct domainData {
-    string name;
-    string version;
-    uint64 chainId;
-    address verifyingContract;
-}    
-```
-
-`data` ia an abi encoded struct defined as:
-
-```solidity
-/**
-* @notice Struct used to define the message context used to construct a typed data signature, defined in EIP-712, 
-* to authorize and define the deferred mutation being performed.
-* @param functionSelector The function selector of the corresponding mutation.
-* @param sender The address of the user performing the mutation (msg.sender).
-* @param parameter[] A list of <key, value> pairs defining the inputs used to perform the deferred mutation.
-*/
-struct messageData {
-    bytes4 functionSelector;
-    address sender;
-    parameter[] parameters;
-    uint256 expirationTimestamp;
-}
-
-/**
-* @notice Struct used to define a parameter for Off-Chain Database Handler deferral.
-* @param name The variable name of the parameter.
-* @param value The string encoded value representation of the parameter.
-*/
-struct parameter {
-    string name;
-    string value;
-}
-```
-
-`signature` is generated by using the `sender` & `data` parameters to construct an [EIP-712](./eip-712) typed data signature.
-
-The body used in the HTTP POST request is defined as:
-
-```json
-{
-    "sender": "<abi encoded domainData (sender)>",
-    "data": "<abi encoded messageData (data)>",
-    "signature": "<EIP-712 typed data signature of corresponding message data & domain definition>"
-}
-```
-
-#### Example
-
-Suppose a contract has the following method:
-
-```solidity
-function setAddr(bytes32 node, address a) external;
-```
-
-Data for this mutations is stored and tracked in some kind of off-chain database. The contract author wants the user to be able to authorize and make modifications to their `Addr` without having to pay a gas fee. Therefore, the mutation is deferred to a off-chain handler by reverting with the `StorageHandledByOffChainDatabase(sender, url, data)` error.
-
-One example of a valid implementation of `setAddr` would be:
-
-```solidity
-function setAddr(bytes32 node, address a) external {
-    IWriteDeferral.parameter[] memory params = new IWriteDeferral.parameter[](3);
-
-    params[0].name = "node";
-    params[0].value = BytesToString.bytes32ToString(node);
-
-    params[1].name = "coin_type";
-    params[1].value = Strings.toString(coinType);
-
-    params[2].name = "address";
-    params[2].value = BytesToString.bytesToString(a);
-
-    revert StorageHandledByOffChainDatabase(
-        IWriteDeferral.domainData(
-            {
-                name: WRITE_DEFERRAL_DOMAIN_NAME,
-                version: WRITE_DEFERRAL_DOMAIN_VERSION,
-                chainId: 1,
-                verifyingContract: address(this)
-            }
-        ),
-        _offChainDatabaseUrl,
-        IWriteDeferral.messageData(
-            {
-                functionSelector: msg.sig,
-                sender: msg.sender,
-                parameters: params,
-                expirationTimestamp: block.timestamp + _offChainDatabaseTimeoutDuration
-            }
-        )
+// Generic function in a contract
+function setValue(
+    bytes32 node,
+    bytes32 key,
+    bytes32 value
+) external {
+    // Get metadata from on-chain sources
+    (
+        address contractL2, // Contract address on L2; may be globally constant
+        uint256 chainId // L2 ChainID; may be globally constant
+    ) = getMetadata(node); // Arbitrary code
+    // contract = 0x32f94e75cde5fa48b6469323742e6004d701409b
+    // chainId = 21
+    // Defer write call to L2 handler
+    revert StorageHandledByL2( 
+        contractL2,
+        chainId
     );
+};
+```
+
+In this example, the deferral must prompt the client to build the transaction with the exact same original calldata, and submit it to the L2 by calling the exact same function on L2 as L1.
+
+```solidity
+// Function in L2 contract
+function setValue(
+    bytes32 node,
+    bytes32 key,
+    bytes32 value
+) external {
+    // Verify owner or manager permissions
+    require(authorised(node), "NOT_ALLOWED");
+    // Some code storing data mapped by node & sender
+    ...
 }
 ```
 
-For example, if a contract reverts with the following:
+### Database Handler: `StorageHandledByDatabase()`
+A minimal database handler is similar to an L2 in the sense that:
+
+  a) Similar to `chainId`, it requires the `gatewayUrl` that is tasked with handling off-chain write operations, and
+
+  b) Similar to `eth_call`, it requires `eth_sign` output to secure the data, and the client must prompt the users for these signatures.
+
+This specification does not require any other data to be stored on L1 other than the bespoke `gatewayUrl`; the storage handler therefore should only return the `gatewayUrl` in revert.
+
+```solidity
+error StorageHandledByDatabase(
+    string gatewayUrl
+);
+
+// Generic function in a contract
+function setValue(
+    bytes32 node,
+    bytes32 key,
+    bytes32 value
+) external {
+    (
+        string gatewayUrl // Gateway URL; may be globally constant
+    ) = getMetadata(node);
+    // gatewayUrl = "https://api.namesys.xyz"
+    // Defer write call to database handler
+    revert StorageHandledByDatabase( 
+        gatewayUrl
+    );
+};
+```
+
+Following the revert, the client must take these steps:
+
+1. Request the user for a secret signature `sigKeygen` to generate a deterministic `dataSigner` keypair,
+
+2. Sign the calldata with generated data signer's private key and produce verifiable data signature `sigData`,
+
+3. Request the user for an `approval` approving the generated data signer, and finally,
+
+4. Post the calldata to gateway along with signatures `sigData` and `approval`, and the `dataSigner`.
+
+These steps are described in detail below.
+
+#### 1. Generate Data Signer
+The data signer must be generated deterministically from ethereum wallet signatures; see figure below.
+
+![](https://raw.githubusercontent.com/namesys-eth/namesys-ccip-write/main/images/keygen.png)
+
+The deterministic key generation can be implemented concisely in a single unified `keygen()` function as follows.
+
+```js
+/* Pseudo-code for key generation */
+function keygen(
+  username, // CAIP identifier for the blockchain account
+  sigKeygen, // Deterministic signature from wallet
+  password // Optional password
+) {
+  // Calculate input key by hashing signature bytes using SHA256 algorithm
+  let inputKey = sha256(sigKeygen);
+  // Calculate salt for keygen by hashing concatenated username, hashed password and hex-encoded signature using SHA256 algorithm
+  let salt = sha256(`${username}:${sha256(password || "")}:${sigKeygen}`);
+  // Calculate hash key output by feeding input key, salt & username to the HMAC-based key derivation function (HKDF) with dLen = 42
+  let hashKey = hkdf(sha256, inputKey, salt, username, 42);
+  // Calculate and return secp256k1 keypair
+  return secp256k1(hashKey) // Calculate secp256k1 keypair from hash key
+}
+```
+
+This `keygen()` function requires three variables: `username`, `password` and `sigKeygen`. Their definitions are given below.
+
+##### `username`
+CAIP-10 identifier `username` is auto-derived from the connected wallet's checksummed address `wallet` and `chainId`.
+
+```js
+/* CAIP-10 identifier */
+const caip10 = `eip155:${chainId}:${wallet}`
+```
+
+##### `password`
+`password` is an optional private field and it must be prompted from the user by the client; this field allows users to change data signers for a given `username`.
+```js
+/* Secret derived key identifier */ 
+// Clients must prompt the user for this
+const password = 'key1'
+```
+
+##### `sigKeygen`
+The data signer must be derived from the owner or manager keys of a node. Message payload for the required `sigKeygen` must then be formatted as:
 
 ```text
-StorageHandledByOffChainDatabase(
-    (
-        "CoinbaseResolver", 
-        "1", 
-        1, 
-        0x32f94e75cde5fa48b6469323742e6004d701409b
-    ), 
-    "https://example.com/r/{sender}", 
-    (
-        0xd5fa2b00, 
-        0x727f366727d3c9cc87f05d549ee2068f254b267c, 
-        [
-            ("node", "0x418ae76a9d04818c7a8001095ad01a78b9cd173ee66fe33af2d289b5dc5f4cba"), 
-            ("coin_type", "60"), 
-            ("address", "0x727f366727d3c9cc87f05d549ee2068f254b267c")
-        ], 
-        181
+Requesting Signature To Generate Keypair(s)\n\nOrigin: ${username}\nProtocol: ${protocol}\nExtradata: ${extradata}
+```
+
+where the `extradata` is calculated as follows,
+
+```solidity
+// Calculating extradata in keygen signatures
+bytes32 extradata = keccak256(
+    abi.encodePacked(
+        pbkdf2(
+            password, 
+            salt, 
+            iterations
+        ), // Stretch password with PBKDF2
+        wallet
     )
 )
 ```
 
-The user, receiving this error, constructs the typed data signature, signs it, and performs that request via a HTTP POST to `url`. 
+where `PBKDF2` - with `keccak256(abi.encodePacked(username))` as salt and the `iterations` count is fixed to `500,000` for brute-force vulnerability protection.
 
-Example HTTP POST request body including `requestParams` and `signature`:
-
-```json
-{
-    "sender": "<abi encoded domainData (sender)>",
-    "data": "<abi encoded messageData (data)>",
-    "signature": "<EIP-712 typed data signature of corresponding message data & domain definition>"
-}
+```js
+/* Definitions of salt and iterations in PBKDF2 */
+let salt = keccak256(abi.encodePacked(username));
+let iterations = 500000; // 500,000 iterations
 ```
 
-Note that the message could be altered could be altered in any way, shape, or form prior to signature and request. It is the backend's responsibility to correctly permission and process these mutations. From a security standpoint, this is no different then a user being able to call a smart contract with any params they want, as it is the smart contract's responsibility to permission and handle those requests.
+The remaining `protocol` field is a protocol-specific identifier limiting the scope to a specific protocol represented by a unique contract address. This identifier cannot be global and must be uniquely defined for each implementating `contract` such that:
 
+```js
+/* Protocol identifier in CAIP-10 format */
+const protocol = `eth:${chainId}:${contract}`;
+```
 
-### Data Stored in an L2 & an Off-Chain Database
+With this deterministic format for signature message payload, the client must prompt the user for the ethereum signature. Once the user signs the messages, the `keygen()` function can derive the data signer keypair. 
+
+#### 2. Sign Data
+Since the derived signer is wallet-specific, it can 
+
+- sign batch data for multiple keys for a given node, and 
+- sign batches of data for multiple nodes owned by a wallet
+
+simultaneously in the background without ever prompting the user. Signature(s) `sigData` accompanying the off-chain calldata must implement the following format in their message payloads:  
 
 ```text
-┌──────┐                                           ┌───────────┐  ┌─────────────┐  ┌────────────────────┐
-│Client│                                           │L1 Contract│  │ L2 Contract │  │ Off-Chain Database │
-└──┬───┘                                           └─────┬─────┘  └──────┬──────┘  └──────────┬─────────┘
-   │                                                     │               │                    │
-   │ somefunc(...)                                       │               │                    │
-   ├────────────────────────────────────────────────────►│               │                    │
-   │                                                     │               │                    │
-   │ revert StorageHandledByL2(chainId, contractAddress) │               │                    │
-   │◄────────────────────────────────────────────────────┤               │                    │
-   │                                                     │               │                    │
-   │ Execute Tx [chainId] [contractAddress] [callData]   │               │                    │
-   ├─────────────────────────────────────────────────────┼──────────────►│                    │
-   │                                                     │               │                    │
-   │ revert StorageHandledByOffChainDatabase(sender, url, data)          │                    │
-   │◄────────────────────────────────────────────────────┼───────────────┤                    │
-   │                                                     │               │                    │
-   │ HTTP Request {requestParams, signature}             │               │                    │
-   ├─────────────────────────────────────────────────────┼───────────────┼───────────────────►│
-   │                                                     │               │                    │
-   │ response                                            │               │                    │
-   │◄────────────────────────────────────────────────────┼───────────────┼────────────────────┤
-   │                                                     │               │                    │
+Requesting Signature To Update Off-Chain Data\n\nOrigin: ${username}\nData Type: ${dataType}\nData Value: ${dataValue}
 ```
 
-The call or transaction to the L1 contract reverts with the `StorageHandledByL2(chainId, contractAddress)` error.
+where `dataType` parameters are protocol-specific and formatted as object keys delimited by `/`. For instance, if the off-chain data is nested in keys as `a > b > c > field > key`, then the equivalent `dataType` is `a/b/c/field/key`. For example, in order to update off-chain ENS record `text > avatar` and `address > 60`, `dataType` must be formatted as `text/avatar` and `address/60` respectively.
+ 
+#### 3. Approve Data Signer
+To further save on gas costs, we do not store the `dataSigner` on L1. Instead, the clients must
 
-In this case, the client builds a new transaction for `contractAddress` with the original `callData` and sends it to a RPC of their choice for the corresponding `chainId`. 
+- request an `approval` signature for `dataSigner` signed by the owner or manager of a node, and
+- post this `approval` and the `dataSigner` along with the signed calldata in encoded form.
 
-That call or transaction to the L2 contract then reverts with the `StorageHandledByOffChainDatabase(sender, url, data)` error.
+CCIP-Read-enabled contracts can then verify during resolution time that the `approval` attached with the signed calldata comes from the node's manager or owner, and that it approves the expected `dataSigner`. The `approval` signature must have the following message payload format:
 
-In this case, the client then performs a HTTP POST request against the gateway service. The gateway service is defined by `url`. The body attached to the request is a JSON object that includes `sender`, `data`, and `signature` -- a typed data signature corresponding to [EIP-712](./eip-712). 
+```text
+Requesting Signature To Approve Data Signer\n\nOrigin: ${username}\nApproved Signer: ${dataSigner}\nApproved By: ${caip10}
+```
 
-### Events
+where `dataSigner` must be checksummed.
 
-When making changes to core variables of the handler, the corresponding event MUST be emitted. This increases the transparency associated with different managerial actions. Core variables include `chainId` and `contractAddress` for L2 solutions and `url` for Off-Chain Database solutions. The events are outlined below in the WriteDeferral Interface.
-
-### Write Deferral Interface
-
-Below is a basic interface that defines and describes all of the reversion types and their corresponding parameters.
+#### 4. Post CCIP-Read Compatible Payload
+The final EIP-3668-compatible `data` payload in the off-chain data file must then follow the format
 
 ```solidity
-pragma solidity ^0.8.13;
+bytes encodedData = abi.encode(['bytes'], [dataValue])
+bytes dataPayload = abi.encode(
+    ['address', 'bytes32', 'bytes32', 'bytes'],
+    [dataSigner, sigData, approval, encodedData]
+)
+```
 
-interface IWriteDeferral {
-    /*//////////////////////////////////////////////////////////////
-                                 EVENTS
-    //////////////////////////////////////////////////////////////*/
+The client must construct this `data` and pass it to the gateway in the `POST` request along with the raw values for indexing. The CCIP-Read-enabled contracts after decoding the four parameters from this `data` must 
 
-    /// @notice Event raised when the default chainId is changed for the corresponding L2 handler.
-    event L2HandlerDefaultChainIdChanged(uint256 indexed previousChainId, uint256 indexed newChainId);
-    /// @notice Event raised when the contractAddress is changed for the L2 handler corresponding to chainId.
-    event L2HandlerContractAddressChanged(uint256 indexed chainId, address indexed previousContractAddress, address indexed newContractAddress);
+- verify that the `dataSigner` is approved by the owner or manager of the node through `approval`, and
+- verify that the `sigData` is produced by `dataSigner`
 
-    /// @notice Event raised when the url is changed for the corresponding Off-Chain Database handler.
-    event OffChainDatabaseHandlerURLChanged(string indexed previousUrl, string indexed newUrl);
+before resolving the `encodedData` value in decoded form.
 
-    /*//////////////////////////////////////////////////////////////
-                                 STRUCTS
-    //////////////////////////////////////////////////////////////*/
+##### `POST` Request
+The `POST` request made by the client to the `gatewayUrl` must follow the format as described below.
 
-    /**
-     * @notice Struct used to define the domain of the typed data signature, defined in EIP-712.
-     * @param name The user friendly name of the contract that the signature corresponds to.
-     * @param version The version of domain object being used.
-     * @param chainId The ID of the chain that the signature corresponds to (ie Ethereum mainnet: 1, Goerli testnet: 5, ...). 
-     * @param verifyingContract The address of the contract that the signature pertains to.
-     */
-    struct domainData {
-        string name;
-        string version;
-        uint64 chainId;
-        address verifyingContract;
-    }    
-
-    /**
-     * @notice Struct used to define the message context used to construct a typed data signature, defined in EIP-712, 
-     * to authorize and define the deferred mutation being performed.
-     * @param functionSelector The function selector of the corresponding mutation.
-     * @param sender The address of the user performing the mutation (msg.sender).
-     * @param parameter[] A list of <key, value> pairs defining the inputs used to perform the deferred mutation.
-     */
-    struct messageData {
-        bytes4 functionSelector;
-        address sender;
-        parameter[] parameters;
-        uint256 expirationTimestamp;
+```ts
+/* POST request format*/
+type Post = {
+  node: string
+  preimage: string
+  chainId: number
+  approval: string
+  payload: {
+    field1: {
+      value: string
+      signature: string
+      timestamp: number
+      data: string
     }
-
-    /**
-     * @notice Struct used to define a parameter for off-chain Database Handler deferral.
-     * @param name The variable name of the parameter.
-     * @param value The string encoded value representation of the parameter.
-     */
-    struct parameter {
-        string name;
-        string value;
-    }
-
-
-    /*//////////////////////////////////////////////////////////////
-                                 ERRORS
-    //////////////////////////////////////////////////////////////*/
-
-    /**
-     * @dev Error to raise when mutations are being deferred to an L2.
-     * @param chainId Chain ID to perform the deferred mutation to.
-     * @param contractAddress Contract Address at which the deferred mutation should transact with.
-     */
-    error StorageHandledByL2(
-        uint256 chainId, 
-        address contractAddress
-    );
-
-    /**
-     * @dev Error to raise when mutations are being deferred to an Off-Chain Database.
-     * @param sender the EIP-712 domain definition of the corresponding contract performing the off-chain database, write 
-     * deferral reversion.
-     * @param url URL to request to perform the off-chain mutation.
-     * @param data the EIP-712 message signing data context used to authorize and instruct the mutation deferred to the 
-     * off-chain database handler. 
-     * In order to authorize the deferred mutation to be performed, the user must use the domain definition (sender) and message data 
-     * (data) to construct a type data signature request defined in EIP-712. This signature, message data (data), and domainData (sender) 
-     * are then included in the HTTP POST request, denoted sender, data, and signature.
-     * 
-     * Example HTTP POST request:
-     *  {
-     *      "sender": <abi encoded domainData (sender)>,
-     *      "data": <abi encoded message data (data)>,
-     *      "signature": <EIP-712 typed data signature of corresponding message data & domain definition>
-     *  }
-     * 
-     */
-    error StorageHandledByOffChainDatabase(
-        domainData sender, 
-        string url, 
-        messageData data
-    );     
+    field2: [
+      {
+        index: number
+        value: string
+        signature: string
+        timestamp: number
+        data: string
+      }
+    ]
+    field3: [
+      {
+        key: number
+        value: string
+        signature: string
+        timestamp: number
+        data: string
+      }
+    ]
+  }
 }
 ```
 
-### Use of transactions with storage-deferral reversions
-In some cases the contract might conditionally defer and handle mutations, in which case a transaction may be required. It is simple to use this method for sending transactions that may result in deferral reversions, as a client should receive the corresponding reversion while `preflighting` the transaction.
+Example of a complete `Post` typed object for updating multiple ENS records for a node is shown below.
 
-This functionality is ideal for applications that want to allow their users to define the security guarantees and costs associated with their actions. For example, in the case of a decentralized identity profile, a user might not care if their data is decentralized and chooses to defer the handling of their records to the off-chain handler to reduce gas fees and on-chain transactions. 
+```ts
+/* Example of a POST request */
+let post: Post = {
+  "node": "0xe4ad669b4f80715d286697885cfdf2552d3042e07717247924532662b1eda1da",
+  "preimage": "sub.domain.eth",
+  "chainId": 1,
+  "approval" : "0x1cc5e5efa312dc292560a26e3dba2584070b02ec203c51440a3e23d49ba56b342a4404d8b0d9dc26a94190691e47652343183bf1c64bf9c5081a2f1d887937f11b",
+  "payload" : {
+    "contenthash": {
+      "value" : "ipfs://QmRAQB6YaCyidP37UdDnjFY5vQuiBrcqdyoW1CuDgwxkD4",
+      "signature": "0x0679eaedb300308680a0e8c11725e891d1500fb98b65d6d09d538e2655567fdf06b989689a01db312ad6df0752cbcb1756b3405a7163f8b4b7c01e70b1a9c5c31c",
+      "timestamp": 1708322868,
+      "data": "0x2b45eb2b0000000000000000000000005ee86839080d2593b30604e3eeb78271fdc29ec800000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000000414abb7b2b9fc395910b4387ff69897ee639fe1cf9b79c31bf2d3743134e77a9b222ec175e563d13d60bc722c8829ce91d9af51bcd949816f95979abef4378d84e1c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041cbfb2300d60b8602db32ad4ac57279e7a3632e35bb5966eb686e0ac8ec8e7b4a6e306a13a0adee15fce5a9e2bbf3a016db023b0ab66f04bde62a13343287e3851b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000026e3010170122022380b0884d9e85ef3ff5f71ea7a25874738da71f38b999dc8ffec2f6389a3670000000000000000000000000000000000000000000000000000"
+    },
+    "address": [
+      {
+        "coinType": 0,
+        "value": "1FfmbHfnpaZjKFvyi1okTjJJusN455paPH",
+        "signature": "0x60ecd4979ae2c39399ffc7ad361066d46fc3d20f2b2902c52e01549a1f6912643c21d23d1ad817507413dc8b73b59548840cada57481eb55332c4327a5086a501b",
+        "timestamp": 1708322877,
+        "data": "0x2b45eb2b0000000000000000000000005ee86839080d2593b30604e3eeb78271fdc29ec800000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000000419c7c185335898d7ec57cffb842e88116a82f367237815f35e16d5f8b28dc3e7b0f0b40edd9f9fc48f771f921986c45973f4c2a82e8c2ebe1732a9f552f8b033a1c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041cbfb2300d60b8602db32ad4ac57279e7a3632e35bb5966eb686e0ac8ec8e7b4a6e306a13a0adee15fce5a9e2bbf3a016db023b0ab66f04bde62a13343287e3851b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000001111000000000000000000000000000000000001"
+      },
+      {
+        "coinType": 60,
+        "value": "0x839B3B540A9572448FD1B2335e0EB09Ac1A02885",
+        "signature": "0xaad74ddef8c031131b6b83b3bf46749701ed11aeb585b63b72246c8dab4fff4f79ef23aea5f62b227092719f72f7cfe04f3c97bfad0229c19413f5cb491e966c1b",
+        "timestamp": 1708322917,
+        "data": "0x2b45eb2b0000000000000000000000005ee86839080d2593b30604e3eeb78271fdc29ec800000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000000419bb4494a9ac6b37d5d979cbb6c43cccbbd8790ebbd8f898d8427e1ebfd8bb8bd29a2fbc2b20b0a53c3fdde9dd8ce3df648112754742156d3a5ac6fd1b80d8bd01b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041cbfb2300d60b8602db32ad4ac57279e7a3632e35bb5966eb686e0ac8ec8e7b4a6e306a13a0adee15fce5a9e2bbf3a016db023b0ab66f04bde62a13343287e3851b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001c68747470733a2f2f6e616d657379732e78797a2f6c6f676f2e706e6700000000"
+      }
+    ],
+    "text": [
+      {
+        "key": "avatar",
+        "value": "https://domain.com/avatar",
+        "signature": "0xbc3c7f1b511de151bffe8df033859295d83d400413996789e706e222055a2353404ce17027760c927af99e0bf621bfb24d3bfc52abb36bcfbe6e20cf43db7c561b",
+        "timestamp": 1708329377,
+        "data": "0x2b45eb2b0000000000000000000000005ee86839080d2593b30604e3eeb78271fdc29ec80000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000041dc6ca55c1d1c75eec223a7eb01eb5942a2bdb79708c25ff2827cfc0343f97fb76faefd9fbc40de5103956bbdc841f2cc2d53630cd2836a6b76d8d2c107ccadd21b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041cbfb2300d60b8602db32ad4ac57279e7a3632e35bb5966eb686e0ac8ec8e7b4a6e306a13a0adee15fce5a9e2bbf3a016db023b0ab66f04bde62a13343287e3851b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000046e6e6e6e00000000000000000000000000000000000000000000000000000000"
+      },
+      {
+        "key": "com.github",
+        "value": "namesys-eth",
+        "signature": "0xc9c33ff219e90510f79b6c9bb489917ee6e00ab123c55abe1117e71ea0d171356cf316420c71cfcf4bd63a791aaf37388ef1832e582f54a8c2df173917240fff1b",
+        "timestamp": 1708322898,
+        "data": "0x2b45eb2b0000000000000000000000005ee86839080d2593b30604e3eeb78271fdc29ec80000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000041bfd0ab74712b98bc472ef0e5bbb031acba077fc98a54cdfcb3f11e64b02d7fe21477ba5ea9d508a0265616d74a8df99b9c8f3c04e6bfd41f2df554fe11e1fe141c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041cbfb2300d60b8602db32ad4ac57279e7a3632e35bb5966eb686e0ac8ec8e7b4a6e306a13a0adee15fce5a9e2bbf3a016db023b0ab66f04bde62a13343287e3851b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000046b6b6b6b00000000000000000000000000000000000000000000000000000000"
+      }
+    ]
+  }
+}
+```
 
-## Rationale
-### Use of `revert` to convey call information
-[EIP-3668](./eip-3668) adopted the idea of using a `revert` to convey call information. It was proposed as a simple mechanism in which any pre-existing interface or function signature could be satisfied while maintain a mechanism to instruct and trigger an off-chain lookup. 
+### New Revert Events
+1. Each new storage handler must submit their `StorageHandledBy__()` identifier through an ERC track proposal referencing the current draft.
 
-This is very similar for the write deferral protocol, defined in this EIP; without any modifications to the ABI or underlying EVM, `revert` provides a clean mechanism in which we can "return" a typed instruction - and the corresponding elements to complete that action - without modifying the signature of the corresponding function. This makes it easy to comply with pre-existing interfaces and infrastructure. 
+2. Each `StorageHandledBy__()` provider must be supported with detailed documentation of its structure and the necessary metadata that its implementers must return.
 
-### Use of multiple reversion & handler types to better define security guarantees 
-By further defining the class of the handler, it gives the developer increased granularity to define the characteristics and different guarantees associated storing the data off-chain. In addition, different handlers require different parameters and verification mechanisms. This is very important for the transparency of the protocol, as they store data outside of the native ethereum ecosystem. Common implementations of this protocol could include storing non-operational data in L2 solutions and off-chain databases to reduce gas fees, while maintaining open interoperability.   
+3. Each `StorageHandledBy__()` proposal must define the precise formatting of any message payloads that require signatures and complete descriptions of custom cryptographic techniques implemented for additional security, accessibility or privacy.
 
+## Implementation featuring ENS on L2 & Database
+ENS off-chain resolvers capable of reading from and writing to databases are perhaps the most common use-case for CCIP-Read and CCIP-Write. One example of such a (minimal) resolver is given below along with the client-side code for handling the storage handler revert.
+
+### L1 Contract
+```solidity
+/* ENS resolver implementing StorageHandledByDatabase() */
+interface iResolver {
+    // Defined in EIP-5559
+    error StorageHandledByL2(
+        uint chainId,
+        address contractL2
+    );
+    error StorageHandledByDatabase(
+        string gatewayUrl
+    );
+    // Defined in EIP-137
+    function setAddr(bytes32 node, address addr) external;
+}
+
+// Defined in EIP-5559
+string public gatewayUrl = "https://post.namesys.xyz"; // RESTful API endpoint
+uint256 public chainId = uint(21); // ChainID of L2
+address public contractL2 = "0x839B3B540A9572448FD1B2335e0EB09Ac1A02885"; // Contract on L2
+
+/**
+* Sets the ethereum address associated with an ENS node
+* [!] May only be called by the owner or manager of that node in ENS registry
+* @param node Namehash of ENS domain to update
+* @param addr Ethereum address to set
+*/
+function setAddr(
+    bytes32 node,
+    address addr
+) authorised(node) {
+    // Defer to database storage
+    revert StorageHandledByDatabase(
+        gatewayUrl
+    );
+}
+
+/**
+* Sets the avatar text record associated with an ENS node
+* [!] May only be called by the owner or manager of that node in ENS registry
+* @param node Namehash of ENS domain to update
+* @param key Key for ENS text record
+* @param value URL to avatar
+*/
+function setText(
+    bytes32 node,
+    string key,
+    string value
+) external {
+    // Verify owner or manager permissions
+    require(authorised(node), "NOT_ALLOWED");
+    // Defer to L2 storage
+    revert StorageHandledByL2(
+        chainId, 
+        contractL2
+    );
+}
+```
+
+### L2 Contract
+```solidity
+// Function in L2 contract
+function setText(
+    bytes32 node,
+    bytes32 key,
+    bytes32 value
+) external {
+    // Store record mapped by node & sender
+    records[keccak256(abi.encodePacked(node, msg.sender))]["text"][key] = value;
+}
+```
+
+### Client-side Code
+```ts
+/* Client-side pseudo-code in ENS App */
+// Deterministically generate signer keypair
+let signer = keygen(username, sigKeygen, password);
+// Construct POST body by signing calldata with derived private key
+let post: Post = signData(node, addr, signer.priv);
+// POST to gateway
+await fetch(gatewayUrl, {
+  method: "POST",
+  body: JSON.stringify(post)
+});
+```
 
 ## Backwards Compatibility
-Existing contracts that do not wish to use this specification are unaffected. Clients can add support for Cross Chain Write Deferrals to all contract calls without introducing any new overhead or incompatibilities.
-
-Contracts that require Cross Chain Write Deferrals will not function in conjunction with clients that do not implement this specification. Attempts to call these contracts from non-compliant clients will result in the contract throwing an exception that is propagated to the user.
+`StorageHandledByDatabase()` method in this document is NOT compatible with the previous EIP-5559 specification.
 
 ## Security Considerations
-Deferred mutations should never resolve to mainnet ethereum. Such attempts to defer the mutation back to ETH could include hijacking attempts in which the contract developer is trying to get the user to sign and send a malicious transaction. Furthermore, when a transaction is deferred to an L2 system, it must use the original `calldata`, this prevents against potentially malicious contextual changes in the transaction.
+1. Clients must purge the derived signer private keys from local storage immediately after signing the off-chain data.
 
-### Fingerprinting attacks
-As all deferred mutations will include the `msg.sender` parameter in `data`, it is possible that `StorageHandledByOffChainDatabase` reversions could fingerprint wallet addresses and the corresponding IP address used to make the HTTP request. The impact of this is application-specific and something the user should understand is a risk associated with off-chain handlers. To minimize the security impact of this, we make the following recommendations:
+2. Signature message payload and the resulting deterministic signature `sigKeygen` must be treated as a secret by the clients and immediately purged from local storage after usage in the `keygen()` function.
 
-1. Smart contract developers should provide users with the option to resolve data directly on the network. Allowing them to enable on-chain storage provides the user with a simple cost-benefit analysis of where they would like their data to resolve and different guarantees / risks associated with the resolution location.
-2. Client libraries should provide clients with a hook to override Cross Chain Write Deferral `StorageHandledByOffChainDatabase` calls - either by rewriting them to use a proxy service, or by denying them entirely. This mechanism or another should be written so as to easily facilitate adding domains to allowlists or blocklists.
-
-We encourage applications to be as transparent as possible with their setup and different precautions put in place.
+3. Clients must immediately purge the `password` from local storage after usage in the `keygen()` function.
 
 ## Copyright
-Copyright and related rights waived via [CC0](../LICENSE.md).
+Copyright and related rights waived via [`CC0`](../LICENSE.md).

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -3,7 +3,7 @@ eip: 5559
 title: "Cross-chain Write Deferral Protocol"
 description: The cross-chain write deferral protocol provides a mechanism to replace L1 storage with L2 and databases through off-chain handlers
 author: Avneet Singh (@sshmatrix), 0xc0de4c0ffee (@0xc0de4c0ffee), Nick Johnson (@arachnid), Paul Gauvreau (@0xpaulio)
-discussions-to: https://ethereum-magicians.org/t/erc-5559-cross-chain-write-deferral-protocol/19664
+discussions-to: https://ethereum-magicians.org/t/eip-5559-cross-chain-write-deferral-protocol/19664
 status: Draft
 type: Standards Track
 category: ERC
@@ -12,7 +12,7 @@ requires: 155
 ---
 
 ## Abstract
-The cross-chain write deferral protocol, aka CCIP-Write, facilitates replacing Ethereum L1 storage with L2 chains and/or centralised databases with an aim to cut gas costs and further privacy while retaining the secure aspects of on-chain storage. Methods in this document specifically target security and cost-effectiveness of write deferrals. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](./erc-3668)-compliant contracts completing the cross-chain data life cycle. This document, alongside [EIP-3668](./erc-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
+The cross-chain write deferral protocol, aka CCIP-Write, facilitates replacing Ethereum L1 storage with L2 chains and/or centralised databases with an aim to cut gas costs and further privacy while retaining the secure aspects of on-chain storage. Methods in this document specifically target security and cost-effectiveness of write deferrals. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](./eip-3668)-compliant contracts completing the cross-chain data life cycle. This document, alongside [EIP-3668](./eip-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
 
 ## Specification
 ### Overview
@@ -218,7 +218,7 @@ Requesting Signature To Approve Data Signer\n\nOrigin: ${username}\nApproved Sig
 where `dataSigner` must be checksummed.
 
 #### 4. Post CCIP-Read Compatible Payload
-The final [EIP-3668](./erc-3668)-compatible `data` payload in the off-chain data file must then follow the format
+The final [EIP-3668](./eip-3668)-compatible `data` payload in the off-chain data file must then follow the format
 
 ```solidity
 bytes encodedData = abi.encode(['bytes'], [dataValue])
@@ -423,14 +423,14 @@ await fetch(gatewayUrl, {
 ```
 
 ## Rationale
-[EIP-3668](./erc-3668), aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum. 
+[EIP-3668](./eip-3668), aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum. 
 
-Cross-chain data retrieval through [EIP-3668](./erc-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and centralised databases (or decentralised storages, although they are not covered by this draft). On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage.
+Cross-chain data retrieval through [EIP-3668](./eip-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and centralised databases (or decentralised storages, although they are not covered by this draft). On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage.
 
-[EIP-5559](./erc-5559) is the first step toward such a tolerant CCIP-Write protocol which outlines how secure write deferrals can be made to L2s and centralised databases. The cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
+[EIP-5559](./eip-5559) is the first step toward such a tolerant CCIP-Write protocol which outlines how secure write deferrals can be made to L2s and centralised databases. The cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
 
 ## Backwards Compatibility
-`StorageHandledByDatabase()` method in this document is NOT compatible with the previous [EIP-5559](./erc-5559) specification.
+`StorageHandledByDatabase()` method in this document is NOT compatible with the previous [EIP-5559](./eip-5559) specification.
 
 ## Security Considerations
 1. Clients must purge the derived signer private keys from local storage immediately after signing the off-chain data.

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -436,7 +436,7 @@ await fetch(gatewayUrl, {
 Technically, the cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification. The methods in this proposal perform these precise tasks when deferring write operations to external handlers. 
 
 ## Backwards Compatibility
-`StorageHandledByDatabase()` method in this document is NOT compatible with the previous [EIP-5559](./eip-5559) specification.
+N/A
 
 ## Security Considerations
 1. Clients must purge the derived signer private keys from local storage immediately after signing the off-chain data.

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -2,7 +2,7 @@
 eip: 5559
 title: "Cross-chain Write Deferral Protocol"
 description: The cross-chain write deferral protocol provides a mechanism to replace L1 storage with L2 and databases through off-chain handlers
-author: Avneet Singh (@sshmatrix), 0xc0de4c0ffee (@0xc0de4c0ffee), Nick Johnson (@arachnid), Makoto Inoue (@makoto), Paul Gauvreau (@0xpaulio)
+author: Avneet Singh (@sshmatrix), 0xc0de4c0ffee (@0xc0de4c0ffee), Nick Johnson (@arachnid), Makoto () Paul Gauvreau (@0xpaulio)
 discussions-to: https://ethereum-magicians.org/t/eip-5559-cross-chain-write-deferral-protocol/19664
 status: Draft
 type: Standards Track
@@ -12,7 +12,9 @@ requires: 155
 ---
 
 ## Abstract
-The cross-chain write deferral protocol, aka CCIP-Write, facilitates replacing Ethereum L1 storage with L2 chains and/or centralised databases with an aim to cut gas costs and further privacy while retaining the secure aspects of on-chain storage. Methods in this document specifically target security and cost-effectiveness of write deferrals. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](./eip-3668)-compliant contracts completing the cross-chain data life cycle. This document, alongside [EIP-3668](./eip-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
+The following standard provides a mechanism by which smart contracts can defer certain tasks to external providers. In particular, protocols can reduce the gas fees associated with storing data on mainnet by deferring the handling of write operations to another system or network. These storage handlers act as an extension to the core L1 contract.
+
+Methods in this document specifically target security and cost-effectiveness of write deferrals to two handler types: L2 and databases. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](./eip-3668)-compliant contracts completing the cross-chain data life cycle. This document, alongside [EIP-3668](./eip-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
 
 ## Specification
 ### Overview
@@ -423,11 +425,12 @@ await fetch(gatewayUrl, {
 ```
 
 ## Rationale
-[EIP-3668](./eip-3668), aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum. 
+Cross-chain data retrieval through [EIP-3668](./eip-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and databases. On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage. Examples of this include:
 
-Cross-chain data retrieval through [EIP-3668](./eip-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and centralised databases (or decentralised storages, although they are not covered by this draft). On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage.
+- Services that allow the management of namespaces, e.g. ENS domains, stored externally on an L2 solution or off-chain database as if they were native L1 tokens, and,
+- Services allowing the management of digital identities stored on external storages as if they were stored in the native L1 smart contract.
 
-[EIP-5559](./eip-5559) is the first step toward such a tolerant CCIP-Write protocol which outlines how secure write deferrals can be made to L2s and centralised databases. The cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
+In this context, a specification which allows write deferrals to external handlers will facilitate creation of services that are agnostic to the underlying storage solution. This in turn enables new applications to operate without knowledge of the underlying handlers. This proposal outlines precisely this part of the process, i.e. how the bespoke write deferrals can be made by smart contracts to L2s and databases. Technically, the cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
 
 ## Backwards Compatibility
 `StorageHandledByDatabase()` method in this document is NOT compatible with the previous [EIP-5559](./eip-5559) specification.

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -3,7 +3,7 @@ eip: 5559
 title: "Cross-chain Write Deferral Protocol"
 description: The cross-chain write deferral protocol provides a mechanism to replace L1 storage with L2 and databases through off-chain handlers
 author: (@sshmatrix), (@0xc0de4c0ffee), (@arachnid), (@0xpaulio)
-discussions-to: https://ethereum-magicians.org/t/eip-cross-chain-write-deferral-protocol/10576
+discussions-to: https://ethereum-magicians.org/t/erc-5559-cross-chain-write-deferral-protocol/19664
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -2,13 +2,13 @@
 eip: 5559
 title: "Cross-chain Write Deferral Protocol"
 description: The cross-chain write deferral protocol provides a mechanism to replace L1 storage with L2 and databases through off-chain handlers
-author: (@sshmatrix), (@0xc0de4c0ffee), (@arachnid), (@0xpaulio)
+author: Avneet Singh (@sshmatrix), 0xc0de4c0ffee (@0xc0de4c0ffee), Nick Johnson (@arachnid), (@0xpaulio)
 discussions-to: https://ethereum-magicians.org/t/erc-5559-cross-chain-write-deferral-protocol/19664
 status: Draft
 type: Standards Track
 category: ERC
-created: 2024-04-16
-requires: 712
+created: 2024-04-15
+requires: 155
 ---
 
 ## Abstract

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -2,7 +2,7 @@
 eip: 5559
 title: "Cross-chain Write Deferral Protocol"
 description: The cross-chain write deferral protocol provides a mechanism to replace L1 storage with L2 and databases through off-chain handlers
-author: Avneet Singh (@sshmatrix), 0xc0de4c0ffee (@0xc0de4c0ffee), Nick Johnson (@arachnid), Paul Gauvreau (@0xpaulio)
+author: Avneet Singh (@sshmatrix), 0xc0de4c0ffee (@0xc0de4c0ffee), Nick Johnson (@arachnid), Makoto Inoue (@makoto), Paul Gauvreau (@0xpaulio)
 discussions-to: https://ethereum-magicians.org/t/eip-5559-cross-chain-write-deferral-protocol/19664
 status: Draft
 type: Standards Track

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -340,10 +340,10 @@ let post: Post = {
 
 3. Each `StorageHandledBy__()` proposal must define the precise formatting of any message payloads that require signatures and complete descriptions of custom cryptographic techniques implemented for additional security, accessibility or privacy.
 
-## Implementation featuring ENS on L2 & Database
+### Implementation featuring ENS on L2 & Database
 ENS off-chain resolvers capable of reading from and writing to databases are perhaps the most common use-case for CCIP-Read and CCIP-Write. One example of such a (minimal) resolver is given below along with the client-side code for handling the storage handler revert.
 
-### L1 Contract
+#### L1 Contract
 ```solidity
 /* ENS resolver implementing StorageHandledByDatabase() */
 interface iResolver {
@@ -402,7 +402,7 @@ function setText(
 }
 ```
 
-### L2 Contract
+#### L2 Contract
 ```solidity
 // Function in L2 contract
 function setText(
@@ -415,7 +415,7 @@ function setText(
 }
 ```
 
-### Client-side Code
+#### Client-side Code
 ```ts
 /* Client-side pseudo-code in ENS App */
 // Deterministically generate signer keypair
@@ -430,7 +430,7 @@ await fetch(gatewayUrl, {
 ```
 
 ## Backwards Compatibility
-`StorageHandledByDatabase()` method in this document is NOT compatible with the previous EIP-5559 specification.
+`StorageHandledByDatabase()` method in this document is NOT compatible with the previous [EIP-5559](https://eips.ethereum.org/EIPS/eip-5559) specification.
 
 ## Security Considerations
 1. Clients must purge the derived signer private keys from local storage immediately after signing the off-chain data.

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -12,20 +12,18 @@ requires: 155
 ---
 
 ## Abstract
-The cross-chain write deferral protocol, aka CCIP-Write, facilitates replacing Ethereum L1 storage with L2 chains and/or centralised databases with an aim to cut gas costs and further privacy while retaining the secure aspects of on-chain storage. Methods in this document specifically target security and cost-effectiveness of write deferrals. The cross-chain data written with these methods can be retrieved by generic EIP-3668-compliant contracts completing the cross-chain data life cycle. This document, alongside EIP-3668, is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
+The cross-chain write deferral protocol, aka CCIP-Write, facilitates replacing Ethereum L1 storage with L2 chains and/or centralised databases with an aim to cut gas costs and further privacy while retaining the secure aspects of on-chain storage. Methods in this document specifically target security and cost-effectiveness of write deferrals. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](https://eips.ethereum.org/EIPS/eip-3668)-compliant contracts completing the cross-chain data life cycle. This document, alongside [EIP-3668](https://eips.ethereum.org/EIPS/eip-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
 
 ## Motivation
-EIP-3668, aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum. 
+[EIP-3668](https://eips.ethereum.org/EIPS/eip-3668), aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum. 
 
-Cross-chain data retrieval through EIP-3668 is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and centralised databases (or decentralised storages, although they are not covered by this draft). On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage.
+Cross-chain data retrieval through [EIP-3668](https://eips.ethereum.org/EIPS/eip-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and centralised databases (or decentralised storages, although they are not covered by this draft). On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage.
 
-EIP-5559 is the first step toward such a tolerant CCIP-Write protocol which outlines how secure write deferrals can be made to L2s and centralised databases. The cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
+[EIP-5559](https://eips.ethereum.org/EIPS/eip-5559) is the first step toward such a tolerant CCIP-Write protocol which outlines how secure write deferrals can be made to L2s and centralised databases. The cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
 
 ## Specification
 ### Overview
 The following specification revolves around the structure and description of a cross-chain storage handler tasked with the responsibility of writing to an L2 or database storage. This draft introduces `StorageHandledByL2()` and `StorageHandledByDatabase()` storage handlers, and proposes that new `StorageHandledBy__()` reverts be allowed through new EIPs that sufficiently detail their interfaces and designs. Some foreseen examples of new storage handlers include `StorageHandledBySolana()` for Solana, `StorageHandledByFilecoin()` for Filecoin, `StorageHandledByIPFS()` for IPFS, `StorageHandledByIPNS()` for IPNS, `StorageHandledByArweave()` for Arweave, `StorageHandledByArNS()` for ArNS, `StorageHandledBySwarm()` for Swarm etc.
-
-![](https://raw.githubusercontent.com/namesys-eth/namesys-ccip-write/main/images/schematic.png)
 
 ### L2 Handler: `StorageHandledByL2()`
 A minimal L2 handler only requires the list of `chainId` values and the corresponding `contract` addresses, while the clients must ensure that the calldata is invariant under routing to L2. One example implementation of an L2 handler in an L1 contract is shown below.
@@ -119,8 +117,6 @@ These steps are described in detail below.
 
 #### 1. Generate Data Signer
 The data signer must be generated deterministically from ethereum wallet signatures; see figure below.
-
-![](https://raw.githubusercontent.com/namesys-eth/namesys-ccip-write/main/images/keygen.png)
 
 The deterministic key generation can be implemented concisely in a single unified `keygen()` function as follows.
 
@@ -229,7 +225,7 @@ Requesting Signature To Approve Data Signer\n\nOrigin: ${username}\nApproved Sig
 where `dataSigner` must be checksummed.
 
 #### 4. Post CCIP-Read Compatible Payload
-The final EIP-3668-compatible `data` payload in the off-chain data file must then follow the format
+The final [EIP-3668](https://eips.ethereum.org/EIPS/eip-3668)-compatible `data` payload in the off-chain data file must then follow the format
 
 ```solidity
 bytes encodedData = abi.encode(['bytes'], [dataValue])

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -16,6 +16,16 @@ The following standard provides a mechanism by which smart contracts can defer c
 
 Methods in this document specifically target security and cost-effectiveness of write deferrals to two handler types: L2 and databases. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](./eip-3668)-compliant contracts completing the cross-chain data life cycle. This document, alongside [EIP-3668](./eip-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
 
+## Motivation
+[EIP-3668](./eip-3668), aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum.
+
+Cross-chain data retrieval through [EIP-3668](./eip-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and databases. On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage. Examples of this include:
+
+- Services that allow the management of namespaces, e.g. ENS domains, stored externally on an L2 solution or off-chain database as if they were native L1 tokens, and,
+- Services that allow the management of digital identities stored on external storages as if they were stored in the native L1 smart contract.
+
+In this context, a specification which allows write deferrals to external handlers will facilitate creation of services that are agnostic to the underlying storage solution. This in turn enables new applications to operate without knowledge of the underlying handlers. This proposal outlines precisely this part of the process, i.e. how the bespoke write deferrals can be made by smart contracts to L2s and databases. 
+
 ## Specification
 ### Overview
 The following specification revolves around the structure and description of a cross-chain storage handler tasked with the responsibility of writing to an L2 or database storage. This draft introduces `StorageHandledByL2()` and `StorageHandledByDatabase()` storage handlers, and proposes that new `StorageHandledBy__()` reverts be allowed through new EIPs that sufficiently detail their interfaces and designs. Some foreseen examples of new storage handlers include `StorageHandledBySolana()` for Solana, `StorageHandledByFilecoin()` for Filecoin, `StorageHandledByIPFS()` for IPFS, `StorageHandledByIPNS()` for IPNS, `StorageHandledByArweave()` for Arweave, `StorageHandledByArNS()` for ArNS, `StorageHandledBySwarm()` for Swarm etc.
@@ -425,12 +435,7 @@ await fetch(gatewayUrl, {
 ```
 
 ## Rationale
-Cross-chain data retrieval through [EIP-3668](./eip-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and databases. On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage. Examples of this include:
-
-- Services that allow the management of namespaces, e.g. ENS domains, stored externally on an L2 solution or off-chain database as if they were native L1 tokens, and,
-- Services that allow the management of digital identities stored on external storages as if they were stored in the native L1 smart contract.
-
-In this context, a specification which allows write deferrals to external handlers will facilitate creation of services that are agnostic to the underlying storage solution. This in turn enables new applications to operate without knowledge of the underlying handlers. This proposal outlines precisely this part of the process, i.e. how the bespoke write deferrals can be made by smart contracts to L2s and databases. Technically, the cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
+Technically, the cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification. The methods in this proposal perform these precise tasks when deferring write operations to external handlers. 
 
 ## Backwards Compatibility
 `StorageHandledByDatabase()` method in this document is NOT compatible with the previous [EIP-5559](./eip-5559) specification.

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -2,7 +2,7 @@
 eip: 5559
 title: "Cross-chain Write Deferral Protocol"
 description: The cross-chain write deferral protocol provides a mechanism to replace L1 storage with L2 and databases through off-chain handlers
-author: Avneet Singh (@sshmatrix), 0xc0de4c0ffee (@0xc0de4c0ffee), Nick Johnson (@arachnid), Makoto () Paul Gauvreau (@0xpaulio)
+author: Avneet Singh (@sshmatrix), 0xc0de4c0ffee (@0xc0de4c0ffee), Nick Johnson (@arachnid), Makoto Inoue (@makoto), Paul Gauvreau (@0xpaulio)
 discussions-to: https://ethereum-magicians.org/t/eip-5559-cross-chain-write-deferral-protocol/19664
 status: Draft
 type: Standards Track
@@ -428,7 +428,7 @@ await fetch(gatewayUrl, {
 Cross-chain data retrieval through [EIP-3668](./eip-3668) is a relatively simpler task since it assumes that all relevant data originating from cross-chain storages is translated by CCIP-Read-compliant HTTP gateways; this includes L2 chains and databases. On the flip side however, so far each service leveraging CCIP-Read must handle writing this data securely to these storage types on their own, while also incorporating reasonable security measures in their CCIP-Read-compatible contracts for verifying this data on L1. While these security measures are in-built into L2 architectures, database storage providers on the other hand must incorporate some form of explicit security measures during write operations so that cross-chain data's integrity can be verified by CCIP-Read contracts during data retrieval stage. Examples of this include:
 
 - Services that allow the management of namespaces, e.g. ENS domains, stored externally on an L2 solution or off-chain database as if they were native L1 tokens, and,
-- Services allowing the management of digital identities stored on external storages as if they were stored in the native L1 smart contract.
+- Services that allow the management of digital identities stored on external storages as if they were stored in the native L1 smart contract.
 
 In this context, a specification which allows write deferrals to external handlers will facilitate creation of services that are agnostic to the underlying storage solution. This in turn enables new applications to operate without knowledge of the underlying handlers. This proposal outlines precisely this part of the process, i.e. how the bespoke write deferrals can be made by smart contracts to L2s and databases. Technically, the cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification.
 

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -433,10 +433,10 @@ await fetch(gatewayUrl, {
 ```
 
 ## Rationale
-Technically, the cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification. The methods in this proposal perform these precise tasks when deferring write operations to external handlers. 
+Technically, the cases of L2s and databases are similar; deferral to an L2 involves routing the `eth_call` to another EVM, while deferral to a database can be made by extracting `eth_sign` from `eth_call` and posting the resulting signature explicitly along with the data for later verification. Methods in this document perform these precise tasks when deferring write operations to external handlers. In addition, methods such as signing data with a derived signer (for databases) allows for significant UX improvement by fixing the number of signature prompts in wallets to 2, irrespective of the number of data instances to sign per node or the total number of nodes to update. This improvement comes at no additional cost to the user or allows services to perform batch updates.
 
 ## Backwards Compatibility
-N/A
+None.
 
 ## Security Considerations
 1. Clients must purge the derived signer private keys from local storage immediately after signing the off-chain data.

--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -12,9 +12,7 @@ requires: 155
 ---
 
 ## Abstract
-The following standard provides a mechanism by which smart contracts can defer certain tasks to external providers. In particular, protocols can reduce the gas fees associated with storing data on mainnet by deferring the handling of write operations to another system or network. These storage handlers act as an extension to the core L1 contract.
-
-Methods in this document specifically target security and cost-effectiveness of write deferrals to two handler types: L2 and databases. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](./eip-3668)-compliant contracts completing the cross-chain data life cycle. This document, alongside [EIP-3668](./eip-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
+The following standard provides a mechanism by which smart contracts can defer certain tasks to external providers. In particular, protocols can reduce the gas fees associated with storing data on mainnet by deferring the handling of write operations to another system or network. These storage handlers act as an extension to the core L1 contract. Methods in this document specifically target security and cost-effectiveness of write deferrals to two handler types: L2 and databases. The cross-chain data written with these methods can be retrieved by generic [EIP-3668](./eip-3668)-compliant contracts, thus completing the cross-chain data life cycle. This document, alongside [EIP-3668](./eip-3668), is a meaningful step toward a secure infrastructure for cross-chain write deferrals and data retrievals.
 
 ## Motivation
 [EIP-3668](./eip-3668), aka 'CCIP-Read', has been key to retrieving cross-chain data for a variety of contracts on Ethereum blockchain, ranging from price feeds for DeFi contracts, to more recently records for ENS users. The latter case dedicatedly uses cross-chain storage to bypass the usually high gas fees associated with on-chain storage; this aspect has a plethora of use cases well beyond ENS records and a potential for significant impact on universal affordability and accessibility of Ethereum.


### PR DESCRIPTION
The following proposal is a superseding version of [EIP-5559: Cross Chain Write Deferral Protocol](https://ethereum-magicians.org/t/eip-5559-cross-chain-write-deferral-protocol/10576), aka CCIP-Write, replacing Ethereum L1 storage with L2 chains and cryptographically secure databases with an aim to cut gas costs and further privacy while retaining the secure aspects of on-chain storage. Methods in this document specifically target security and cost-effectiveness of write deferrals in context of databases. The cross-chain data written with these methods can be retrieved by generic EIP-3668-compliant contracts completing the cross-chain data life cycle.
