### PR TITLE
Update EIP-1: Introduce `implementation-status` & `implementation-status-url`

### DIFF
--- a/ERCS/eip-1.md
+++ b/ERCS/eip-1.md
@@ -417,6 +417,20 @@ The top-level URL field must resolve to a copy of the referenced document which 
 
 References to other EIPs should follow the format `EIP-N` where `N` is the EIP number you are referring to.  Each EIP that is referenced in an EIP **MUST** be accompanied by a relative markdown link the first time it is referenced, and **MAY** be accompanied by a link on subsequent references.  The link **MUST** always be done via relative paths so that the links work in this GitHub repository, forks of this repository, the main EIPs site, mirrors of the main EIP site, etc.  For example, you would link to this EIP as `./eip-1.md`.
 
+```markdown
+[EIP-1](./eip-1.md)
+```
+
+Which renders to:
+
+[EIP-1](./eip-1.md)
+
+Links to other EIPs must be relative paths and match this regular expression:
+
+```regex
+^(./eip-[0-9]+\.md)$
+```
+
 ## Auxiliary Files
 
 Images, diagrams and auxiliary files should be included in a subdirectory of the `assets` folder for that EIP as follows: `assets/eip-N` (where **N** is to be replaced with the EIP number). When linking to an image in the EIP, use relative links such as `../assets/eip-1/image.png`.
@@ -489,7 +503,7 @@ The `description` field in the preamble:
 
 ### EIP numbers
 
-When referring to an EIP with a `category` of `ERC`, it must be written in the hyphenated form `ERC-X` where `X` is that EIP's assigned number. When referring to EIPs with any other `category`, it must be written in the hyphenated form `EIP-X` where `X` is that EIP's assigned number.
+When referring to an EIP with a `category` of `ERC`, it must be written in the hyphenated form `ERC-X` where `X` is that EIP's assigned number. When referring to EIPs with any other `category`, it must be written in the hyphenated form `EIP-X` where `X` is that EIP's assigned number. With regards to linking see the [Linking to other EIPs](#linking-to-other-eips) section.
 
 ### RFC 2119 and RFC 8174
 

--- a/ERCS/eip-1.md
+++ b/ERCS/eip-1.md
@@ -192,6 +192,18 @@ EIPs may have a `requires` header, indicating the EIP numbers that this EIP depe
 
 A `requires` dependency is created when the current EIP cannot be understood or implemented without a concept or technical element from another EIP. Merely mentioning another EIP does not necessarily create such a dependency.
 
+### `implementation-status` header
+
+The `implementation-status` header is used to provide extra context regarding usage or highlight popular example implementation of a EIP. This information should be light and concise.
+
+This field is optional and to be used sparingly.
+
+### `implementation-status-url` header
+
+The `implentation-status-url` header can be used when combined with the `implementation-status` header to provide a link to an external resource that provides more information about the current implementation status of an EIP.
+
+Keep in mind that linkage to external resources requires extra consideration and could be rejected by EIP Editors.
+
 ## Linking to External Resources
 
 Other than the specific exceptions listed below, links to external resources **SHOULD NOT** be included. External resources may disappear, move, or change unexpectedly.


### PR DESCRIPTION
> [!NOTE]
> This proposal is intended for demonstration purposes only.
> and this message is self-referential.. in a weird way

## Motivation

To date, nearly 6000 commits have been made to the [ethereum/EIPs](https://eips.ethereum.org) (and [ethereum/ERCs](https://ercs.ethereum.org)) repositories.
Covering a wide range of content from ethos and technical standards, to procedures and processes, these repositories lay the foundation for the protocol and ecosystem we know today.

However not all specs are created equal. Some are abandoned, others superseded, and some are never implemented to begin with.
When taking a peek at [MDN](https://developer.mozilla.org/en-US/docs/)'s playbook, we can see a similar situation play out with regards to browser implementations of web specifications.

[![image](https://github.com/user-attachments/assets/c8a72a42-d4e3-46fc-9247-7ed67be7ef9b)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)

Mozilla's solution for this was a widget, at the top of the page, highlighting the current status and imporant context the reader might need to be able to be informed.
In addition to this the widget is color coded to give the reader a seamless "at-a-glance" experience.

So what if we applied this to ERCs? Take [ERC-20](https://ercs.ethereum.org/ERCS/erc-20), wouldn't it be awesome if the average developer who lands on this page could easily see thats its a widely adopted standard?
A possible rendering of such section could look like this:

![image](https://github.com/user-attachments/assets/476fee0a-330e-4bff-88ce-3a00929f14e4)

The above aims to render an example for the ERC-20 standard, however you could imagine a similar use case for the URL standards, which also involve successive standards, and many more.
In other cases, where implementation of a spec might differ between wallets (think WalletConnect or ENS support), or clients (think protocol level changes) documents could link out to resources to showcase what clients implement what.

This would allow beginning developers, teams, and organizations a better first glance at the collective works that represents ethereum.

## Isn't maintaining this going to be an absolute pain?

Oh absolute, but as with anything it is dependent on the granularity withwhich it is kept up-to-date.
As mentioned in the proposed changes, this field is ment to be used sparingly.

### Isn't this a registry?

As outlined in [EIP-5069: EIP Editor Handbook](https://eips.ethereum.org/EIPS/eip-5069) "What we Don't"-section:

> Track Registries: We want all proposals to eventually become immutable, but a registry will never get there if anyone can keep adding items. To be clear, exhaustive and/or static lists are fine.

So here is my response; there are a few conditions which must be met for this to be tolerable:

- It must be **used sparingly**, no overuse, no verbosity, keep it simple
- Only cover general status, **not track specific implementations**, or point fingers
- Linkout to at-most three (or one) resource(s), that compare the state of available options (think L2Beat)

## Should this be merged?

Maybe. I think writing this was a fun experience, but although an `implementation-status` header could be a very nice tool in some places, the ability for its abuse, and its use of external linking could cause for additional spam or undesirable extra flare.
