### PR TITLE
Update ERC-7540: Fix event names

### DIFF
--- a/ERCS/erc-7540.md
+++ b/ERCS/erc-7540.md
@@ -15,15 +15,15 @@ requires: 20, 165, 4626, 7575
 
 The following standard extends [ERC-4626](./eip-4626.md) by adding support for asynchronous deposit and redemption flows. The async flows are called Requests.
 
-New methods are added to asynchronously Request a deposit or redemption, and view the status of the Request. The existing `deposit`, `mint`, `withdraw`, and `redeem` ERC-4626 methods are used for executing Claimable Requests.
+New methods are added to asynchronously Request a deposit or redemption, and view the status of the Request. The existing `deposit`, `mint`, `withdraw`, and `redeem` ERC-4626 methods are used for executing Claimable Requests. 
 
-Implementations can choose whether to add asynchronous flows for deposits, redemptions, or both.
+Implementations can choose whether to add asynchronous flows for deposits, redemptions, or both. 
 
 ## Motivation
 
 The ERC-4626 Tokenized Vaults standard has helped to make yield-bearing tokens more composable across decentralized finance. The standard is optimized for atomic deposits and redemptions up to a limit. If the limit is reached, no new deposits or redemptions can be submitted.
 
-This limitation does not work well for any smart contract system with asynchronous actions or delays as a prerequisite for interfacing with the Vault (e.g. real-world asset protocols, undercollateralized lending protocols, cross-chain lending protocols, liquid staking tokens, or insurance safety modules).
+This limitation does not work well for any smart contract system with asynchronous actions or delays as a prerequisite for interfacing with the Vault (e.g. real-world asset protocols, undercollateralized lending protocols, cross-chain lending protocols, liquid staking tokens, or insurance safety modules). 
 
 This standard expands the utility of ERC-4626 Vaults for asynchronous use cases. The existing Vault interface (`deposit`/`withdraw`/`mint`/`redeem`) is fully utilized to claim asynchronous Requests.
 
@@ -46,7 +46,7 @@ The existing definitions from [ERC-4626](./eip-4626.md) apply. In addition, this
 
 ### Request Flows
 
-[ERC-7540 Vaults](./eip-7540.md) MUST implement one or both of asynchronous deposit and redemption Request flows. If both flows are not implemented in a Request pattern, it MUST use the ERC-4626 standard synchronous interaction pattern.
+[ERC-7540 Vaults](./eip-7540.md) MUST implement one or both of asynchronous deposit and redemption Request flows. If both flows are not implemented in a Request pattern, it MUST use the ERC-4626 standard synchronous interaction pattern. 
 
 All ERC-7540 asynchronous tokenized Vaults MUST implement ERC-4626 with overrides for certain behavior described below.
 
@@ -57,7 +57,7 @@ Asynchronous deposit Vaults MUST override the ERC-4626 specification as follows:
 
 Asynchronous redeem Vaults MUST override the ERC-4626 specification as follows:
 
-1. The `redeem` and `withdraw` methods do not transfer `shares` to the Vault, because this already happened on `requestRedeem`.
+1. The `redeem` and `withdraw` methods do not transfer `shares` to the Vault, because this already happened on `requestRedeem`. 
 2. The `owner` field of `redeem` and `withdraw` SHOULD be renamed to `controller`, and the controller MUST be `msg.sender` unless the `controller` has approved the `msg.sender` as an operator.
 3. `previewRedeem` and `previewWithdraw` MUST revert for all callers and inputs.
 
@@ -65,23 +65,22 @@ Asynchronous redeem Vaults MUST override the ERC-4626 specification as follows:
 
 After submission, Requests go through Pending, Claimable, and Claimed stages. An example lifecycle for a deposit Request is visualized in the table below.
 
-| **State** | **User**                                    | **Vault**                                                                                                                      |
-| --------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Pending   | `requestDeposit(assets, controller, owner)` | `asset.transferFrom(owner, vault, assets)`; `pendingDepositRequest[controller] += assets`                                      |
-| Claimable |                                             | _Internal Request fulfillment_: `pendingDepositRequest[controller] -= assets`; `claimableDepositRequest[controller] += assets` |
-| Claimed   | `deposit(assets, receiver, controller)`     | `claimableDepositRequest[controller] -= assets`; `vault.balanceOf[receiver] += shares`                                         |
+| **State**   | **User**                         | **Vault** |
+|-------------|---------------------------------|-----------|
+| Pending     | `requestDeposit(assets, controller, owner)` | `asset.transferFrom(owner, vault, assets)`; `pendingDepositRequest[controller] += assets` |
+| Claimable   |                                 | *Internal Request fulfillment*:  `pendingDepositRequest[controller] -= assets`; `claimableDepositRequest[controller] += assets` |
+| Claimed     | `deposit(assets, receiver, controller)` | `claimableDepositRequest[controller] -= assets`; `vault.balanceOf[receiver] += shares` |
 
 Note that `maxDeposit` increases and decreases in sync with `claimableDepositRequest`.
 
-Requests MUST NOT skip or otherwise short-circuit the Claim state. In other words, to initiate and claim a Request, a user MUST call both request\* and the corresponding Claim function separately, even in the same block. Vaults MUST NOT "push" tokens onto the user after a Request, users MUST "pull" the tokens via the Claim function.
+Requests MUST NOT skip or otherwise short-circuit the Claim state. In other words, to initiate and claim a Request, a user MUST call both request* and the corresponding Claim function separately, even in the same block. Vaults MUST NOT "push" tokens onto the user after a Request, users MUST "pull" the tokens via the Claim function.
 
 For asynchronous Vaults, the exchange rate between `shares` and `assets` including fees and yield is up to the Vault implementation. In other words, pending redemption Requests MAY NOT be yield-bearing and MAY NOT have a fixed exchange rate.
 
 ### Request Ids
-
 The request ID (`requestId`) of a request is returned by the corresponding `requestDeposit` and `requestRedeem` functions.
 
-Multiple requests may have the same `requestId`, so a given Request is discriminated by both the `requestId` and the `controller`.
+Multiple requests may have the same `requestId`, so a given Request is discriminated by both the `requestId` and the `controller`. 
 
 Requests of the same `requestId` MUST be fungible with each other (except in the special case `requestId == 0` described below), i.e. all Requests with the same `requestId` MUST transition from Pending to Claimable at the same time and receive the same exchange rate between `assets` and `shares`. If a Request with `requestId != 0` becomes partially claimable, all requests of the same `requestId` MUST become claimable at the same pro-rata rate.
 
@@ -93,7 +92,7 @@ When `requestId == 0`, the Vault MUST use purely the `controller` to discriminat
 
 #### requestDeposit
 
-Transfers `assets` from `owner` into the Vault and submits a Request for asynchronous `deposit`. This places the Request in Pending state, with a corresponding increase in `pendingDepositRequest` for the amount `assets`.
+Transfers `assets` from `owner` into the Vault and submits a Request for asynchronous `deposit`. This places the Request in Pending state, with a corresponding increase in `pendingDepositRequest` for the amount `assets`. 
 
 The output `requestId` is used to partially discriminate the request along with the `controller`. See [Request Ids](#request-ids) section for more info.
 
@@ -182,11 +181,11 @@ MUST NOT revert unless due to integer overflow caused by an unreasonably large i
 
 #### requestRedeem
 
-Assumes control of `shares` from `owner` and submits a Request for asynchronous `redeem`. This places the Request in Pending state, with a corresponding increase in `pendingRedeemRequest` for the amount `shares`.
+Assumes control of `shares` from `owner` and submits a Request for asynchronous `redeem`. This places the Request in Pending state, with a corresponding increase in `pendingRedeemRequest` for the amount `shares`. 
 
 The output `requestId` is used to discriminate the request along with the `controller`. See [Request Ids](#request-ids) section for more info.
 
-`shares` MAY be temporarily locked in the Vault until the Claimable or Claimed state for accounting purposes, or they MAY be burned immediately upon `requestRedeem`.
+`shares` MAY be temporarily locked in the Vault until the Claimable or Claimed state for accounting purposes, or they MAY be burned immediately upon `requestRedeem`. 
 
 In either case, the `shares` MUST be removed from the custody of `owner` upon `requestRedeem` and burned by the time the request is Claimed.
 
@@ -422,13 +421,12 @@ Asynchronous redemption Vaults MUST return the constant value `true` if `0x620ee
 
 ### [ERC-7575](./eip-7575.md) support
 
-Smart contracts implementing this Vault standard MUST implement the [ERC-7575](./eip-7575.md) standard (in particular the `share` method).
+Smart contracts implementing this Vault standard MUST implement the [ERC-7575](./eip-7575.md) standard (in particular the `share` method). 
 
 ## Rationale
 
 ### Including Request IDs but not including a Claim by ID method
-
-Requests in an Asynchronous Vault have properties of NFTs or Semi-Fungible tokens due to their asynchronicity. However, trying to pigeonhole all ERC-7540 Vaults into supporting [ERC-721](./eip-721) or [ERC-1155](./eip-1155) for Requests would create too much interface bloat.
+Requests in an Asynchronous Vault have properties of NFTs or Semi-Fungible tokens due to their asynchronicity. However, trying to pigeonhole all ERC-7540 Vaults into supporting [ERC-721](./eip-721) or [ERC-1155](./eip-1155) for Requests would create too much interface bloat. 
 
 Using both an id and address to discriminate Requests allows for any of these use cases to be developed at an external layer without adding too much complexity to the core interface.
 
@@ -463,7 +461,6 @@ If claims can short-circuit, this creates ambiguity for integrators and complica
 An example of a short-circuiting Request flow could be as follows: user triggers a Request which enters Pending state. When the Vault fulfills the Request, the corresponding `assets/shares` are pushed straight to the user. This requires only 1 step on the user's behalf.
 
 This approach has a few issues:
-
 - cost/lack of scalability: as the number of vault users grows it can become intractably expensive to offload the Claim costs to the Vault operator
 - hinders integration potential: Vault integrators would need to handle both the 2-step and 1-step cases, with the 1-step pushing arbitrary tokens in from an unknown Request at an unknown time. This pushes complexity out onto integrators and reduces the standard's utility.
 
@@ -494,7 +491,6 @@ It reduces code and implementation complexity at little to no cost to simply man
 Implementing support for [ERC-165](./eip-165.md) is mandated because of the [optionality of flows](#optionality-of-flows). Integrations can use the `supportsInterface` method to check whether a vault is fully asynchronous, partially asynchronous, or fully synchronous (for which it is just following the [ERC-4626](./eip-4626)), and use a single contract to support all cases.
 
 ### Not Allowing Pending Claims to be Fungible
-
 The async pending claims represent a sort of semi-fungible intermediate share class. Vaults can elect to wrap these claims in any token standard they like, for example, ERC-20, [ERC-1155](./eip-1155.md), or ERC-721 depending on the use case. This is intentionally left out of the spec to provide flexibility to implementers.
 
 ## Backwards Compatibility
@@ -507,7 +503,7 @@ The interface is fully backward compatible with [ERC-4626](./eip-4626.md). The s
     // This code snippet is incomplete pseudocode used for example only and is no way intended to be used in production or guaranteed to be secure
 
     mapping(address => uint256) public pendingDepositRequest;
-
+    
     mapping(address => uint256) public claimableDepositRequest;
 
     mapping(address controller => mapping(address operator => bool)) public isOperator;
@@ -555,12 +551,12 @@ The interface is fully backward compatible with [ERC-4626](./eip-4626.md). The s
 
 In general, asynchronicity concerns make state transitions in the Vault much more complex and vulnerable to security risks. Access control on Vault operations, clear documentation of state transitions, and invariant checks should all be performed to mitigate these risks. For example:
 
-- The view methods for viewing Pending and Claimable request states (e.g. pendingDepositRequest) are estimates useful for display purposes but can be outdated. The inability to know the final exchange rate on any Request requires users to trust the implementation of the asynchronous Vault in the computation of the exchange rate and fulfillment of their Request.
-- Shares or assets locked for Requests can be stuck in the Pending state. Vaults may elect to allow for the fungibility of pending claims or implement some cancellation functionality to protect users.
+* The view methods for viewing Pending and Claimable request states (e.g. pendingDepositRequest) are estimates useful for display purposes but can be outdated. The inability to know the final exchange rate on any Request requires users to trust the implementation of the asynchronous Vault in the computation of the exchange rate and fulfillment of their Request.
+* Shares or assets locked for Requests can be stuck in the Pending state. Vaults may elect to allow for the fungibility of pending claims or implement some cancellation functionality to protect users.
 
 ### Operators
 
-An operator has the ability to transfer the `asset` of the vault from the approver to any address, and simultaneously grants control over the `share` of the vault.
+An operator has the ability to transfer the `asset` of the vault from the approver to any address, and simultaneously grants control over the `share` of the vault. 
 
 Any user approving an operator must trust that operator with both the `asset` and `share` of the Vault.
 

--- a/ERCS/erc-7540.md
+++ b/ERCS/erc-7540.md
@@ -15,15 +15,15 @@ requires: 20, 165, 4626, 7575
 
 The following standard extends [ERC-4626](./eip-4626.md) by adding support for asynchronous deposit and redemption flows. The async flows are called Requests.
 
-New methods are added to asynchronously Request a deposit or redemption, and view the status of the Request. The existing `deposit`, `mint`, `withdraw`, and `redeem` ERC-4626 methods are used for executing Claimable Requests. 
+New methods are added to asynchronously Request a deposit or redemption, and view the status of the Request. The existing `deposit`, `mint`, `withdraw`, and `redeem` ERC-4626 methods are used for executing Claimable Requests.
 
-Implementations can choose whether to add asynchronous flows for deposits, redemptions, or both. 
+Implementations can choose whether to add asynchronous flows for deposits, redemptions, or both.
 
 ## Motivation
 
 The ERC-4626 Tokenized Vaults standard has helped to make yield-bearing tokens more composable across decentralized finance. The standard is optimized for atomic deposits and redemptions up to a limit. If the limit is reached, no new deposits or redemptions can be submitted.
 
-This limitation does not work well for any smart contract system with asynchronous actions or delays as a prerequisite for interfacing with the Vault (e.g. real-world asset protocols, undercollateralized lending protocols, cross-chain lending protocols, liquid staking tokens, or insurance safety modules). 
+This limitation does not work well for any smart contract system with asynchronous actions or delays as a prerequisite for interfacing with the Vault (e.g. real-world asset protocols, undercollateralized lending protocols, cross-chain lending protocols, liquid staking tokens, or insurance safety modules).
 
 This standard expands the utility of ERC-4626 Vaults for asynchronous use cases. The existing Vault interface (`deposit`/`withdraw`/`mint`/`redeem`) is fully utilized to claim asynchronous Requests.
 
@@ -36,8 +36,8 @@ The existing definitions from [ERC-4626](./eip-4626.md) apply. In addition, this
 - Request: a request to enter (`requestDeposit`) or exit (`requestRedeem`) the Vault
 - Pending: the state where a Request has been made but is not yet Claimable
 - Claimable: the state where a Request is processed by the Vault enabling the user to claim corresponding `shares` (for async deposit) or `assets` (for async redeem)
-- Claimed: the state where a Request is finalized by the user and the user receives the output token (e.g. `shares` for a deposit Request)
-- Claim function: the corresponding Vault method to bring a Request to Claimed state (e.g. `deposit` or `mint` claims `shares` from `requestDeposit`). Lowercase claim always describes the verb action of calling a Claim function.
+- Claimed: the state where a Request is finalized by the user and the user receives the output token (i.e. `shares` for async deposit and `assets` for async redeem)
+- Claim function: the corresponding Vault method to bring a Request to Claimed state (i.e. `deposit` or `mint` claims `shares` from `requestDeposit`, and `redeem` or `withdraw` claims `assets` from `requestRedeem`). Lowercase claim always describes the verb action of calling a Claim function.
 - asynchronous deposit Vault: a Vault that implements asynchronous Requests for deposit flows
 - asynchronous redemption Vault: a Vault that implements asynchronous Requests for redemption flows
 - fully asynchronous Vault: a Vault that implements asynchronous Requests for both deposit and redemption flows
@@ -46,18 +46,18 @@ The existing definitions from [ERC-4626](./eip-4626.md) apply. In addition, this
 
 ### Request Flows
 
-[ERC-7540 Vaults](./eip-7540.md) MUST implement one or both of asynchronous deposit and redemption Request flows. If either flow is not implemented in a Request pattern, it MUST use the ERC-4626 standard synchronous interaction pattern. 
+[ERC-7540 Vaults](./eip-7540.md) MUST implement one or both of asynchronous deposit and redemption Request flows. If both flows are not implemented in a Request pattern, it MUST use the ERC-4626 standard synchronous interaction pattern.
 
 All ERC-7540 asynchronous tokenized Vaults MUST implement ERC-4626 with overrides for certain behavior described below.
 
 Asynchronous deposit Vaults MUST override the ERC-4626 specification as follows:
 
-1. The `deposit` and `mint` methods do not transfer  `assets` to the Vault, because this already happened on `requestDeposit`.
+1. The `deposit` and `mint` methods do not transfer `assets` to the Vault, because this already happened on `requestDeposit`.
 2. `previewDeposit` and `previewMint` MUST revert for all callers and inputs.
 
 Asynchronous redeem Vaults MUST override the ERC-4626 specification as follows:
 
-1. The `redeem` and `withdraw` methods do not transfer `shares` to the Vault, because this already happened on `requestRedeem`. 
+1. The `redeem` and `withdraw` methods do not transfer `shares` to the Vault, because this already happened on `requestRedeem`.
 2. The `owner` field of `redeem` and `withdraw` SHOULD be renamed to `controller`, and the controller MUST be `msg.sender` unless the `controller` has approved the `msg.sender` as an operator.
 3. `previewRedeem` and `previewWithdraw` MUST revert for all callers and inputs.
 
@@ -65,34 +65,35 @@ Asynchronous redeem Vaults MUST override the ERC-4626 specification as follows:
 
 After submission, Requests go through Pending, Claimable, and Claimed stages. An example lifecycle for a deposit Request is visualized in the table below.
 
-| **State**   | **User**                         | **Vault** |
-|-------------|---------------------------------|-----------|
-| Pending     | `requestDeposit(assets, controller, owner)` | `asset.transferFrom(owner, vault, assets)`; `pendingDepositRequest[controller] += assets` |
-| Claimable   |                                 | *Internal Request fulfillment*:  `pendingDepositRequest[controller] -= assets`; `claimableDepositRequest[controller] += assets` |
-| Claimed     | `deposit(assets, receiver)`      | `claimableDepositRequest[controller] -= assets`; `vault.balanceOf[receiver] += shares` |
+| **State** | **User**                                    | **Vault**                                                                                                                      |
+| --------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Pending   | `requestDeposit(assets, controller, owner)` | `asset.transferFrom(owner, vault, assets)`; `pendingDepositRequest[controller] += assets`                                      |
+| Claimable |                                             | _Internal Request fulfillment_: `pendingDepositRequest[controller] -= assets`; `claimableDepositRequest[controller] += assets` |
+| Claimed   | `deposit(assets, receiver, controller)`     | `claimableDepositRequest[controller] -= assets`; `vault.balanceOf[receiver] += shares`                                         |
 
 Note that `maxDeposit` increases and decreases in sync with `claimableDepositRequest`.
 
-Requests MUST NOT skip or otherwise short-circuit the Claim state. In other words, to initiate and claim a Request, a user MUST call both request* and the corresponding claim* function separately, even in the same block. Vaults MUST NOT "push" tokens onto the user after a Request, users MUST "pull" the tokens via the Claim function.
+Requests MUST NOT skip or otherwise short-circuit the Claim state. In other words, to initiate and claim a Request, a user MUST call both request\* and the corresponding Claim function separately, even in the same block. Vaults MUST NOT "push" tokens onto the user after a Request, users MUST "pull" the tokens via the Claim function.
 
 For asynchronous Vaults, the exchange rate between `shares` and `assets` including fees and yield is up to the Vault implementation. In other words, pending redemption Requests MAY NOT be yield-bearing and MAY NOT have a fixed exchange rate.
 
 ### Request Ids
+
 The request ID (`requestId`) of a request is returned by the corresponding `requestDeposit` and `requestRedeem` functions.
 
-Multiple requests may have the same `requestId`, so a given Request is discriminated by both the `requestId` and the `controller`. 
+Multiple requests may have the same `requestId`, so a given Request is discriminated by both the `requestId` and the `controller`.
 
-Requests of the same `requestId` MUST be fungible with each other (except in the special case `requestId == 0` described below). I.e. all Requests with the same `requestId` MUST transition from Pending to Claimable at the same time and receive the same exchange rate between `assets` and `shares`. If a Request with `requestId != 0` becomes partially claimable, all requests of the same `requestId` MUST become claimable at the same pro-rata rate.
+Requests of the same `requestId` MUST be fungible with each other (except in the special case `requestId == 0` described below), i.e. all Requests with the same `requestId` MUST transition from Pending to Claimable at the same time and receive the same exchange rate between `assets` and `shares`. If a Request with `requestId != 0` becomes partially claimable, all requests of the same `requestId` MUST become claimable at the same pro-rata rate.
 
-There are no assumptions or requirements of requests with different `requestId`. I.e. they MAY transition to Claimable at different times and exchange rates with no ordering or correlation enforced in any way.
+There are no assumptions or requirements of requests with different `requestId`, i.e. they MAY transition to Claimable at different times and exchange rates with no ordering or correlation enforced in any way.
 
-When `requestId==0`, the Vault MUST use purely the `controller` to discriminate the request state. The Pending and Claimable state of multiple requests from the same `controller` would be aggregated. If a Vault returns `0` for the `requestId` of any request, it MUST return `0` for all requests.
+When `requestId == 0`, the Vault MUST use purely the `controller` to discriminate the request state. The Pending and Claimable state of multiple requests from the same `controller` would be aggregated. If a Vault returns `0` for the `requestId` of any request, it MUST return `0` for all requests.
 
 ### Methods
 
 #### requestDeposit
 
-Transfers `assets` from `owner` into the Vault and submits a Request for asynchronous `deposit`. This places the Request in Pending state, with a corresponding increase in `pendingDepositRequest` for the amount `assets`. 
+Transfers `assets` from `owner` into the Vault and submits a Request for asynchronous `deposit`. This places the Request in Pending state, with a corresponding increase in `pendingDepositRequest` for the amount `assets`.
 
 The output `requestId` is used to partially discriminate the request along with the `controller`. See [Request Ids](#request-ids) section for more info.
 
@@ -108,7 +109,7 @@ MUST revert if all of `assets` cannot be requested for `deposit`/`mint` (due to 
 
 Note that most implementations will require pre-approval of the Vault with the Vault's underlying `asset` token.
 
-MUST emit the `RequestDeposit` event.
+MUST emit the `DepositRequest` event.
 
 ```yaml
 - name: requestDeposit
@@ -181,11 +182,11 @@ MUST NOT revert unless due to integer overflow caused by an unreasonably large i
 
 #### requestRedeem
 
-Assumes control of `shares` from `owner` and submits a Request for asynchronous `redeem`. This places the Request in Pending state, with a corresponding increase in `pendingRedeemRequest` for the amount `shares`. 
+Assumes control of `shares` from `owner` and submits a Request for asynchronous `redeem`. This places the Request in Pending state, with a corresponding increase in `pendingRedeemRequest` for the amount `shares`.
 
 The output `requestId` is used to discriminate the request along with the `controller`. See [Request Ids](#request-ids) section for more info.
 
-`shares` MAY be temporarily locked in the Vault until the Claimable or Claimed state for accounting purposes, or they MAY be burned immediately upon `requestRedeem`. 
+`shares` MAY be temporarily locked in the Vault until the Claimable or Claimed state for accounting purposes, or they MAY be burned immediately upon `requestRedeem`.
 
 In either case, the `shares` MUST be removed from the custody of `owner` upon `requestRedeem` and burned by the time the request is Claimed.
 
@@ -197,7 +198,7 @@ The `assets` that will be received on `redeem` or `withdraw` MAY NOT be equivale
 
 MUST revert if all of `shares` cannot be requested for `redeem` / `withdraw` (due to withdrawal limit being reached, slippage, the owner not having enough shares, etc).
 
-MUST emit the `RequestRedeem` event.
+MUST emit the `RedeemRequest` event.
 
 ```yaml
 - name: requestRedeem
@@ -421,16 +422,17 @@ Asynchronous redemption Vaults MUST return the constant value `true` if `0x620ee
 
 ### [ERC-7575](./eip-7575.md) support
 
-Smart contracts implementing this Vault standard MUST implement the [ERC-7575](./eip-7575.md) standard (in particular the `share` method). 
+Smart contracts implementing this Vault standard MUST implement the [ERC-7575](./eip-7575.md) standard (in particular the `share` method).
 
 ## Rationale
 
 ### Including Request IDs but not including a Claim by ID method
-Requests in an Asynchronous Vault have properties of NFTs or Semi-Fungible tokens due to their asynchronicity. However, trying to pigeonhole all ERC-7540 Vaults into supporting [ERC-721](./eip-721) or [ERC-1155](./eip-1155) for Requests would create too much interface bloat. 
+
+Requests in an Asynchronous Vault have properties of NFTs or Semi-Fungible tokens due to their asynchronicity. However, trying to pigeonhole all ERC-7540 Vaults into supporting [ERC-721](./eip-721) or [ERC-1155](./eip-1155) for Requests would create too much interface bloat.
 
 Using both an id and address to discriminate Requests allows for any of these use cases to be developed at an external layer without adding too much complexity to the core interface.
 
-Certain Vaults, especially `requestId==0` cases, benefit from using the underlying [ERC-4626](./eip-4626) methods for claiming because there is no discrimination at the `requestId` level. This standard is written primarily with those use cases in mind. A future standard can optimize for nonzero request ID with support for claiming and transferring requests discriminated also with a `requestId`.
+Certain Vaults, especially `requestId == 0` cases, benefit from using the underlying [ERC-4626](./eip-4626) methods for claiming because there is no discrimination at the `requestId` level. This standard is written primarily with those use cases in mind. A future standard can optimize for nonzero request ID with support for claiming and transferring requests discriminated also with a `requestId`.
 
 ### Symmetry and Non-inclusion of requestWithdraw and requestMint
 
@@ -461,6 +463,7 @@ If claims can short-circuit, this creates ambiguity for integrators and complica
 An example of a short-circuiting Request flow could be as follows: user triggers a Request which enters Pending state. When the Vault fulfills the Request, the corresponding `assets/shares` are pushed straight to the user. This requires only 1 step on the user's behalf.
 
 This approach has a few issues:
+
 - cost/lack of scalability: as the number of vault users grows it can become intractably expensive to offload the Claim costs to the Vault operator
 - hinders integration potential: Vault integrators would need to handle both the 2-step and 1-step cases, with the 1-step pushing arbitrary tokens in from an unknown Request at an unknown time. This pushes complexity out onto integrators and reduces the standard's utility.
 
@@ -491,6 +494,7 @@ It reduces code and implementation complexity at little to no cost to simply man
 Implementing support for [ERC-165](./eip-165.md) is mandated because of the [optionality of flows](#optionality-of-flows). Integrations can use the `supportsInterface` method to check whether a vault is fully asynchronous, partially asynchronous, or fully synchronous (for which it is just following the [ERC-4626](./eip-4626)), and use a single contract to support all cases.
 
 ### Not Allowing Pending Claims to be Fungible
+
 The async pending claims represent a sort of semi-fungible intermediate share class. Vaults can elect to wrap these claims in any token standard they like, for example, ERC-20, [ERC-1155](./eip-1155.md), or ERC-721 depending on the use case. This is intentionally left out of the spec to provide flexibility to implementers.
 
 ## Backwards Compatibility
@@ -503,7 +507,7 @@ The interface is fully backward compatible with [ERC-4626](./eip-4626.md). The s
     // This code snippet is incomplete pseudocode used for example only and is no way intended to be used in production or guaranteed to be secure
 
     mapping(address => uint256) public pendingDepositRequest;
-    
+
     mapping(address => uint256) public claimableDepositRequest;
 
     mapping(address controller => mapping(address operator => bool)) public isOperator;
@@ -551,12 +555,12 @@ The interface is fully backward compatible with [ERC-4626](./eip-4626.md). The s
 
 In general, asynchronicity concerns make state transitions in the Vault much more complex and vulnerable to security risks. Access control on Vault operations, clear documentation of state transitions, and invariant checks should all be performed to mitigate these risks. For example:
 
-* The view methods for viewing Pending and Claimable request states (e.g. pendingDepositRequest) are estimates useful for display purposes but can be outdated. The inability to know the final exchange rate on any Request requires users to trust the implementation of the asynchronous Vault in the computation of the exchange rate and fulfillment of their Request.
-* Shares or assets locked for Requests can be stuck in the Pending state. Vaults may elect to allow for the fungibility of pending claims or implement some cancellation functionality to protect users.
+- The view methods for viewing Pending and Claimable request states (e.g. pendingDepositRequest) are estimates useful for display purposes but can be outdated. The inability to know the final exchange rate on any Request requires users to trust the implementation of the asynchronous Vault in the computation of the exchange rate and fulfillment of their Request.
+- Shares or assets locked for Requests can be stuck in the Pending state. Vaults may elect to allow for the fungibility of pending claims or implement some cancellation functionality to protect users.
 
 ### Operators
 
-An operator has the ability to transfer the `asset` of the vault from the approver to any address, and simultaneously grants control over the `share` of the vault. 
+An operator has the ability to transfer the `asset` of the vault from the approver to any address, and simultaneously grants control over the `share` of the vault.
 
 Any user approving an operator must trust that operator with both the `asset` and `share` of the Vault.
 


### PR DESCRIPTION
The `DepositRequest` and `RedeemRequest` events were mistyped as `RequestDeposit` and `RequestRedeem`.

Also adds minor punctuation fixes.