### PR TITLE
Update ERC-7847: Clarifying how to handle whitespace for ID calculation

### DIFF
--- a/ERCS/erc-7847.md
+++ b/ERCS/erc-7847.md
@@ -41,7 +41,8 @@ To obtain the id, we sha256 the serialized attributes in this order. The seriali
 **To prevent implementation differences from creating a different event ID for the same event, the following rules MUST be followed while serializing:**
 
 - UTF-8 should be used for encoding.
-- Whitespace, line breaks or other unnecessary formatting should not be included in the output JSON.
+- Preceding and trailing whitespace must be trimmed from serialized JSON and field values.
+- If spaces are used in tags they must be single spaces within array values.
 - The following characters in the content field must be escaped as shown, and all other characters must be included verbatim:
   - A line break (0x0A), use \n
   - A double quote (0x22), use \"


### PR DESCRIPTION
This should clarify how to handle whitespace in the JSON before before taking the sha256 to get the event ID. 

Responding to https://github.com/ethereum/ERCs/pull/782#discussion_r2087677697