### PR TITLE
Update ERC-7677: Move to Last Call

### DIFF
--- a/ERCS/erc-7677.md
+++ b/ERCS/erc-7677.md
@@ -4,7 +4,8 @@ title: Paymaster Web Service Capability
 description: A way for apps to communicate with smart wallets about paymaster web services
 author: Lukas Rosario (@lukasrosario), Dror Tirosh (@drortirosh), Wilson Cusack (@wilsoncusack), Kristof Gazso (@kristofgazso), Hazim Jumali (@hazim-j)
 discussions-to: https://ethereum-magicians.org/t/erc-7677-paymaster-web-service-capability/19530
-status: Review
+status: Last Call
+last-call-deadline: 2024-09-05
 type: Standards Track
 category: ERC
 created: 2024-04-03


### PR DESCRIPTION
moves ERC-7677 to last call with deadline 9/5/2024
