### PR TITLE
Update ERC-4337: Clarify usage of `beneficiary` entrypoint param

### DIFF
--- a/ERCS/erc-4337.md
+++ b/ERCS/erc-4337.md
@@ -242,7 +242,7 @@ In the execution loop, the `handleOps` call must perform the following steps for
 * After the call, refund the account's deposit with the excess gas cost that was pre-charged.\
  A penalty of `10%` (`UNUSED_GAS_PENALTY_PERCENT`) is applied on the amounts of `callGasLimit` and `paymasterPostOpGasLimit` gas that remains **unused**.\
  This penalty is necessary to prevent the UserOps from reserving large parts of the gas space in the bundle but leaving it unused and preventing the bundler from including other UserOperations.
-* After the execution of all calls, pay the collected fees from all UserOperations to the bundler's provided address
+* After the execution of all calls, pay the collected fees from all UserOperations to the `beneficiary` address provided by the bundler
 
 ![](../assets/eip-4337/bundle-seq.svg)
 


### PR DESCRIPTION
the definition of this parameter and only reference to it are quite far apart.

This change explicitly names the parameter to make the connection easier to discover - eg, by `ctrl-f - beneficiary` after reading the Entrypoint interface definition.