### PR TITLE
Update ERC-4337: Fix refs in erc-4337.md

### DIFF
--- a/ERCS/erc-4337.md
+++ b/ERCS/erc-4337.md
@@ -369,7 +369,7 @@ A node MAY drop a UserOperation if it expires too soon (e.g. wouldn't make it to
 If the `ValidationResult` includes `sigFail`, the client SHOULD drop the `UserOperation`.
 
 To prevent DoS attacks on bundlers, they must make sure the validation methods above pass the validation rules, which constrain their usage of opcodes and storage.
-For the complete procedure see [ERC-7562](./eip-7562.md)
+For the complete procedure see [ERC-7562](./erc-7562.md)
 
 ### Alternative Mempools
 
@@ -380,7 +380,7 @@ A bundler cannot simply "whitelist" a request from a specific paymaster: if that
 bundlers, then its support will be sporadic at best.
 Instead, we introduce the term "alternate mempool": a modified validation rules, and procedure of propagating them to other bundlers.
 
-The procedure of using alternate mempools is defined in [ERC-7562](./eip-7562.md#alt-mempools-rules)
+The procedure of using alternate mempools is defined in [ERC-7562](./erc-7562.md#alt-mempools-rules)
 
 ### Bundling
 
@@ -448,7 +448,7 @@ The next step is protecting the bundlers from denial-of-service attacks by a mas
 There are two types of UserOperations that can fail validation:
 1. UserOperations that succeed in initial validation (and accepted into the mempool), but rely on the environment state to fail later when attempting to include them in a block.
 2. UserOperations that are valid when checked independently, by fail when bundled together to be put on-chain.
-To prevent such rogue UserOperations, the bundler is required to follow a set of [restrictions on the validation function](./eip-7562.md), to prevent such denial-of-service attacks.
+To prevent such rogue UserOperations, the bundler is required to follow a set of [restrictions on the validation function](./erc-7562.md), to prevent such denial-of-service attacks.
 
 ### Reputation Rationale.
 


### PR DESCRIPTION
ERC-7562 was referenced as "eip-7562" and not as "erc-7562". 

Old links lead to "https://github.com/ethereum/ERCs/blob/master/ERCS/eip-7562.md" - 404 page
New : "https://github.com/ethereum/ERCs/blob/master/ERCS/erc-7562.md"

