### PR TITLE
Update ERC-7821: Remove Call Struct from Specification

### DIFF
--- a/ERCS/erc-7821.md
+++ b/ERCS/erc-7821.md
@@ -38,13 +38,6 @@ The minimal batch executor interface is defined as follows:
 ```solidity
 /// @dev Interface for minimal batch executor.
 interface IERC7821 {
-    /// @dev Call struct for the `execute` function.
-    struct Call {
-        address target; // Replaced with `address(this)` if `address(0)`.
-        uint256 value; // Amount of native currency (i.e. Ether) to send.
-        bytes data; // Calldata to send with the call.
-    }
-
     /// @dev Executes the calls in `executionData`.
     /// Reverts and bubbles up error if any call fails.
     ///


### PR DESCRIPTION
Update (Feb 7, 2025): Based on convo, this PR just removes the `Call` struct from the Specification section since it is not needed to standardize the execution interface. The Reference Implementation has been left unchanged.

---

ERC-7821 implies using a `Call` struct. ERC-7579 already leverages an `Execution` struct in their reference implementation.

This is to change the `Call` struct to the referenced ERC-7579 `Execution` struct.

---

*Another option is to remove the struct from this standard altogether since you are really trying to standardize the execute interface*
