### PR TITLE
Update ERC-7579: executeUserOp + multitype module onInstall/onUninstall

### DIFF
--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -92,6 +92,7 @@ function executeUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) 
 ```
 
 If an account chooses to implement `executeUserOp`, this method SHOULD ensure the account executes `userOp.calldata` except 4 most significant bytes, which are reserved for `executeUserOp.selector` as per ERC-4337. Thus the `userOp.callData[4:]` should represent the calldata for a valid call to the account. It is RECOMMENDED that the account executes a `delegatecall` in order to preserve the original `msg.sender` to the account. 
+
 Example:
 ```
 (bool success, bytes memory innerCallRet) = address(this).delegatecall(userOp.callData[4:]);

--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -230,7 +230,7 @@ If the smart account has a fallback handler installed, it:
 - MAY implement authorization control, which SHOULD be done via hooks 
 
 If the account is adding features via fallback, in context of requirements defined by this specification, it should be considered the same as if the account was implementing those features natively.
-ERC-165 support (see below) is one example of such an approach.
+ERC-165 support (see below) is one example of such an approach. Note, that it is only RECOMMENDED to implement view functions via fallback where this can lead to greater extensibility. It is NOT RECOMMENDED to implement core account logic via a fallback.
 
 #### ERC-165
 

--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -91,6 +91,12 @@ The account MAY also implement the following function in accordance with ERC-433
 function executeUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external;
 ```
 
+If account chooses to implement `executeUserOp`, this method SHOULD execute `userOp.calldata` except 4 most significant bytes, which are reserved for `executeUserOp.selector` as per ERC-4337.
+Example:
+```
+(bool success, bytes memory innerCallRet) = address(this).delegatecall(userOp.callData[4:]);
+```
+
 The execution mode is a `bytes32` value that is structured as follows:
 
 - callType (1 byte): `0x00` for a single `call`, `0x01` for a batch `call`, `0xfe` for `staticcall` and `0xff` for `delegatecall`
@@ -267,6 +273,8 @@ interface IModule {
     function isModuleType(uint256 moduleTypeId) external view returns(bool);
 }
 ```
+
+Note: A single module that is of multiple types MAY decide to pass `moduleTypeId` inside `data` to `onInstall` and/or `onUninstall` methods, so those methods are able to properly handle installation/uninstallation for various types.
 
 #### Validators
 

--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -278,7 +278,16 @@ interface IModule {
 }
 ```
 
-Note: A single module that is of multiple types MAY decide to pass `moduleTypeId` inside `data` to `onInstall` and/or `onUninstall` methods, so those methods are able to properly handle installation/uninstallation for various types.
+Note: A single module that is of multiple types MAY decide to pass `moduleTypeId` inside `data` to `onInstall` and/or `onUninstall` methods, so those methods are able to properly handle installation/uninstallation for various types.  
+Example:
+```solidity
+// Module.sol
+function onInstall(bytes calldata data) external {
+    // ...
+    (uint256 moduleTypeId, bytes memory otherData) = abi.decode(data, (uint256, bytes));
+    // ...
+}
+```
 
 #### Validators
 

--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -91,7 +91,7 @@ The account MAY also implement the following function in accordance with ERC-433
 function executeUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external;
 ```
 
-If account chooses to implement `executeUserOp`, this method SHOULD execute `userOp.calldata` except 4 most significant bytes, which are reserved for `executeUserOp.selector` as per ERC-4337.
+If account chooses to implement `executeUserOp`, this method SHOULD ensure the account executes `userOp.calldata` except 4 most significant bytes, which are reserved for `executeUserOp.selector` as per ERC-4337. Thus the `userOp.callData[4:]` should represent a valid call to the account as per [Contract ABI specification](https://docs.soliditylang.org/en/develop/abi-spec.html).  
 Example:
 ```
 (bool success, bytes memory innerCallRet) = address(this).delegatecall(userOp.callData[4:]);
@@ -228,6 +228,9 @@ If the smart account has a fallback handler installed, it:
 - MUST utilize [ERC-2771](./eip-2771.md) to add the original `msg.sender` to the `calldata` sent to the fallback handler
 - MUST route to fallback handlers based on the function selector of the calldata
 - MAY implement authorization control, which SHOULD be done via hooks 
+
+If the account is adding features via fallback, in context of requirements defined by this specification, it should be considered the same as if the account was implementing those features natively.
+ERC-165 support (see below) is one example of such an approach.
 
 #### ERC-165
 

--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -91,7 +91,7 @@ The account MAY also implement the following function in accordance with ERC-433
 function executeUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external;
 ```
 
-If account chooses to implement `executeUserOp`, this method SHOULD ensure the account executes `userOp.calldata` except 4 most significant bytes, which are reserved for `executeUserOp.selector` as per ERC-4337. Thus the `userOp.callData[4:]` should represent a valid call to the account as per [Contract ABI specification](https://docs.soliditylang.org/en/develop/abi-spec.html).  
+If account chooses to implement `executeUserOp`, this method SHOULD ensure the account executes `userOp.calldata` except 4 most significant bytes, which are reserved for `executeUserOp.selector` as per ERC-4337. Thus the `userOp.callData[4:]` should represent a valid call to the account as per Contract ABI specification.  
 Example:
 ```
 (bool success, bytes memory innerCallRet) = address(this).delegatecall(userOp.callData[4:]);

--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -229,7 +229,7 @@ If the smart account has a fallback handler installed, it:
 - MUST route to fallback handlers based on the function selector of the calldata
 - MAY implement authorization control, which SHOULD be done via hooks 
 
-If the account is adding features via fallback, in context of requirements defined by this specification, it should be considered the same as if the account was implementing those features natively.
+If the account adds features via fallback, these should be considered the same as if the account was implementing those features natively.
 ERC-165 support (see below) is one example of such an approach. Note, that it is only RECOMMENDED to implement view functions via fallback where this can lead to greater extensibility. It is NOT RECOMMENDED to implement core account logic via a fallback.
 
 #### ERC-165

--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -91,7 +91,7 @@ The account MAY also implement the following function in accordance with ERC-433
 function executeUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external;
 ```
 
-If account chooses to implement `executeUserOp`, this method SHOULD ensure the account executes `userOp.calldata` except 4 most significant bytes, which are reserved for `executeUserOp.selector` as per ERC-4337. Thus the `userOp.callData[4:]` should represent a valid call to the account as per Contract ABI specification.  
+If an account chooses to implement `executeUserOp`, this method SHOULD ensure the account executes `userOp.calldata` except 4 most significant bytes, which are reserved for `executeUserOp.selector` as per ERC-4337. Thus the `userOp.callData[4:]` should represent the calldata for a valid call to the account. It is RECOMMENDED that the account executes a `delegatecall` in order to preserve the original `msg.sender` to the account. 
 Example:
 ```
 (bool success, bytes memory innerCallRet) = address(this).delegatecall(userOp.callData[4:]);


### PR DESCRIPTION
Introducing two changes to ERC-7579

## Standardise where in `userOp.callData` the 7579 account expects the actual `calldata` for `executeUserOp` to sit.

**Motivation:** what ERC7579 started with, was the need for the validator to always know where is what in the callData.
Validators need this knowledge to parse data about the execution and use it to validate/not validate a given userOp.
So 7579 proposed standard execution interface for the compliant SA: `execute(bytes32 mode, bytes calldata executionCalldata) method`

However, with `executeUserOp` this is not the case anymore.

With a standard execution flow, we know that the `EP` will call `SA` with `userOp.callData`
When `EP` calls `executeUserOp` , the `executeUserOp` implementation is free to use any part of the userOp.callData for the actual execution
Thus, with the `executeUserOp` flow, the module can never know for sure, where in the `userOp.callData` the actual execution sits.
So to avoid this ambiguity some validators may even deny `executeUserOp` flow for userOp’s which should be validated through them.
However, `executeUserOp` flow is very important as it provides the full `userOp` on the execution stage and it’s usage should not be limited.

## Add suggestion for multitype modules to pass module type in the `data` argument for `onInstall` and `onUninstall` methods.
**Motivation:** Multitype modules may want or even have to handle installation and uninstallation for different module types in different ways. For example, If the same module is IValidator (module type 1) and IExecutor (module type 2), it may use different storage to store configs for validation and execution. Thus if given module is being uninstalled as executor, onUnistall should only clear executor config, but not validator config.

## Add a point, that implementing features via fallback should be considered equally efficient as implementing natively
One example is ERC-165 support. Since the modular account is extendable, it may happen that it requires adding some supported erc-165 interfaces. Thus it makes sense to implement erc-165 support via fallback so it will be much easier to add new supported interfaces. It itwas implemented natively, the full account implementation update may be required for this
