### PR TITLE
Update ERC-4337: return values of estimateUserOperationGas

### DIFF
--- a/ERCS/erc-4337.md
+++ b/ERCS/erc-4337.md
@@ -683,17 +683,19 @@ Still, it might require putting a "semi-valid" signature (e.g. a signature in th
 **Return Values:**
 
 * **preVerificationGas** gas overhead of this UserOperation
-* **verificationGasLimit** actual gas used by the validation of this UserOperation
-* **paymasterVerificationGasLimit** actual gas used by used for paymaster verification (if paymaster exists in the UserOperation)
-* **callGasLimit** value used by inner account execution
+* **verificationGasLimit** estimation of gas limit required by the validation of this UserOperation
+* **paymasterVerificationGasLimit** estimation of gas limit required by the paymaster verification, if the
+  UserOperation defines a Paymaster address
+* **callGasLimit** estimation of gas limit required by the inner account execution
 
-**Note:** actual postOpGasLimit cannot be reliably estimated. Paymasters should provide this value to account,
+**Note:** actual `postOpGasLimit` cannot be reliably estimated. Paymasters should provide this value to account,
   and require that specific value on-chain.
 
 ##### Error Codes:
 
 Same as `eth_sendUserOperation`
-This operation may also return an error if the inner call to the account contract (or paymaster's postOp) revert.
+This operation may also return an error if either the inner call to the account contract reverts,
+or paymaster's `postOp` call reverts.
 
 #### * eth_getUserOperationByHash
 

--- a/ERCS/erc-4337.md
+++ b/ERCS/erc-4337.md
@@ -684,14 +684,16 @@ Still, it might require putting a "semi-valid" signature (e.g. a signature in th
 
 * **preVerificationGas** gas overhead of this UserOperation
 * **verificationGasLimit** actual gas used by the validation of this UserOperation
+* **paymasterVerificationGasLimit** actual gas used by used for paymaster verification (if paymaster exists in the UserOperation)
 * **callGasLimit** value used by inner account execution
-* **paymasterVerificationGasLimit** value used for paymaster verification (if paymaster exists in the UserOperation)
-* **paymasterPostOpGasLimit** value used for paymaster post op execution (if paymaster exists in the UserOperation)
+
+**Note:** actual postOpGasLimit cannot be reliably estimated. Paymasters should provide this value to account,
+  and require that specific value on-chain.
 
 ##### Error Codes:
 
 Same as `eth_sendUserOperation`
-This operation may also return an error if the inner call to the account contract reverts.
+This operation may also return an error if the inner call to the account contract (or paymaster's postOp) revert.
 
 #### * eth_getUserOperationByHash
 


### PR DESCRIPTION
The value of postOpGasLimit can't be reliably estimated: the paymaster depends on this value, and can't trust the account to estimate a proper value, so it must require a fixed, known value.