### PR TITLE
Update ERC-5559: Remove quotes from 5559 title to improve automatic parsing

### DIFF
--- a/ERCS/erc-5559.md
+++ b/ERCS/erc-5559.md
@@ -1,6 +1,6 @@
 ---
 eip: 5559
-title: "Cross Chain Write Deferral Protocol"
+title: Cross Chain Write Deferral Protocol
 description: The cross chain write deferral protocol provides a mechanism to defer the storage & resolution of mutations to off-chain handlers
 author: Paul Gauvreau (@0xpaulio), Nick Johnson (@arachnid)
 discussions-to: https://ethereum-magicians.org/t/eip-cross-chain-write-deferral-protocol/10576


### PR DESCRIPTION
I was trying to automatically process/parse the ERC documents, and my script got stuck on ERC-5559 having quotes aroung the title. 

IMO it would be better to remove these quote to match all the other documents.