### PR TITLE
Update ci.yml: make htmlproofer run again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
   htmlproofer:
     name: HTMLProofer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout EIPs


### PR DESCRIPTION
HTMLProofer was using an obsolete ubuntu image, and no longer runs. e.g, this PR failure: https://github.com/ethereum/ERCs/actions/runs/14498862932/job/40673433529
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
