### PR TITLE
ERC-7683: 'open' and 'fill' methods should be payable

### DIFF
--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -166,13 +166,13 @@ interface IOriginSettler {
 	/// @param order The GaslessCrossChainOrder definition
 	/// @param signature The user's signature over the order
 	/// @param originFillerData Any filler-defined data required by the settler
-	function openFor(GaslessCrossChainOrder calldata order, bytes calldata signature, bytes calldata originFillerData) external;
+	function openFor(GaslessCrossChainOrder calldata order, bytes calldata signature, bytes calldata originFillerData) external payable;
 
 	/// @notice Opens a cross-chain order
 	/// @dev To be called by the user
 	/// @dev This method must emit the Open event
 	/// @param order The OnchainCrossChainOrder definition
-	function open(OnchainCrossChainOrder calldata order) external;
+	function open(OnchainCrossChainOrder calldata order) external payable;
 
 	/// @notice Resolves a specific GaslessCrossChainOrder into a generic ResolvedCrossChainOrder
 	/// @dev Intended to improve standardized integration of various order types and settlement contracts
@@ -199,7 +199,7 @@ interface IDestinationSettler {
 	/// @param orderId Unique order identifier for this order
 	/// @param originData Data emitted on the origin to parameterize the fill
 	/// @param fillerData Data provided by the filler to inform the fill or express their preferences
-	function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) external;
+	function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) external payable;
 }
 ```
 
@@ -218,27 +218,33 @@ A key consideration is to ensure that a broad range of cross-chain intent design
 #### Gasless cross-chain intents flow
 
 Origin Chain:
+
 1. The user signs an off-chain message defining the parameters of their order
 2. The order is disseminated to fillers
 3. The filler calls resolve to unpack the order's requirements
 4. The filler opens the order on the origin chain
 
 Destination Chain(s):
+
 - The filler fills each leg of the order on the destination chain(s)
 
 Settlement:
+
 - A cross-chain settlement process takes place to settle the order
 
 #### Onchain cross-chain intents flow
 
 Origin Chain:
+
 1. The caller signs a transaction calling open with their order
 2. The filler retrieves the emitted event to determine requirements
 
 Destination Chain(s):
+
 - The filler fills each leg of the order on the destination chain(s)
 
 Settlement:
+
 - A cross-chain settlement process takes place to settle the order
 
 #### Customization
@@ -322,7 +328,7 @@ struct Message {
 The `Message` sub-type is designed to be used by a 7683 user to incentivize a filler to execute arbitrary calldata on a target destination chain contract on the user's behalf. For example, the settlement contract might decode the `orderData` containing the message information as follows:
 
 ```solidity
-function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) public {
+function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) public payable {
 	(
 		address user,
 		uint32 fillDeadline,
@@ -353,7 +359,6 @@ function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerD
 ```
 
 In this example, the Message sub-type allows the user to delegate destination chain contract execution to fillers. However, because transactions are executed via filler, the `msg.sender` would be the `DestinationSettler`, making this `Message` sub-type limited if the target contract authenticates based on the `msg.sender`. Ideally, 7683 orders containing Messages can be combined with smart contract wallets like implementations of [ERC-4337](./eip-4337.md) or [EIP-7702](./eip-7702.md) to allow complete cross-chain delegated execution.
-
 
 ## Security Considerations
 


### PR DESCRIPTION
Making the `open` methods payable allows for natives to trivially be used in user requests. Native payment can easily be accounted for alongside ERC-20 tokens by using address(0). Adding the `payable` modifier will make it much easier for integrators to account for native payments. This logic also follows for `fill`, as fillers might need to provide native payment to the settlement contract to fulfill the user's order. It seems like an anti-pattern to require handling native payment in functions outside of the spec.