### PR TITLE
Update ERC-7677: "Update ERC-7677: chain id update"

### DIFF
--- a/ERCS/erc-7677.md
+++ b/ERCS/erc-7677.md
@@ -244,18 +244,15 @@ The `paymasterService` capability is implemented by both apps and wallets.
 
 #### App Implementation
 
-Apps need to give wallets paymaster service URLs they can make the above RPC calls to. They can do this using the `paymasterService` capability as part of an [EIP-5792](./eip-5792.md) `wallet_sendCalls` call.
+Apps need to give wallets a paymaster service URL they can make the above RPC calls to. They can do this using the `paymasterService` capability as part of an [EIP-5792](./eip-5792.md) `wallet_sendCalls` call.
 
 ##### `wallet_sendCalls` Paymaster Capability Specification
 
 ```typescript
-type PaymasterCapabilityParams = Record<
-  `0x${string}`, // Chain ID
-  {
-    url: string; // Paymaster service URL for provided chain ID
-    context: Record<string, any>; // Additional data defined by paymaster service providers
-  }
->;
+type PaymasterCapabilityParams = {
+  url: string;
+  context: Record<string, any>;
+}
 ```
 
 ###### `wallet_sendCalls` Example Parameters
@@ -264,34 +261,25 @@ type PaymasterCapabilityParams = Record<
 [
   {
     "version": "1.0",
+    "chainId": "0x01",
     "from": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
     "calls": [
       {
         "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
         "value": "0x9184e72a",
-        "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
-        "chainId": "0x01"
+        "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
       },
       {
         "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
         "value": "0x182183",
-        "data": "0xfbadbaf01",
-        "chainId": "0x2105"
+        "data": "0xfbadbaf01"
       }
     ],
     "capabilities": {
       "paymasterService": {
-        "0x01": {
-          "url": "https://...",
-          "context": {
-            "policyId": "962b252c-a726-4a37-8d86-333ce0a07299"
-          }
-        },
-        "0x2105": {
-          "url": "https://...",
-          "context": {
-            "policyId": "0a268db9-3243-4178-b1bd-d9b67a47d37b"
-          }
+        "url": "https://...",
+        "context": {
+          "policyId": "962b252c-a726-4a37-8d86-333ce0a07299"
         }
       }
     }
@@ -299,7 +287,7 @@ type PaymasterCapabilityParams = Record<
 ]
 ```
 
-The wallet will then make the above paymaster RPC calls to the URLs specified in the `paymasterService` capability field.
+The wallet will then make the above paymaster RPC calls to the URL specified in the `paymasterService` capability field.
 
 #### Wallet Implementation
 


### PR DESCRIPTION
Reverts ethereum/ERCs#571 as chain ids are no longer per-call.