### PR TITLE
Docs: Rectify typographical inaccuracies

### DIFF
--- a/ERCS/eip-1.md
+++ b/ERCS/eip-1.md
@@ -91,7 +91,7 @@ A PR moving an EIP from Last Call to Final SHOULD contain no changes other than 
 
 >*EIP Authors are notified of any algorithmic change to the status of their EIP*
 
-**Withdrawn** - The EIP Author(s) have withdrawn the proposed EIP. This state has finality and can no longer be resurrected using this EIP number. If the idea is pursued at later date it is considered a new proposal.
+**Withdrawn** - The EIP Author(s) have withdrawn the proposed EIP. This state has finality and can no longer be resurrected using this EIP number. If the idea is pursued at a later date it is considered a new proposal.
 
 **Living** - A special status for EIPs that are designed to be continually updated and not reach a state of finality. This includes most notably EIP-1.
 

--- a/ERCS/erc-1046.md
+++ b/ERCS/erc-1046.md
@@ -58,13 +58,13 @@ interface InteroperabilityMetadata {
 
     /**
      * This MUST be true if this is ERC-721 Token Metadata, otherwise, this MUST be omitted.
-     * Setting this to true indicates to wallets that the address should be treated as a ERC-721 token.
+     * Setting this to true indicates to wallets that the address should be treated as an ERC-721 token.
      **/
     erc721?: boolean | undefined;
 
     /**
      * This MUST be true if this is ERC-1155 Token Metadata, otherwise, this MUST be omitted.
-     * Setting this to true indicates to wallets that the address should be treated as a ERC-1155 token.
+     * Setting this to true indicates to wallets that the address should be treated as an ERC-1155 token.
      **/
     erc1155?: boolean | undefined;
 }

--- a/ERCS/erc-1056.md
+++ b/ERCS/erc-1056.md
@@ -222,7 +222,7 @@ Contract Events are a useful feature for storing data from smart contracts exclu
 
 2. Lookup all events for given identity address using web3, but only for the `previousChange` block
 
-3. Do something with event
+3. Do something with the event
 
 4. Find `previousChange` from the event  and repeat
 

--- a/ERCS/erc-1062.md
+++ b/ERCS/erc-1062.md
@@ -18,9 +18,9 @@ The following standard details the implementation of how to combine the IPFS cry
 We think that this implementation is not only aim to let more developers and communities to provide more use cases, but also leverage the human-readable features to gain more user adoption accessing decentralized resources. We considered the IPFS ENS resolver mapping standard a cornerstone for building future Web3.0 service.
 
 ## Motivation
-To build fully decentralized web service, it’s necessary to have a decentralized file storage system. Here comes the IPFS, for three following advantages :
+To build a fully decentralized web service, it’s necessary to have a decentralized file storage system. Here comes the IPFS, for three following advantages :
 - Address large amounts of data, and has unique cryptographic hash for every record.
-- Since IPFS is also based on peer to peer network, it can be really helpful to deliver large amounts of data to users, with safer way and lower the millions of cost for the bandwidth.
+- Since IPFS is also based on peer to peer network, it can be really helpful to deliver large amounts of data to users, in a safer way and lower the millions of cost for the bandwidth.
 - IPFS stores files in high efficient way via tracking version history for every file, and removing the duplications across the network.
   
 Those features makes perfect match for integrating into ENS, and these make users can easily access content through ENS, and show up in the normal browser.

--- a/ERCS/erc-1066.md
+++ b/ERCS/erc-1066.md
@@ -480,7 +480,7 @@ AwesomeCoin                 DEX                     TraderBot
 
 Status codes are encoded as a `byte`. Hex values break nicely into high and low nibbles: `category` and `reason`. For instance, `0x01` stands for general success (ie: `true`) and `0x00` for general failure (ie: `false`).
 
-As a general approach, all even numbers are blocking conditions (where the receiver does not have control), and odd numbers are nonblocking (the receiver is free to contrinue as they wish). This aligns both a simple bit check with the common encoding of Booleans.
+As a general approach, all even numbers are blocking conditions (where the receiver does not have control), and odd numbers are nonblocking (the receiver is free to continue as they wish). This aligns both a simple bit check with the common encoding of Booleans.
 
 `bytes1` is very lightweight, portable, easily interoperable with `uint8`, cast from `enum`s, and so on.
 

--- a/ERCS/erc-1077.md
+++ b/ERCS/erc-1077.md
@@ -19,7 +19,7 @@ Allows users to offer [EIP-20] token for paying the gas used in a call.
 
 ## Abstract
 
-A main barrier for adoption of DApps is the requirement of multiple tokens for executing in chain actions. Allowing users to sign messages to show intent of execution, but allowing a third party relayer to execute them can circumvent this problem, while ETH will always be required for ethereum transactions, it's possible for smart contract to take [EIP-191] signatures and forward a payment incentive to an untrusted party with ETH for executing the transaction. 
+A main barrier for the adoption of DApps is the requirement of multiple tokens for executing in chain actions. Allowing users to sign messages to show intent of execution, but allowing a third party relayer to execute them can circumvent this problem, while ETH will always be required for ethereum transactions, it's possible for smart contract to take [EIP-191] signatures and forward a payment incentive to an untrusted party with ETH for executing the transaction. 
 
 ## Motivation
 
@@ -83,7 +83,7 @@ In order to be compliant, the transaction **MUST** request to sign a "messageHas
 
 The fields **MUST** be constructed as this method:
 
-The first and second fields are to make it [EIP-191] compliant. Starting a transaction with `byte(0x19)` ensure the signed data from being a [valid ethereum transaction](https://github.com/ethereum/wiki/wiki/RLP). The second argument is a version control byte. The third being the validator address (the account contract address) according to version 0 of [EIP-191]. The remaining arguments being the application specific data for the gas relay: chainID as per [EIP-1344], execution nonce, execution data, agreed gas Price, gas limit of gas relayed call, gas token to pay back and gas relayer authorized to receive reward.
+The first and second fields are to make it [EIP-191] compliant. Starting a transaction with `byte(0x19)` ensure the signed data from being a [valid ethereum transaction](https://github.com/ethereum/wiki/wiki/RLP). The second argument is a version control byte. The third being the validator address (the account contract address) according to version 0 of [EIP-191]. The remaining arguments being the application specific data for the gas relay: chainID as per [EIP-1344], execution nonce, execution data, agreed gas Price, gas limit of gas relayed call, gas token to pay back and gas relayer authorized to receive the reward.
 
 The [EIP-191] message must be constructed as following:
 ```solidity

--- a/ERCS/erc-1078.md
+++ b/ERCS/erc-1078.md
@@ -17,7 +17,7 @@ This presents a method to replace the usual signup/login design pattern with a m
 
 ## Simple Summary
 
-The unique identifier of the user is a contract which implements both Identity and the Executable Signed Messages ERCs. The user should not need provide this address directly, only a ens name pointing to it. These types of contracts are indirectly controlled by private keys that can sign messages indicating intents, which are then deployed to the contract by a third party (or a decentralized network of deployers).  
+The unique identifier of the user is a contract that implements both Identity and the Executable Signed Messages ERCs. The user should not need provide this address directly, only a ens name pointing to it. These types of contracts are indirectly controlled by private keys that can sign messages indicating intents, which are then deployed to the contract by a third party (or a decentralized network of deployers).  
 
 In this context, therefore, a device "logging into" an app using an identity, means that the device will generate a private key locally and then request an authorization to add that key as one of the signers of that identity, with a given set of permissions. Since that private key is only used for signing messages, it is not required to hold ether, tokens or assets, and if lost, it can be simply be replaced by a new one – the user's funds are kept on the identity contract.
 

--- a/ERCS/erc-1078.md
+++ b/ERCS/erc-1078.md
@@ -12,7 +12,7 @@ requires: 191, 681, 725, 1077
 
 ## Abstract
 
-This presents a method to replace the usual signup/login design pattern with a minimal ethereum native scheme, that doesn’t require passwords, backing up private keys nor typing seed phrases. From the user point of view it will be very similar to patterns they’re already used to with second factor authentication (without relying in a central server), but for dapp developers it requires a new way to think about ethereum transactions.
+This presents a method to replace the usual signup/login design pattern with a minimal ethereum native scheme, that doesn’t require passwords, backing up private keys nor typing seed phrases. From the user's point of view it will be very similar to patterns they’re already used to with second factor authentication (without relying in a central server), but for dapp developers it requires a new way to think about ethereum transactions.
 
 
 ## Simple Summary


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.

