### PR TITLE
Update ERC-7677: postopgas callout

### DIFF
--- a/ERCS/erc-7677.md
+++ b/ERCS/erc-7677.md
@@ -32,7 +32,9 @@ We define two JSON-RPC methods to be implemented by paymaster web services.
 
 Returns stub values to be used in paymaster-related fields of an unsigned user operation for gas estimation. Accepts an unsigned user operation, entrypoint address, chain id, and a context object. Paymaster service providers can define fields that app developers should use in the context object. 
 
-This method MAY return paymaster-specific gas values if applicable to the provided EntryPoint version. For example, if provided with EntryPoint v0.7, this method MAY return `paymasterVerificationGasLimit` and `paymasterPostOpGasLimit` values. The wallet SHOULD use these provided gas values when submitting the `UserOperation` to a bundler for gas estimation.
+This method MAY return paymaster-specific gas values if applicable to the provided EntryPoint version. For example, if provided with EntryPoint v0.7, this method MAY return `paymasterVerificationGasLimit`. Furthermore, for EntryPoint v0.7, this method MUST return a value for `paymasterPostOpGasLimit`. This is because it is the paymaster that pays the postOpGasLimit, so it cannot trust the account to estimate this amount.
+
+The wallet SHOULD use these provided gas values when submitting the `UserOperation` to a bundler for gas estimation.
 
 This method MAY also return a `sponsor` object with a `name` field and an optional `icon` field. The `name` field is the name of the party sponsoring the transaction, and the `icon` field is a URI pointing to an image. Wallet developers MAY choose to display sponsor information to users. The `icon` string MUST be a data URI as defined in [RFC-2397]. The image SHOULD be a square with 96x96px minimum resolution. The image format is RECOMMENDED to be either lossless or vector based such as PNG, WebP or SVG to make the image easy to render on the wallet. Since SVG images can execute Javascript, wallets MUST render SVG images using the `<img>` tag to ensure no untrusted Javascript execution can occur.
 

--- a/ERCS/erc-7677.md
+++ b/ERCS/erc-7677.md
@@ -32,7 +32,7 @@ We define two JSON-RPC methods to be implemented by paymaster web services.
 
 Returns stub values to be used in paymaster-related fields of an unsigned user operation for gas estimation. Accepts an unsigned user operation, entrypoint address, chain id, and a context object. Paymaster service providers can define fields that app developers should use in the context object. 
 
-This method MAY return paymaster-specific gas values if applicable to the provided EntryPoint version. For example, if provided with EntryPoint v0.7, this method MAY return `paymasterVerificationGasLimit`. Furthermore, for EntryPoint v0.7, this method MUST return a value for `paymasterPostOpGasLimit`. This is because it is the paymaster that pays the postOpGasLimit, so it cannot trust the account to estimate this amount.
+This method MAY return paymaster-specific gas values if applicable to the provided EntryPoint version. For example, if provided with EntryPoint v0.7, this method MAY return `paymasterVerificationGasLimit`. Furthermore, for EntryPoint v0.7, this method MUST return a value for `paymasterPostOpGasLimit`. This is because it is the paymaster that pays the postOpGasLimit, so it cannot trust the wallet to estimate this amount.
 
 The wallet SHOULD use these provided gas values when submitting the `UserOperation` to a bundler for gas estimation.
 


### PR DESCRIPTION
- specified that paymaster service must return postOpGasLimit for EntryPoint v0.7, as the paymaster pays this and should not trust the account to estimate it.