### PR TITLE
Update ERC-7786: Remove Attributes, Add ExtraData; Support Hooks and Interoperable Addresses

### DIFF
--- a/ERCS/erc-7786.md
+++ b/ERCS/erc-7786.md
@@ -10,9 +10,10 @@ category: ERC
 created: 2024-10-14
 ---
 
+
 ## Abstract
 
-This proposal describes an interface, and the corresponding workflow, for smart contracts to send arbitrary data through cross-chain messaging protocols. The end goal of this proposal is to have all such messaging protocols accessible via this interface (natively or using "adapters") to improve their composability and interoperability. That would allow a new class of cross-chain native smart contracts to emerge while reducing vendor lock-in. This proposal is modular by design, allowing users to leverage bridge-specific features through attributes while providing simple "universal" access to the simple feature of "just getting a simple message through".
+This proposal describes an interface, and the corresponding workflow, for smart contracts to send arbitrary data through cross-chain messaging protocols. The end goal of this proposal is to have all such messaging protocols accessible via this interface (natively or using "adapters") to improve their composability and interoperability. That would allow a new class of cross-chain native smart contracts to emerge while reducing vendor lock-in. This proposal is modular by design, allowing users to leverage bridge-specific features through extra data and custom logic using hooks while providing simple "universal" access to the simple feature of "just getting a simple message through".
 
 ## Motivation
 
@@ -30,140 +31,188 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Message Field Encoding
 
-A cross-chain message consists of a sender, receiver, payload, and list of attributes.
+A cross-chain message consists of a sender, recipient, payload, optional extra data, and optional hooks.
 
-#### Sender & Receiver
+### Sender and Recipient
 
-The sender account (in the source chain) and receiver account (in the destination chain) MUST be represented using [CAIP-10] account identifiers. Note that these are ASCII-encoded strings.
+The sender account (in the source chain) and receiver account (in the destination chain) MUST be input in an Interoperable Address binary format, specified in ERC-7930, which MUST be serialized according to CAIP-350. The recipient field MAY be omitted or zeroed (contain an Interoperable Address with all fields set to zero) to indicate an unspecified destination, such as when a broadcast mode is employed and the final recipients are determined by the protocol itself.
 
-A [CAIP-10] account identifier embeds a [CAIP-2] chain identifier along with an address. In some parts of the interface, the address and the chain parts will be provided separately rather than as a single string, or the chain part will be implicit.
-
-#### Payload
+### Payload
 
 The payload is an opaque `bytes` value.
 
-#### Attributes
+### Extra Data
 
-Attributes are structured pieces of message data and/or metadata. Each attribute is a key-value pair, where the key determines the type and encoding of the value, as well as its meaning and behavior.
+`extraData` is an opaque `bytes` value. This field is OPTIONAL and MUST be interpreted only on source. If unused, MUST be empty.
 
-Some attributes are message data that must be sent to the receiver, although they can be transformed as long as their meaning is preserved. Other attributes are metadata that will be used by the intervening gateways and potentially removed before the message reaches the receiver.
+### Hook Data
 
-The set of attributes is extensible. It is RECOMMENDED to standardize attributes and their characteristics by publishing them as ERCs.
+The hook is a structure that invokes a low-level call in the source chain atomically after the message is sent.
 
-A gateway MAY support any set of attributes. An empty attribute list MUST always be accepted by a gateway.
-
-Each attribute key MUST have the format of a Solidity function signature, i.e., a name followed by a list of types in parentheses. For example, `minGasLimit(uint256)`.
-
-In this specification attributes are encoded as an array of `bytes` (i.e., `bytes[]`). Each element of the array MUST encode an attribute in the form of a Solidity function call, i.e., the first 4 bytes of the hash of the key followed by the ABI-encoded value.
+If unused, MUST be empty. It is RECOMMENDED to standardize hooks as part of new ERCs. For instance, Gateways MAY delegate hook execution to a dedicated *hook executor*. Nevertheless, implementation details are outside the scope of the standard. 
 
 ### Sending Procedure
 
-An **Source Gateway** is a contract that offers a protocol to send a message to a receiver on another chain. It MUST implement `IERC7786GatewaySource`.
+A **Source Gateway** is a contract that uses a messaging protocol to send a message to a receiver on another chain. MUST implement `IERC7786GatewaySource`.
 
 ```solidity
 interface IERC7786GatewaySource {
-    event MessagePosted(bytes32 indexed outboxId, string sender, string receiver, bytes payload, uint256 value, bytes[] attributes);
-
-    error UnsupportedAttribute(bytes4 selector);
-
-    function supportsAttribute(bytes4 selector) external view returns (bool);
-
-    function sendMessage(
-        string calldata destinationChain, // [CAIP-2] chain identifier
-        string calldata receiver, // [CAIP-10] account address
-        bytes calldata payload,
-        bytes[] calldata attributes
-    ) external payable returns (bytes32 outboxId);
+  // Optional Hook data struct
+  struct HookData {
+    address hook;        // Native source chain address
+    bytes hookPayload;   // Low-level call data: selector and parameters for the hook
+    uint256 value;       // Optional, amount of native token forwarded to the hook 
+  }
+ 
+  // MessageSent event
+  event MessageSent(
+    bytes32 messageId, // Unique identifier
+    bytes sender,      // Binary Interoperable Address
+    bytes recipient,   // Binary Interoperable Address
+    bytes payload,     // Message content
+    bytes extraData,   // Optional encoded gateway metadata (leave empty if unused)
+    HookData hookData  // Optional Hook data (leave empty if unused)
+  );
+  
+  // sendMessage function
+  function sendMessage(
+      bytes calldata recipient,                   // Binary Interoperable Address 
+      bytes calldata payload,                     // Message content
+      bytes calldata extraData,                   // Optional encoded gateway metadata (leave empty if unused)
+      HookData calldata hookData                  // Optional Hook data (leave empty if unused)
+  ) external payable returns (bytes32 messageId); // Unique identifier
 }
 ```
 
-#### `supportsAttribute`
-
-Returns a boolean indicating whether an attribute is supported by the gateway, identified by the selector computed from the attribute signature.
-
-A gateway MAY be upgraded with support for additional attributes. Once present support for an attribute SHOULD NOT be removed to preserve backwards compatibility with users of the gateway.
-
-#### `sendMessage`
+### `sendMessage`
 
 Initiates the sending of a message.
 
 Further action MAY be required by the gateway to make the sending of the message effective, such as providing payment for gas. See Post-processing.
 
-MUST revert with `UnsupportedAttribute` if an unsupported attribute key is included. MAY revert if the value of an attribute is not a valid encoding for its expected type.
+SHOULD revert if it executes supplying `extraData` bytes that the underlying protocol does not support. 
 
-MAY accept call value (native token) to be sent with the message. MUST revert if call value is included but it is not a feature supported by the gateway. It is unspecified how this value is represented on the destination.
+MAY accept call value (native token) to be sent with the message. MUST revert if the call value is included, but it is not a feature supported by the gateway. It is unspecified how this value is represented on the destination.
 
-MAY generate and return a unique non-zero _outbox identifier_, otherwise returning zero. This identifier can be used to track the lifecycle of the message in the outbox in events and for post-processing.
+MUST generate and return a unique non‑zero `messageId`. This identifier MUST already be final and valid for the underlying protocol. It MUST be able to be used immediately after the call (for example, by hooks or by off‑chain actors).
 
-MUST emit a `MessagePosted` event, including the optional outbox identifier that is returned by the function.
+MUST emit a `MessageSent` event.
 
-#### `MessagePosted`
+### `MessageSent`
 
 This event signals that a would-be sender has requested a message to be sent.
 
-If `outboxId` is present, post-processing MAY be required to send the message through the cross-chain channel.
+### Post-processing through Hooks
 
-#### Post-processing
+After a sender has invoked `sendMessage`, further action MAY be required by the gateways to make the message effective. This is called *post-processing*. For example, some payment is typically required to cover the cost of executing the message at the destination.
 
-After a sender has invoked `sendMessage`, further action MAY be required by the gateways to make the message effective. This is called _post-processing_. For example, some payment is typically required to cover the gas of executing the message at the destination.
+The Gateway MUST call the hook, and the hook MAY query the Gateway to obtain the context used in its execution logic. If the hook call returns false or reverts, `sendMessage` MUST revert.
 
-The exact interface for any such action is out of scope of this ERC. If the `postProcessingOwner` attribute is supported and present, such actions MUST be restricted to the specified account, otherwise they MUST be able to be performed by any party in a way that MUST NOT be able to compromise the eventual receipt of the message.
+The exact interface for any such action is out of this ERC’s scope. If post-processing hooks are expected, such actions MUST be restricted to the specified account.
 
 ### Reception Procedure
 
-A **Destination Gateway** is a contract that implements a protocol to validate messages sent on other chains. The interface of the destination gateway and how it is invoked is out of scope of this ERC.
+A **Destination Gateway** is a contract implementing a protocol to validate messages sent on other chains. The interface of the destination gateway and how it is invoked are out of scope of this ERC.
 
-The protocol MUST ensure delivery of a sent message to its **receiver** using the `IERC7786Receiver` interface (specified below), which the receiver MUST implement.
+The protocol MUST ensure delivery of a sent message to the **recipient** using the `IERC7786Recipient` interface (specified below), which the recipient MUST implement.
 
-Once the message can be safely delivered (see Properties), the gateway MUST invoke `executeMessage` with the message identifier and contents, unless the sender or the receiver explicitly requested otherwise.
+Once the message can be safely delivered (see Properties), the gateway MUST invoke `receiveMessage` with the message identifier and contents, unless the sender or the receiver explicitly requested otherwise.
 
-The `messageId` MUST be either empty or unique (for the calling gateway) to the message being relayed. The format of this identifier is not specified, and the gateway can use it at its own discretion. For example it can be an identifier of the `MessagePosted` event that created the message.
+The `messageId` MUST be unique (for the calling gateway) to the message being relayed. The format of this identifier is not specified, and the gateway can use it at its own discretion. For example it can be an identifier of the `MessageSent` event that created the message.
 
-The gateway MUST verify that `executeMessage` returns the correct value, and MUST revert otherwise.
+The gateway MUST verify that `receiveMessage` returns the correct value, and MUST revert otherwise.
 
 ```solidity
-interface IERC7786Receiver {
-    function executeMessage(
-        string calldata messageId, // gateway specific, empty or unique
-        string calldata sourceChain, // [CAIP-2] chain identifier
-        string calldata sender, // [CAIP-10] account address
-        bytes calldata payload,
-        bytes[] calldata attributes
-    ) external payable returns (bytes4);
+interface IERC7786Recipient {
+    function receiveMessage(
+        bytes32 messageId,  // Unique ID supplied by the destination gateway
+        bytes sender,       // Binary Interoperable Address representation
+        bytes payload       // Message content
+    ) external payable;
 }
 ```
 
-#### `executeMessage`
+### `receiveMessage`
 
 Delivery of a message sent from another chain.
 
 The receiver MUST validate that the caller of this function is a **known gateway**, i.e., one whose underlying cross-chain messaging protocol it trusts.
 
-MUST return `IERC7786Receiver.executeMessage.selector` (`0x675b049b`).
+### Interaction Diagram
 
-#### Interaction Diagram
+```mermaid
+sequenceDiagram
+    participant User
+    participant GatewayA as Source Gateway (Chain A)
+    participant Hook as Hook (optional)
+    participant GatewayB as Destination Gateway (Chain B)
+    participant Receiver as Recipient
 
-![](../assets/eip-7786/send-execute.png)
+    User->>GatewayA: sendMessage
+    GatewayA-->>Hook: execute hookData (optional)
+    GatewayA->>GatewayA: emit MessageSent
+    GatewayA-->>GatewayB: [Underlying protocol]
+    GatewayB->>Receiver: receiveMessage
+```
 
 ### Properties
 
-The protocol underlying a pair of gateways is expected to guarantee a series of properties. For detailed definition and discussion we refer to XChain Research’s _Cross-chain Interoperability Report_.
+The protocol underlying a pair of gateways is expected to guarantee a series of properties. For a detailed definition and discussion, we refer to XChain Research’s *Cross-chain Interoperability Report*.
 
 - The protocol MUST guarantee Safety: A message is delivered at the destination if and only if it was sent at the source. The delivery process must ensure a message is only delivered once the sending transaction is finalized, and not delivered more than once. Note that there can be multiple messages with identical parameters that must be delivered separately.
-- The protocol MUST guarantee Liveness: A sent message is delivered at the destination eventually, assuming Liveness and censorship-resistance of the source and destination chains.
+- The protocol MUST guarantee Liveness: A sent message is eventually delivered to the destination, assuming Liveness and censorship-resistance of the source and destination chains.
 - The protocol SHOULD guarantee Timeliness: A sent message is delivered at the destination within a bounded delivery time, which should be documented.
-- The above properties SHOULD NOT rely on trust in some centralized actor. For example, safety should be guaranteed by some trustless mechanism such as a light client proof, or attestations by an open, decentralized validator set. Relaying should be decentralized or permissionless to ensure liveness; a centralized relayer can fail and thus halt the protocol.
+- The above properties SHOULD NOT rely on trust in some centralized actor. For example, safety should be guaranteed by some trustless mechanism such as a light client proof or attestations by an open, decentralized validator set. Relaying should be decentralized or permissionless to ensure liveness; a centralized relayer can fail and thus halt the protocol.
 
 ## Rationale
 
-Attributes are designed so that gateways can expose any specific features the bridge offers without having to use a specific endpoint. Having a unique endpoint, with modularity through attributes, SHOULD allow contracts to change the gateway they use while continuing to express messages the same way. This portability offers many advantages:
+**Separation of concerns**
 
-- A contract that relies on a specific gateway for sending messages is vulnerable to the gateway being paused, deprecated, or simply breaking. If the communication between the contract and the gateway is standard, an admin of the contract COULD update the address (in storage) of the gateway to use. In particular, senders to update to the new gateway when a new version is available.
-- Bridge layering SHOULD be possible. In particular, this interface should allow for a new class of bridges that routes the message through multiple independent bridges. Delivery of the message could require one or multiple of these independent bridges depending on whether improved liveness or safety is desired.
+The interface keeps a single, predictable entry point and lets every bridge expose its peculiarities through two completely generic fields:
 
-As some cross-chain communication protocols require additional parameters beyond the destination and the payload, and because we want to send messages through those bridges without any knowledge of these additional parameters, a post-processing of the message MAY be required (after `sendMessage` is called, and before the message is delivered). The additional parameters MAY be supported through attributes, which would remove the need for a post-processing step. If these additional parameters are not provided through an attribute, an additional call to the gateway is REQUIRED for the message to be sent. If possible, the gateway SHOULD be designed so that anyone with an incentive for the message to be delivered can jump in. A malicious actor providing invalid parameters SHOULD NOT prevent the message from being successfully relayed by someone else.
+- `extraData` : an opaque blob the gateway consumes internally.
+- `hookData`: an optional low-level call executed on the source chain after the `sendMessage` logic.
 
-Some protocols gateway support doing arbitrary direct calls on the receiver. In that case, the receiver must detect that they are being called by the gateway to properly identify cross-chain messages. Getters are available on the gateway to figure out where the cross-chain message comes from (source chain and sender address). This approach has the downside that it allows anyone to trigger any call from the gateway to any contract. This is dangerous if the gateway ever holds any assets ([ERC-20](./eip-20.md) or similar). The use of a dedicated `executeMessage` function on the receiver protects any assets or permissions held by the gateway against such attacks. If the ability to perform direct calls is desired, this can be implemented as a wrapper on top of any gateway that implements this ERC.
+This follows the separation‑of‑concerns principle: gateway‑specific parameters are surfaced through extraData, while application‑level logic is injected via hooks. Both mechanisms extend the core messaging primitive in a complementary, independent way.
+
+An application can swap one gateway address for another in storage and emit the same messages. That portability guards the app against a gateway being paused, deprecated, or simply breaking. It also enables *bridge layering*: a “meta‑gateway” can relay the same opaque message through two or more underlying bridges, choosing the combination that gives the desired blend of liveness and safety.
+
+**On Extra Data**
+
+Some bridges need specific parameters provided by the sender. Those parameters are specified on the `extraData` parameter. If the sender leaves `extraData empty`, the gateway forwards the message without supplying any protocol‑specific metadata to the underlying bridge. Any additional information injected by other components is outside the gateway flow and therefore outside the scope.
+
+Gateways MAY provide a view that returns a human‑readable decoding of extraData for off‑chain use. The exact name and signature of such a helper are left out of this ERC and can be standardised separately.
+
+**On Hooks**
+
+Hooks keep the core interface minimal while giving developers a plug‑and‑play extension point for post-processing, all without bloating the gateway or forcing the entire ecosystem to agree on new parameters. One example is payment for relayers to deliver the message in the destination. The flow might be:
+
+1. `hook` points to the relayers payment contract address.
+2. `hookData` encodes the call to pay the gas fee (`payForGas(messageId, gasAmount, refundAddress)`).
+3. `value` includes the ETH (or native token) payment amount.
+
+Suppose a “`RelayerPaymentsContract`” exposes the function:
+
+```solidity
+function payForGas(bytes32 messageId, uint256 gasAmount, address refundAddress)
+  external payable;
+
+```
+
+The `hookData` passed to `sendMessage` would be:
+
+```solidity
+HookData({
+  hook: address(RelayerPaymentsContract),
+  hookPayload: abi.encodeCall(
+    RelayerPaymentsContract.payForGas,
+    (messageId, 300_000, userAddress)
+  ),
+  value: 0.02 ether
+});
+```
+
+Since the low-level call could derive itself into other subsequent calls, hooks MAY call other hooks or have their conditional logic for sequential calls.
 
 ## Backwards Compatibility
 
@@ -171,11 +220,18 @@ Existing cross-chain messaging protocols implement proprietary interfaces. We re
 
 ## Security Considerations
 
-Unfortunately, [CAIP-2] and [CAIP-10] names are not unique. Using non-canonical strings may lead to undefined behavior, including message delivery failure and locked assets. While source gateways have a role to play in checking that user input are valid, we also believe that more effort should be put into standardizing and documenting what the canonical format is for each [CAIP-2] namespace. This effort is beyond the scope of this ERC.
+**Handling addresses**
+
+Interoperable Addresses (ERC‑7930) rely on CAIP‑350 serialization. Using non‑canonical encodings can lead to silent delivery failures. Gateways SHOULD reject non‑canonical encodings and MAY normalize them before emission.
+
+**`ExtraData` parsing**
+
+Because `extraData` is opaque to the interface, each gateway SHOULD validate its format and gracefully revert with an explicit error (e.g., `UnsupportedExtraData()`) if the blob cannot be decoded.  Never assume well‑formed input. It is RECOMMENDED to include a view function for this purpose.
+
+**Hook Execution**
+
+The Gateway should never call a non-trusted hook directly. As it is recommended that hook calls have a dedicated executor middleware contract, it is up to the protocol to ensure the hook entity is the expected one.
 
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
-
-[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/3da24e4e912ae179713b2b1b11d6ecb5df06a8dc/CAIPs/caip-10.md
-[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/cbee09d2885065ba15482398828d5c5e3ac57faa/CAIPs/caip-2.md


### PR DESCRIPTION
This PR is based on the previous discussion of the Ethereum Interop working group. The major changes include support for Interoperable Addresses, removing attributes, adding extraData, supporting hooks, and other changes in semantics.