### PR TITLE
Update ERC-7888: Correct Typos in ERC-7888

### DIFF
--- a/ERCS/erc-7888.md
+++ b/ERCS/erc-7888.md
@@ -20,7 +20,7 @@ Critically, the logic for verifying storage proofs is not hardcoded in the Recei
 
 ## Motivation
 
-The Ethereum ecosystem is experiencing a rapid growth in the number of rollup chains. As the number of chains grows, the experience becomes more fragmented for users, creating a need for trustless "interop" between rollup chains. These rollup chains, hosted on different rollup stacks, have heterogenous properties, and as yet there does not exist a simple, trustless, unified mechanism for sending messages between these diverse chains.
+The Ethereum ecosystem is experiencing a rapid growth in the number of rollup chains. As the number of chains grows, the experience becomes more fragmented for users, creating a need for trustless "interop" between rollup chains. These rollup chains, hosted on different rollup stacks, have heterogeneous properties, and as yet there does not exist a simple, trustless, unified mechanism for sending messages between these diverse chains.
 
 Many classes of applications could benefit from a unified system for broadcasting messages across chains. Some examples include:
 
@@ -335,7 +335,7 @@ Chains are often identified by chain ID's. Chain ID's are set by the chain owner
 #### BlockHashProvers
 Each rollup implements unique logic for managing and storing block hashes. To accommodate this diversity, BlockHashProvers implement chain-specific procedures. This flexibility allows integration with each rollup's distinct architecture.
 
-The BlockHashProver handles the final step of verifying a storage slot given a target block hash to accomodate rollups with differing state trie formats.
+The BlockHashProver handles the final step of verifying a storage slot given a target block hash to accommodate rollups with differing state trie formats.
 
 #### BlockHashProverPointers
 Routes reference BlockHashProvers through Pointers rather than directly. This indirection is crucial because:


### PR DESCRIPTION


This PR corrects minor spelling mistakes in the `ERC-7888.md` file.

**Changes:**

*   In the Motivation section, `heterogenous` has been corrected to `heterogeneous`.
*   In the BlockHashProvers section, `accomodate` has been corrected to `accommodate`.