### PR TITLE
Update ERC-3668: Update typo in erc-3668.md

### DIFF
--- a/ERCS/erc-3668.md
+++ b/ERCS/erc-3668.md
@@ -50,7 +50,7 @@ In step 3, the client calls the original contract, supplying the `response` from
    │ somefunc(...)                                    │             │
    ├─────────────────────────────────────────────────►│             │
    │                                                  │             │
-   │ revert OffchainData(sender, urls, callData,      │             │
+   │ revert OffchainLookup(sender, urls, callData,    │             │
    │                     callbackFunction, extraData) │             │
    │◄─────────────────────────────────────────────────┤             │
    │                                                  │             │


### PR DESCRIPTION
Updates the label in the graph of erc 3668 to use the correct error code as defined a few lines below