### PR TITLE
Update ERC-7715: Simplify specification to ease wallet implementation

### DIFF
--- a/ERCS/erc-7715.md
+++ b/ERCS/erc-7715.md
@@ -2,7 +2,7 @@
 eip: 7715
 title: Grant Permissions from Wallets
 description: Adds JSON-RPC method for granting permissions from a wallet
-author: Luka Isailovic (@lukaisailovic), Derek Rein (@arein), Dan Finlay (@danfinlay), Derek Chiang (@derekchiang), Fil Makarov (@filmakarov), Pedro Gomes (@pedrouid), Conner Swenberg (@ilikesymmetry), Lukas Rosario (@lukasrosario), Idris Bowman (@V00D00-child)
+author: Luka Isailovic (@lukaisailovic), Derek Rein (@arein), Dan Finlay (@danfinlay), Derek Chiang (@derekchiang), Fil Makarov (@filmakarov), Pedro Gomes (@pedrouid), Conner Swenberg (@ilikesymmetry), Lukas Rosario (@lukasrosario), Idris Bowman (@V00D00-child), Jeff Smale (@jeffsmale90)
 discussions-to: https://ethereum-magicians.org/t/erc-7715-grant-permissions-from-wallets/20100
 status: Draft
 type: Standards Track

--- a/ERCS/erc-7715.md
+++ b/ERCS/erc-7715.md
@@ -2,7 +2,7 @@
 eip: 7715
 title: Grant Permissions from Wallets
 description: Adds JSON-RPC method for granting permissions from a wallet
-author: Luka Isailovic (@lukaisailovic), Derek Rein (@arein), Dan Finlay (@danfinlay), Derek Chiang (@derekchiang), Fil Makarov (@filmakarov), Pedro Gomes (@pedrouid), Conner Swenberg (@ilikesymmetry), Lukas Rosario (@lukasrosario)
+author: Luka Isailovic (@lukaisailovic), Derek Rein (@arein), Dan Finlay (@danfinlay), Derek Chiang (@derekchiang), Fil Makarov (@filmakarov), Pedro Gomes (@pedrouid), Conner Swenberg (@ilikesymmetry), Lukas Rosario (@lukasrosario), Idris Bowman (@V00D00-child)
 discussions-to: https://ethereum-magicians.org/t/erc-7715-grant-permissions-from-wallets/20100
 status: Draft
 type: Standards Track
@@ -13,7 +13,7 @@ requires: 4337, 5792, 7679, 7710
 
 ## Abstract
 
-We define a new JSON-RPC method `wallet_grantPermissions` for DApp to request a Wallet to grant permissions in order to execute transactions on the user’s behalf. This enables two use cases:
+We define a new JSON-RPC method `wallet_requestExecutionPermissions` for DApp to request a Wallet to grant permissions in order to execute transactions on the user’s behalf. This enables two use cases:
 
 - Executing transactions for users without a wallet connection.
 - Executing transactions for users with a wallet connection that is scoped with permissions.
@@ -35,150 +35,13 @@ In the context of AA, there are multiple vendor-specific implementations of sess
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-### `wallet_grantPermissions`
+### Signer, Permission Types, Rule Types
 
-We introduce a `wallet_grantPermissions` method for the DApp to request the Wallet to grant permissions.
+In this ERC, we specify a list of signers, base permission and base rule types that we expect to be commonly used.
 
-#### Permission schema
+This ERC does not specify an exhaustive list of signer or permission types, since we expect more signer and permission types to be developed as wallets get more advanced. A signer, permission type, or rule type is valid as long as both the DApp and the wallet are willing to support it.
 
-```tsx
-type PermissionRequest = {
-  chainId: Hex; // hex-encoding of uint256
-  address?: Address;
-  expiry: number; // unix timestamp
-  signer: {
-    type: string; // enum defined by ERCs
-    data: Record<string, any>;
-  };
-  permissions: {
-    type: string; // enum defined by ERCs
-    data: Record<string, any>;
-  }[];
-}[];
-```
-
-`chainId` defines the chain with [EIP-155](./eip-155.md) which applies to this permission request and all addresses can be found defined by other parameters.
-
-`address` identifies the account being targetted for this permission request which is useful when a connection has been established and multiple accounts have been exposed. It is optional to let the user choose which account to grant permission for.
-
-`expiry` is a UNIX timestamp (in seconds) that specifies the time by which this session MUST expire.
-
-`signer` is a field that identifies the key or account associated with the permission or alternatively the wallet will manage the session. See the “Signers” section for details.
-
-`permissions` defines the allowed behavior the signer can do on behalf of the account. See the “Permissions” section for details.
-
-**Request example**:
-
-An array of `PermissionRequest` objects is the final `params` field expected by the `wallet_grantPermissions` RPC.
-
-```tsx
-[
-    {
-        chainId: 123,
-        address: '0x...'
-        expiry: 1577840461
-        signer: {
-            type: 'account',
-            data: {
-                address:'0x016562aA41A8697720ce0943F003141f5dEAe006',
-            }
-        },
-        permissions: [
-          {
-            type: 'native-token-transfer',
-            data: {
-                allowance: '0x1DCD6500'
-            }
-          }
-        ],
-    }
-]
-```
-
-#### Response Specification
-
-```tsx
-type PermissionResponse = PermissionRequest & {
-  context: Hex;
-  accountMeta?: {
-    factory: `0x${string}`;
-    factoryData: `0x${string}`;
-  };
-  signerMeta?: {
-    // 7679 userOp building
-    userOpBuilder?: `0x${string}`;
-    // 7710 delegation
-    delegationManager?: `0x${string}`;
-  };
-};
-```
-
-First note that the response contains all of the parameters of the original request and it is not guaranteed that the values received are equivalent to those requested.
-
-`context` is a catch-all to identify a permission for revoking permissions or submitting userOps, and can contain non-identifying data as well. It MAY be the `context` as defined in [ERC-7679](./eip-7679.md) and [ERC-7710](./eip-7710.md). See “Rationale” for details.
-
-`accountMeta` is optional but when present then fields for `factory` and `factoryData` are required as defined in [ERC-4337](./eip-4337.md). They are either both specified, or none. If the account has not yet been deployed, the wallet MUST return `accountMeta`, and the DApp MUST deploy the account by calling the `factory` contract with `factoryData` as the calldata.
-
-`signerMeta` is dependent on the account type. If the signer type is `wallet` then it's not required. If the signer type is `key` or `keys` then `userOpBuilder` is required as defined in [ERC-7679](./eip-7679.md). If the signer type is `account` then `delegationManager` is required as defined in [ERC-7710](./eip-7710.md).
-
-If the request is malformed or the wallet is unable/unwilling to grant permissions, wallet MUST return an error with a code as defined in [ERC-1193](./eip-1193.md).
-
-`wallet_grantPermissions` response example:
-
-An array of `PermissionResponse` objects is the final `result` field expected by the `wallet_grantPermissions` RPC.
-
-```tsx
-[
-    {
-        // original request with modifications
-        chainId: 123,
-        address: '0x...'
-        expiry: 1577850000
-        signer: {
-            type: 'account',
-            data: {
-                address:'0x016562aA41A8697720ce0943F003141f5dEAe006',
-            }
-        },
-        permissions: [
-          {
-            type: 'native-token-transfer',
-            data: {
-                allowance: '0x1DCD65000000'
-            }
-          },
-        ]
-        // response-specific fields
-        context: "0x0x016562aA41A8697720ce0943F003141f5dEAe0060000771577157715"
-    }
-]
-```
-
-### `wallet_revokePermissions`
-
-Permissions can be revoked by calling this method and the wallet will respond with an empty response when successful.
-
-#### Request Specification
-
-```tsx
-type RevokePermissionsRequestParams = {
-  permissionContext: "0x{string}";
-};
-```
-
-#### Response Specification
-
-```tsx
-type RevokePermissionsResponseResult = {};
-```
-
-### Signer & Permission Types
-
-In this ERC, we specify a list of signers and permissions that we expect to be commonly used.
-
-This ERC does not specify an exhaustive list of signer or permission types, since we expect more signer and permission types to be developed as wallets get more advanced. A signer or permission type is valid as long as both the DApp and the wallet are willing to support it.
-
-However, if two signers or two permissions share the same type name, a DApp could request with one type of signer or permission while the wallet grants another. Therefore, it’s important that no two signers or two permissions share the same type. Therefore, new signer or permission types should be specified in ERCs, either in this ERC as an amendment or in another ERC.
+However, if two signers, two permissions or two rules share the same type name, a DApp could request with one type of signer, permission, or rule while the wallet grants another. Therefore, it’s important that no two signers, two permissions, or two rules share the same type. Therefore, new signer permission types or rule types should be specified in ERCs, either in this ERC as an amendment or in another ERC. In all cases, these new types MUST inherit from the base permission or base rule.
 
 #### Signers
 
@@ -224,70 +87,187 @@ type AccountSigner = {
 };
 ```
 
-#### Permissions
+#### Permission
+
+`isAdjustmentAllowed` defines a boolean value that allows DApp to define whether the "permission" can be _attenuated_–adjusted to meet the user’s terms.
+
+_For example, a DApp may require an allowance for a specific asset to complete a payment and does not want the user to adjust the requested allowance._
 
 ```tsx
-// Native token transfer, e.g. ETH on Ethereum
-type NativeTokenTransferPermission = {
-  type: "native-token-transfer";
-  data: {
-    allowance: "0x..."; // hex value
-  };
+type BasePermission = {
+  type: string; // enum defined by ERCs
+  isAdjustmentAllowed: boolean; // whether the permission can be adjusted
+  data: Record<string, any>; // specific to the type, structure defined by ERCs
 };
+```
 
-// ERC20 token transfer
-type ERC20TokenTransferPermission = {
-  type: "erc20-token-transfer";
-  data: {
-    address: "0x..."; // erc20 contract
-    allowance: "0x..."; // hex value
-  };
-};
+#### Rule
 
-// ERC721 token transfer
-type ERC721TokenTransferPermission = {
-  type: "erc721-token-transfer";
-  data: {
-    address: "0x..."; // erc721 contract
-    tokenIds: "0x..."[]; // hex value array
-  };
-};
+`isAdjustmentAllowed` defines a boolean value that allows DApp to define whether the "rule" can be _attenuated_–adjusted to meet the user’s terms.
 
-// ERC1155 token transfer
-type ERC1155TokenTransferPermission = {
-  type: "erc1155-token-transfer";
-  data: {
-    address: "0x..."; // erc1155 contract
-    allowances: {
-      [tokenId: string]: "0x..."; // hex value
-    };
-  };
+```tsx
+type BaseRule = {
+  type: string; // enum defined by ERCs
+  isAdjustmentAllowed: boolean; // whether the rule can be adjusted
+  data: Record<string, any>; // specific to the type, structure defined by ERCs
 };
+```
 
-// The maximum gas limit spent in the session in total
-type GasLimitPermission = {
-  type: "gas-limit";
+**Example: Expiry Rule**
+A DApp may want to enforce that a permission (e.g., to spend tokens or access a feature) is only valid for a specific time period. It can define an expiry rule and use `isAdjustmentAllowed` to indicate whether the user is allowed to reduce that time window.
+```tsx
+type ExpiryRule = BaseRule & {
+  type: "expiry", // rule type, enum value defined by an ERC the requires ERC-7715
+  isAdjustmentAllowed: true, // user can shorten the expiry if they want
   data: {
-    limit: "0x..."; // hex value
-  };
+    timestamp: 1767484800 // unix timestamp
+  }
 };
+```
 
-// The number of calls the session can make in total
-type CallLimitPermission = {
-  type: "call-limit";
-  data: {
-    count: number;
-  };
-};
+### `wallet_requestExecutionPermissions`
 
-// The number of calls the session can make during each interval
-type RateLimitPermission = {
-  type: "rate-limit";
-  data: {
-    count: number; // the number of times during each interval
-    interval: number; // in seconds
+We introduce a `wallet_requestExecutionPermissions` method for the DApp to request the Wallet to grant permissions.
+
+#### Request Specification
+
+```tsx
+type PermissionRequest = {
+  chainId: Hex; // hex-encoding of uint256
+  address?: Address;
+  signer: {
+    type: string; // enum defined by ERCs
+    data: Record<string, any>;
+  };
+  permission: {
+    type: string; // enum defined by ERCs
+    isAdjustmentAllowed: boolean; // whether the permission can be adjusted
+    data: Record<string, any>; //specific to the type, structure defined by ERCs
+  };
+  rules?: {
+    type: string; // enum defined by ERCs
+    isAdjustmentAllowed: boolean; // whether the rule can be adjusted
+    data: Record<string, any>; // specific to the type, structure defined by ERCs
+  }[];
+}[];
+```
+
+`chainId` defines the chain with [EIP-155](./eip-155.md) which applies to this permission request and all addresses can be found defined by other parameters.
+
+`address` identifies the account being targetted for this permission request which is useful when a connection has been established and multiple accounts have been exposed. It is optional to let the user choose which account to grant permission for.
+
+`signer` is a field that identifies the key or account associated with the permission or alternatively the wallet will manage the session. See the “Signers” section for details.
+
+`permission` defines the allowed behavior the signer can do on behalf of the account. See the “Permission” section for details.
+
+`rules` defined the restrictions or conditions that a signer MUST abide by when using a permission to act on behalf of an account. See the “Rule” section for details.
+
+**Request example**:
+
+An array of `PermissionRequest` objects is the final `params` field expected by the `wallet_requestExecutionPermissions` RPC.
+
+```tsx
+[
+  {
+    chainId: 123,
+    address: '0x...'
+    expiry: 1577840461
+    signer: {
+      type: 'account',
+      data: {
+        address:'0x016562aA41A8697720ce0943F003141f5dEAe006',
+      }
+    },
+    permission: {
+      type: 'native-token-transfer',
+      data: {
+        allowance: '0x1DCD6500'
+      }
+    },
+  }
+]
+```
+
+#### Response Specification
+
+```tsx
+type PermissionResponse = PermissionRequest & {
+  context: Hex;
+  dependencyInfo: {
+    factory: `0x${string}`;
+    factoryData: `0x${string}`;
+  }[];
+  signerMeta?: {
+    // 7679 userOp building
+    userOpBuilder?: `0x${string}`;
+    // 7710 delegation
+    delegationManager?: `0x${string}`;
   };
 };
+```
+
+First note that the response contains all of the parameters of the original request and it is not guaranteed that the values received are equivalent to those requested.
+
+`context` is a catch-all to identify a permission for revoking permissions or submitting userOps, and can contain non-identifying data as well. It MAY be the `context` as defined in [ERC-7679](./eip-7679.md) and [ERC-7710](./eip-7710.md). See “Rationale” for details.
+
+`dependencyInfo` is an array of objects, each containing fields for `factory` and `factoryData` as defined in [ERC-4337](./eip-4337.md). Either both `factory` and `factoryData` must be specified in an entry, or neither. This array is used describe accounts that are not yet deployed but MUST be deployed in order for a permission to be successfully redeemed. If any of the involved accounts have not yet been deployed, the wallet MUST return the corresponding `dependencyInfo`. If all accounts have already been deployed, the wallet MUST return an empty `dependencyInfo` array. The DApp MUST deploy each account by calling the `factory` contract with `factoryData` as the calldata.
+
+`signerMeta` is dependent on the account type. If the signer type is `wallet` then it's not required. If the signer type is `key` or `keys` then `userOpBuilder` is required as defined in [ERC-7679](./eip-7679.md). If the signer type is `account` then `delegationManager` is required as defined in [ERC-7710](./eip-7710.md).
+
+If the request is malformed or the wallet is unable/unwilling to grant permissions, wallet MUST return an error with a code as defined in [ERC-1193](./eip-1193.md).
+
+`wallet_requestExecutionPermissions` response example:
+
+An array of `PermissionResponse` objects is the final `result` field expected by the `wallet_requestExecutionPermissions` RPC.
+
+```tsx
+[
+  {
+    // original request with modifications
+    chainId: 123,
+    address: '0x...'
+    expiry: 1577850000
+    signer: {
+      type: 'account',
+      data: {
+        address:'0x016562aA41A8697720ce0943F003141f5dEAe006',
+      }
+    },
+    permission: {
+      type: 'native-token-transfer',
+      isAdjustmentAllowed: true,
+      data: {
+        allowance: '0x1DCD65000000'
+      }
+    },
+    // response-specific fields
+    context: "0x0x016562aA41A8697720ce0943F003141f5dEAe0060000771577157715",
+    dependencyInfo: [
+      {
+        factory: '0x...',
+        factoryData: '0x...'
+      }
+    ]
+  }
+]
+```
+
+### `wallet_revokeExecutionPermission` 
+
+Permissions can be revoked by calling this method and the wallet will respond with an empty response when successful.
+
+#### Request Specification
+
+```tsx
+type RevokeExecutionPermissionRequestParams = {
+  permissionContext: "0x{string}";
+};
+```
+
+#### Response Specification
+
+```tsx
+type RevokeExecutionPermissionResponseResult = {};
 ```
 
 ### Wallet-managed Sessions
@@ -327,7 +307,7 @@ Upon receiving this request, the wallet MUST send the calls in accordance with t
 
 If the wallet supports [ERC-5792](./eip-5792.md), wallet SHOULD respond on **`wallet_getCapabilities`** request using the `permissions` key.
 
-The wallet SHOULD include `signerTypes` (`string[]`) and `permissionTypes` (`string[]`) in the response, to specify the signer types and permission types it supports.
+The wallet SHOULD include `signerTypes` (`string[]`), `permissionTypes` (`string[]`) and `ruleTypes` (`string[]`) in the response, to specify the signer types and permission types it supports.
 Example:
 
 ```json
@@ -337,13 +317,14 @@ Example:
       "supported": true,
       "signerTypes": ["keys", "account"],
       "keyTypes": ["secp256k1", "secp256r1"],
-      "permissionTypes": ["erc20-token-transfer", "erc721-token-transfer"]
+      "permissionTypes": ["erc20-token-transfer", "erc721-token-transfer"],
+      "rulesTypes": ["expiry", "rate-limit", "call-limit"]
     }
   }
 }
 ```
 
-If the wallet is using CAIP-25 authorization, wallet SHOULD include `permissions` key in the CAIP-25 `sessionProperties` object. Additional keys to include are `permissionTypes` with the comma separated list of supported permission types and `signerTypes` with the comma separated list of supported signer types.
+If the wallet is using CAIP-25 authorization, wallet SHOULD include `permissions` key in the CAIP-25 `sessionProperties` object. Additional keys to include are `permissionTypes` with the comma separated list of supported permission types, `rulesTypes` with the comma separated list of supported rule types and `signerTypes` with the comma separated list of supported signer types.
 
 Example:
 
@@ -353,7 +334,8 @@ Example:
   "sessionProperties": {
     "permissions": "true",
     "signerTypes": "keys,account",
-    "permissionTypes": "erc20-token-transfer,erc721-token-transfer"
+    "permissionTypes": "erc20-token-transfer,erc721-token-transfer",
+    "rulesTypes": "expiry,rate-limit,call-limit"
   }
 }
 ```
@@ -362,9 +344,9 @@ Example:
 
 #### ERC-7679 with `Key` type signer
 
-`wallet_grantPermissions` replies with `permissionsContext` and `userOpBuilder` address inside the `signerMeta` field. DApps can use that data with methods provided by [ERC-7679](./eip-7679.md) to build the [ERC-4337](./eip-4337.md) userOp.
+`wallet_requestExecutionPermissions` replies with `permissionsContext` and `userOpBuilder` address inside the `signerMeta` field. DApps can use that data with methods provided by [ERC-7679](./eip-7679.md) to build the [ERC-4337](./eip-4337.md) userOp.
 
-[ERC-7679](./eip-7679.md) UserOp Builder contract defines `bytes calldata context` parameter in all of its methods. It’s equivalent to the`permissionsContext` returned by the `wallet_grantPermissions` call.
+[ERC-7679](./eip-7679.md) UserOp Builder contract defines `bytes calldata context` parameter in all of its methods. It’s equivalent to the`permissionsContext` returned by the `wallet_requestExecutionPermissions` call.
 
 Example of formatting userOp signature using the [ERC-7679](./eip-7679.md) UserOp Builder
 
@@ -393,9 +375,9 @@ When requesting permissions with a `type` of `account`, the returned data will b
 
 ```
 struct Action {
-    address to;
-    uint256 value;
-    bytes data;
+  address to;
+  uint256 value;
+  bytes data;
 }
 ```
 
@@ -404,31 +386,39 @@ A simple pseudocode example of using a permission in this way, given two ethers 
 ```
 // Alice requests a permission from Bob
 const permissionsResponse = await bob.request({
-  method: 'wallet_grantPermissions',
+  method: 'wallet_requestExecutionPermissions',
   params: [{
     address: bob.address,
     chainId: 123,
     signer: {
       type: 'account',
       data: {
-        id: alice.address
+        address: alice.address
       }
     },
-    permissions: [
-      {
-        type: 'native-token-transfer',
-        data: {
-          allowance: '0x0DE0B6B3A7640000'
-        },
+    permission: {
+      type: 'native-token-transfer',
+      isAdjustmentAllowed: true,
+      data: {
+        allowance: '0x0DE0B6B3A7640000'
       },
+    },
+    rules: [
       {
         type: 'gas-limit';
+        isAdjustmentAllowed: true,
         data: {
           limit: '0x0186A0',
         },
       },
+      {
+        type: 'expiry';
+        isAdjustmentAllowed: false,
+        data: {
+          timestamp: Math.floor(Date.now() / 1000) + 3600 // 1 hour from now
+        },
+      },
     ],
-    expiry: Math.floor(Date.now() / 1000) + 3600 // 1 hour from now
   }]
 });
 
@@ -480,7 +470,7 @@ With the advancement in wallet technologies, we expect new types of signers and 
 
 ## **Backwards Compatibility**
 
-Wallets that don’t support `wallet_grantPermissions` SHOULD return an error message if the JSON-RPC method is called.
+Wallets that don’t support `wallet_requestExecutionPermissions` SHOULD return an error message if the JSON-RPC method is called.
 
 ## **Security Considerations**
 


### PR DESCRIPTION
This PR proposes simplifications to the ERC-7715 specification to support a more manageable implementation across wallets.

For additional context and rationale behind these changes, please refer to the supporting document: [Proposal to Simplify ERC-7715](https://metamask-consensys.notion.site/Proposal-to-Simplify-ERC-7715-215f86d67d688041b580dd161968b2df?pvs=143)