### PR TITLE
Update ERC-7779: Add enforcement to use keccak

### DIFF
--- a/ERCS/erc-7779.md
+++ b/ERCS/erc-7779.md
@@ -37,6 +37,8 @@ Account Abstraction Wallets, given the wallet-specific validation and execution 
 
 This spec provides a standard approach for fetching the storage base used in the delegated account together with an optional mechanism to clean up the storage.
 
+Moreover, it is worth noting that this spec is not limited to [EIP-7702](./eip-7702.md) based smart accounts but smart accounts and smart contracts in general that uses a custom storage slot.
+
 ## Specification
 
 The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
@@ -61,6 +63,7 @@ interface IInteroperableDelegatedAccount {
 	 *         The bytes32 array should be stored at the storage slot: keccak(keccak('InteroperableDelegatedAccount.ERC.Storage')-1) & ~0xff
 	 *         This is an append-only array so newly redelegated accounts should not overwrite the storage at this slot, but just append their base to the array.
 	 *         This append operation should be done during the initialization of the account.
+	 * 		   This array should return a value of keccak hash unless using external storage.
 	 */
 	function accountStorageBases() external view returns (bytes32[]);
 
@@ -84,6 +87,8 @@ interface IRedelegableDelegatedAccount {
 
 Accounts MUST implement the `IInteroperableDelegatedAccount` to be compliant with the standard.
 
+Accounts MUST use `keccak256()` to compute the storage bases for `accountStorageBases()`, unless using external storage contract.
+
 Accounts MAY implement the `IRedelegableDelegatedAccount`.
 
 ### `accountId()`
@@ -97,6 +102,8 @@ Wallet A information could be extracted from `accountId()`.
 ### `accountStorageBases()`
 
 This function returns the list of base storage slots of that account has used.
+
+To comply with this standard, the account MUST use `keccak256()` to prevent collision when calculating the storage slot.
 
 EIP-7702 Accounts do plan to use a custom non-zero storage slot to avoid storage collision as much as possible, however, there hasn’t been a standardized approach on how to fetch them.
 
@@ -185,6 +192,8 @@ This standard was specifically for Smart Accounts for EOA, but this could be app
 4. `onRedelegation()` should not reset the replay protection considering that it could incur a vulnerability(e.g., signature reply attack).
 
 5. It is worth noting that this standard is an ERC, which means that even if the ERC enforces it, the actual implementation may not be compliant with it. e.g., accounts pretending to support this standard which is not, in fact. So it is recommend to validate if the account is a know implementation that is secure and compliant with the standard.
+
+6. The standard ENFORCES the storage slot to be calculated through `keccak256()` to reduce collision. The preimage of the hash could be the name/version or a combination, it is under full discretion of the account.
 
 ## Copyright
 


### PR DESCRIPTION
Update the ERC to enforce the usage of `keccak256()` for calculating the storage bases of the smart contract.