### PR TITLE
Update ERC-7677: add isFinal flag, move sponsor, and specify validation expectations

### DIFF
--- a/ERCS/erc-7677.md
+++ b/ERCS/erc-7677.md
@@ -33,6 +33,12 @@ Returns stub values to be used in paymaster-related fields of an unsigned user o
 
 This method MAY return paymaster-specific gas values if applicable to the provided EntryPoint version. For example, if provided with EntryPoint v0.7, this method MAY return `paymasterVerificationGasLimit` and `paymasterPostOpGasLimit` values. The wallet SHOULD use these provided gas values when submitting the `UserOperation` to a bundler for gas estimation.
 
+This method MAY also return a `sponsor` object with `name` and `icon` fields. The `name` field is the name of the party sponsoring the transaction, and the `icon` field is a URI pointing to an image. Wallet developers MAY choose to display sponsor information to users. The `icon` string MUST be a data URI as defined in [RFC-2397]. The image SHOULD be a square with 96x96px minimum resolution. The image format is RECOMMENDED to be either lossless or vector based such as PNG, WebP or SVG to make the image easy to render on the wallet. Since SVG images can execute Javascript, wallets MUST render SVG images using the `<img>` tag to ensure no untrusted Javascript execution can occur.
+
+There are cases where a call to just `pm_getPaymasterStubData` is sufficient to provide valid paymaster-related user operation fields, e.g. when the `paymasterData` does not contain a signature. In such cases, the second RPC call to `pm_getPaymasterData` (defined below) MAY be skipped, by returning `isFinal: true` by this RPC call.
+
+Paymaster web services SHOULD do validations on incoming user operations during `pm_getPaymasterStubData` execution and reject the request at this stage if it would not sponsor the operation.
+
 ##### `pm_getPaymasterStubData` RPC Specification
 
 Note that the user operation parameter does not include a signature, as the user signs after all other fields are populated.
@@ -63,6 +69,7 @@ type GetPaymasterStubDataResult = {
   paymasterVerificationGasLimit?: `0x${string}`; // Paymaster validation gas (entrypoint v0.7)
   paymasterPostOpGasLimit?: `0x${string}`; // Paymaster post-op gas (entrypoint v0.7)
   paymasterAndData?: string; // Paymaster and data (entrypoint v0.6)
+  isFinal?: boolean; // Indicates that the caller does not need to call pm_getPaymasterData
 }
 ```
 
@@ -98,6 +105,10 @@ For example, if using entrypoint v0.6:
 
 ```json
 {
+  "sponsor": {
+    "name": "My App",
+    "icon": "https://..."
+  },
   "paymasterAndData": "0x..."
 }
 ```
@@ -106,6 +117,10 @@ If using entrypoint v0.7:
 
 ```json
 {
+  "sponsor": {
+    "name": "My App",
+    "icon": "https://..."
+  },
   "paymaster": "0x...",
   "paymasterData": "0x..."
 }
@@ -115,6 +130,10 @@ If using entrypoint v0.7, with paymaster gas estimates:
 
 ```json
 {
+  "sponsor": {
+    "name": "My App",
+    "icon": "https://..."
+  },
   "paymaster": "0x...",
   "paymasterData": "0x...",
   "paymasterVerificationGasLimit": "0x...",
@@ -122,11 +141,23 @@ If using entrypoint v0.7, with paymaster gas estimates:
 }
 ```
 
+Indicating that the caller does not need to make a `pm_getPaymasterData` RPC call:
+
+```json
+{
+  "sponsor": {
+    "name": "My App",
+    "icon": "https://..."
+  },
+  "paymaster": "0x...",
+  "paymasterData": "0x...",
+  "isFinal": true
+}
+```
+
 #### `pm_getPaymasterData`
 
 Returns values to be used in paymaster-related fields of a signed user operation. These are not stub values and will be used during user operation submission to a bundler. Similar to `pm_getPaymasterStubData`, accepts an unsigned user operation, entrypoint address, chain id, and a context object.
-
-This method also returns a `sponsor` object with `name` and `icon` fields. The `name` field is the name of the party sponsoring the transaction, and the `icon` field is a URI pointing to an image. Wallet developers MAY choose to display sponsor information to users. The `icon` string MUST be a data URI as defined in [RFC-2397]. The image SHOULD be a square with 96x96px minimum resolution. The image format is RECOMMENDED to be either lossless or vector based such as PNG, WebP or SVG to make the image easy to render on the wallet. Since SVG images can execute Javascript, wallets MUST render SVG images using the `<img>` tag to ensure no untrusted Javascript execution can occur.
 
 ##### `pm_getPaymasterData` RPC Specification
 
@@ -192,10 +223,6 @@ For example, if using entrypoint v0.6:
 
 ```json
 {
-  "sponsor": {
-    "name": "My App",
-    "icon": "https://..."
-  },
   "paymasterAndData": "0x..."
 }
 ```
@@ -204,10 +231,6 @@ If using entrypoint v0.7:
 
 ```json
 {
-  "sponsor": {
-    "name": "My App",
-    "icon": "https://..."
-  },
   "paymaster": "0x...",
   "paymasterData": "0x..."
 }


### PR DESCRIPTION
- add optional `isFinal` field to `pm_getPaymasterStubData` response. this is used to indicate that a caller does not need to call `pm_getPaymasterData` because the paymaster data does not include a signature that needs to be generated by the service
- move sponsor to `pm_getPaymasterStubData`. this is so users can know who would sponsor their operation before needing to do the final gas calculations + `pm_getPaymasterData` call
- specify that paymaster web services should validate incoming user operations during `pm_getPaymasterStubData` calls and reject at this stage.
