### PR TITLE
Add section about evaluating a settlementContract's security 

### DIFF
--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -12,7 +12,7 @@ created: 2024-04-11
 
 ## Abstract
 
-The following standard allows for the implementation of a standard API for cross-chain trade execution systems. This standard provides a generic `CrossChainOrder` struct, as well as a standard `ISettlementContract` smart contract interface.
+The following standard allows for the implementation of a standard API for cross-chain value-transfer systems. This standard provides generic order structs, as well as a standard `ISettlementContract` smart contract interface.
 
 ## Motivation
 
@@ -24,20 +24,20 @@ By implementing a standard, cross-chain intents systems can interoperate and sha
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-### CrossChainOrder struct
+### Order structs
 
-A compliant cross-chain order type MUST be ABI decodable into the `CrossChainOrder` type.
+A compliant cross-chain order type MUST be ABI decodable into either `GaslessCrossChainOrder` or `OnchainCrossChainOrder` type.
 
 ```solidity
-/// @title CrossChainOrder type
-/// @notice Standard order struct to be signed by swappers, disseminated to fillers, and submitted to settlement contracts
-struct CrossChainOrder {
+/// @title GaslessCrossChainOrder CrossChainOrder type
+/// @notice Standard order struct to be signed by users, disseminated to fillers, and submitted to settlement contracts
+struct GaslessCrossChainOrder {
 	/// @dev The contract address that the order is meant to be settled by.
 	/// Fillers send this order to this contract address on the origin chain
 	address settlementContract;
 	/// @dev The address of the user who is initiating the swap,
 	/// whose input tokens will be taken and escrowed
-	address swapper;
+	address user;
 	/// @dev Nonce to be used as replay protection for the order
 	uint256 nonce;
 	/// @dev The chainId of the origin chain
@@ -51,9 +51,26 @@ struct CrossChainOrder {
 	/// or any other order-type specific information
 	bytes orderData;
 }
+
+/// @title OnchainCrossChainOrder CrossChainOrder type
+/// @notice Standard order struct for user-initiated orders, where the user is the msg.sender.
+struct OnchainCrossChainOrder {
+	/// @dev The timestamp by which the order must be initiated
+	uint32 initiateDeadline;
+	/// @dev The chainId of the origin chain
+	uint32 originChainId;
+	/// @dev The timestamp by which the order must be filled on the destination chain
+	uint32 fillDeadline;
+	/// @dev Arbitrary implementation-specific data
+	/// Can be used to define tokens, amounts, destination chains, fees, settlement parameters,
+	/// or any other order-type specific information
+	bytes orderData;
+}
 ```
 
-Cross-chain execution systems implementing this standard SHOULD create a custom sub-type that can be parsed from the arbitrary `orderData` field. This may include information such as the tokens involved in the swap, the destination chain IDs, fulfillment constraints or settlement oracles.
+Cross-chain execution systems implementing this standard SHOULD use a sub-type that can be parsed from the arbitrary `orderData` field. This may include information such as the tokens involved in the transfer, the destination chain IDs, fulfillment constraints or settlement oracles.
+
+All sub-types SHOULD be registered at github.com/erc-7683/order-subtypes to encourage sharing of sub-types based on their functionality.
 
 ### ResolvedCrossChainOrder struct
 
@@ -65,12 +82,8 @@ A compliant cross-chain order type MUST be convertible into the `ResolvedCrossCh
 /// @dev Defines all requirements for filling an order by unbundling the implementation-specific orderData.
 /// @dev Intended to improve integration generalization by allowing fillers to compute the exact input and output information of any order
 struct ResolvedCrossChainOrder {
-	/// @dev The contract address that the order is meant to be settled by.
-	address settlementContract;
-	/// @dev The address of the user who is initiating the swap
-	address swapper;
-	/// @dev Nonce to be used as replay protection for the order
-	uint256 nonce;
+	/// @dev The address of the user who is initiating the transfer
+	address user;
 	/// @dev The chainId of the origin chain
 	uint32 originChainId;
 	/// @dev The timestamp by which the order must be initiated
@@ -78,15 +91,15 @@ struct ResolvedCrossChainOrder {
 	/// @dev The timestamp by which the order must be filled on the destination chain(s)
 	uint32 fillDeadline;
 
-	/// @dev The inputs to be taken from the swapper as part of order initiation
-	Input[] swapperInputs;
-	/// @dev The outputs to be given to the swapper as part of order fulfillment
-	Output[] swapperOutputs;
+	/// @dev The inputs to be taken from the user as part of order initiation
+	Input[] userInputs;
+	/// @dev The outputs to be given to the user as part of order fulfillment
+	Output[] maxOutputs;
 	/// @dev The outputs to be given to the filler as part of order settlement
-	Output[] fillerOutputs;
+	Output[] minFillerOutputs;
 }
 
-/// @notice Tokens sent by the swapper as inputs to the order
+/// @notice Tokens sent by the user as inputs to the order
 struct Input {
 	/// @dev The address of the ERC20 token on the origin chain
 	address token;
@@ -98,58 +111,125 @@ struct Input {
 struct Output {
 	/// @dev The address of the ERC20 token on the destination chain
 	/// @dev address(0) used as a sentinel for the native token
-	address token;
+	bytes32 token;
 	/// @dev The amount of the token to be sent
 	uint256 amount;
 	/// @dev The address to receive the output tokens
-	address recipient;
+	bytes32 recipient;
 	/// @dev The destination chain for this output
 	uint32 chainId;
 }
-
 ```
 
-### ISettlementContract interface
+### Initiated event
 
-A compliant settlement contract implementation MUST implement the `ISettlementContract` interface:
+A compliant `Initiated` event MUST adhere to the following abi:
 
 ```solidity
-/// @title ISettlementContract
-/// @notice Standard interface for settlement contracts
-interface ISettlementContract {
-	/// @notice Initiates the settlement of a cross-chain order
-	/// @dev To be called by the filler
-	/// @param order The CrossChainOrder definition
-	/// @param signature The swapper's signature over the order
-	/// @param fillerData Any filler-defined data required by the settler
-	function initiate(CrossChainOrder order, bytes signature, bytes fillerData) external;
+/// @title FillInstructions type
+/// @notice Instructions to parameterize each leg of the fill
+/// @dev Provides all the origin-generated information required to produce a valid fill leg
+struct FillInstructions {
+	/// @dev The contract address that the order is meant to be settled by
+	uint32 destinationChainId;
+	/// @dev The contract address that the order is meant to be filled on
+	bytes32 destinationSettler;
+	/// @dev The data generated on the origin chain necessary to inform the fill
+	bytes originData;
+}
 
-	/// @notice Resolves a specific CrossChainOrder into a generic ResolvedCrossChainOrder
+/// @notice Signals that an order has been initiated
+/// @param orderId a unique order identifier within this settlement system
+/// @param fillInstructions Fill instructions to parameterize each leg of the fill
+event Initiated(bytes32 indexed orderId, FillInstructions[] fillInstructions);
+```
+
+### Settlement interfaces
+
+A compliant origin settlement contract implementation MUST implement the `IOriginSettler` interface:
+
+```solidity
+/// @title IOriginSettler
+/// @notice Standard interface for settlement contracts on the origin chain
+interface IOriginSettler {
+	/// @notice Initiates the settlement of a gasless cross-chain order on behalf of a user.
+	/// @dev To be called by the filler.
+	/// @dev This method must emit the Initiated event
+	/// @param order The GaslessCrossChainOrder definition
+	/// @param signature The user's signature over the order
+	/// @param fillerData Any filler-defined data required by the settler
+	/// @returns fillInstructions instructions to parameterize all fill legs required by this order
+	function initiateFor(GaslessCrossChainOrder order, bytes signature, bytes originFillerData) external returns (FillInstructions[]);
+
+	/// @notice Initiates the settlement of a cross-chain order
+	/// @dev To be called by the user
+	/// @dev This method must emit the Initiated event
+	/// @param order The OnchainCrossChainOrder definition
+	/// @param signature The user's signature over the order
+	/// @param fillerData Any filler-defined data required by the settler
+	/// @returns fillInstructions instructions to parameterize all fill legs required by this order
+	function initiate(OnchainCrossChainOrder order) external returns (FillInstructions[] fillInstructions);
+
+	/// @notice Resolves a specific GaslessCrossChainOrder into a generic ResolvedCrossChainOrder
 	/// @dev Intended to improve standardized integration of various order types and settlement contracts
-	/// @param order The CrossChainOrder definition
+	/// @param order The GaslessCrossChainOrder definition
+	/// @param originFillerData Any filler-defined data required by the settler
+	/// @returns ResolvedCrossChainOrder hydrated order data including the inputs and outputs of the order
+	function resolveFor(GaslessCrossChainOrder order, bytes originFillerData) external view returns (ResolvedCrossChainOrder);
+
+	/// @notice Resolves a specific OnchainCrossChainOrder into a generic ResolvedCrossChainOrder
+	/// @dev Intended to improve standardized integration of various order types and settlement contracts
+	/// @param order The OnchainCrossChainOrder definition
 	/// @param fillerData Any filler-defined data required by the settler
 	/// @returns ResolvedCrossChainOrder hydrated order data including the inputs and outputs of the order
-	function resolve(CrossChainOrder order, bytes fillerData) external view returns (ResolvedCrossChainOrder);
+	function resolve(OnchainCrossChainOrder order) external view returns (ResolvedCrossChainOrder);
 }
 ```
+
+A compliant destination settlement contract implementation MUST implement the `IDestinationSettler` interface:
+
+```solidity
+/// @title IDestinationSettler
+/// @notice Standard interface for settlement contracts on the destination chain
+interface IDestinationSettler {
+	/// @notice Fills a single leg of a particular order on the destination chain
+	/// @param orderId Unique order identifier for this order
+	/// @param originData Data emitted on the origin to parameterize the fill
+	/// @param fillerData Data provided by the filler to inform the fill or express their preferences
+	function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) external;
+}
+```
+
+Cross-chain execution systems implementing this standard SHOULD use a sub-type that can be parsed from the arbitrary `fillerData` field. This may include information such as the desired timing or form of payment for the filler
+
+All sub-types SHOULD be registered at github.com/erc-7683/filler-data-subtypes to encourage sharing of sub-types based on their functionality.
+
+### fillerData
 
 ## Rationale
 
 ### Generic OrderData
 
-A key consideration is to ensure that a broad range of cross-chain intent designs can work within the same standard. To enable this, the specification is designed around a standard cross-chain intents *flow*, while allowing for varying implementation details within that flow.
+A key consideration is to ensure that a broad range of cross-chain intent designs can work within the same standard. To enable this, the specification is designed around a cross-chain intents *flow*, with two variations: gasless and onchain.
 
-Standard cross-chain intents flow:
+Gasless cross-chain intents flow:
 
-1. The swapper signs an off-chain message defining the parameters of their order
+1. The user signs an off-chain message defining the parameters of their order
 2. The order is disseminated to fillers
-3. The filler initiates the trade on the origin chain
+3. The filler initiates the order on the origin chain
 4. The filler fills the order on the destination chain
 5. A cross-chain settlement process takes place to settle the order
 
+Onchain cross-chain intents flow:
+
+1. The user signs a transaction calling initiate with their order
+2. The filler retrieves the emitted event
+3. The filler fills the order on the destination chain
+4. A cross-chain settlement process takes place to settle the order
+
 Within this flow, implementers of the standard have design flexibility to customize behavior such as:
 
-- Price resolution, e.g. dutch auctions or oracle-based pricing
+- Price resolution, e.g. dutch auctions (on origin or destination) or oracle-based pricing
 - Fulfillment constraints
 - Settlement procedures.
 
@@ -157,17 +237,48 @@ The `orderData` field allows implementations to take arbitrary specifications fo
 
 This functionality also motivated the `resolve` view function and `ResolvedCrossChainOrder` type. Resolution enables integrating fillers to validate and assess orders without specific knowledge of the `orderData` field at hand.
 
+### Emission of FillInstructions
+
+An important component of the standard is creating a flexible and robust mechanism for fillers to ensure their fills are valid. For a fill to be valid,
+it typically must satisfy the following constraints:
+1. It must be filled on the correct destination chain(s)
+2. It must be filled on the correct destination contract
+3. It must include some (not necessarily all) information from the order that the user provided on the origin chain
+4. It may require some execution information from the initiate call on the origin chain (ex. dutch auctions based on initiate timing)
+
+1 & 2 could potentially be generated by a re-simulation of `resolve`. However, a filler must deeply understand the settlement system to determine
+3 & 4. `FillInstructions` is intended to remove this burden from the filler, allowing them to rely on the origin settler contract to provide them
+the information needed to both simulate and perform fills.
+
+One may notice that the `originData` field within `FillInstructions` is completely opaque. This opaqueness allows the settler implementations to
+freely customize the data they transmit. Because fillers do not need to interpret this information, the opaqueness does not result in any
+additional implementation costs on fillers.
+
+This functionality also makes it feasible for a user, filler, or order distribution system to perform an end-to-end simulation of the order initiation
+and fill to evaluate all resulting state transitions without understanding the nuances of a particular execution system.
+
+### Cross-compatibility
+
+Since this standard is intended to reduce friction for users moving value across chains, non-EVM ecosystems should not be excluded. However, attempting
+to pull each non-EVM ecosystem in would dramatically increase the size and complexity of this standard, while ommitting any that come in the future.
+
+Instead, this standard is intended to be cross-compatible with other ecosystems. It standardizes interfaces and data types on EVM chains, but allows
+for the creation of sibling standards that define compatible interfaces, data types, and flows within other ecosystems. Intents created within these
+sibling standards should be able to be filled on an EVM chain and vice versa.
+
+To ensure this cross-compatibility, all foreign addresses use `bytes32` rather than `address` to allow for larger address identifiers.
+
 ### Usage of Permit2
 
-Permit2 is not specifically required by this standard, but does provide an efficient and straightforward approach to building standard-adherent protocols. Specifically, the `witness` functions of permit2 allow swappers to both approve the token transfer *and* the order itself with a single signature. This also nicely couples the transfer of tokens with a successful initiation of the order.
+Permit2 is not specifically required by this standard, but does provide an efficient and straightforward approach to building standard-adherent protocols. Specifically, the `witness` functions of permit2 allow users to both approve the token transfer *and* the order itself with a single signature. This also nicely couples the transfer of tokens with a successful initiation of the order.
 
-In contrast, a standard approval model would require two separate signatures - a token approval (either [ERC-2612](./eip-2612.md) or on-chain) and a signature to approve the terms of the swap. It also decouples the token approval from the swap, meaning approved tokens could potentially be taken at any time due to a buggy or untrusted settler contract.
+In contrast, a standard approval model would require two separate signatures - a token approval (either [ERC-2612](./eip-2612.md) or on-chain) and a signature to approve the terms of the order. It also decouples the token approval from the order, meaning approved tokens could potentially be taken at any time due to a buggy or untrusted settler contract.
 
 When building a standard-compliant settler system around Permit2, the following considerations should be made
 
 - `nonce` in the order struct should be a permit2 nonce
 - `initiateDeadline` in the order struct should be the permit2 deadline
-- A full order struct including the parsed `orderData` should be used as the witness type during the permit2 call. This ensures maximum transparency to the swapper as they sign their order permit.
+- A full order struct including the parsed `orderData` should be used as the witness type during the permit2 call. This ensures maximum transparency to the user as they sign their order permit.
 
 ## Security Considerations
 

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -12,7 +12,7 @@ created: 2024-04-11
 
 ## Abstract
 
-The following standard allows for the implementation of a standard API for cross-chain value-transfer systems. This standard provides generic order structs, as well as a standard `ISettlementContract` smart contract interface.
+The following standard allows for the implementation of a standard API for cross-chain value-transfer systems. This standard provides generic order structs, as well as a standard set of settlement smart contract interfaces.
 
 ## Motivation
 

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -204,6 +204,12 @@ Cross-chain execution systems implementing this standard SHOULD use a sub-type t
 
 All sub-types SHOULD be registered at github.com/erc-7683/filler-data-subtypes to encourage sharing of sub-types based on their functionality.
 
+#### Evaluating settlement contract security
+
+This ERC is agnostic of how the `settlementContract` validates a 7683 order fulfillment and refunds the filler. In fact, this ERC is designed to delegate the responsibility of evaluating the settlement contract's security to the filler and the application that creates the user's 7683 order.
+
+This design decision is motivated by the existence of many viable cross-chain messaging systems today offering settlement contracts a variety of tradeoffs. We hope that ERC7683 can eventually support an ERC dedicated to standardizing a safe, cross-chain messaging layer.
+
 ### fillerData
 
 ## Rationale


### PR DESCRIPTION
We've received enough feedback that its worth mentioning explicitly the reason for this ERC being proof-agnostic.

Perhaps this section is where we can add @wilsoncusack 's work on [RIP7755/Cross-Chain-L2-Call-Standard](https://github.com/wilsoncusack/RIPs/blob/cross-l2-call-standard/RIPS/rip-7755.md)