### PR TITLE
Update ERC-6860: typos

### DIFF
--- a/ERCS/erc-6860.md
+++ b/ERCS/erc-6860.md
@@ -120,7 +120,7 @@ The manual mode will use the raw **mPathQuery** as calldata of the message direc
 
 The returned message data will be treated as ABI-encoded bytes and the decoded bytes will be returned to the frontend.
 
-The MIME type returned to the frontend is ``text/html`` by default, but will be overriden if a **fileExtension**  is present. In this case, the MIME type will be deduced from the filename extension.
+The MIME type returned to the frontend is ``text/html`` by default, but will be overridden if a **fileExtension**  is present. In this case, the MIME type will be deduced from the filename extension.
 
 ```
 relMPathQuery   = relMPath [ "?" mQuery ]
@@ -202,7 +202,7 @@ bytesSizes      = %x31-39              ; 1-9
 
 The "returns" attribute in **aQuery** tells the format of the returned data. It follows the syntax of the arguments part of the ethereum ABI function signature (``uint`` and ``int`` aliases are authorized).
 
-- If the "returns" attribute value is undefined or empty, the returned message data will be treated as ABI-encoded bytes and the decoded bytes will be returned to the frontend. The MIME type returned to the frontend will be undefined by default, but will be overriden if the last argument is of string type and has a **fileExtension**, in which case the MIME type will be deduced from the filename extension. (Note that **fileExtension** is not excluded from the string argument given to the smartcontract)
+- If the "returns" attribute value is undefined or empty, the returned message data will be treated as ABI-encoded bytes and the decoded bytes will be returned to the frontend. The MIME type returned to the frontend will be undefined by default, but will be overridden if the last argument is of string type and has a **fileExtension**, in which case the MIME type will be deduced from the filename extension. (Note that **fileExtension** is not excluded from the string argument given to the smartcontract)
 - If the "returns" attribute value is equal to "()", the raw bytes of the returned message data will be returned, encoded as a "0x"-prefixed hex string in an array in JSON format: ``["0xXXXXX"]``
 - Otherwise, the returned message data will be ABI-decoded in the data types specified in the **returns** value and encoded in JSON format. The encoding of the data will follow the Ethereum JSON-RPC format:
   - Unformatted data (bytes, address) will be encoded as hex, prefixed with "0x", two hex digits per byte
@@ -257,7 +257,7 @@ web3://vitalikblog.eth:5/
 
 where the contract of **vitalikblog.eth:5** is in manual mode.
 
-The protocol will find the address of **vitalikblog.eth** from ENS on chainid 5 (Goerli). Then after determing the contract is in manual mode, the protocol will call the address with "To" = **contractAddress** and "Calldata" = "0x2F" with chainid = 5. The returned data will be treated as ABI-type "(bytes)", and the decoded bytes will be returned to the frontend, with the information that the MIME type is ``text/html``.
+The protocol will find the address of **vitalikblog.eth** from ENS on chainid 5 (Goerli). Then after determining the contract is in manual mode, the protocol will call the address with "To" = **contractAddress** and "Calldata" = "0x2F" with chainid = 5. The returned data will be treated as ABI-type "(bytes)", and the decoded bytes will be returned to the frontend, with the information that the MIME type is ``text/html``.
 
 #### Example 4
 
@@ -267,7 +267,7 @@ web3://0xe4ba0e245436b737468c206ab5c8f4950597ab7f:42170/
 
 where the contract "0xe4ba0e245436b737468c206ab5c8f4950597ab7f:42170" is in manual mode.
 
-After determing the contract is in manual mode, the protocol will call the address with "To" = "0xe4ba0e245436b737468c206ab5c8f4950597ab7f" and "Calldata" = "0x2F" with chainid = 42170 (Arbitrum Nova). The returned data will be treated as ABI-type "(bytes)", and the decoded bytes will be returned to the frontend, with the information that the MIME type is ``text/html``.
+After determining the contract is in manual mode, the protocol will call the address with "To" = "0xe4ba0e245436b737468c206ab5c8f4950597ab7f" and "Calldata" = "0x2F" with chainid = 42170 (Arbitrum Nova). The returned data will be treated as ABI-type "(bytes)", and the decoded bytes will be returned to the frontend, with the information that the MIME type is ``text/html``.
 
 #### Example 5
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

Description correction:
Corrected `overriden` to `overridden`
Corrected `determing` to `determining`

Please review the changes and let me know if any additional changes are needed.