### PR TITLE
Update ERC-3770: Move to Draft

### DIFF
--- a/ERCS/erc-3770.md
+++ b/ERCS/erc-3770.md
@@ -4,7 +4,7 @@ title: Chain-specific addresses
 description: Prepending chain-specific addresses with a human-readable chain identifier
 author: Lukas Schor (@lukasschor), Richard Meissner (@rmeissner), Pedro Gomes (@pedrouid), ligi <ligi@ligi.de>
 discussions-to: https://ethereum-magicians.org/t/chain-specific-addresses/6449
-status: Stagnant
+status: Draft
 type: Standards Track
 category: ERC
 created: 2021-08-26
@@ -58,7 +58,7 @@ Ethereum addresses without the chain specifier will continue to require addition
 
 ## Security Considerations
 
-The Ethereum List curators must consider how similar looking chain short names can be used to confuse users.
+Similar looking chain short names can be used to confuse users.
 
 ## Copyright
 


### PR DESCRIPTION
we should revive this one (especially as it is used and currently pushed by @vbuterin here: https://x.com/VitalikButerin/status/1810633473750683974)

So moving it from stagnant to draft.

Also removing the responsibility on Ethereum-Lists curators (currently only me) to care for similar looking names. This is just not possible. It is just a drawback of this EIP in contrast of CAIP-10.