### PR TITLE
Update ERC-7743: Move to Final

### DIFF
--- a/ERCS/erc-7743.md
+++ b/ERCS/erc-7743.md
@@ -4,8 +4,7 @@ title: Multi-Owner Non-Fungible Tokens (MO-NFT)
 description: Non-fungible token that supports multiple owners, allowing shared ownership and transferability among users.
 author: Cheng Qian (@jamesavechives) <james.walstonn@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/discussion-on-eip-7743-multi-owner-non-fungible-tokens-mo-nft/20577
-status: Last Call
-last-call-deadline: 2025-05-27
+status: Final
 type: Standards Track
 category: ERC
 created: 2024-07-13


### PR DESCRIPTION
This ERC proposes a new standard for non-fungible tokens (NFTs) that supports multiple owners. The MO-NFT standard allows a single NFT to have multiple owners, reflecting the shared and distributable nature of digital assets. This model incorporates mechanisms for provider-defined transfer fees and ownership burning, enabling flexible and collaborative ownership structures. It maintains compatibility with the existing [ERC-721](https://eips.ethereum.org/EIPS/eip-721) standard to ensure interoperability with current tools and platforms.