### PR TITLE
Update ERC-3770: Fix broken links and formatting

### DIFF
--- a/ERCS/erc-3770.md
+++ b/ERCS/erc-3770.md
@@ -12,13 +12,13 @@ created: 2021-08-26
 
 ## Abstract
 
-[ERC-3770](./eip-3770.md) introduces a new address standard to be adapted by wallets and dApps to display chain-specific addresses by using a human-reacable prefix.
-  
+[ERC-3770](./erc-3770.md) introduces a new address standard to be adapted by wallets and dApps to display chain-specific addresses by using a human-readable prefix.
+
 ## Motivation
 
 The need for this proposal emerges from the increasing adoption of non-Ethereum Mainnet chains that use the Ethereum Virtual Machine (EVM). In this context, addresses become ambiguous, as the same address may refer to an EOA on chain X or a smart contract on chain Y. This will eventually lead to Ethereum users losing funds due to human error. For example, users sending funds to a smart contract wallet address which was not deployed on a particular chain.
 
-Therefore we should prefix addresses with a unique identifier that signals to Dapps and wallets on what chain the target account is. In theory, this prefix could be a [EIP-155](./eip-155.md) chainID. However, these chain IDs are not meant to be displayed to users in dApps or wallets, and they were optimized for developer interoperability, rather than human readability.
+Therefore we should prefix addresses with a unique identifier that signals to Dapps and wallets on what chain the target account is. In theory, this prefix could be a [EIP-155](https://github.com/ethereum/EIPs/blob/1868f756f11cf38f74375451c7b79eb908cd3798/EIPS/eip-155.md) chainID. However, these chain IDs are not meant to be displayed to users in dApps or wallets, and they were optimized for developer interoperability, rather than human readability.
 
 ## Specification
 
@@ -36,13 +36,8 @@ Chain-specific address = "`shortName`" "`:`" "`address`"
 
 ### Semantics
 
-```
-
-`shortName` is mandatory and MUST be a valid chain short name from https://github.com/ethereum-lists/chains
-  
-`address` is mandatory and MUST be a [ERC-55](./eip-55.md) compatible hexadecimal address
-
-```
+* `shortName` is mandatory and MUST be a valid chain short name from https://github.com/ethereum-lists/chains
+* `address` is mandatory and MUST be a [ERC-55](./erc-55.md) compatible hexadecimal address
 
 ### Examples
 

--- a/ERCS/erc-3770.md
+++ b/ERCS/erc-3770.md
@@ -12,13 +12,13 @@ created: 2021-08-26
 
 ## Abstract
 
-[ERC-3770](./erc-3770.md) introduces a new address standard to be adapted by wallets and dApps to display chain-specific addresses by using a human-readable prefix.
+[ERC-3770](./eip-3770.md) introduces a new address standard to be adapted by wallets and dApps to display chain-specific addresses by using a human-readable prefix.
 
 ## Motivation
 
 The need for this proposal emerges from the increasing adoption of non-Ethereum Mainnet chains that use the Ethereum Virtual Machine (EVM). In this context, addresses become ambiguous, as the same address may refer to an EOA on chain X or a smart contract on chain Y. This will eventually lead to Ethereum users losing funds due to human error. For example, users sending funds to a smart contract wallet address which was not deployed on a particular chain.
 
-Therefore we should prefix addresses with a unique identifier that signals to Dapps and wallets on what chain the target account is. In theory, this prefix could be a [EIP-155](https://github.com/ethereum/EIPs/blob/1868f756f11cf38f74375451c7b79eb908cd3798/EIPS/eip-155.md) chainID. However, these chain IDs are not meant to be displayed to users in dApps or wallets, and they were optimized for developer interoperability, rather than human readability.
+Therefore we should prefix addresses with a unique identifier that signals to Dapps and wallets on what chain the target account is. In theory, this prefix could be a [EIP-155](./eip-155.md) chainID. However, these chain IDs are not meant to be displayed to users in dApps or wallets, and they were optimized for developer interoperability, rather than human readability.
 
 ## Specification
 
@@ -37,7 +37,7 @@ Chain-specific address = "`shortName`" "`:`" "`address`"
 ### Semantics
 
 * `shortName` is mandatory and MUST be a valid chain short name from https://github.com/ethereum-lists/chains
-* `address` is mandatory and MUST be a [ERC-55](./erc-55.md) compatible hexadecimal address
+* `address` is mandatory and MUST be a [ERC-55](./eip-55.md) compatible hexadecimal address
 
 ### Examples
 


### PR DESCRIPTION
Fixes broken links from the eip -> erc move, fixes typos and formatting