### PR TITLE
Made the possibility to use a hash instead of encryption more explici…

### DIFF
--- a/ERCS/erc-7573.md
+++ b/ERCS/erc-7573.md
@@ -52,7 +52,7 @@ function inceptTransfer(bytes32 id, int amount, address from, string memory keyE
 
 Called from the buyer of the token to initiate token transfer. Emits a `TransferIncepted` event.
 The parameter `id` is an identifier of the trade. The parameter `from` is the address of the seller (the address of the buyer is `msg.sender`).
-The parameter `keyEncryptedSeller` is an encryption of the key that can be used by the seller to (re-)claim the token. See below on "encryption".
+The parameter `keyEncryptedSeller` is an encryption (or, alternatively, hash) of the key that can be used by the seller to (re-)claim the token. See below on "encryption".
 
 ##### Initiation of Transfer: `confirmTransfer`
 
@@ -62,7 +62,7 @@ function confirmTransfer(bytes32 id, int amount, address to, string memory keyEn
 
 Called from the seller of the token to confirm token transfer. Emits a `TransferConfirmed` event.
 The parameter `id` is an identifier of the trade. The parameter `to` is the address of the buyer (the address of the seller is `msg.sender`).
-The parameter `keyEncryptedBuyer` is an encryption of the key that can be used by the buyer to claim the token.
+The parameter `keyEncryptedBuyer` is an encryption (or, alternatively, hash) of the key that can be used by the buyer to claim the token.
 
 If the trade specification, that is, the quadruppel (`id`, `amount`, `from`, `to`), in a call to `confirmTransfer`
 matches that of a previous call to `inceptTransfer`, and the balance is sufficient, the corresponding `amount`
@@ -184,6 +184,11 @@ the decryption oracle, which is known to both parties.
 It is implicitly assumed that the two parties may check that
 the strings `keyEncryptedBuyer` and `keyEncryptedSeller` are
 in a valid format.
+
+To avoid on chain encryption in the `ILockingContract`, it is possible to use a simpler hashing algorithm
+on the `ILockingContract`. In that case, the decryption oracle has
+to provide a method that allows to obtain the hash *H(K)* for an
+encrypted key *E(K)* without exposing the key *K*, cf. [^2].
 
 ### Sequence diagram of delivery versus payment
 

--- a/assets/erc-7573/contracts/ILockingContract.sol
+++ b/assets/erc-7573/contracts/ILockingContract.sol
@@ -16,7 +16,7 @@ pragma solidity >=0.7.0;
  * This is the locking contracts interface.
  *
  * The rationale is that the token is locked with with two encrypted keys
- * or a hashes of keys associated with two different adresses (buyer/seller).
+ * or hashes of keys associated with two different adresses (buyer/seller).
  *
  * The asset in transfered to the address of the buyer, if the buyer's key is presented.
  *
@@ -31,7 +31,7 @@ interface ILockingContract {
      * @param id the trade identifier of the trade.
      * @param from The address of the seller.
      * @param to The address of the buyer.
-     * @param keyEncryptedSeller Encryption of the key that can be used by the seller to (re-)claim the token.
+     * @param keyEncryptedSeller Encryption (or, alternatively, hash) of the key that can be used by the seller to (re-)claim the token.
      */
     event TransferIncepted(bytes32 id, int amount, address from, address to, string keyEncryptedSeller);
 
@@ -41,7 +41,7 @@ interface ILockingContract {
      * @param amount the number of tokens to be transfered.
      * @param from The address of the seller.
      * @param to The address of the buyer.
-     * @param keyEncryptedBuyer Encryption of the key that can be used by the buyer to claim the token.
+     * @param keyEncryptedBuyer Encryption (or, alternatively, hash) of the key that can be used by the buyer to claim the token.
      */
     event TransferConfirmed(bytes32 id, int amount, address from, address to, string keyEncryptedBuyer);
 
@@ -67,7 +67,7 @@ interface ILockingContract {
      * @param id the trade identifier of the trade.
      * @param amount the number of tokens to be transfered.
      * @param from The address of the seller (the address of the buyer is message.sender).
-     * @param keyEncryptedSeller Encryption of the key that can be used by the seller to (re-)claim the token.
+     * @param keyEncryptedSeller Encryption (or, alternatively, hash) of the key that can be used by the seller to (re-)claim the token.
      */
     function inceptTransfer(bytes32 id, int amount, address from, string memory keyEncryptedSeller) external;
 
@@ -77,7 +77,7 @@ interface ILockingContract {
      * @param id the trade identifier of the trade.
      * @param amount the number of tokens to be transfered.
      * @param to The address of the buyer (the address of the seller is message.sender).
-     * @param keyEncryptedBuyer Encryption of the key that can be used by the buyer to claim the token.
+     * @param keyEncryptedBuyer Encryption (or, alternatively, hash) of the key that can be used by the buyer to claim the token.
      */
     function confirmTransfer(bytes32 id, int amount, address to, string memory keyEncryptedBuyer) external;
 


### PR DESCRIPTION
This is just a minor change to the modification that makes it more explicit that the in ILockingContract the "keyEncrypted" argument may be a hash or an alternative encryption method (rather an implemetation detail).