### PR TITLE
Add ERC: Proof-based Broadcast in ERC-7786 Gateways

### DIFF
--- a/ERCS/erc-7965.md
+++ b/ERCS/erc-7965.md
@@ -40,7 +40,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 [ERC-7786] defines broadcasting as using "omitted or zeroed" recipient addresses (containing an [ERC-7930] interoperable address with all fields set to zero). This specification extends that concept to enable granular broadcasting patterns through [ERC-7930]'s flexible address structure:
 
-[ERC-7930]: ./erc-7930.md
+[ERC-7930]: ./eip-7930.md
 
 Broadcasting semantics in this specification extend [ERC-7786] by allowing:
 


### PR DESCRIPTION
Extends ERC-7786 cross-chain messaging with cryptographic proof-based verification and granular broadcasting semantics. It enables trustless message verification using blockchain consensus mechanisms rather than external validators or multisigs. 

The specification defines three ERC-7786 attributes: `route()` for multi-hop verification paths, `inclusionProof()` for cryptographic evidence of message commitment, and optional `targetBlock()` for finality validation. 

Broadcasting leverages ERC-7930 addresses to enable targeted message distribution: empty address components broadcast to all addresses on specific chains, empty chain references broadcast to all chains of a type, and fully zeroed addresses enable universal broadcasting.
