### PR TITLE
Update ERC-7656: Fix wording, using service instead of account, when needed

### DIFF
--- a/ERCS/erc-7656.md
+++ b/ERCS/erc-7656.md
@@ -61,15 +61,15 @@ interface IERC7656Registry {
   error CreationFailed();
 
   /**
-   * @notice Creates a token linked account for a non-fungible token.
-   * If account has already been created, returns the account address without calling create2.
+   * @notice Creates a token linked service for a non-fungible token.
+   * If the service has already been created, returns the service address without calling create2.
    * @param implementation The address of the implementation contract
    * @param salt The salt to use for the create2 operation
-   * @param chainId The chain id of the chain where the account is being created
+   * @param chainId The chain id of the chain where the service is being created
    * @param tokenContract The address of the token contract
    * @param tokenId The id of the token
    * Emits Created event.
-   * @return account The address of the token linked account
+   * @return service The address of the token linked service
    */
   function create(
     address implementation,
@@ -77,16 +77,16 @@ interface IERC7656Registry {
     uint256 chainId,
     address tokenContract,
     uint256 tokenId
-  ) external returns (address account);
+  ) external returns (address service);
 
   /**
-   * @notice Returns the computed token linked account address for a non-fungible token.
+   * @notice Returns the computed token linked service address for a non-fungible token.
    * @param implementation The address of the implementation contract
    * @param salt The salt to use for the create2 operation
-   * @param chainId The chain id of the chain where the account is being created
+   * @param chainId The chain id of the chain where the service is being created
    * @param tokenContract The address of the token contract
    * @param tokenId The id of the token
-   * @return account The address of the token linked account
+   * @return service The address of the token linked service
    */
   function compute(
     address implementation,
@@ -94,15 +94,15 @@ interface IERC7656Registry {
     uint256 chainId,
     address tokenContract,
     uint256 tokenId
-  ) external view returns (address account);
+  ) external view returns (address service);
 }
 ```
 
 Any `ERC7656Registry` implementation MUST support the `IERC7656Registry`'s interface ID, i.e., `0xc6bdc908`.
 
-Similarly to [ERC-6551](./eip-6551.md), The registry MUST deploy each token linked account as an [ERC-1167](./eip-1167.md) minimal proxy with immutable constant data appended to the bytecode.
+Similarly to [ERC-6551](./eip-6551.md), The registry MUST deploy each token linked service as an [ERC-1167](./eip-1167.md) minimal proxy with immutable constant data appended to the bytecode.
 
-The deployed bytecode of each token bound account MUST have the following structure:
+The deployed bytecode of each token bound service MUST have the following structure:
 ```
 ERC-1167 Header               (10 bytes)
 <implementation (address)>    (20 bytes)
@@ -116,6 +116,7 @@ ERC-1167 Footer               (15 bytes)
 Any contract created using a `ERC7656Registry` SHOULD implement the `IERC7656Service` interface:
 
 ```solidity
+// InterfaceId 0xfc0c546a
 interface IERC7656Service {
   /**
   * @notice Returns the token linked to the contract
@@ -189,12 +190,12 @@ contract ERC7656Registry is IERC7656Registry {
       mstore(0x01, shl(96, address())) // registry address
       mstore(0x15, salt) // salt
 
-    // Compute account address
+    // Compute service address
       let computed := keccak256(0x00, 0x55)
 
-    // If the account has not yet been deployed
+    // If the service has not yet been deployed
       if iszero(extcodesize(computed)) {
-      // Deploy account contract
+      // Deploy service contract
         let deployed := create2(0, 0x55, 0xb7, salt)
 
       // Revert if the deployment fails
@@ -203,7 +204,7 @@ contract ERC7656Registry is IERC7656Registry {
           revert(0x1c, 0x04)
         }
 
-      // Store account address in memory before salt and chainId
+      // Store service address in memory before salt and chainId
         mstore(0x6c, deployed)
 
       // Emit the Created event
@@ -216,11 +217,11 @@ contract ERC7656Registry is IERC7656Registry {
           tokenId
         )
 
-      // Return the account address
+      // Return the service address
         return(0x6c, 0x20)
       }
 
-    // Otherwise, return the computed account address
+    // Otherwise, return the computed service address
       mstore(0x00, shr(96, shl(96, computed)))
       return(0x00, 0x20)
     }
@@ -247,10 +248,10 @@ contract ERC7656Registry is IERC7656Registry {
       mstore(0x01, shl(96, address())) // registry address
       mstore(0x15, salt) // salt
 
-    // Store computed account address in memory
+    // Store computed service address in memory
       mstore(0x00, shr(96, shl(96, keccak256(0x00, 0x55))))
 
-    // Return computed account address
+    // Return computed service address
       return(0x00, 0x20)
     }
   }


### PR DESCRIPTION
In some of the interfaces it was used the word `account` instead of the more generic `service`. The wording has been fixed. Also, the interfaceId of `IERC7656Service` has been specified.