### PR TITLE
Update ERC-6909: Nit, adds case to `transferFrom` where `sender` is `msg.sender`.

### DIFF
--- a/ERCS/erc-6909.md
+++ b/ERCS/erc-6909.md
@@ -134,7 +134,7 @@ MUST return True.
 
 Transfers an `amount` of a token `id` from a `sender` to a `receiver` by the caller.
 
-MUST revert when the caller is not an operator for the `sender` and the caller's allowance for the token `id` for the `sender` is insufficient.
+MUST revert when the caller is neither the `sender` nor an operator for the `sender` and the caller's allowance for the token `id` for the `sender` is insufficient.
 
 MUST revert when the `sender`'s balance for the token id is insufficient.
 
@@ -144,7 +144,7 @@ MUST decrease the caller's `allowance` by the same `amount` of the `sender`'s ba
 
 SHOULD NOT decrease the caller's `allowance` for the token `id` for the `sender` if the `allowance` is infinite.
 
-SHOULD NOT decrease the caller's `allowance` for the token `id` for the `sender` if the caller is an operator.
+SHOULD NOT decrease the caller's `allowance` for the token `id` for the `sender` if the caller is an operator or the `sender`.
 
 MUST return True.
 


### PR DESCRIPTION
ohhh i'm gonna `[Informational - 1]`