### PR TITLE
Fixing Typographical Errors in Documentation

### DIFF
--- a/assets/erc-4675/contracts/interface/IERC721.sol
+++ b/assets/erc-4675/contracts/interface/IERC721.sol
@@ -10,7 +10,7 @@ abstract contract IERC721 {
     event Transfer(
         address indexed from,
         address indexed to,
-        uint256 indexed tokenaId
+        uint256 indexed tokenId
     );
 
     event Approval(

--- a/assets/erc-5247/ProposalRegistry.sol
+++ b/assets/erc-5247/ProposalRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// A fully runnalbe version can be found in https://github.com/ercref/ercref-contracts/tree/869843f23dc4da793f0d9d018ed92e3950da8f75
+// A fully runnable version can be found in https://github.com/ercref/ercref-contracts/tree/869843f23dc4da793f0d9d018ed92e3950da8f75
 pragma solidity ^0.8.17;
 
 import "./IERC5247.sol";


### PR DESCRIPTION
changed:

tokenaId - tokenId

runnalbe - runnable 