### PR TITLE
Update ERC-3770: Update erc-3770.md - fixed the examples image link

### DIFF
--- a/ERCS/erc-3770.md
+++ b/ERCS/erc-3770.md
@@ -46,7 +46,7 @@ Chain-specific address = "`shortName`" "`:`" "`address`"
 
 ### Examples
 
-![Chain-specific addresses](../assets/eip-3770/examples.png "Examples of chain-specific addresses")
+![Chain-specific addresses](../assets/erc-3770/examples.png "Examples of chain-specific addresses")
 
 ## Rationale
 


### PR DESCRIPTION
The examples image link was pointing to "../assets/eip-3770/examples.png" instead of "../assets/erc-3770/examples.png".

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
