### PR TITLE
Update ERC-4337: Improve sections

### DIFF
--- a/ERCS/erc-4337.md
+++ b/ERCS/erc-4337.md
@@ -79,7 +79,7 @@ A specialized class of actors called **bundlers** (either block builders running
 
 To prevent replay attacks (both cross-chain and multiple `EntryPoint` implementations), the `signature` should depend on `chainid` and the `EntryPoint` address.
 
-### EntryPoint definition
+### PackedUserOperation
 
 When passed to on-chain contacts (the EntryPoint contract, and then to the account and paymaster), a packed version of the above structure is used:
 
@@ -95,6 +95,8 @@ When passed to on-chain contacts (the EntryPoint contract, and then to the accou
 | `paymasterAndData`   | `bytes`   | concatenation of paymaster fields (or empty)                           |
 | `signature`          | `bytes`   |                                                                        |
 
+
+### EntryPoint Interface
 
 The core interface of the entry point contract is as follows:
 


### PR DESCRIPTION
It's hard to navigate ERC-4337. In particular, it's very hard to find the definition of PackedUserOperation. This change should improve that.

I think it would also be nice to have the entire EntryPoint interface in one section. Currently it's scattered around.