### PR TITLE
Update ERC-4883: Update erc-4883.md

### DIFF
--- a/ERCS/erc-4883.md
+++ b/ERCS/erc-4883.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2022-03-08
-requires: 165, 721
+requires: 721
 ---
 
 ## Abstract
@@ -24,7 +24,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 ```solidity
 /// @title EIP-4883 Non-Fungible Token Standard
-interface IERC4883 is IERC165 {
+interface IERC4883 {
     function renderTokenById(uint256 id) external view returns (string memory);
 }
 ```


### PR DESCRIPTION
Remove ERC165 requirement for compatibility with earlier SVG NFTs 