### PR TITLE
Update ERC-7656: Rename IERC7656Contract as IER7656Linked

### DIFF
--- a/ERCS/erc-7656.md
+++ b/ERCS/erc-7656.md
@@ -116,7 +116,7 @@ ERC-1167 Footer               (15 bytes)
 Any contract created using a `ERC7656Registry` SHOULD implement the `IERC7656Contract` interface:
 
 ```solidity
-interface IERC7656Contract {
+interface IERC7656Linked {
   /**
   * @notice Returns the token linked to the contract
   * @return chainId The chainId of the token
@@ -263,10 +263,10 @@ contract ERC7656Registry is IERC7656Registry {
 }
 ```
 
-A simple implementation of `IERC7656Contract`:
+A simple implementation of `IERC7656Linked`:
 
 ```solidity
-contract ERC7656Contract is IERC7656Contract, EIP5313 {
+contract LinkedContract is IERC7656Linked, EIP5313 {
 
   function token() public view virtual returns (uint256, address, uint256) {
     bytes memory footer = new bytes(0x60);


### PR DESCRIPTION
Renaming the token linked contract interface from the too generic `IERC7656Contract` to `IERC7656Linked`