### PR TITLE
Update ERC-4626: replace old repo link

### DIFF
--- a/ERCS/erc-4626.md
+++ b/ERCS/erc-4626.md
@@ -576,7 +576,7 @@ For production implementations of Vaults which do not use EIP-4626, wrapper adap
 
 ## Reference Implementation
 
-See [Solmate EIP-4626](https://github.com/Rari-Capital/solmate/blob/main/src/mixins/ERC4626.sol):
+See [Solmate EIP-4626](https://github.com/transmissions11/solmate/blob/main/src/tokens/ERC4626.sol):
 a minimal and opinionated implementation of the standard with hooks for developers to easily insert custom logic into deposits and withdrawals.
 
 See [Vyper EIP-4626](https://github.com/fubuloubu/ERC4626):


### PR DESCRIPTION
Old link is invalid now because author changed file path. I replace that with correct url.