### PR TITLE
Update ERC-7821: Fix return type of `supportsExecutionMode` in interface definition.

### DIFF
--- a/ERCS/erc-7821.md
+++ b/ERCS/erc-7821.md
@@ -73,7 +73,7 @@ interface IERC7821 {
     /// Only returns true for:
     /// - `bytes32(0x01000000000000000000...)`: does not support optional `opData`.
     /// - `bytes32(0x01000000000078210001...)`: supports optional `opData`.
-    function supportsExecutionMode(bytes32 mode) external view returns (uint256);
+    function supportsExecutionMode(bytes32 mode) external view returns (bool);
 }
 ```
 


### PR DESCRIPTION
The ERC refers to `supportsExecutionMode` as returning a boolean:
> Only returns true for:

And the reference implementation returns a boolean. Yet the interface specify returning a uint256. This looks like a mistake.