### PR TITLE
Update ERC-5630: Move to Draft

### DIFF
--- a/ERCS/erc-5630.md
+++ b/ERCS/erc-5630.md
@@ -4,7 +4,7 @@ title: New approach for encryption / decryption
 description: defines a specification for encryption and decryption using Ethereum wallets.
 author: Firn Protocol (@firnprotocol), Fried L. Trout, Weiji Guo (@weijiguo)
 discussions-to: https://ethereum-magicians.org/t/eip-5630-encryption-and-decryption/10761
-status: Review
+status: Draft
 type: Standards Track
 category: ERC
 created: 2022-09-07

--- a/ERCS/erc-5630.md
+++ b/ERCS/erc-5630.md
@@ -4,7 +4,7 @@ title: New approach for encryption / decryption
 description: defines a specification for encryption and decryption using Ethereum wallets.
 author: Firn Protocol (@firnprotocol), Fried L. Trout, Weiji Guo (@weijiguo)
 discussions-to: https://ethereum-magicians.org/t/eip-5630-encryption-and-decryption/10761
-status: Stagnant
+status: Review
 type: Standards Track
 category: ERC
 created: 2022-09-07


### PR DESCRIPTION
The EIP was moved to Stagnant state automatically, but there are many applications waiting for a replacement to the now deprecated support for eth_getEncryptionPublicKey   .  

Authors: J.D. Bertron <jdbertron> 