### PR TITLE
Update ERC-7528: update required EIP for ETH (Native Asset) Address Convention

### DIFF
--- a/ERCS/erc-7528.md
+++ b/ERCS/erc-7528.md
@@ -8,7 +8,7 @@ status: Final
 type: Standards Track
 category: ERC
 created: 2023-10-03
-requires: 20, 155, 4626
+requires: 20, 55, 4626
 ---
 
 ## Abstract
@@ -37,7 +37,7 @@ Any fields or events where an [ERC-20](./eip-20.md) address is used, yet the und
 
 Any fields or events where the Token is a non-enshrined wrapped ERC-20 version of ETH (i.e WETH9) MUST use that Token's address and MUST NOT use `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`.
 
-Where appropriate, the address should be checksummed. E.g. the [EIP-155](./eip-155.md) checksum is `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`.
+Where appropriate, the address should be checksummed. E.g. the [EIP-55](./eip-55.md) checksum is `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`.
 
 ## Rationale
 


### PR DESCRIPTION
The required EIP is actually ERC-55: Mixed-case checksum address encoding, not EIP-155: Simple replay attack protection

Source: https://eips.ethereum.org/EIPS/eip-55, https://eips.ethereum.org/EIPS/eip-155

