### PR TITLE
Update ERC-6860: Add _blockNumber parameter to Web3 URL specification

### DIFF
--- a/ERCS/erc-6860.md
+++ b/ERCS/erc-6860.md
@@ -307,8 +307,15 @@ chainid         = %x31-39 *DIGIT
 pathQuery       = mPathQuery [ evmQuery ] ; path+query for manual mode
                 / aPathQuery [ evmQuery ] ; path+query for auto mode
 
-evmQuery        = *( "&" blockNumberQuery )
-blockNumberQuery = "_blockNumber=" 1*DIGIT
+evmQuery        = *[(evmPath evmParams)]
+evmPath         =  "?" ; begins with "/" but not "//" 
+                / "&" 
+evmParams       = blockNumberQuery
+                / gasLimitQuery
+                / fromQuery
+blockNumberQuery= "_blockNumber=" uintArg
+gasLimitQuery   = "_gasLimit=" uintArg
+fromQuery       = "_from=" addressArg
 
 web3UrlRef      = web3URL 
                 / relativeWeb3URL

--- a/ERCS/erc-6860.md
+++ b/ERCS/erc-6860.md
@@ -2,7 +2,7 @@
 eip: 6860
 title: Web3 URL to EVM Call Message Translation
 description: A translation of an HTTP-style Web3 URL to an EVM call message
-author: Qi Zhou (@qizhou), Chao Pi (@pichaoqkc), Sam Wilson (@SamWilsn), Nicolas Deschildre (@nand2) Box (@nishuzumi)
+author: Qi Zhou (@qizhou), Chao Pi (@pichaoqkc), Sam Wilson (@SamWilsn), Nicolas Deschildre (@nand2), Box (@nishuzumi)
 discussions-to: https://ethereum-magicians.org/t/eip-4804-web3-url-to-evm-call-message-translation/8300
 status: Draft
 type: Standards Track

--- a/ERCS/erc-6860.md
+++ b/ERCS/erc-6860.md
@@ -2,7 +2,7 @@
 eip: 6860
 title: Web3 URL to EVM Call Message Translation
 description: A translation of an HTTP-style Web3 URL to an EVM call message
-author: Qi Zhou (@qizhou), Chao Pi (@pichaoqkc), Sam Wilson (@SamWilsn), Nicolas Deschildre (@nand2)
+author: Qi Zhou (@qizhou), Chao Pi (@pichaoqkc), Sam Wilson (@SamWilsn), Nicolas Deschildre (@nand2) Box (@nishuzumi)
 discussions-to: https://ethereum-magicians.org/t/eip-4804-web3-url-to-evm-call-message-translation/8300
 status: Draft
 type: Standards Track

--- a/ERCS/erc-6860.md
+++ b/ERCS/erc-6860.md
@@ -63,14 +63,11 @@ chainid         = %x31-39 *DIGIT
 **chainid** indicates which chain to resolve **contractName** and call the message. If not specified, the protocol will use the primary chain of the name service provider used, e.g., 1 for eth. If no name service provider was used, the default chainid is 1.
 
 ```
-pathQuery       = mPathQuery [ evmQuery ] ; path+query for manual mode
-                / aPathQuery [ evmQuery ] ; path+query for auto mode
-evmQuery        = *( "&" blockNumberQuery )
-blockNumberQuery = "_blockNumber=" 1*DIGIT
+pathQuery       = mPathQuery ; path+query for manual mode
+                / aPathQuery ; path+query for auto mode
 ```
 
 **pathQuery**, made of the path and optional query, will have a different structure whether the resolve mode is "manual" or "auto".
-**_blockNumber** If _blockNumber is specified, the EVM call message should be executed at the state of the blockchain at the specified block number.
 
 ```
 web3UrlRef      = web3URL 
@@ -304,18 +301,8 @@ contractName    = address
                 / domainName
 chainid         = %x31-39 *DIGIT
 
-pathQuery       = mPathQuery [ evmQuery ] ; path+query for manual mode
-                / aPathQuery [ evmQuery ] ; path+query for auto mode
-
-evmQuery        = *[(evmPath evmParams)]
-evmPath         =  "?" ; begins with "/" but not "//" 
-                / "&" 
-evmParams       = blockNumberQuery
-                / gasLimitQuery
-                / fromQuery
-blockNumberQuery= "_blockNumber=" uintArg
-gasLimitQuery   = "_gasLimit=" uintArg
-fromQuery       = "_from=" addressArg
+pathQuery       = mPathQuery ; path+query for manual mode
+                / aPathQuery ; path+query for auto mode
 
 web3UrlRef      = web3URL 
                 / relativeWeb3URL
@@ -342,11 +329,21 @@ segmentNzNc     = 1*( unreserved / pct-encoded / sub-delims / "@" )
                 ; as in RFC 3986: non-zero-length segment without any colon ":"
 
 mQuery          = *( pchar / "/" / "?" ) ; as in RFC 3986
+                / evmParams *( "&" evmParams )
 
 aPathQuery      = aPath [ "?" aQuery ]
 aPath           = [ "/" [ method *( "/" argument ) ] ]
 relAPathQuery   = aPath [ "?" aQuery ]
 method          = ( ALPHA / "$" / "_" ) *( ALPHA / DIGIT / "$" / "_" )
+
+evmParams       = blockNumberQuery
+                / gasLimitQuery
+                / fromQuery
+blockNumberQuery= "_blockNumber=" uintArg
+gasLimitQuery   = "_gasLimit=" uintArg
+fromQuery       = "_from=" addressArg
+aQuery          = attribute  / evmParams *( "&" attribute / evmParams )
+
 argument        = boolArg
                 / uintArg
                 / intArg

--- a/ERCS/erc-6860.md
+++ b/ERCS/erc-6860.md
@@ -63,11 +63,14 @@ chainid         = %x31-39 *DIGIT
 **chainid** indicates which chain to resolve **contractName** and call the message. If not specified, the protocol will use the primary chain of the name service provider used, e.g., 1 for eth. If no name service provider was used, the default chainid is 1.
 
 ```
-pathQuery       = mPathQuery ; path+query for manual mode
-                / aPathQuery ; path+query for auto mode
+pathQuery       = mPathQuery [ evmQuery ] ; path+query for manual mode
+                / aPathQuery [ evmQuery ] ; path+query for auto mode
+evmQuery        = *( "&" blockNumberQuery )
+blockNumberQuery = "_blockNumber=" 1*DIGIT
 ```
 
 **pathQuery**, made of the path and optional query, will have a different structure whether the resolve mode is "manual" or "auto".
+**_blockNumber** If _blockNumber is specified, the EVM call message should be executed at the state of the blockchain at the specified block number.
 
 ```
 web3UrlRef      = web3URL 
@@ -283,6 +286,14 @@ where the contract ”0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48“ is in auto m
 
 The protocol will find the address of **vitalik.eth** from ENS on chainid 1 (Mainnet) and then call the method "balanceOf(address)" of the address. The returned data from the call of the contract will be treated as raw bytes and will be encoded in JSON format like `["0x000000000000000000000000000000000000000000000000000009184e72a000"]` and returned to the frontend, with the information that the MIME type is ``application/json``.
 
+### Example 7
+
+```
+web3://0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/balanceOf/vitalik.eth?returns=()&_blockNumber=12000000
+```
+where the contract "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" is in auto mode.
+The protocol will find the address of vitalik.eth from ENS on chainid 1 (Mainnet) and then call the method "balanceOf(address)" of the address at block number 12,000,000. The returned data from the call of the contract will be treated as raw bytes and will be encoded in JSON format like ["0x000000000000000000000000000000000000000000000000000004a817c8000"] and returned to the frontend, with the information that the MIME type is application/json. This allows querying the historical balance of the address at a specific block height (12000000).
+
 ### Appendix A: Complete ABNF for Web3 URLs
 
 ```
@@ -293,8 +304,11 @@ contractName    = address
                 / domainName
 chainid         = %x31-39 *DIGIT
 
-pathQuery       = mPathQuery ; path+query for manual mode
-                / aPathQuery ; path+query for auto mode
+pathQuery       = mPathQuery [ evmQuery ] ; path+query for manual mode
+                / aPathQuery [ evmQuery ] ; path+query for auto mode
+
+evmQuery        = *( "&" blockNumberQuery )
+blockNumberQuery = "_blockNumber=" 1*DIGIT
 
 web3UrlRef      = web3URL 
                 / relativeWeb3URL


### PR DESCRIPTION
This PR extends the Web3 URL specification to include support for the _blockNumber parameter, allowing users to specify a particular block number when making queries and enabling access to historical blockchain data.

## Summary of changes:

- Modified `pathQuery` to optionally include `evmQuery`
- Added new `evmQuery` rule to handle EVM-specific parameters
- Introduced `blockNumberQuery` rule for _blockNumber parameter