### PR TITLE
Update ERC-7744: Move to Review

### DIFF
--- a/ERCS/erc-7744.md
+++ b/ERCS/erc-7744.md
@@ -122,9 +122,11 @@ Reference implementation of the Code Index can be found in the assets folder. Th
 
 **Storage contents of registered contracts**: The index only refers to the bytecode of the contract, not the storage contents. This means that the contract state is not indexed and may change over time.
 
-**EIP-7702**: The index does not index the EIP-7702 delegated accounts, as it is a special case and its bytecode is not deterministic. During attempt to register, it checks `EXTCODEHASH` for new address and if value is `0xeadcdba66a79ab5dce91622d1d75c8cff5cff0b96944c3bf1072cd08ce018329` (`keccak256(0xef01)`) it will revert.
+**[EIP-7702]**: The index does not index the EIP-7702 delegated accounts, as it is a special case and its bytecode is not deterministic. During attempt to register, it checks `EXTCODEHASH` for new address and if value is `0xeadcdba66a79ab5dce91622d1d75c8cff5cff0b96944c3bf1072cd08ce018329` (`keccak256(0xef01)`) it will revert.
 
 **Self-Destruct Contracts**: In case of indexed contract storage becomes empty, contracts may be re-indexed, During register function call, iF contract is already indexed, we run `isValidContainer` check on the indexed address. It it fails, re-indexing is allowed with a newly specified address.
+
+[EIP-7702]: ./eip-7702.md
 
 ## Copyright
 

--- a/ERCS/erc-7744.md
+++ b/ERCS/erc-7744.md
@@ -4,7 +4,7 @@ title: Code Index
 description: Global repository of bytecode, enabling developers, auditors, and researchers to find, analyze, and reuse bytecode efficiently.
 author: Tim Pechersky (@peersky) <t@peersky.xyz>
 discussions-to: https://ethereum-magicians.org/t/erc-7744-code-index/20569
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2024-07-16
@@ -34,16 +34,15 @@ Its simplicity and generic nature make it suitable for a wide range of applicati
 
 Ultimately, this feature should be incorporated into EIP standards, as it is a fundamental building block for trustless and secure smart contract development. This standard is a step towards this goal.
 
-
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 ```solidity
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity =0.8.20;
+pragma solidity 0.8.28;
 
-interface ICodeIndex {
+interface IERC7744 {
     event Indexed(address indexed container, bytes32 indexed codeHash);
     error alreadyExists(bytes32 id, address source);
 
@@ -58,19 +57,28 @@ interface ICodeIndex {
  * @dev This allows to query contracts by their bytecode instead of addresses.
  * @author Tim Pechersky (@Peersky)
  */
-contract CodeIndex is ICodeIndex {
+contract ERC7744 is IERC7744 {
     mapping(bytes32 => address) private index;
+
+    function isValidContainer(address container) private view returns (bool) {
+        bytes memory code = container.code;
+        bytes32 codeHash = container.codehash;
+        bytes32 eip7702Hash = bytes32(0xeadcdba66a79ab5dce91622d1d75c8cff5cff0b96944c3bf1072cd08ce018329);
+        // Contract should have non-empty code and valid codehash
+        return (code.length > 0 && codeHash != bytes32(0) && codeHash != eip7702Hash);
+    }
 
     /**
      * @notice Registers a contract in the index by its bytecode hash
      * @param container The contract to register
      * @dev `msg.codeHash` will be used
-     * @dev It will revert if the contract is already indexed
+     * @dev It will revert if the contract is already indexed or if returns EIP7702 hash
      */
     function register(address container) external {
         address etalon = index[container.codehash];
+        require(isValidContainer(container), "Invalid container");
         if (etalon != address(0)) {
-            revert alreadyExists(container.codehash, etalon);
+            if (isValidContainer(etalon)) revert alreadyExists(container.codehash, container);
         }
         index[container.codehash] = container;
         emit Indexed(container, container.codehash);
@@ -87,11 +95,12 @@ contract CodeIndex is ICodeIndex {
     }
 }
 
+
 ```
 
 ### Deployment method
 
-The `CodeIndex` contract is deployed at: `0xc0D31d398c5ee86C5f8a23FA253ee8a586dA03Ce` using `CREATE2` via the deterministic deployer at `0x4e59b44847b379578588920ca78fbf26c0b4956c` with a salt of `0x220a70730c743a005cfd55180805d2c0d5b8c7695c5496100dcffa91c02befce` is obtained by seeking a vanity address with meaningful name "Code ID (`c0D31d`).
+The `CodeIndex` contract is deployed at: `0xC0dE1D2F7662c63796E544B2647b2A94EE658E07` using `CREATE2` via the deterministic deployer at `0x4e59b44847b379578588920ca78fbf26c0b4956c` with a salt of `0x70b27c94ed692bfb60748cee464ef910d4bf768ac1f3a63eeb4c05258f629256` is obtained by seeking a vanity address with meaningful name "Code ID (`0xC0dE1D`).
 
 ## Rationale
 
@@ -112,6 +121,10 @@ Reference implementation of the Code Index can be found in the assets folder. Th
 **Malicious Code**: The index does NOT guarantee the safety or functionality of indexed contracts. Users MUST exercise caution and perform their own due diligence before interacting with indexed contracts.
 
 **Storage contents of registered contracts**: The index only refers to the bytecode of the contract, not the storage contents. This means that the contract state is not indexed and may change over time.
+
+**EIP-7702**: The index does not index the EIP-7702 delegated accounts, as it is a special case and its bytecode is not deterministic. During attempt to register, it checks `EXTCODEHASH` for new address and if value is `0xeadcdba66a79ab5dce91622d1d75c8cff5cff0b96944c3bf1072cd08ce018329` (`keccak256(0xef01)`) it will revert.
+
+**Self-Destruct Contracts**: In case of indexed contract storage becomes empty, contracts may be re-indexed, During register function call, iF contract is already indexed, we run `isValidContainer` check on the indexed address. It it fails, re-indexing is allowed with a newly specified address.
 
 ## Copyright
 

--- a/ERCS/erc-7746.md
+++ b/ERCS/erc-7746.md
@@ -2,9 +2,9 @@
 eip: 7746
 title: Composable Security Middleware Hooks
 description: An interface for composable, runtime security checks in smart contracts.
-author: Tim Pechersky (@peersky) <t@peersky.xyz>
+author: Tim Pechersky (@peersky)
 discussions-to: https://ethereum-magicians.org/t/erc-7746-composable-security-middleware-hooks/19471
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2024-07-17

--- a/ERCS/erc-7746.md
+++ b/ERCS/erc-7746.md
@@ -86,7 +86,7 @@ A protected contract MAY integrate security layers by calling the `beforeCallVal
 ## Reference Implementation
 
 A reference implementation of the `ILayer` interface and a sample protected contract can be found in the repository:
-In the [`../assets/eip-7746/ILayer.sol`](../assets/eip-7746/ILayer.sol) a reference interface is provided.
+In the [`ILayer.sol`](../assets/eip-7746/ILayer.sol) a reference interface is provided.
 
 In this test, a [`Protected.sol`](../assets/eip-7746/test/Protected.sol) contract is protected by a [`RateLimitLayer.sol`](../assets/eip-7746/test/RateLimitLayer.sol) layer. The `RateLimitLayer` implements the `ILayer` interface and enforces a rate which client has configured.
 The `Drainer` simulates a vulnerable contract that acts in a malicious way. In the `test.ts` The `Drainer` contract is trying to drain the funds from the `Protected` contract. It is assumed that `Protected` contract has bug that allows partial unauthorized access to the state.

--- a/ERCS/erc-7746.md
+++ b/ERCS/erc-7746.md
@@ -16,7 +16,8 @@ This EIP proposes a standard interface, `ILayer`, for implementing composable se
 
 ## Motivation
 
-Current smart contract security practices often rely on monolithic validation logic within the contract itself. This can lead to tightly coupled code, making it difficult to isolate and address security concerns. Existing ERCs already are using something that can be seen as specific implementation of such layers wrapping: [ERC-4337](./eip-4337.md) describes requirements to perform validate user operations in a separate contract, and later elaborates same need to paymaster validation, that can be seen as a separate layers of a generic system.
+Current smart contract security practices often rely on monolithic validation logic within the contract itself. This can lead to tightly coupled code, making it difficult to isolate and address security concerns. Better structured architecture is needed, middleware like approach is widely used in the industry, allowing to wrap calls in other calls in generic and repeatable pattern with same call signatures. 
+
 The Security Layers Standard introduces a modular approach, enabling:
 
 - **Independent Security Providers:** Specialized security providers can focus on developing and maintaining specific security checks.

--- a/assets/erc-7744/CodeIndex.sol
+++ b/assets/erc-7744/CodeIndex.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity 0.8.20;
-import "./ICodeIndex.sol";
+pragma solidity 0.8.28;
+import {IERC7744} from "./IERC7744.sol";
 
 /**
  * @title Byte Code Indexer Contract
@@ -8,19 +8,28 @@ import "./ICodeIndex.sol";
  * @dev This allows to query contracts by their bytecode instead of addresses.
  * @author Tim Pechersky (@Peersky)
  */
-contract CodeIndex is ICodeIndex {
+contract ERC7744 is IERC7744 {
     mapping(bytes32 => address) private index;
+
+    function isValidContainer(address container) private view returns (bool) {
+        bytes memory code = container.code;
+        bytes32 codeHash = container.codehash;
+        bytes32 eip7702Hash = bytes32(0xeadcdba66a79ab5dce91622d1d75c8cff5cff0b96944c3bf1072cd08ce018329);
+        // Contract should have non-empty code and valid codehash
+        return (code.length > 0 && codeHash != bytes32(0) && codeHash != eip7702Hash);
+    }
 
     /**
      * @notice Registers a contract in the index by its bytecode hash
      * @param container The contract to register
      * @dev `msg.codeHash` will be used
-     * @dev It will revert if the contract is already indexed
+     * @dev It will revert if the contract is already indexed or if returns EIP7702 hash
      */
     function register(address container) external {
         address etalon = index[container.codehash];
+        require(isValidContainer(container), "Invalid container");
         if (etalon != address(0)) {
-            revert alreadyExists(container.codehash, etalon);
+            if (isValidContainer(etalon)) revert alreadyExists(container.codehash, container);
         }
         index[container.codehash] = container;
         emit Indexed(container, container.codehash);

--- a/assets/erc-7744/ICodeIndex.sol
+++ b/assets/erc-7744/ICodeIndex.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity 0.8.20;
+pragma solidity >=0.8.0 <0.9.0;
 
-interface ICodeIndex {
+interface IERC7744 {
     event Indexed(address indexed container, bytes32 indexed codeHash);
     error alreadyExists(bytes32 id, address source);
 


### PR DESCRIPTION
This PR concludes discussion that was facilitated on the Magician forums, particularly: 

- Addresses self-destruct concerns
- Addresses EIP7702 delegated address concern 
- Changes solidity file names according to standard number 
- Changes salt and deployment address to accommodate bytecode changes
- New artifact was compiled with no metadata included to avoid bytecode changes if somone tries to re-compile it locally 