### PR TITLE
Update ERC-7631: Move to Last Call

### DIFF
--- a/ERCS/erc-7631.md
+++ b/ERCS/erc-7631.md
@@ -5,7 +5,7 @@ description: A specification for a co-joined fungible and non-fungible token pai
 author: vectorized (@vectorized), Thomas (@0xth0mas), Quit (@quitcrypto), Michael Amadi (@AmadiMichael), cygaar (@cygaar), Harrison (@pop-punk)
 discussions-to: https://ethereum-magicians.org/t/erc-7631-dual-nature-token-pair/18796
 status: Last Call
-last-call-deadline: 2025-04-30
+last-call-deadline: 2025-05-19
 type: Standards Track
 category: ERC
 created: 2024-02-21

--- a/ERCS/erc-7631.md
+++ b/ERCS/erc-7631.md
@@ -4,7 +4,8 @@ title: Dual Nature Token Pair
 description: A specification for a co-joined fungible and non-fungible token pair
 author: vectorized (@vectorized), Thomas (@0xth0mas), Quit (@quitcrypto), Michael Amadi (@AmadiMichael), cygaar (@cygaar), Harrison (@pop-punk)
 discussions-to: https://ethereum-magicians.org/t/erc-7631-dual-nature-token-pair/18796
-status: Review
+status: Last Call
+last-call-deadline: 2025-04-30
 type: Standards Track
 category: ERC
 created: 2024-02-21


### PR DESCRIPTION
The implementations in the wild do not have any request for changes for more than a year, so moving to last call.