### PR TITLE
Update ERC-4671: Fix Reference Link to EIP-4671

### DIFF
--- a/ERCS/erc-4671.md
+++ b/ERCS/erc-4671.md
@@ -258,7 +258,7 @@ A decision was made to keep the data off-chain (via `tokenURI()`) for two main r
 
 ## Reference Implementation
 
-You can find an implementation of this standard in [../assets/eip-4671](https://github.com/ethereum/EIPs/tree/master/assets/eip-4671).
+You can find an implementation of this standard in [../assets/eip-4671](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4671.md).
 
 Using this implementation, this is how you would create a token:
 


### PR DESCRIPTION
Replaced old link to the assets folder with a direct link to the actual EIP markdown.

Old:
.../tree/master/assets/eip-4671
New:
.../blob/master/EIPS/eip-4671.md


