### PR TITLE
Update ERC-7683: Use uint40 for timestamps instead of uint32

### DIFF
--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -53,9 +53,9 @@ struct GaslessCrossChainOrder {
 	/// @dev The chainId of the origin chain
 	uint256 originChainId;
 	/// @dev The timestamp by which the order must be opened
-	uint32 openDeadline;
+	uint40 openDeadline;
 	/// @dev The timestamp by which the order must be filled on the destination chain
-	uint32 fillDeadline;
+	uint40 fillDeadline;
 	/// @dev Type identifier for the order data. This is an EIP-712 typehash.
 	bytes32 orderDataType;
 	/// @dev Arbitrary implementation-specific data
@@ -68,7 +68,7 @@ struct GaslessCrossChainOrder {
 /// @notice Standard order struct for user-opened orders, where the user is the msg.sender.
 struct OnchainCrossChainOrder {
 	/// @dev The timestamp by which the order must be filled on the destination chain
-	uint32 fillDeadline;
+	uint40 fillDeadline;
 	/// @dev Type identifier for the order data. This is an EIP-712 typehash.
 	bytes32 orderDataType;
 	/// @dev Arbitrary implementation-specific data
@@ -97,9 +97,9 @@ struct ResolvedCrossChainOrder {
 	/// @dev The chainId of the origin chain
 	uint256 originChainId;
 	/// @dev The timestamp by which the order must be opened
-	uint32 openDeadline;
+	uint40 openDeadline;
 	/// @dev The timestamp by which the order must be filled on the destination chain(s)
-	uint32 fillDeadline;
+	uint40 fillDeadline;
 	/// @dev The unique identifier for this order within this settlement system
 	bytes32 orderId;
 
@@ -218,27 +218,33 @@ A key consideration is to ensure that a broad range of cross-chain intent design
 #### Gasless cross-chain intents flow
 
 Origin Chain:
+
 1. The user signs an off-chain message defining the parameters of their order
 2. The order is disseminated to fillers
 3. The filler calls resolve to unpack the order's requirements
 4. The filler opens the order on the origin chain
 
 Destination Chain(s):
+
 - The filler fills each leg of the order on the destination chain(s)
 
 Settlement:
+
 - A cross-chain settlement process takes place to settle the order
 
 #### Onchain cross-chain intents flow
 
 Origin Chain:
+
 1. The caller signs a transaction calling open with their order
 2. The filler retrieves the emitted event to determine requirements
 
 Destination Chain(s):
+
 - The filler fills each leg of the order on the destination chain(s)
 
 Settlement:
+
 - A cross-chain settlement process takes place to settle the order
 
 #### Customization
@@ -325,7 +331,7 @@ The `Message` sub-type is designed to be used by a 7683 user to incentivize a fi
 function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) public {
 	(
 		address user,
-		uint32 fillDeadline,
+		uint40 fillDeadline,
 		Output memory fillerOutput,
 		Message memory message
 	) = abi.decode(originData);
@@ -353,7 +359,6 @@ function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerD
 ```
 
 In this example, the Message sub-type allows the user to delegate destination chain contract execution to fillers. However, because transactions are executed via filler, the `msg.sender` would be the `DestinationSettler`, making this `Message` sub-type limited if the target contract authenticates based on the `msg.sender`. Ideally, 7683 orders containing Messages can be combined with smart contract wallets like implementations of [ERC-4337](./eip-4337.md) or [EIP-7702](./eip-7702.md) to allow complete cross-chain delegated execution.
-
 
 ## Security Considerations
 


### PR DESCRIPTION
Uint40 should be used for timestamps instead of uint32. In systems that use signed integers, an int32 value is only good until the year 2038. External systems might use signed alternatives because it allows them to utilize timestamps from before the Unix epoch. Uint40 would allow systems that use signed integers to be functional until the year ~19000. Such a simple change to enable these systems to be resilient for more than 14 years in this regard seems like a no-brainer.