### PR TITLE
Fix site URL in Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ description: >-
   Ethereum Improvement Proposals (EIPs) describe standards for the Ethereum
   platform, including core protocol specifications, client APIs, and contract
   standards.
-url: "https://eips.ethereum.org"
+url: "https://ercs.ethereum.org"
 github_username:  ethereum
 repository: ethereum/EIPs
 


### PR DESCRIPTION
Meta tags are currently broken in the site. For example:

```html
<link rel="canonical" href="https://eips.ethereum.org/ERCS/erc-7739" />
<meta property="og:url" content="https://eips.ethereum.org/ERCS/erc-7739" />
```