### PR TITLE
Update ERC-7531: Fix typo and remove unnecessary specifications

### DIFF
--- a/ERCS/erc-7531.md
+++ b/ERCS/erc-7531.md
@@ -84,7 +84,7 @@ The `RightsHolderChange` event is crucial for accurately identifying the actual 
 
 ### Timing of Event Emission:
 
-The `RightsHolderChange` event MUST be emitted either in the same block as the corresponding `Transfer` event or in any subsequent block. This approach offers flexibility for existing pools to upgrade their systems without compromising past compatibility. Specifically, staking pools can emit this event for all previously staked tokens, or they can allow users to actively reclaim their ownership. In the latter case, the event SHOULD be emitted as part of the ownership reclamation process. This flexibility ensures that the system can adapt to both current and future states while accurately reflecting the actual ownership of held tokens.
+The `RightsHolderChange` event MUST be emitted either in the same block as the corresponding `Transfer` event or in any subsequent block. This approach offers flexibility for existing pools to upgrade their systems without compromising past compatibility. Specifically, staking pools can emit this event for all previously staked tokens, or they can allow users to actively reclaim their ownership. This flexibility ensures that the system can adapt to both current and future states while accurately reflecting the actual ownership of held tokens.
 
 ### Invalidation of Previous `RightsHolderChange` Events:
 
@@ -98,7 +98,7 @@ The two default rights are:
 
 However, there can ben NFTs that only need to validate the ownership, others may need to validate the usage, and others may need to validate both, some other NFT may need to manage totally different rights.
 
-To give NFTs the necessary flexibility, we also propose the following RECOMMENDED but OPTIONAL extension.
+To give NFTs the necessary flexibility, we also propose the following OPTIONAL extension.
 
 ```solidity
 interface IERC7531Rights {
@@ -118,7 +118,7 @@ interface IERC7531Rights {
 }
 ```
 
-It allows NFTs to return the list of rights it supports, and projects to verify it the NFT supports a specific right. Since the rights are identified by the bytes4 hash of the right name, when introducing new rights, NFT projects SHOULD make public statements about the string that corresponds to the bytes4 hash and explain the rationale for it.
+It allows NFTs to return the list of rights they support, and projects to verify it an NFT supports a specific right. Since the rights are identified by the bytes4 hash of the right name, when introducing new rights, NFT projects SHOULD make public statements about the string that corresponds to the bytes4 hash and explain the rationale for it.
 
 If the NFT does not support the interface (for example, if an existing NFT), project using NFTs SHOULD consider only the standard rights.
 


### PR DESCRIPTION
This fixes a typo and remove restrictions that where mistakenly set.