### PR TITLE
Editorial changes to ERC-7730 before publication

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -19,11 +19,11 @@ The [ERC-7730](./eip-7730.md) specification enriches type data contained in the 
 
 Wallets will use (wallet-curated) ERC-7730 files alongside the raw data to sign in order to construct a display adapted to be reviewed by humans.
 
-In the current scope, the only structured data supported are smart contract calls (aka calldata) in EVM transactions and EIP-712 structured messages. 
+At the time of writing (version 1 of this specification), the only structured data supported are smart contract calls (aka calldata) in EVM transactions and EIP-712 structured messages. 
 
 ## Motivation
 
-Properly validating a transaction on a Hardware Wallets screen (also known as Clear Signing) is a key element of good security practices for end users when interacting with any Blockchain. Unfortunately, most data to sign, even enriched with the data structure description (like ABIs or EIP-712 types) are not self-sufficient in terms of correctly displaying them to the user for review. Among other things:
+Properly validating a transaction on a hardware wallet's screen (also known as Clear Signing) is a key element of good security practices for end users when interacting with any Blockchain. Unfortunately, most data to sign, even enriched with the data structure description (like ABIs or EIP-712 types) are not self-sufficient in terms of correctly displaying them to the user for review. Among other things:
 
 * Function name or main message type is often a developer oriented name and does not translate to a clear intent for the user
 * Fields in the data to sign are tied to primitive types only, but those can be displayed in many different ways. For instance, integers can be displayed as percentages, dates, etc...
@@ -44,12 +44,12 @@ The following is an example of how to clear sign a `transfer` function call on a
 
 ```json
 {
-    "$schema": "https://github.com/LedgerHQ/clear-signing-erc7730-registry/blob/master/specs/erc7730-v1.schema.json",
+    "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v1.schema.json",
 
     "context": {
-        "$id": "Tether USD",
+        "$id": "Example ERC-20",
         "contract" : {
-            "abi": "https://api.etherscan.io/api?module=contract&action=getabi&address=0xdac17f958d2ee523a2206206994597c13d831ec7",
+            "abi": "https://api.example.io/api?module=contract&action=getabi&address=0xdac17f958d2ee523a2206206994597c13d831ec7",
             "deployments": [ 
                 {
                     "chainId": 1,
@@ -68,10 +68,10 @@ The following is an example of how to clear sign a `transfer` function call on a
     }, 
 
     "metadata": {
-        "owner": "Tether",
+        "owner": "Example",
         "info": {
-            "legalName": "Tether Limited",
-            "url": "https://tether.to/",
+            "legalName": "Example Inc.",
+            "url": "https://example.io/",
             "deploymentDate": "2017-11-28T12:41:21Z"  
         }
     },
@@ -107,7 +107,7 @@ The `$schema` key refers to the latest version of this specification json schema
 
 The `context` key is used to provide binding context information for this file. It can be seen as a set of *constraints* on the structured data being reviewed, indicating whether the ERC-7730 file is valid for this data. A wallet MUST ensure these constraints are met before ERC-7730 formatting information is applied to the data being signed. 
 
-In this example, the context section indicates that the ERC-7730 file should only be applied to the USDT smart contract whose deployment addresses are provided and only if they match the reference ABI. Note that the ABI is used to define unique *path* references to fields being formatted in the `display.formats` section, so the ABI is mandatory for all contracts clear-signed.
+In this example, the context section indicates that the ERC-7730 file should only be applied to the Example smart contract whose deployment addresses are provided and only if they match the reference ABI. Note that the ABI is used to define unique *path* references to fields being formatted in the `display.formats` section, so the ABI is mandatory for all contracts clear-signed.
 
 The `metadata` section contains constants that can be trusted when the ERC-7730 file is applicable for the given context. This section is typically used to:
 * Provide displayable information about the recipient of the contract call / message
@@ -124,7 +124,7 @@ In this example, the function being described is identified by its solidity sign
 * The `required` key indicates which parameters wallets SHOULD display. 
 * The `excluded` key indicates which parameters are intentionally left out (none in this example). 
   
-In this example, the `_to` parameter and the `_value` SHOULD both be displayed, one as an address replaceable by a trusted name (ENS or others), the other as an amount formatted using metadata of the target ERC-20 contract (USDT). 
+In this example, the `_to` parameter and the `_value` SHOULD both be displayed, one as an address replaceable by a trusted name (ENS or others), the other as an amount formatted using metadata of the target ERC-20 contract. 
 
 ### Common concepts
 
@@ -273,7 +273,7 @@ The following file would include this generic interface and bind it to the speci
 ```json
 {
     "context": {
-        "$id": "Tether USD",
+        "$id": "Example Contract",
         "contract" : {
             "deployments": [
                 {
@@ -287,15 +287,15 @@ The following file would include this generic interface and bind it to the speci
     "includes": "./example-erc20.json",
     
     "metadata": {
-        "owner": "Tether",
+        "owner": "Example",
         "info": {
-            "legalName": "Tether Limited",
-            "url": "https://tether.to/",
+            "legalName": "Example Inc.",
+            "url": "https://example.io/",
             "deploymentDate": "2017-11-28T12:41:21Z"  
         },
         "token": {
-            "ticker": "USDT",
-            "name": "Tether USD",
+            "ticker": "STABLE",
+            "name": "Example Stablecoin",
             "decimals": 6
         }
     },
@@ -1073,11 +1073,9 @@ Sources values are wallet manufacturer specific. Some example values could be:
 | local       | Address MAY be replaced with a local name trusted by user. Wallets MAY consider that `local` setting for `sources` is always valid |
 | ens         | Address MAY be replaced with an associated ENS domain                                                                              |
 
-### Wallets
+### Wallets specific layouts
 
-#### Ledger
-
-<!-- TBD --> Link to ledger specification
+Wallets MAY extend the specification with wallet specific layout instructions by defining a schema bound to the `display.formats.screens` field.  
 
 ## Rationale
 
@@ -1118,7 +1116,7 @@ In the future, this specification could be extended to structured data like Meta
 
 ## Test Cases
 
-More examples can be found in the asset folder.
+More examples can be found in the asset folder [here](../assets/eip-7730/example-main.json) and [here](../assets/eip-7730/example-include.json).
 
 ## Security Considerations
 
@@ -1132,9 +1130,9 @@ Two main attack vectors that needs to be mitigated:
 
 The binding `context` is the way we mitigate the first attack, by specifying in the ERC-7730 file itself, **what kind** of structured data should be formatted by said file.
 
-dApps developers MUST make sure that constraints in the binding context are restrictive enough to apply only to relevant data.
+dApps developers must make sure that constraints in the binding context are restrictive enough to apply only to relevant data.
 
-Wallets MUST ensure that all constraints are met before formatting any data for review by the end user. 
+Wallets must ensure that all constraints are met before formatting any data for review by the end user. 
 
 It is also expected that the way the formatting is applied to the data is not vulnerable to MITM or tampering attack from an attacker in control of communication means. Constraints have been design simple, so that a strong cryptographic binding to the data can be created even on resource constrained Hardware Wallets.
 

--- a/assets/erc-7730/example-include.json
+++ b/assets/erc-7730/example-include.json
@@ -1,6 +1,6 @@
 {
     "context": {
-        "$id": "Tether USD",
+        "$id": "Example USD",
         "contract" : {
             "deployments": [
                 {
@@ -14,15 +14,15 @@
     "includes": "./example-erc20.json",
     
     "metadata": {
-        "owner": "Tether",
+        "owner": "Example",
         "info": {
-            "legalName": "Tether Limited",
-            "url": "https://tether.to/",
+            "legalName": "Example Inc.",
+            "url": "https://example.io/",
             "deploymentDate": "2017-11-28T12:41:21Z"  
         },
         "token": {
-            "ticker": "USDT",
-            "name": "Tether USD",
+            "ticker": "EXA",
+            "name": "Example Stablecoin",
             "decimals": 6
         }
     },

--- a/assets/erc-7730/example-main.json
+++ b/assets/erc-7730/example-main.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "https://github.com/LedgerHQ/clear-signing-erc7730-registry/blob/master/specs/erc7730-v1.schema.json",
+    "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v1.schema.json",
 
     "context": {
-        "$id": "Tether USD",
+        "$id": "Example ERC-20",
         "contract" : {
-            "abi": "https://api.etherscan.io/api?module=contract&action=getabi&address=0xdac17f958d2ee523a2206206994597c13d831ec7",
+            "abi": "https://api.example.io/api?module=contract&action=getabi&address=0xdac17f958d2ee523a2206206994597c13d831ec7",
             "deployments": [ 
                 {
                     "chainId": 1,
@@ -23,10 +23,10 @@
     }, 
 
     "metadata": {
-        "owner": "Tether",
+        "owner": "Example",
         "info": {
-            "legalName": "Tether Limited",
-            "url": "https://tether.to/",
+            "legalName": "Example Inc.",
+            "url": "https://example.io/",
             "deploymentDate": "2017-11-28T12:41:21Z"  
         }
     },


### PR DESCRIPTION
- Changed links to schema in examples to link to the asset folder once published
- Removed any explicit mentions to products
- Implemented suggested wording fixes in the specification