### PR TITLE
Update ERC-6900: Fix typo in responsibilities section

### DIFF
--- a/ERCS/erc-6900.md
+++ b/ERCS/erc-6900.md
@@ -434,7 +434,7 @@ struct PluginManifest {
 
 ### Expected behavior
 
-#### Responsibilties of `StandardExecutor` and `PluginExecutor`
+#### Responsibilities of `StandardExecutor` and `PluginExecutor`
 
 `StandardExecutor` functions are used for open-ended calls to external addresses.
 


### PR DESCRIPTION
- Corrected "Responsibilties" to "Responsibilities".