### PR TITLE
Update ERC-6900: Prefix ERC-6900 interfaces names to avoid conflicts

### DIFF
--- a/ERCS/erc-6900.md
+++ b/ERCS/erc-6900.md
@@ -65,26 +65,26 @@ Each step is modular, supporting different implementations, which allows for ope
 Modular accounts MUST implement:
 
 - `IAccount.sol` and `IAccountExecute.sol` from [ERC-4337](./eip-4337.md).
-- `IModularAccount.sol` to support module management and usage, and account identification.
+- `IERC6900ModularAccount.sol` to support module management and usage, and account identification.
 - The function `isValidSignature` from [ERC-1271](./eip-1271.md)
 
 Modular accounts MAY implement:
 
-- `IModularAccountView.sol` to support visibility in account states on-chain.
+- `IERC6900ModularAccountView.sol` to support visibility in account states on-chain.
 - [ERC-165](./eip-165.md) for interfaces installed from modules.
 
 Modules MUST implement:
 
-- `IModule.sol` described below and implement ERC-165 for `IModule`.
+- `IERC6900Module.sol` described below and implement ERC-165 for `IERC6900Module`.
 
 Modules MAY implement any of the following module types:
 
-- `IValidationModule` to support validation functions for the account.
-- `IValidationHookModule` to support hooks for validation functions.
-- `IExecutionModule` to support execution functions and their installations on the account.
-- `IExecutionHookModule` to support pre & post execution hooks for execution functions.
+- `IERC6900ValidationModule` to support validation functions for the account.
+- `IERC6900ValidationHookModule` to support hooks for validation functions.
+- `IERC6900ExecutionModule` to support execution functions and their installations on the account.
+- `IERC6900ExecutionHookModule` to support pre & post execution hooks for execution functions.
 
-#### `IModularAccount.sol`
+#### `IERC6900ModularAccount.sol`
 
 Module execution and management interface. Modular accounts MUST implement this interface to support installing and uninstalling modules, and open-ended execution.
 
@@ -131,7 +131,7 @@ struct Call {
     bytes data;
 }
 
-interface IModularAccount {
+interface IERC6900ModularAccount {
     event ExecutionInstalled(address indexed module, ExecutionManifest manifest);
     event ExecutionUninstalled(address indexed module, bool onUninstallSucceeded, ExecutionManifest manifest);
     event ValidationInstalled(address indexed module, uint32 indexed entityId);
@@ -217,7 +217,7 @@ interface IModularAccount {
 }
 ```
 
-#### `IModularAccountView.sol`
+#### `IERC6900ModularAccountView.sol`
 
 Module inspection interface. Modular accounts MAY implement this interface to support visibility in module configuration.
 
@@ -253,7 +253,7 @@ struct ValidationDataView {
     bytes4[] selectors;
 }
 
-interface IModularAccountView {
+interface IERC6900ModularAccountView {
     /// @notice Get the execution data for a selector.
     /// @dev If the selector is a native function, the module address will be the address of the account.
     /// @param selector The selector to get the data for.
@@ -271,12 +271,12 @@ interface IModularAccountView {
 }
 ```
 
-#### `IModule.sol`
+#### `IERC6900Module.sol`
 
 Module interface. Modules MUST implement this interface to support module management and interactions with [ERC-6900](./eip-6900.md) modular accounts.
 
 ```solidity
-interface IModule is IERC165 {
+interface IERC6900Module is IERC165 {
     /// @notice Initialize module data for the modular account.
     /// @dev Called by the modular account during `installExecution`.
     /// @param data Optional bytes array to be decoded and used by the module to setup initial module data for the
@@ -297,12 +297,12 @@ interface IModule is IERC165 {
 }
 ```
 
-#### `IValidationModule.sol`
+#### `IERC6900ValidationModule.sol`
 
 Validation module interface. Modules MAY implement this interface to provide validation functions for the account.
 
 ```solidity
-interface IValidationModule is IModule {
+interface IERC6900ValidationModule is IERC6900Module {
     /// @notice Run the user operation validation function specified by the `entityId`.
     /// @param entityId An identifier that routes the call to different internal implementations, should there
     /// be more than one.
@@ -350,12 +350,12 @@ interface IValidationModule is IModule {
 }
 ```
 
-#### `IValidationHookModule.sol`
+#### `IERC6900ValidationHookModule.sol`
 
 Validation hook module interface. Modules MAY implement this interface to provide hooks for validation functions for the account.
 
 ```solidity
-interface IValidationHookModule is IModule {
+interface IERC6900ValidationHookModule is IERC6900Module {
     /// @notice Run the pre user operation validation hook specified by the `entityId`.
     /// @dev Pre user operation validation hooks MUST NOT return an authorizer value other than 0 or 1.
     /// @param entityId An identifier that routes the call to different internal implementations, should there
@@ -396,7 +396,7 @@ interface IValidationHookModule is IModule {
 }
 ```
 
-#### `IExecutionModule.sol`
+#### `IERC6900ExecutionModule.sol`
 
 Execution module interface. Modules MAY implement this interface to provide execution functions for the account.
 
@@ -423,11 +423,11 @@ struct ExecutionManifest {
     ManifestExecutionFunction[] executionFunctions;
     ManifestExecutionHook[] executionHooks;
     // List of ERC-165 interface IDs to add to account to support introspection checks. This MUST NOT include
-    // IModule's interface ID.
+    // IERC6900Module's interface ID.
     bytes4[] interfaceIds;
 }
 
-interface IExecutionModule is IModule {
+interface IERC6900ExecutionModule is IERC6900Module {
     /// @notice Describe the contents and intended configuration of the module.
     /// @dev This manifest MUST stay constant over time.
     /// @return A manifest describing the contents and intended configuration of the module.
@@ -435,12 +435,12 @@ interface IExecutionModule is IModule {
 }
 ```
 
-#### `IExecutionHookModule.sol`
+#### `IERC6900ExecutionHookModule.sol`
 
 Execution hook module interface. Modules MAY implement this interface to provide hooks for execution functions for the account.
 
 ```solidity
-interface IExecutionHookModule is IModule {
+interface IERC6900ExecutionHookModule is IERC6900Module {
     /// @notice Run the pre execution hook specified by the `entityId`.
     /// @dev To indicate the entire call should revert, the function MUST revert.
     /// @param entityId An identifier that routes the call to different internal implementations, should there
@@ -554,7 +554,7 @@ To implement direct call validation, the modular account MUST treat direct funct
 
 ### Execution Call Flow
 
-For all non-view functions within `IModularAccount` except `executeWithRuntimeValidation`, all module-defined execution functions, and any additional native functions that the modular account MAY wish to include, the modular account MUST adhere to these steps during execution:
+For all non-view functions within `IERC6900ModularAccount` except `executeWithRuntimeValidation`, all module-defined execution functions, and any additional native functions that the modular account MAY wish to include, the modular account MUST adhere to these steps during execution:
 
 If the caller is not the `EntryPoint` or the account, the account MUST check access control for direct call validation.
 

--- a/ERCS/erc-6900.md
+++ b/ERCS/erc-6900.md
@@ -65,12 +65,12 @@ Each step is modular, supporting different implementations, which allows for ope
 Modular accounts MUST implement:
 
 - `IAccount.sol` and `IAccountExecute.sol` from [ERC-4337](./eip-4337.md).
-- `IERC6900ModularAccount.sol` to support module management and usage, and account identification.
+- `IERC6900Account.sol` to support module management and usage, and account identification.
 - The function `isValidSignature` from [ERC-1271](./eip-1271.md)
 
 Modular accounts MAY implement:
 
-- `IERC6900ModularAccountView.sol` to support visibility in account states on-chain.
+- `IERC6900AccountView.sol` to support visibility in account states on-chain.
 - [ERC-165](./eip-165.md) for interfaces installed from modules.
 
 Modules MUST implement:
@@ -84,7 +84,7 @@ Modules MAY implement any of the following module types:
 - `IERC6900ExecutionModule` to support execution functions and their installations on the account.
 - `IERC6900ExecutionHookModule` to support pre & post execution hooks for execution functions.
 
-#### `IERC6900ModularAccount.sol`
+#### `IERC6900Account.sol`
 
 Module execution and management interface. Modular accounts MUST implement this interface to support installing and uninstalling modules, and open-ended execution.
 
@@ -131,7 +131,7 @@ struct Call {
     bytes data;
 }
 
-interface IERC6900ModularAccount {
+interface IERC6900Account {
     event ExecutionInstalled(address indexed module, ExecutionManifest manifest);
     event ExecutionUninstalled(address indexed module, bool onUninstallSucceeded, ExecutionManifest manifest);
     event ValidationInstalled(address indexed module, uint32 indexed entityId);
@@ -217,7 +217,7 @@ interface IERC6900ModularAccount {
 }
 ```
 
-#### `IERC6900ModularAccountView.sol`
+#### `IERC6900AccountView.sol`
 
 Module inspection interface. Modular accounts MAY implement this interface to support visibility in module configuration.
 
@@ -253,7 +253,7 @@ struct ValidationDataView {
     bytes4[] selectors;
 }
 
-interface IERC6900ModularAccountView {
+interface IERC6900AccountView {
     /// @notice Get the execution data for a selector.
     /// @dev If the selector is a native function, the module address will be the address of the account.
     /// @param selector The selector to get the data for.
@@ -554,7 +554,7 @@ To implement direct call validation, the modular account MUST treat direct funct
 
 ### Execution Call Flow
 
-For all non-view functions within `IERC6900ModularAccount` except `executeWithRuntimeValidation`, all module-defined execution functions, and any additional native functions that the modular account MAY wish to include, the modular account MUST adhere to these steps during execution:
+For all non-view functions within `IERC6900Account` except `executeWithRuntimeValidation`, all module-defined execution functions, and any additional native functions that the modular account MAY wish to include, the modular account MUST adhere to these steps during execution:
 
 If the caller is not the `EntryPoint` or the account, the account MUST check access control for direct call validation.
 


### PR DESCRIPTION
ERC-6900 defines multiples interfaces (`IModularAccount`, `IModule`, ...), some of which may clash with different interfaces defined in other ERCs. For example, both ERC-6900 and ERC-7579 define a `IModule` interfaces (and they are not compatibles).

Prefixing all interfaces declared in ERC-6900 with the name of the ERC avoid that kind of conflict. 

This is common practice: for example, ERC-721 and ERC-1155 defined `ERC721TokenReceiver` and `ERC1155TokenReceiver` respectivelly.

[A similar PR is targetting erc-7579.md with similar changes](https://github.com/ethereum/ERCs/pull/876)