### PR TITLE
Update ERC-6909: ERC-6909 nits

### DIFF
--- a/ERCS/erc-6909.md
+++ b/ERCS/erc-6909.md
@@ -62,7 +62,7 @@ The total `amount` of a token `id` that an `owner` owns.
 
 #### `allowance`
 
-The total `amount` of a token id that a spender is permitted to transfer on behalf of an owner.
+The total `amount` of a token `id` that a `spender` is permitted to transfer on behalf of an `owner`.
 
 ```yaml
 - name: allowance

--- a/ERCS/erc-6909.md
+++ b/ERCS/erc-6909.md
@@ -29,6 +29,8 @@ A hybrid allowance-operator permission scheme enables granular yet scalable cont
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
+Every ERC-6909 compliant contract must implement the [ERC-165](./erc-165.md) interface in addition to the following interface.
+
 ### Definitions
 
 - infinite: The maximum value for a uint256 (`2 ** 256 - 1`).

--- a/ERCS/erc-6909.md
+++ b/ERCS/erc-6909.md
@@ -13,13 +13,13 @@ requires: 165
 
 ## Abstract
 
-The following specifies a multi-token contract as a simplified alternative to the [ERC-1155](./erc-1155.md) Multi-Token Standard. In contrast to ERC-1155, callbacks and batching have been removed from the interface and the permission system is a hybrid operator-approval scheme for granular and scalable permissions. Functionally, the interface has been reduced to the bare minimum required to manage multiple tokens under the same contract.
+The following specifies a multi-token contract as a simplified alternative to the [ERC-1155](./eip-1155.md) Multi-Token Standard. In contrast to ERC-1155, callbacks and batching have been removed from the interface and the permission system is a hybrid operator-approval scheme for granular and scalable permissions. Functionally, the interface has been reduced to the bare minimum required to manage multiple tokens under the same contract.
 
 ## Motivation
 
 The ERC-1155 standard includes unnecessary features such as requiring recipient accounts with code to implement callbacks returning specific values and batch-calls in the specification. In addition, the single operator permission scheme grants unlimited allowance on every token ID in the contract. Backwards compatibility is deliberately removed only where necessary. Additional features such as batch calls, increase and decrease allowance methods, and other user experience improvements are deliberately omitted in the specification to minimize the required external interface.
 
-According to ERC-1155, callbacks are required for each transfer and batch transfer to contract accounts. This requires potentially unnecessary external calls to the recipient when the recipient account is a contract account. While this behavior may be desirable in some cases, there is no option to opt-out of this behavior, as is the case for [ERC-721](./erc-721.md) having both `transferFrom` and `safeTransferFrom`. In addition to runtime performance of the token contract itself, it also impacts the runtime performance and codesize of recipient contract accounts, requiring multiple callback functions and return values to receive the tokens.
+According to ERC-1155, callbacks are required for each transfer and batch transfer to contract accounts. This requires potentially unnecessary external calls to the recipient when the recipient account is a contract account. While this behavior may be desirable in some cases, there is no option to opt-out of this behavior, as is the case for [ERC-721](./eip-721.md) having both `transferFrom` and `safeTransferFrom`. In addition to runtime performance of the token contract itself, it also impacts the runtime performance and codesize of recipient contract accounts, requiring multiple callback functions and return values to receive the tokens.
 
 Batching transfers, while useful, are excluded from this standard to allow for opinionated batch transfer operations on different implementations. For example, a different ABI encoding may provide different benefits in different environments such as calldata size optimization for rollups with calldata storage commitments or runtime performance for environments with expensive gas fees.
 
@@ -29,7 +29,7 @@ A hybrid allowance-operator permission scheme enables granular yet scalable cont
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-Every [ERC-6909](./erc-6909.md) compliant contract must implement the [ERC-165](./erc-165.md) interface in addition to the following interface.
+Every [ERC-6909](./eip-6909.md) compliant contract must implement the [ERC-165](./eip-165.md) interface in addition to the following interface.
 
 ### Definitions
 
@@ -538,7 +538,7 @@ The `totalSupply` for a token `id`.
 
 ### Granular Approvals
 
-While the "operator model" from the ERC-1155 standard allows an account to set another account as an operator, giving full permissions to transfer any amount of any token id on behalf of the owner, this may not always be the desired permission scheme. The "allowance model" from [ERC-20](./erc-20.md) allows an account to set an explicit amount of the token that another account can spend on the owner's behalf. This standard requires both be implemented, with the only modification being to the "allowance model" where the token id must be specified as well. This allows an account to grant specific approvals to specific token ids, infinite approvals to specific token ids, or infinite approvals to all token ids.
+While the "operator model" from the ERC-1155 standard allows an account to set another account as an operator, giving full permissions to transfer any amount of any token id on behalf of the owner, this may not always be the desired permission scheme. The "allowance model" from [ERC-20](./eip-20.md) allows an account to set an explicit amount of the token that another account can spend on the owner's behalf. This standard requires both be implemented, with the only modification being to the "allowance model" where the token id must be specified as well. This allows an account to grant specific approvals to specific token ids, infinite approvals to specific token ids, or infinite approvals to all token ids.
 
 ### Removal of Batching
 

--- a/ERCS/erc-6909.md
+++ b/ERCS/erc-6909.md
@@ -29,7 +29,7 @@ A hybrid allowance-operator permission scheme enables granular yet scalable cont
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-Every ERC-6909 compliant contract must implement the [ERC-165](./erc-165.md) interface in addition to the following interface.
+Every [ERC-6909](./erc-6909.md) compliant contract must implement the [ERC-165](./erc-165.md) interface in addition to the following interface.
 
 ### Definitions
 

--- a/ERCS/erc-6909.md
+++ b/ERCS/erc-6909.md
@@ -3,7 +3,7 @@ eip: 6909
 title: Minimal Multi-Token Interface
 description: A minimal specification for managing multiple tokens by their id in a single contract.
 author: JT Riley (@jtriley-eth), Dillon (@d1ll0n), Sara (@snreynolds), Vectorized (@Vectorized), Neodaoist (@neodaoist)
-discussions-to: https://ethereum-magicians.org/t/eip-6909-multi-token-standard/13891
+discussions-to: https://ethereum-magicians.org/t/erc-6909-multi-token-standard/13891
 status: Review
 type: Standards Track
 category: ERC
@@ -13,13 +13,13 @@ requires: 165
 
 ## Abstract
 
-The following specifies a multi-token contract as a simplified alternative to the [ERC-1155](./eip-1155.md) Multi-Token Standard. In contrast to ERC-1155, callbacks and batching have been removed from the interface and the permission system is a hybrid operator-approval scheme for granular and scalable permissions. Functionally, the interface has been reduced to the bare minimum required to manage multiple tokens under the same contract.
+The following specifies a multi-token contract as a simplified alternative to the [ERC-1155](./erc-1155.md) Multi-Token Standard. In contrast to ERC-1155, callbacks and batching have been removed from the interface and the permission system is a hybrid operator-approval scheme for granular and scalable permissions. Functionally, the interface has been reduced to the bare minimum required to manage multiple tokens under the same contract.
 
 ## Motivation
 
 The ERC-1155 standard includes unnecessary features such as requiring recipient accounts with code to implement callbacks returning specific values and batch-calls in the specification. In addition, the single operator permission scheme grants unlimited allowance on every token ID in the contract. Backwards compatibility is deliberately removed only where necessary. Additional features such as batch calls, increase and decrease allowance methods, and other user experience improvements are deliberately omitted in the specification to minimize the required external interface.
 
-According to ERC-1155, callbacks are required for each transfer and batch transfer to contract accounts. This requires potentially unnecessary external calls to the recipient when the recipient account is a contract account. While this behavior may be desirable in some cases, there is no option to opt-out of this behavior, as is the case for [ERC-721](./eip-721.md) having both `transferFrom` and `safeTransferFrom`. In addition to runtime performance of the token contract itself, it also impacts the runtime performance and codesize of recipient contract accounts, requiring multiple callback functions and return values to receive the tokens.
+According to ERC-1155, callbacks are required for each transfer and batch transfer to contract accounts. This requires potentially unnecessary external calls to the recipient when the recipient account is a contract account. While this behavior may be desirable in some cases, there is no option to opt-out of this behavior, as is the case for [ERC-721](./erc-721.md) having both `transferFrom` and `safeTransferFrom`. In addition to runtime performance of the token contract itself, it also impacts the runtime performance and codesize of recipient contract accounts, requiring multiple callback functions and return values to receive the tokens.
 
 Batching transfers, while useful, are excluded from this standard to allow for opinionated batch transfer operations on different implementations. For example, a different ABI encoding may provide different benefits in different environments such as calldata size optimization for rollups with calldata storage commitments or runtime performance for environments with expensive gas fees.
 
@@ -538,7 +538,7 @@ The `totalSupply` for a token `id`.
 
 ### Granular Approvals
 
-While the "operator model" from the ERC-1155 standard allows an account to set another account as an operator, giving full permissions to transfer any amount of any token id on behalf of the owner, this may not always be the desired permission scheme. The "allowance model" from [ERC-20](./eip-20.md) allows an account to set an explicit amount of the token that another account can spend on the owner's behalf. This standard requires both be implemented, with the only modification being to the "allowance model" where the token id must be specified as well. This allows an account to grant specific approvals to specific token ids, infinite approvals to specific token ids, or infinite approvals to all token ids.
+While the "operator model" from the ERC-1155 standard allows an account to set another account as an operator, giving full permissions to transfer any amount of any token id on behalf of the owner, this may not always be the desired permission scheme. The "allowance model" from [ERC-20](./erc-20.md) allows an account to set an explicit amount of the token that another account can spend on the owner's behalf. This standard requires both be implemented, with the only modification being to the "allowance model" where the token id must be specified as well. This allows an account to grant specific approvals to specific token ids, infinite approvals to specific token ids, or infinite approvals to all token ids.
 
 ### Removal of Batching
 

--- a/ERCS/erc-6909.md
+++ b/ERCS/erc-6909.md
@@ -315,7 +315,7 @@ The interface ID is `0x0f632fb3`.
 
 ##### name
 
-The `name` of the contract.
+The `name` for a token `id`.
 
 ```yaml
 - name: name
@@ -333,7 +333,7 @@ The `name` of the contract.
 
 ##### symbol
 
-The ticker `symbol` of the contract.
+The ticker `symbol` for a token `id`.
 
 ```yaml
 - name: symbol

--- a/ERCS/erc-6909.md
+++ b/ERCS/erc-6909.md
@@ -375,7 +375,7 @@ The `amount` of decimals for a token `id`.
 
 ##### contractURI
 
-The `URI` for a token `id`.
+The `URI` for the contract.
 
 ```yaml
 - name: contractURI


### PR DESCRIPTION
- moved `eip` to `erc` where relevant
- added explicit requirement for ERC-165 implementation
- change metadata method descriptions (`name`/`symbol`) to say "_ for a token `id`" rather than "_ of the contract"
- added backticks where relevant