### PR TITLE
Update ERC-1967: fix very bad error

### DIFF
--- a/ERCS/erc-1967.md
+++ b/ERCS/erc-1967.md
@@ -13,7 +13,7 @@ created: 2019-04-24
 ## Abstract
 Delegating **proxy contracts** are widely used for both upgradeability and gas savings. These proxies rely on a **logic contract** (also known as implementation contract or master copy) that is called using `delegatecall`. This allows proxies to keep a persistent state (storage and balance) while the code is delegated to the logic contract.
 
-To avoid clashes in storage usage between the proxy and logic contract, the address of the logic contract is typically saved in a specific storage slot (for example `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc` in OpenZeppelin contracts) guaranteed to be never allocated by a compiler. This EIP proposes a set of standard slots to store proxy information. This allows clients like block explorers to properly extract and show this information to end users, and logic contracts to optionally act upon it.
+To avoid clashes in storage usage between the proxy and logic contract, the address of the logic contract is typically saved in a specific storage slot guaranteed to be never allocated by a compiler. This EIP proposes a set of standard slots to store proxy information. This allows clients like block explorers to properly extract and show this information to end users, and logic contracts to optionally act upon it.
 
 ## Motivation
 Delegating proxies are widely in use, as a means to both support upgrades and reduce gas costs of deployments. Examples of these proxies are found in OpenZeppelin Contracts, Gnosis, AragonOS, Melonport, Limechain, WindingTree, Decentraland, and many others.


### PR DESCRIPTION
**Update erc-1967.md: fix very bad error**

This PR fixes very bad error. (I will explain in the end of this message why this error is very bad.)

Current text says this:

> the address of the logic contract is typically saved in a specific storage slot (for example `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc` in OpenZeppelin contracts)

The most straightforward way to understand this sentence is so: "the address of the logic contract is typically saved in a specific storage slot, for example, OpenZeppelin's **unstructured storage proxy pattern**, which **existed before introduction of this ERC**, used `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc` for this purpose".

This is how I understood that sentence when I have read it for the first time. In my opinion this is the most obvious way to understand it.

Yet such interpretation is, of course, wrong. There is no way that OpenZeppelin used `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc` for this purpose, because `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc` (as explained later in this ERC) is `bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)`. I. e. it is hash of string, which includes `1967` in it.

It is highly unlikely OpenZeppelin did know beforehand that this ERC will get number 1967 before its introduction. Thus this is simply impossible that they used exact same hash.

And indeed they used `keccak256('org.zeppelinos.proxy.implementation')`, not `keccak256('eip1967.proxy.implementation')`, as explained here: https://blog.openzeppelin.com/upgradeability-using-unstructured-storage .

So, conclusion: that sentence from this ERC is wrong (I mean that its most straightforward interpretation is wrong).

So, that sentence should be somehow fixed.

One way to fix is change hash to correct hash, i. e. to `keccak256('org.zeppelinos.proxy.implementation')`. But I'm afraid this will confuse reader.

So I propose just to remove that misleading part.

And now let me get to final part: why I think current wording is very bad.

When I first read current wording, I thought: "Wait, what?! OpenZeppelin used `keccak256('eip1967.proxy.implementation')` **before** they knew this ERC will be published? How they guessed its number? Or... Well... OpenZeppelin just used some random number, and authors of this ERC were able to somehow craft string, which includes number of this ERC and has matching hash?! I. e. authors of this ERC were able to perform preimage attack against Keccak?!!! So we are all doomed?!"

So I started to investigate what is going on. Keccak preimage attack?! Ethereum is doomed?! Well, it turned out this was merely error in text of this ERC.

So, please, merge this PR. It fixes mistake and also prevents readers from Keccak attack horrors