### PR TITLE
Update ERC-7743: update erc-7743

### DIFF
--- a/ERCS/erc-7743.md
+++ b/ERCS/erc-7743.md
@@ -2,7 +2,7 @@
 eip: 7743
 title: Multi-Owner Non-Fungible Tokens (MO-NFT)
 description: Non-fungible token that supports multiple owners, allowing shared ownership and transferability among users.
-author: James Savechives (@jamesavechives)
+author: Cheng Qian (@jamesavechives) <james.walstonn@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/discussion-on-eip-7743-multi-owner-non-fungible-tokens-mo-nft/20577
 status: Last Call
 last-call-deadline: 2025-05-27
@@ -64,7 +64,7 @@ Traditional NFTs enforce a single-ownership model, which does not align with the
    - Owners can mark themselves as archived for a specific token, meaning they can no longer transfer that token. Once set, this status cannot be reversed. And for Digital Asset platform, this status means the owner can download the real digital asset directly; if it is not archived, then it must be changed to archived first, then owner can download the real digital asset.
 
      ```solidity
-     function setArchivedStatus(uint256 tokenId, bool archived) external;
+     function archive(uint256 tokenId) external;
      ```
 
 
@@ -98,9 +98,9 @@ Traditional NFTs enforce a single-ownership model, which does not align with the
 
 - `function setTransferValue(uint256 tokenId, uint256 newTransferValue) external;`
 
-**Archived Status Function**:
+**Archived Status Function**
 
-- `function setArchivedStatus(uint256 tokenId, bool archived) external;`
+- `function archive(uint256 tokenId) external;`
 
 ### Events
 
@@ -206,7 +206,7 @@ Developers should be aware of these differences when integrating MO-NFTs into sy
 3. **Archiving Ownership**:
 
    - **Input**:
-     - An owner calls `setArchivedStatus(tokenId, true)`.
+     - An owner calls `archive(tokenId)`.
 
    - **Expected Output**:
      - The owner’s transfer ability for that token is archived.
@@ -301,17 +301,17 @@ function transferFrom(address from, address to, uint256 tokenId) public override
 **Archiving Ownership**
 
 ```solidity
-function setArchivedStatus(uint256 tokenId, bool archived) external {
+function archive(uint256 tokenId) external {
         require(
             isOwner(tokenId, msg.sender),
             "MO-NFT: Caller is not the owner of this token"
         );
         // Once archived, the status cannot be reversed
         require(
-            archived == true,
+            _archivedStatus[tokenId][msg.sender] == false,
             "MO-NFT: Token can only be archived once for an owner"
         );
-        _archivedStatus[tokenId][msg.sender] = archived;
+        _archivedStatus[tokenId][msg.sender] = true;
         emit ArchivedStatusUpdated(tokenId, msg.sender, archived);
     }
 ```

--- a/assets/erc-7743/MONFT.sol
+++ b/assets/erc-7743/MONFT.sol
@@ -236,17 +236,17 @@ contract MultiOwnerNFT is Context, ERC165, IERC721, Ownable {
     }
 
     // Function to update the archived status for a specific owner of a token (permanent change)
-    function setArchivedStatus(uint256 tokenId, bool archived) external {
+    function archive(uint256 tokenId) external {
         require(
             isOwner(tokenId, msg.sender),
             "MO-NFT: Caller is not the owner of this token"
         );
         // Once archived, the status cannot be reversed
         require(
-            archived == true,
+            _archivedStatus[tokenId][msg.sender] == false,
             "MO-NFT: Token can only be archived once for an owner"
         );
-        _archivedStatus[tokenId][msg.sender] = archived;
+        _archivedStatus[tokenId][msg.sender] = true;
         emit ArchivedStatusUpdated(tokenId, msg.sender, archived);
     }
 


### PR DESCRIPTION
This ERC proposes a new standard for non-fungible tokens (NFTs) that supports multiple owners. The MO-NFT standard allows a single NFT to have multiple owners, reflecting the shared and distributable nature of digital assets. This model incorporates mechanisms for provider-defined transfer fees and ownership burning, enabling flexible and collaborative ownership structures. It maintains compatibility with the existing [ERC-721](https://eips.ethereum.org/EIPS/eip-721) standard to ensure interoperability with current tools and platforms.
