### PR TITLE
Update ERC-3668: fix typo in erc3668 lookup process

### DIFF
--- a/ERCS/erc-3668.md
+++ b/ERCS/erc-3668.md
@@ -1,6 +1,6 @@
 ---
 eip: 3668
-title: "CCIP Read: Secure offchain data retrieval"
+title: CCIP Read—Secure offchain data retrieval
 description: CCIP Read provides a mechanism to allow a contract to fetch external data.
 author: Nick Johnson (@arachnid)
 discussions-to: https://ethereum-magicians.org/t/durin-secure-offchain-data-retrieval/6728

--- a/ERCS/erc-3668.md
+++ b/ERCS/erc-3668.md
@@ -295,8 +295,8 @@ A client that supports CCIP read MUST make contract calls using the following pr
  5. If the `sender` field does not match the address of the contract that was called, return an error to the caller and stop.
  6. Construct a request URL by replacing `sender` with the lowercase 0x-prefixed hexadecimal formatted `sender` parameter, and replacing `data` with the 0x-prefixed hexadecimal formatted `callData` parameter. The client may choose which URLs to try in which order, but SHOULD prioritise URLs earlier in the list over those later in the list.
  7. Make an HTTP GET request to the request URL.
- 8. If the response code from step (5) is in the range 400-499, return an error to the caller and stop.
- 9. If the response code from step (5) is in the range 500-599, go back to step (5) and pick a different URL, or stop if there are no further URLs to try.
+ 8. If the response code from step (7) is in the range 400-499, return an error to the caller and stop.
+ 9. If the response code from step (7) is in the range 500-599, go back to step (5) and pick a different URL, or stop if there are no further URLs to try.
  10. Otherwise, replace `data` with an ABI-encoded call to the contract function specified by the 4-byte selector `callbackFunction`, supplying the data returned from step (7) and `extraData` from step (4), and return to step (1).
 
 Clients MUST handle HTTP status codes appropriately, employing best practices for error reporting and retries.


### PR DESCRIPTION
fixing ~4 years old typo 😆 

<img width="782" alt="Screenshot" src="https://github.com/user-attachments/assets/cd87835c-a04c-43ec-9f69-173c9ad2ad06"> 

https://discuss.ens.domains/t/erc-3668-edge-case-for-clientside-http-ssl-errors/19617/2?u=0xc0de4c0ffee

cc @Arachnid 🙏 