### PR TITLE
Update ERC-7603: fix broken erc link erc-7603.md

### DIFF
--- a/ERCS/erc-7603.md
+++ b/ERCS/erc-7603.md
@@ -55,7 +55,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ```solidity
 /// @title ERC-7603 Context-Dependent Multi-Asset Tokens, ERC-1155 Execution
-/// @dev See https://eips.ethereum.org/EIPS/erc-7603
+/// @dev See https://eips.ethereum.org/EIPS/eip-7603
 
 pragma solidity ^0.8.23;
 


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL

https://eips.ethereum.org/EIPS/erc-7603 - old link
https://eips.ethereum.org/EIPS/eip-7603 - new link 

<img width="945" alt="image" src="https://github.com/user-attachments/assets/08249c18-81c4-4aeb-bde0-946ffc057ec9" />
