### PR TITLE
Update ERC-7837: update author

### DIFF
--- a/ERCS/erc-7837.md
+++ b/ERCS/erc-7837.md
@@ -2,7 +2,7 @@
 eip: 7837
 title: Diffusive Tokens
 description: A fungible token that mints new tokens on transfer, charges a per-token native fee, and enforces a capped supply.
-author: James Savechives (@jamesavechives)
+author: Cheng Qian (@jamesavechives) <james.walstonn@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/erc-7837-diffusive-tokens/21989
 status: Last Call
 last-call-deadline: 2025-05-25


### PR DESCRIPTION
This ERC proposes a standard for a new type of fungible token, called Diffusive Tokens (DIFF). Unlike traditional ERC-20 tokens, transferring DIFF tokens does not decrease the sender’s balance. Instead, it mints new tokens directly to the recipient, increasing the total supply on every transfer action. A fixed native currency fee is charged per token transferred, and this fee is paid by the sender to the contract owner. The supply growth is limited by a maximum supply set by the owner. Token holders can also burn their tokens to reduce the total supply. These features enable a controlled, incentivized token distribution model that merges fungibility with a built-in economic mechanism.
