### PR TITLE
Add proxy call to 6492 reference implementation

### DIFF
--- a/ERCS/erc-6492.md
+++ b/ERCS/erc-6492.md
@@ -101,10 +101,33 @@ interface IERC1271Wallet {
   function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4 magicValue);
 }
 
+error ShouldCallFromValidator();
+
+contract FactoryCaller {
+  address public immutable universalSigValidator;
+
+  constructor(){
+    universalSigValidator = msg.sender;
+  }
+
+  function proxyCall(
+    address _factory,
+    bytes calldata _initCallData
+  ) external returns (bool success, bytes memory err) {
+    if (msg.sender != universalSigValidator) {
+      revert ShouldCallFromValidator();
+    }
+
+    return _factory.call(_initCallData);
+  }
+}
+
 error ERC1271Revert(bytes error);
 error ERC6492DeployFailed(bytes error);
 
 contract UniversalSigValidator {
+  FactoryCaller immutable public factoryCaller = new FactoryCaller();
+
   bytes32 private constant ERC6492_DETECTION_SUFFIX = 0x6492649264926492649264926492649264926492649264926492649264926492;
   bytes4 private constant ERC1271_SUCCESS = 0x1626ba7e;
 
@@ -128,7 +151,8 @@ contract UniversalSigValidator {
       (create2Factory, factoryCalldata, sigToValidate) = abi.decode(_signature[0:_signature.length-32], (address, bytes, bytes));
 
       if (contractCodeLen == 0 || tryPrepare) {
-        (bool success, bytes memory err) = create2Factory.call(factoryCalldata);
+        // Proxy call using factory called to stop arbitrary calls from UniversalSigValidator
+        (bool success, bytes memory err) = factoryCaller.proxyCall(create2Factory, factoryCalldata);
         if (!success) revert ERC6492DeployFailed(err);
       }
     } else {


### PR DESCRIPTION
Fixes one of the concerns raised here: https://github.com/ethereum/ERCs/issues/877

It forces all contract deployment calls to be made using a proxy, ensuring that if `UniversalSigValidator` is inherited then the `isValidSigImpl` method can't be used to make arbitrary calls.
