### PR TITLE
Update ERC-7579: Make ERC165 optional and clarify payable execution

### DIFF
--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -53,7 +53,7 @@ To comply with this standard, smart accounts MUST implement the execution interf
 ```solidity
 interface IExecution {
     /**
-     * @dev Executes a transaction on behalf of the account.
+     * @dev Executes a transaction on behalf of the account. MAY be payable.
      * @param mode The encoded execution mode of the transaction.
      * @param executionCalldata The encoded execution call data.
      *
@@ -63,7 +63,7 @@ interface IExecution {
     function execute(bytes32 mode, bytes calldata executionCalldata) external;
 
     /**
-     * @dev Executes a transaction on behalf of the account.
+     * @dev Executes a transaction on behalf of the account. MAY be payable.
      *         This function is intended to be called by Executor Modules
      * @param mode The encoded execution mode of the transaction.
      * @param executionCalldata The encoded execution call data.
@@ -235,7 +235,7 @@ ERC-165 support (see below) is one example of such an approach. Note, that it is
 
 #### ERC-165
 
-Smart accounts MUST implement ERC-165. However, for every interface function that reverts instead of implementing the functionality, the smart account MUST return `false` for the corresponding interface id.
+Smart accounts MAY implement ERC-165. However, for every interface function that reverts instead of implementing the functionality, the smart account MUST return `false` for the corresponding interface id.
 
 ### Modules
 


### PR DESCRIPTION
### Description

Multiple ERC7579 implementatins skip the ERC-165 interface and seems to not bee too much consensus around providing a usage for it. Other ERC-4337 related standards have implemented their detection mechanisms (e.g. see ERC-7739's detection) without relying on ERC-165.

Also, since the `IExecution` interface is not specified as `payable` but some accounts have implemented it this way, I'm adding comments to improve clarity.