### PR TITLE
Fix incorrect comment in EIP-3448 implementation

### DIFF
--- a/assets/erc-3448/MetaProxyFactory.sol
+++ b/assets/erc-3448/MetaProxyFactory.sol
@@ -85,7 +85,7 @@ contract MetaProxyFactory {
       mstore(ptr, length)
       ptr := add(ptr, 32)
 
-      // The size is deploy code + contract code + calldatasize - 4 + 32.
+      // The size is deploy code + contract code + length + 32.
       addr := create(0, start, sub(ptr, start))
     }
   }


### PR DESCRIPTION
[This comment](https://github.com/ethereum/ERCs/blob/0a8ed97da0d19891293833b378576d21fc84ac9e/assets/erc-3448/MetaProxyFactory.sol#L88) defines deploy code size:
```solidity
  function _metaProxyFromMemory (address targetContract, uint256 offset, uint256 length) internal returns (address addr) {
    ...
@>    // The size is deploy code + contract code + calldatasize - 4 + 32.
      addr := create(0, start, sub(ptr, start))
    }
  }
```
Struggled some time to figure out what is `calldata` in this context. Eventually this comment was copied from previous function where it used the whole calldata except 4 bytes selector.

PR proposes right comment because `length` exactly defines metadata length.