### PR TITLE
Website: Fix typos and spelling errors in documentation

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
   {% if page.layout == "eip" %}
     {% if page.category == "ERC" %}
       <title>ERC-{{ page.eip }}: {{ page.title | escape }}</title>
-      <meta propery="og:title" content="ERC-{{ page.eip }}: {{ page.title | escape }}" />
+      <meta property="og:title" content="ERC-{{ page.eip }}: {{ page.title | escape }}" />
     {% else %}
       <title>EIP-{{ page.eip }}: {{ page.title | escape }}</title>
       <meta property="og:title" content="EIP-{{ page.eip }}: {{ page.title | escape }}" />

--- a/assets/erc-2535/reference/Diamond.sol
+++ b/assets/erc-2535/reference/Diamond.sol
@@ -473,7 +473,7 @@ contract OwnershipFacet is IERC173 {
 // when the `diamondCut` function is called.
 // It is expected that this contract is customized if you want to deploy your diamond
 // with data from a deployment script. Use the init function to initialize state variables
-// of your diamond. Add parameters to the init funciton if you need to.
+// of your diamond. Add parameters to the init function if you need to.
 // DiamondInit can be used during deployment or for upgrades.
 
 // Adding parameters to the `init` or other functions you add here can make a single deployed

--- a/assets/erc-2535/storage-examples/AppStorage.sol
+++ b/assets/erc-2535/storage-examples/AppStorage.sol
@@ -75,7 +75,7 @@ contract SomeOtherFacet {
 // Using the 's.' prefix to access AppStorage is a nice convention because it makes state variables 
 // concise, easy to access, and it distinguishes state variables from local variables and prevents 
 // name clashes/shadowing with local variables and function names. It helps identify and make 
-// explicit state variables in a convenient and concise way. AppStorage can be used in regualar 
+// explicit state variables in a convenient and concise way. AppStorage can be used in regular 
 // contracts as well as proxy contracts, diamonds, implementation contracts, Solidity libraries and 
 // facets.
 


### PR DESCRIPTION
"propery" - "property" 
"funciton" - "function" 
"regualar" - "regular" 

While these typos don't affect code functionality, fixing them:

- Improves documentation clarity
- Follows coding best practices
- Makes codebase more maintainable

I hope my corrections will help you. Thank you for your work.