### PR TITLE
Update ERC-7432: Move to Last Call

### DIFF
--- a/ERCS/erc-7432.md
+++ b/ERCS/erc-7432.md
@@ -4,7 +4,8 @@ title: Non-Fungible Token Roles
 description: Role Management for NFTs. Enables accounts to share the utility of NFTs via expirable role assignments.
 author: Ernani São Thiago (@ernanirst), Daniel Lima (@karacurt)
 discussions-to: https://ethereum-magicians.org/t/eip-7432-non-fungible-token-roles/15298
-status: Review
+status: Last Call
+last-call-deadline: 2024-09-17
 type: Standards Track
 category: ERC
 created: 2023-07-14

--- a/ERCS/erc-7432.md
+++ b/ERCS/erc-7432.md
@@ -338,7 +338,7 @@ Automatic expiration is implemented via the `grantRole` and `roleExpirationDate`
 for setting the expiration date, and `roleExpirationDate` allow developers to check whether the role is expired. Since
 `uint256` is not natively supported by most programming languages, dates are represented as `uint64` on this standard.
 The maximum UNIX timestamp represented by a `uint64` is about the year `584,942,417,355`, which should be enough to be
-considered "permanent". For this reason, it's RECOMMENDED using `type(uint64).max` to support use cases that require a
+considered "permanent". For this reason, it's recommended using `type(uint64).max` to support use cases that require a
 role never to expire.
 
 ### Revocable Roles
@@ -348,8 +348,8 @@ others, the recipient may require assurance that the role cannot be revoked. The
 to the `grantRole` function to specify whether a role can be revoked prematurely, enabling the standard to
 support both use cases.
 
-Regardless of the value of `revocable`, it's RECOMMENDED always to enable the `recipient` to revoke roles, allowing
-them to eliminate undesirable assignments.
+Regardless of the value of `revocable`, it's recommended always to enable the `recipient` to revoke roles, allowing them
+to eliminate undesirable assignments.
 
 ### Custom Data
 


### PR DESCRIPTION
After a few months iterating and gathering feedback, we are proposing to move ERC-7432 to last call.

We are also including a proposed deadline of September 17th, but happy to adjust it as per the EIP Editors feedback.