### PR TITLE
Update ERC-7399: Provided clarity around `maxFlashLoan`

### DIFF
--- a/ERCS/erc-7399.md
+++ b/ERCS/erc-7399.md
@@ -46,6 +46,8 @@ The `amount` and `fee` need to be transferred to a `repayment receiver` before t
 
 The _callback function_ can return any arbitrary data which will be received by the `initiator` as the return value of the `flash` call.
 
+The lender decides which `assets` to support. The lender can decide to support all possible assets.
+
 ### Lender Specification
 
 A `lender` MUST implement the [ERC-7399](./eip-7399.md) interface.
@@ -103,6 +105,8 @@ interface IERC7399 {
 }
 
 ```
+
+The `maxFlashLoan` function MUST return the maximum available loan for `asset`. The `maxFlashLoan` function MUST NOT revert. If the asset is not supported `maxFlashLoan` the value returned MUST be zero.
 
 The `flashFee` function MUST return the fee charged for a loan of `amount` `asset`. If the asset is not supported `flashFee` MUST revert. If the lender doesn't have enough liquidity to loan `amount` the fee returned MUST be `type(uint256).max`. If an `asset`is supported but the available liquidity for it is exactly zero, the fee returned still MUST be `type(uint256).max`.
 


### PR DESCRIPTION
Noticed that there is no specification around `maxFlashLoan`, so I added one consistent to the current implementation of the wrappers at https://github.com/alcueca/erc7399-wrappers
