### PR TITLE
Update ERC-7656: Moving back to review

### DIFF
--- a/ERCS/erc-7656.md
+++ b/ERCS/erc-7656.md
@@ -4,8 +4,7 @@ title: Generalized Token-Linked Services
 description: Define a registry for generic services linked to a specific NFT
 author: Francesco Sullo (@sullof)
 discussions-to: https://ethereum-magicians.org/t/variation-to-erc6551-to-deploy-any-kind-of-contract-linked-to-an-nft/19223
-status: Last Call
-last-call-deadline: 2024-12-30
+status: Review
 type: Standards Track
 category: ERC
 created: 2024-03-15


### PR DESCRIPTION
Recently I proposed a new ERC to link contracts (like ERC4337 accounts) to independently deployed services owned by the linked contract. The ERC has been numbered as ERC7897. After the first feedback, I realized that with some minimal change, it is possible to join the two proposal into a single one. So, I am moving this proposal back to Review in order to take the time necessary to work the new possibility and update the proposal.