### PR TITLE
Update ERC-7682: Add assets

### DIFF
--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -41,7 +41,10 @@ In this specification, a chain's native asset (e.g. Ether on Ethereum) MUST be r
 #### `wallet_getCapabilities` Response Specification
 
 ```typescript
-type AuxiliaryFundsCapability = (`0x${string}` | 'native')[];
+type AuxiliaryFundsCapability = {
+  supported: boolean;
+  assets?: `0x${string}`[]
+}
 ```
 
 ##### `wallet_getCapabilities` Example Response

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -1,7 +1,7 @@
 ---
 eip: 7682
 title: Auxiliary Funds Capability
-description: An EIP-5792 capability allowing wallets to indicate that they have access to additional funds.
+description: An [EIP-5792](./eip-5792.md) capability allowing wallets to indicate that they have access to additional funds.
 author: Lukas Rosario (@lukasrosario), Wilson Cusack (@wilsoncusack)
 discussions-to: https://ethereum-magicians.org/t/erc-7682-auxiliary-funds-capability/19599
 status: Draft

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -1,7 +1,7 @@
 ---
 eip: 7682
 title: Auxiliary Funds Capability
-description: An [EIP-5792](./eip-5792.md) capability allowing wallets to indicate that they have access to additional funds.
+description: A capability allowing wallets to indicate that they have access to additional funds.
 author: Lukas Rosario (@lukasrosario), Wilson Cusack (@wilsoncusack)
 discussions-to: https://ethereum-magicians.org/t/erc-7682-auxiliary-funds-capability/19599
 status: Draft

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -43,7 +43,7 @@ In this specification, a chain's native asset (e.g. Ether on Ethereum) MUST be r
 ```typescript
 type AuxiliaryFundsCapability = {
   supported: boolean;
-  assets?: `0x${string}`[]
+  assets?: `0x${string}`[];
 }
 ```
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -1,7 +1,7 @@
 ---
 eip: 7682
 title: Auxiliary Funds Capability
-description: A way for wallets to indicate to apps that they have access to additional funds
+description: An ERC-5792 capability allowing wallets to indicate that they have access to additional funds.
 author: Lukas Rosario (@lukasrosario), Wilson Cusack (@wilsoncusack)
 discussions-to: https://ethereum-magicians.org/t/erc-7682-auxiliary-funds-capability/19599
 status: Draft
@@ -15,6 +15,11 @@ requires: 5792
 
 An [EIP-5792](./eip-5792.md) compliant capability that allows wallets to indicate to apps that they have access to funds beyond those that can be accounted for by looking up balances onchain given the wallet's address.
 
+A wallet's ability to access auxiliary funds is communicated to apps as part of its response to an [EIP-5792](./eip-5792.md) `wallet_getCapabilities` request. The following standard does not specify the source of these auxiliary funds, but some examples are:
+
+- Funds from offchain sources that can be onramped and used just-in-time
+- Wallets that manage many accounts, where assets across those accounts can be transfered to the required account before submitting a transaction requested by an app
+
 ## Motivation
 
 Many applications check users' balances before letting them complete some action. For example, if a user wants to swap some amount of tokens on a dex, the dex will commonly block the user from doing so if it sees that the user does not have that amount of tokens at their address. However, more advanced wallets have features that let users access funds from other sources. Wallets need a way to tell apps that they have access to additional funds so that users using these more advanced wallets are not blocked by balance checks.
@@ -25,14 +30,16 @@ One new [EIP-5792](./eip-5792.md) wallet capability is defined.
 
 ### Wallet Implementation
 
-To conform to this specification, wallets that wish to indicate that they have access to auxiliary funds MUST respond to `wallet_getCapabilities` calls with an `auxiliaryFunds` object with a `supported` field set to `true` for each chain they have access to auxiliary funds on. This specification does not put any constraints on the source of the auxiliary funds.
+To conform to this specification, wallets that wish to indicate that they have access to auxiliary funds MUST, for each chain they have access to auxiliary funds on, respond to `wallet_getCapabilities` calls with an `auxiliaryFunds` key which maps to an array of addresses (or `"native"`) representing the assets the wallet might have additional access to.
+
+This specification does not put any constraints on the source of the auxiliary funds.
+
+In this specification, a chain's native asset (e.g. Ether on Ethereum) is represented by `"native"`.
 
 #### `wallet_getCapabilities` Response Specification
 
 ```typescript
-type AuxiliaryFundsCapability = {
-  supported: boolean;
-}
+type AuxiliaryFundsCapability = (`0x${string}` | 'native')[];
 ```
 
 ##### `wallet_getCapabilities` Example Response
@@ -40,14 +47,16 @@ type AuxiliaryFundsCapability = {
 ```json
 {
   "0x2105": {
-    "auxiliaryFunds": {
-      "supported": true
-    },
+    "auxiliaryFunds": [
+      "native",
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    ]
   },
   "0x14A34": {
-    "auxiliaryFunds": {
-      "supported": true
-    }
+    "auxiliaryFunds": [
+      "native",
+      "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+    ]
   }
 }
 ```
@@ -65,10 +74,6 @@ When an app sees that a connected wallet has access to auxiliary funds via the `
 An alternative we considered is defining a way for apps to fetch available auxiliary balances. This could be done, for example, by providing a URL as part of the `auxiliaryFunds` capability that apps could use to fetch auxiliary balance information. However, we ultimately decided that a boolean was enough to indicate to apps that they should not block user actions on the basis of balance checks, and it is minimally burdensome for apps to implement.
 
 The shape of this capability allows for a more advanced extension if apps feel more functionality is needed.
-
-#### Auxiliary Funds per Asset
-
-We could also specify auxiliary funds support per asset. We decided against this because this list could get quite large if a wallet has auxiliary funds supports for many assets, and a single boolean should be enough for apps to not block users from taking actions.
 
 ## Security Considerations
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -30,11 +30,13 @@ One new [EIP-5792](./eip-5792.md) wallet capability is defined.
 
 ### Wallet Implementation
 
-To conform to this specification, wallets that wish to indicate that they have access to auxiliary funds MUST, for each chain they have access to auxiliary funds on, respond to `wallet_getCapabilities` calls with an `auxiliaryFunds` key which maps to an array of addresses (or `"native"`) representing the assets the wallet might have additional access to.
+To conform to this specification, wallets that wish to indicate that they have access to auxiliary funds MUST, for each chain they have access to auxiliary funds on, respond to `wallet_getCapabilities` calls with an `auxiliaryFunds` object with a `supported` field set to `true`.
+
+Wallets may also optionally specify which assets they have additional access to with an `assets` field, which maps to an array of addresses representing the assets the wallet might have additional access to. If a wallet does not respond with this optional array of assets, the application SHOULD assume the wallet has additional access to any asset.
 
 This specification does not put any constraints on the source of the auxiliary funds.
 
-In this specification, a chain's native asset (e.g. Ether on Ethereum) is represented by `"native"`.
+In this specification, a chain's native asset (e.g. Ether on Ethereum) MUST be represented by "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" as specified by [EIP-7528](./eip-7528).
 
 #### `wallet_getCapabilities` Response Specification
 
@@ -47,16 +49,22 @@ type AuxiliaryFundsCapability = (`0x${string}` | 'native')[];
 ```json
 {
   "0x2105": {
-    "auxiliaryFunds": [
-      "native",
-      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-    ]
+    "auxiliaryFunds": {
+      "supported": true,
+      "assets": [
+        "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      ]
+    }
   },
   "0x14A34": {
-    "auxiliaryFunds": [
-      "native",
-      "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
-    ]
+    "auxiliaryFunds": {
+      "supported": true,
+      "assets": [
+        "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+      ]
+    }
   }
 }
 ```

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -1,7 +1,7 @@
 ---
 eip: 7682
 title: Auxiliary Funds Capability
-description: An ERC-5792 capability allowing wallets to indicate that they have access to additional funds.
+description: An EIP-5792 capability allowing wallets to indicate that they have access to additional funds.
 author: Lukas Rosario (@lukasrosario), Wilson Cusack (@wilsoncusack)
 discussions-to: https://ethereum-magicians.org/t/erc-7682-auxiliary-funds-capability/19599
 status: Draft


### PR DESCRIPTION
- change `auxiliaryFunds` from a single boolean to an array of supported assets