### PR TITLE
Update ERC-7432: Removed non-unique roles

### DIFF
--- a/ERCS/erc-5189.md
+++ b/ERCS/erc-5189.md
@@ -305,14 +305,14 @@ The payment is always made in the `feeToken`, which can be any token standard (E
 
 All units are expressed in the native token unit. The result of the fee calculation is then converted to the `feeToken` unit using the `feeScalingFactor` and `feeNormalizationFactor`.
 
-The gas units consider a fixed amount of gas (`fixedGas`) and a variable amount of gas (`gasLimit`). Allowing fixed costs caters for gas overheads which may be outside the scope of the on chain execution, such as calldata fees. This also allows repayment to be reduce when execution is cheaper than expected (such as when an inner call fails without reverting the top-level transaction), while still repaying the bundler.
+The gas units consider a fixed amount of gas (`fixedGas`) and a variable amount of gas (`gasLimit`). Allowing fixed costs caters for gas overheads which may be outside the scope of the on chain execution, such as calldata fees. This also allows repayment to be reduced when execution is cheaper than expected (such as when an inner call fails without reverting the top-level transaction), while still repaying the bundler.
 
 The expected gas repayment is calculated as follows:
 
 ```
 gasUnits = op.fixedGas + Min(gasUsed, op.gasLimit)
 feePerGas = Min(op.maxFeePerGas, block.baseFee + op.priorityFeePerGas)
-expectedRepayment = (gasUsed * feePerGas * op.feeScalingFactor) / op.feeNormalizationFactor
+expectedRepayment = (gasUnits * feePerGas * op.feeScalingFactor) / op.feeNormalizationFactor
 ```
 
 While the `endorser` MUST guarantee the repayment of `expectedRepayment`, the actual repayment amount MAY exceed this fee. E.g. For ease of development, a bundler MAY choose to only endorse operations that repay the maximum values provided by the operation.

--- a/ERCS/erc-6900.md
+++ b/ERCS/erc-6900.md
@@ -2,7 +2,7 @@
 eip: 6900
 title: Modular Smart Contract Accounts and Plugins
 description: Interfaces for composable contract accounts optionally supporting upgradability and introspection
-author: Adam Egyed (@adamegyed), Fangting Liu (@trinity-0111), Jay Paik (@jaypaik), Yoav Weiss (@yoavw), Huawei Gu (@huaweigu), Daniel Lim (@dlim-circle), Zhiyu Zhang (@ZhiyuCircle)
+author: Adam Egyed (@adamegyed), Fangting Liu (@trinity-0111), Jay Paik (@jaypaik), Yoav Weiss (@yoavw), Huawei Gu (@huaweigu), Daniel Lim (@dlim-circle), Zhiyu Zhang (@ZhiyuCircle), Ruben Koch (@0xrubes), David Philipson (@dphilipson), Howy Ho (@howydev)
 discussions-to: https://ethereum-magicians.org/t/eip-modular-smart-contract-accounts-and-plugins/13885
 status: Draft
 type: Standards Track


### PR DESCRIPTION
After speaking with other developers about ERC-7432, we reach the conclusion that the interface is becoming overly complex by attempting to support multiple use cases.

We are simplifying this EIP by removing the non-unique roles use case.
