### PR TITLE
Fix: Correct Foundry link

### DIFF
--- a/assets/erc-5218/contracts/README.md
+++ b/assets/erc-5218/contracts/README.md
@@ -4,7 +4,7 @@ This is the source code for a reference implementation of EIP-5218.
 
 ## Build and Test
 
-The repo expects a [Foundry](https://github.com/foundry-rs/foundry/tree/master/forge) build system, optionally using visual studio code for editing. You can run the test suite with:
+The repo expects a [Foundry](https://github.com/foundry-rs/foundry/tree/master/crates/forge) build system, optionally using visual studio code for editing. You can run the test suite with:
 
 ```bash
 forge test -vvvvv


### PR DESCRIPTION
The original link was missing the crates directory level. The new link correctly points to the forge package inside the crates directory of the Foundry repository.