### PR TITLE
Update ERC-4361: Move to Last Call

### DIFF
--- a/ERCS/erc-4361.md
+++ b/ERCS/erc-4361.md
@@ -5,7 +5,7 @@ description: Off-chain authentication for Ethereum accounts to establish session
 author: Wayne Chang (@wyc), Gregory Rocco (@obstropolos), Brantly Millegan (@brantlymillegan), Nick Johnson (@Arachnid), Oliver Terbu (@awoie)
 discussions-to: https://ethereum-magicians.org/t/eip-4361-sign-in-with-ethereum/7263
 status: Last Call
-last-call-deadline: 2025-07-22
+last-call-deadline: 2025-07-29
 type: Standards Track
 category: ERC
 created: 2021-10-11


### PR DESCRIPTION
I'd like to request to move this to Last Call.  [SIWE](https://login.xyz/)'s specification has been settled for a while, it has been implemented in Typescript, Rust, Elixir, Python, Ruby and Go and is used in [thousands of projects](https://github.com/spruceid/siwe/network/dependents).
