### PR TITLE
Update ERC-7682: Add section on `capabilities.auxiliaryFunds` parameter, `requiredAssets`

### DIFF
--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -146,14 +146,14 @@ This mechanism allows advanced wallets to abstract away the complexity of cross-
 
 This specification currently supports three token standards with the following field requirements:
 
-- **ERC-20**: Requires `amount` field only
-- **ERC-721**: Requires both `amount` and `tokenId` fields
-- **ERC-1155**: Requires both `amount` and `tokenId` fields
+- **[ERC-20](./eip-20.md)**: Requires `amount` field only
+- **[ERC-721](./eip-721.md)**: Requires both `amount` and `tokenId` fields
+- **[ERC-1155](./eip-1155.md)**: Requires both `amount` and `tokenId` fields
 
 The `amount` field semantics vary by token standard:
-- **ERC-20**: Represents token quantity in smallest unit (e.g., wei for 18-decimal tokens)
-- **ERC-721**: Represents NFT quantity (typically "0x01" for single NFT instances)
-- **ERC-1155**: Represents quantity of the specified token ID
+- **[ERC-20](./eip-20.md)**: Represents token quantity in smallest unit (e.g., wei for 18-decimal tokens)
+- **[ERC-721](./eip-721.md)**: Represents NFT quantity (typically "0x01" for single NFT instances)
+- **[ERC-1155](./eip-1155.md)**: Represents quantity of the specified token ID
 
 Future token standards MUST specify additional required fields as properties on the asset object root to maintain extensibility.
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -106,13 +106,12 @@ type WalletSendCallsRequest = {
         };
         erc721?: {
           [asset: `0x${string}`]: {
-            tokenId: `0x${string}`; // Token ID as a hex string
+            tokenIds: `0x${string}`[]; // Array of token IDs as hex strings
           };
         };
         erc1155?: {
           [asset: `0x${string}`]: {
-            tokenId: `0x${string}`; // Token ID as a hex string
-            amount: `0x${string}`; // Amount required, as a hex string representing the integer value
+            [tokenId: `0x${string}`]: `0x${string}`; // Token ID to amount mapping, where amount is a hex string
           };
         };
       };
@@ -135,15 +134,14 @@ type ERC20Asset = {
 #### [ERC-721](./eip-721.md)
 ```typescript
 type ERC721Asset = {
-  tokenId: `0x${string}`; // Token ID as a hex string
+  tokenIds: `0x${string}`[]; // Array of token IDs as hex strings
 };
 ```
 
 #### [ERC-1155](./eip-1155.md)
 ```typescript
 type ERC1155Asset = {
-  tokenId: `0x${string}`; // Token ID as a hex string
-  amount: `0x${string}`; // Amount required, as a hex string representing the integer value
+  [tokenId: `0x${string}`]: `0x${string}`; // Token ID to amount mapping, where amount is a hex string
 };
 ```
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -151,10 +151,6 @@ Apps MUST include the `assetsRequiredForExecution` parameter in the `capabilitie
 ### Gas Estimation and Native Asset Handling
 - Applications SHOULD include an estimate for the required native asset (e.g., ETH for gas) in `assetsRequiredForExecution` when possible.
 
-## Backwards Compatibility
-- Applications SHOULD only include the `assetsRequiredForExecution` parameter if the wallet advertises the `auxiliaryFunds` capability.
-- If a wallet does not recognize or support the `assetsRequiredForExecution` parameter, it SHOULD ignore the parameter or return a clear error indicating lack of support. Apps SHOULD be prepared to handle such cases gracefully, potentially falling back to legacy behavior.
-
 ## Rationale
 
 ### Alternatives
@@ -164,6 +160,11 @@ Apps MUST include the `assetsRequiredForExecution` parameter in the `capabilitie
 An alternative we considered is defining a way for apps to fetch available auxiliary balances. This could be done, for example, by providing a URL as part of the `auxiliaryFunds` capability that apps could use to fetch auxiliary balance information. However, we ultimately decided that a boolean was enough to indicate to apps that they should not block user actions on the basis of balance checks, and it is minimally burdensome for apps to implement.
 
 The shape of this capability allows for a more advanced extension if apps feel more functionality is needed.
+
+## Backwards Compatibility
+- Applications SHOULD only include the `assetsRequiredForExecution` parameter if the wallet advertises the `auxiliaryFunds` capability.
+- If a wallet does not recognize or support the `assetsRequiredForExecution` parameter, it SHOULD ignore the parameter or return a clear error indicating lack of support. Apps SHOULD be prepared to handle such cases gracefully, potentially falling back to legacy behavior.
+
 
 ## Security Considerations
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -139,6 +139,9 @@ The wallet, upon receiving this request, can:
 
 This mechanism allows advanced wallets to abstract away the complexity of cross-chain or offchain funding, enabling seamless user experiences even when the user's onchain balance is insufficient on the target chain.
 
+### Auxiliary Funds and Atomic Execution
+
+Auxiliary funds provisioning (bridging, swapping, or other asset retrieval operations) is independent of the `wallet_sendCalls` execution lifecycle. The `atomicRequired` field applies only to the call bundle execution, not to auxiliary funds provisioning.
 
 ### Error Codes
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -151,9 +151,8 @@ The following error codes are defined for auxiliary funds provisioning failures.
 |----------|-----------------------------------|-------------|
 | -32080   | Auxiliary funds provisioning failed | Wallet attempted to provision funds but failed (e.g., bridge/swap error). |
 | -32081   | Asset not supported             | The requested asset is not available through the wallet’s auxiliary fund system. |
-| -32082   | Auxiliary funds timeout         | The provisioning operation took too long or timed out. |
-| -32083   | Auxiliary funds capability not available | The wallet no longer supports auxiliary funds on the requested chain. |
-| -32084   | Invalid assetsRequiredForExecution | The structure of the assetsRequiredForExecution object is malformed. |
+| -32082   | Auxiliary funds capability not available | The wallet no longer supports auxiliary funds on the requested chain. |
+| -32083   | Invalid assetsRequiredForExecution | The structure of the assetsRequiredForExecution object is malformed. |
 
 Applications SHOULD use the `wallet_getCallsStatus` method to track the status of call bundles that involve auxiliary funds provisioning, as the provisioning process may take time to complete. The status response will indicate whether the auxiliary funds provisioning is in progress, completed, or failed.
 
@@ -166,9 +165,6 @@ Apps MAY include the `assetsRequiredForExecution` parameter in the `capabilities
 ### Amount Validation
 
 The wallet MUST cross-check the `amount` value in `assetsRequiredForExecution` against the `decimal()` value specified on the `asset`'s contract to ensure that the amount is interpreted correctly according to the asset's decimal precision.
-
-### Gas Estimation and Native Asset Handling
-- Applications SHOULD include an estimate for the required native asset (e.g., ETH for gas) in `assetsRequiredForExecution` when possible.
 
 ## Rationale
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -2,7 +2,7 @@
 eip: 7682
 title: Auxiliary Funds Capability
 description: A capability allowing wallets to indicate that they have access to additional funds.
-author: Lukas Rosario (@lukasrosario), Wilson Cusack (@wilsoncusack)
+author: Lukas Rosario (@lukasrosario), Wilson Cusack (@wilsoncusack), Alex Donesky (@adonesky1)
 discussions-to: https://ethereum-magicians.org/t/erc-7682-auxiliary-funds-capability/19599
 status: Draft
 type: Standards Track

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -72,9 +72,69 @@ type AuxiliaryFundsCapability = {
 }
 ```
 
-### App Implementation
+### Extended Usage: `assetsRequiredForExecution` Parameter
+
+When a wallet indicates support for the `auxiliaryFunds` capability (i.e., `supported: true`), applications that use the [`wallet_sendCalls`](./eip-5792.md#wallet_sendcalls) method MUST include an additional parameter named `assetsRequiredForExecution` in the call. 
+
+This parameter is necessary because transaction call data alone does not reliably indicate which assets and amounts are needed for successful execution. Calls may involve complex logic or multiple contracts, making it difficult for wallets to infer requirements. By specifying required assets and amounts explicitly, apps ensure wallets have the information needed to provision, bridge, or swap assets as necessary for the transaction to succeed.
+
+### `wallet_sendCalls` Extended Parameter
+
+The `assetsRequiredForExecution` parameter MUST be specified per call in the `calls` array. Each call object MAY include an `assetsRequiredForExecution` array, which details the assets and amounts required for that specific call.
+
+```typescript
+// Example call type extension
+type WalletSendCall = {
+  to: `0x${string}`;
+  data: string;
+  // ... other call fields ...
+  assetsRequiredForExecution?: Array<{
+    asset: `0x${string}`; // Asset address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native asset)
+    amount: string;        // Amount required, as a string representing the integer value in the asset's smallest unit
+    decimals: number;      // Number of decimals for the asset (to interpret amount correctly)
+  }>;
+};
+```
+
+#### Example Scenario: Cross-Chain Deposit to Aave
+
+Suppose a user wants to deposit DAI into Aave on Chain X, but their wallet address on Chain X has no DAI or native gas token. However, the wallet has access to funds on Chain Y (e.g., Ethereum mainnet). The app, upon detecting the `auxiliaryFunds` capability, can construct a `wallet_sendCalls` request as follows:
+
+```json
+{
+  "calls": [
+    {
+      "to": "0xAaveDAIDepositContractOnChainX",
+      "data": "0xd0e30db0", // Example encoded deposit function call
+      "assetsRequiredForExecution": [
+        {
+          "asset": "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI address on Chain X
+          "amount": "1000000000000000000", // 1 DAI
+          "decimals": 18
+        },
+        {
+          "asset": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", // Native asset for gas (e.g., ETH)
+          "amount": "10000000000000000", // 0.01 ETH
+          "decimals": 18
+        }
+      ]
+    }
+  ]
+}
+```
+
+The wallet, upon receiving this request, can:
+- Bridge or swap the required DAI from Chain Y to Chain X
+- Ensure the user has enough native asset (e.g., ETH) for gas on Chain X
+- Complete the deposit call to Aave on Chain X
+
+This mechanism allows advanced wallets to abstract away the complexity of cross-chain or offchain funding, enabling seamless user experiences even when the user's onchain balance is insufficient on the target chain.
+
+### App Implementation Guidance
 
 When an app sees that a connected wallet has access to auxiliary funds via the `auxiliaryFunds` capability in a `wallet_getCapabilities` response, the app SHOULD NOT block users from taking actions on the basis of asset balance checks.
+
+Apps SHOULD include the `assetsRequiredForExecution` parameter per call whenever they rely on the `auxiliaryFunds` capability to fulfill a user action. This ensures the wallet has the necessary information to provision assets as needed for successful execution.
 
 ## Rationale
 
@@ -86,9 +146,25 @@ An alternative we considered is defining a way for apps to fetch available auxil
 
 The shape of this capability allows for a more advanced extension if apps feel more functionality is needed.
 
+### Extensibility
+- The structure of `assetsRequiredForExecution` allows for future extension, such as specifying deadlines, slippage, or preferred bridges. Future versions of this standard MAY introduce additional fields as needed.
+
+### Decimals Source of Truth
+- Applications and wallets SHOULD verify the `decimals` value for each asset against onchain data or trusted sources to avoid errors from incorrect values.
+
+### Gas Estimation and Native Asset Handling
+- Applications SHOULD include an estimate for the required native asset (e.g., ETH for gas) in `assetsRequiredForExecution` when possible.
+
+## Backwards Compatibility
+- Applications SHOULD only include the `assetsRequiredForExecution` parameter if the wallet advertises the `auxiliaryFunds` capability.
+- If a wallet does not recognize or support the `assetsRequiredForExecution` parameter, it SHOULD ignore the parameter or return a clear error indicating lack of support. Apps SHOULD be prepared to handle such cases gracefully, potentially falling back to legacy behavior.
+
 ## Security Considerations
 
-Apps MUST NOT make any assumptions about the source of auxiliary funds. Apps' smart contracts should still, as they would today, make appropriate balance checks onchain when processing a transaction.
+- Apps MUST NOT make any assumptions about the source of auxiliary funds. Apps' smart contracts should still, as they would today, make appropriate balance checks onchain when processing a transaction.
+- Applications MUST NOT assume that the wallet will always be able to fulfill the asset requirements, and SHOULD handle failures gracefully.
+- Wallets SHOULD provide clear error messages or status codes if they are unable to fulfill the asset requirements (e.g., insufficient offchain funds, bridge/swap failure, or unsupported assets).
+- Consider whether specifying asset requirements per call could leak sensitive information about user intent or holdings. Where appropriate, apps and wallets SHOULD follow best practices to minimize privacy risks.
 
 ## Copyright
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -98,10 +98,11 @@ type WalletSendCallsRequest = {
   }>;
   capabilities?: {
     auxiliaryFunds?: {
-      assetsRequiredForExecution?: Array<{
-        asset: `0x${string}`; // Asset address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native asset)
-        amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
-      }>;
+      assetsRequiredForExecution?: {
+        [asset: `0x${string}`]: {
+          amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
+        };
+      };
     };
   };
 };
@@ -121,12 +122,11 @@ Suppose a user wants to deposit DAI into Aave on Chain X, but their wallet addre
   ],
   "capabilities": {
     "auxiliaryFunds": {
-      "assetsRequiredForExecution": [
-        {
-          "asset": "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI address on Chain X
+      "assetsRequiredForExecution": {
+        "0x6B175474E89094C44Da98b954EedeAC495271d0F": { // DAI address on Chain X
           "amount": "0x0de0b6b3a7640000" // 1 DAI
-        },
-      ]
+        }
+      }
     }
   }
 }

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -221,8 +221,6 @@ The shape of this capability allows for a more advanced extension if apps feel m
 
 ## Backwards Compatibility
 - Applications SHOULD only include the `assetsRequiredForExecution` parameter if the wallet advertises the `auxiliaryFunds` capability.
-- If a wallet does not recognize or support the `assetsRequiredForExecution` parameter, it SHOULD ignore the parameter or return a clear error indicating lack of support. Apps SHOULD be prepared to handle such cases gracefully, potentially falling back to legacy behavior.
-
 
 ## Security Considerations
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -43,7 +43,7 @@ In this specification, a chain's native asset (e.g. Ether on Ethereum) MUST be r
 ```typescript
 type AuxiliaryFundsCapability = {
   supported: boolean;
-  assets?: `0x${string}`[];
+  assets?: `0x${string}`[`];
 }
 ```
 
@@ -99,7 +99,7 @@ type WalletSendCallsRequest = {
   capabilities?: {
     auxiliaryFunds?: {
       assetsRequiredForExecution?: {
-        address: `0x${string}`; // Asset contract address (MUST be checksummed)
+        address: `0x${string}`;
         amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
         standard: 'erc20' | 'erc721' | 'erc1155'; // Token standard
         tokenId?: `0x${string}`; // Token ID as a hex string (required for ERC-721 and ERC-1155)

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -125,21 +125,21 @@ type WalletSendCallsRequest = {
 
 The following type definitions specify the structure for each supported token standard:
 
-#### ERC20
+#### ERC-20
 ```typescript
 type ERC20Asset = {
   amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
 };
 ```
 
-#### ERC721
+#### ERC-721
 ```typescript
 type ERC721Asset = {
   tokenId: `0x${string}`; // Token ID as a hex string
 };
 ```
 
-#### ERC1155
+#### ERC-1155
 ```typescript
 type ERC1155Asset = {
   tokenId: `0x${string}`; // Token ID as a hex string

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -80,7 +80,7 @@ This parameter is necessary because transaction call data alone does not reliabl
 
 ### `wallet_sendCalls` Extended Parameter
 
-The `assetsRequiredForExecution` parameter MUST be specified within the `capabilities.auxiliaryFunds` object of the `wallet_sendCalls` request. This allows the application to specify which assets and amounts are required for the successful execution of the requested calls.
+If included, the `assetsRequiredForExecution` parameter MUST be specified within the `capabilities.auxiliaryFunds` object of the `wallet_sendCalls` request.
 
 > **Note**: The `capabilities` object is specified in [EIP-5792](./eip-5792.md) where `wallet_sendCalls` is first defined: "The capabilities field is how an app can communicate with a wallet about capabilities a wallet supports. For example, this is where an app can specify a paymaster service URL from which an [ERC-4337](./eip-4337.md) wallet can request a paymasterAndData input for a user operation."
 
@@ -143,15 +143,11 @@ This mechanism allows advanced wallets to abstract away the complexity of cross-
 
 When an app sees that a connected wallet has access to auxiliary funds via the `auxiliaryFunds` capability in a `wallet_getCapabilities` response, the app SHOULD NOT block users from taking actions on the basis of asset balance checks.
 
-Apps MUST include the `assetsRequiredForExecution` parameter in the `capabilities.auxiliaryFunds` object whenever they rely on the `auxiliaryFunds` capability to fulfill a user action. This ensures the wallet has the necessary information to provision assets as needed for successful execution.
+Apps MAY include the `assetsRequiredForExecution` parameter in the `capabilities.auxiliaryFunds` object to ensure the wallet has the necessary information to provision assets as needed for successful execution.
 
 ### Amount Validation
 
-The `amount` value in `assetsRequiredForExecution` MUST be cross-checked against the asset contract address using the `chainId` specified at the base of the `wallet_sendCalls` request. If no `chainId` is provided in the request, the wallet SHOULD use the currently selected chainId. This validation ensures that the amount is interpreted correctly according to the asset's actual decimal precision on the target chain.
-
-### Asset Decimal Precision
-
-Wallets MUST obtain the decimal precision for each asset by querying the asset contract's `decimals()` function on the target chain. This ensures that the `amount` value is interpreted correctly according to the asset's actual precision, rather than relying on potentially incorrect decimal values provided by applications.
+The wallet MUST cross-check the `amount` value in `assetsRequiredForExecution` against the `decimal()` value specified on the `asset`'s contract to ensure that the amount is interpreted correctly according to the asset's decimal precision.
 
 ### Gas Estimation and Native Asset Handling
 - Applications SHOULD include an estimate for the required native asset (e.g., ETH for gas) in `assetsRequiredForExecution` when possible.

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -80,19 +80,29 @@ This parameter is necessary because transaction call data alone does not reliabl
 
 ### `wallet_sendCalls` Extended Parameter
 
-The `assetsRequiredForExecution` parameter MUST be specified per call in the `calls` array. Each call object MAY include an `assetsRequiredForExecution` array, which details the assets and amounts required for that specific call.
+The `assetsRequiredForExecution` parameter MUST be specified at the base level of the `wallet_sendCalls` request, nested within a `capabilities.auxiliaryFunds` object. This allows the application to specify which assets and amounts are required for the successful execution of the requested calls.
 
 ```typescript
-// Example call type extension
-type WalletSendCall = {
-  to: `0x${string}`;
-  data: string;
-  // ... other call fields ...
-  assetsRequiredForExecution?: Array<{
-    asset: `0x${string}`; // Asset address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native asset)
-    amount: string;        // Amount required, as a string representing the integer value in the asset's smallest unit
-    decimals: number;      // Number of decimals for the asset (to interpret amount correctly)
+// Example wallet_sendCalls type extension
+type WalletSendCallsRequest = {
+  version: string;
+  from: `0x${string}`;
+  chainId: `0x{string}`;
+  atomicRequired: boolean;
+  calls: Array<{
+    to: `0x${string}`;
+    data: string;
+    // ... other call fields ...
   }>;
+  capabilities?: {
+    auxiliaryFunds?: {
+      assetsRequiredForExecution?: Array<{
+        asset: `0x${string}`; // Asset address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native asset)
+        amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
+        decimals: number;      // Number of decimals for the asset (to interpret amount correctly)
+      }>;
+    };
+  };
 };
 ```
 
@@ -105,21 +115,20 @@ Suppose a user wants to deposit DAI into Aave on Chain X, but their wallet addre
   "calls": [
     {
       "to": "0xAaveDAIDepositContractOnChainX",
-      "data": "0xd0e30db0", // Example encoded deposit function call
+      "data": "0xd0e30db0" // Example encoded deposit function call
+    }
+  ],
+  "capabilities": {
+    "auxiliaryFunds": {
       "assetsRequiredForExecution": [
         {
           "asset": "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI address on Chain X
-          "amount": "1000000000000000000", // 1 DAI
+          "amount": "0x0de0b6b3a7640000", // 1 DAI
           "decimals": 18
         },
-        {
-          "asset": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", // Native asset for gas (e.g., ETH)
-          "amount": "10000000000000000", // 0.01 ETH
-          "decimals": 18
-        }
       ]
     }
-  ]
+  }
 }
 ```
 
@@ -134,20 +143,7 @@ This mechanism allows advanced wallets to abstract away the complexity of cross-
 
 When an app sees that a connected wallet has access to auxiliary funds via the `auxiliaryFunds` capability in a `wallet_getCapabilities` response, the app SHOULD NOT block users from taking actions on the basis of asset balance checks.
 
-Apps SHOULD include the `assetsRequiredForExecution` parameter per call whenever they rely on the `auxiliaryFunds` capability to fulfill a user action. This ensures the wallet has the necessary information to provision assets as needed for successful execution.
-
-## Rationale
-
-### Alternatives
-
-#### Advanced Balance Fetching
-
-An alternative we considered is defining a way for apps to fetch available auxiliary balances. This could be done, for example, by providing a URL as part of the `auxiliaryFunds` capability that apps could use to fetch auxiliary balance information. However, we ultimately decided that a boolean was enough to indicate to apps that they should not block user actions on the basis of balance checks, and it is minimally burdensome for apps to implement.
-
-The shape of this capability allows for a more advanced extension if apps feel more functionality is needed.
-
-### Extensibility
-- The structure of `assetsRequiredForExecution` allows for future extension, such as specifying deadlines, slippage, or preferred bridges. Future versions of this standard MAY introduce additional fields as needed.
+Apps MUST include the `assetsRequiredForExecution` parameter in the `capabilities.auxiliaryFunds` object whenever they rely on the `auxiliaryFunds` capability to fulfill a user action. This ensures the wallet has the necessary information to provision assets as needed for successful execution.
 
 ### Decimals Source of Truth
 - Applications and wallets SHOULD verify the `decimals` value for each asset against onchain data or trusted sources to avoid errors from incorrect values.
@@ -158,6 +154,16 @@ The shape of this capability allows for a more advanced extension if apps feel m
 ## Backwards Compatibility
 - Applications SHOULD only include the `assetsRequiredForExecution` parameter if the wallet advertises the `auxiliaryFunds` capability.
 - If a wallet does not recognize or support the `assetsRequiredForExecution` parameter, it SHOULD ignore the parameter or return a clear error indicating lack of support. Apps SHOULD be prepared to handle such cases gracefully, potentially falling back to legacy behavior.
+
+## Rationale
+
+### Alternatives
+
+#### Advanced Balance Fetching
+
+An alternative we considered is defining a way for apps to fetch available auxiliary balances. This could be done, for example, by providing a URL as part of the `auxiliaryFunds` capability that apps could use to fetch auxiliary balance information. However, we ultimately decided that a boolean was enough to indicate to apps that they should not block user actions on the basis of balance checks, and it is minimally burdensome for apps to implement.
+
+The shape of this capability allows for a more advanced extension if apps feel more functionality is needed.
 
 ## Security Considerations
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -43,8 +43,8 @@ In this specification, a chain's native asset (e.g. Ether on Ethereum) MUST be r
 ```typescript
 type AuxiliaryFundsCapability = {
   supported: boolean;
-  assets?: `0x${string}`[`];
-}
+  assets?: `0x${string}`[];
+};
 ```
 
 ##### `wallet_getCapabilities` Example Response
@@ -76,7 +76,9 @@ type AuxiliaryFundsCapability = {
 
 When a wallet indicates support for the `auxiliaryFunds` capability (i.e., `supported: true`), applications that use the [`wallet_sendCalls`](./eip-5792.md#wallet_sendcalls) method MAY include a `requiredAssets` parameter in the `capabilities.auxiliaryFunds` object to enable the wallet to leverage this capability.
 
-This parameter is necessary because transaction call data alone does not reliably indicate which assets and amounts are needed for successful execution. Calls may involve complex logic or multiple contracts, making it difficult for wallets to infer requirements. By specifying required assets and amounts explicitly, apps ensure wallets have the information needed to provision, bridge, or swap assets as necessary for the transaction to succeed.
+A wallet's signaling support for the `auxiliaryFunds` capability does not necessarily mean they can interpret or use the `requiredAssets` metadata. The `requiredAssets` parameter is an optional capability that wallets may or may not support, even when they support the base `auxiliaryFunds` capability.
+
+This parameter may be necessary because transaction call data alone does not reliably indicate which assets and amounts are needed for successful execution. Calls may involve complex logic or multiple contracts, making it difficult for wallets to infer requirements. By specifying required assets and amounts explicitly, apps ensure wallets have the information needed to provision, bridge, or swap assets as necessary for the transaction to succeed.
 
 ### `wallet_sendCalls` Extended Parameter
 
@@ -98,10 +100,11 @@ type WalletSendCallsRequest = {
   }>;
   capabilities?: {
     auxiliaryFunds?: {
+      optional?: boolean;
       requiredAssets?: {
         address: `0x${string}`;
         amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
-        standard: 'erc20' | 'erc721' | 'erc1155'; // Token standard
+        standard: "erc20" | "erc721" | "erc1155"; // Token standard
         tokenId?: `0x${string}`; // Token ID as a hex string (required for ERC-721 and ERC-1155)
       }[];
     };
@@ -123,6 +126,7 @@ Suppose a user wants to deposit DAI into Aave on Chain X, but their wallet addre
   ],
   "capabilities": {
     "auxiliaryFunds": {
+      "optional": true,
       "requiredAssets": [
         {
           "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI address on Chain X
@@ -136,6 +140,7 @@ Suppose a user wants to deposit DAI into Aave on Chain X, but their wallet addre
 ```
 
 The wallet, upon receiving this request, can:
+
 - Bridge or swap the required DAI from Chain Y to Chain X
 - Ensure the user has enough native asset (e.g., ETH) for gas on Chain X
 - Complete the deposit call to Aave on Chain X
@@ -151,6 +156,7 @@ This specification currently supports three token standards with the following f
 - **[ERC-1155](./eip-1155.md)**: Requires both `amount` and `tokenId` fields
 
 The `amount` field semantics vary by token standard:
+
 - **[ERC-20](./eip-20.md)**: Represents token quantity in smallest unit (e.g., wei for 18-decimal tokens)
 - **[ERC-721](./eip-721.md)**: Represents NFT quantity (typically "0x01" for single NFT instances)
 - **[ERC-1155](./eip-1155.md)**: Represents quantity of the specified token ID
@@ -165,12 +171,12 @@ Auxiliary funds provisioning (bridging, swapping, or other asset retrieval opera
 
 The following error codes are defined for auxiliary funds provisioning failures.
 
-| Code     | Message                           | Description |
-|----------|-----------------------------------|-------------|
-| 5770     | Auxiliary funds provisioning failed | Wallet attempted to provision funds but failed (e.g., bridge/swap error). |
-| 5771     | Asset not supported             | The requested asset is not available through the wallet's auxiliary fund system. |
-| 5772     | Auxiliary funds capability not available | The wallet no longer supports auxiliary funds on the requested chain. |
-| 5773     | Invalid requiredAssets | The structure of the requiredAssets object is malformed. |
+| Code | Message                                  | Description                                                                      |
+| ---- | ---------------------------------------- | -------------------------------------------------------------------------------- |
+| 5770 | Auxiliary funds provisioning failed      | Wallet attempted to provision funds but failed (e.g., bridge/swap error).        |
+| 5771 | Asset not supported                      | The requested asset is not available through the wallet's auxiliary fund system. |
+| 5772 | Auxiliary funds capability not available | The wallet no longer supports auxiliary funds on the requested chain.            |
+| 5773 | Invalid requiredAssets                   | The structure of the requiredAssets object is malformed.                         |
 
 Applications SHOULD use the `wallet_getCallsStatus` method to track the status of call bundles that involve auxiliary funds provisioning, as the provisioning process may take time to complete. The status response will indicate whether the auxiliary funds provisioning is in progress, completed, or failed.
 
@@ -178,7 +184,7 @@ Applications SHOULD use the `wallet_getCallsStatus` method to track the status o
 
 When an app sees that a connected wallet has access to auxiliary funds via the `auxiliaryFunds` capability in a `wallet_getCapabilities` response, the app SHOULD NOT block users from taking actions on the basis of asset balance checks.
 
-Apps MAY include the `requiredAssets` parameter in the `capabilities.auxiliaryFunds` object to ensure the wallet has the necessary information to provision assets as needed for successful execution.
+Apps MAY include the `requiredAssets` parameter in the `capabilities.auxiliaryFunds` object to ensure the wallet has the necessary information to provision assets as needed for successful execution. However, apps should be aware that this is an optional capability and should handle cases where wallets do not support or cannot process the `requiredAssets` metadata gracefully.
 
 ### Amount Validation
 
@@ -195,13 +201,14 @@ An alternative we considered is defining a way for apps to fetch available auxil
 The shape of this capability allows for a more advanced extension if apps feel more functionality is needed.
 
 ## Backwards Compatibility
+
 - Applications SHOULD only include the `requiredAssets` parameter if the wallet advertises the `auxiliaryFunds` capability.
+- Applications SHOULD include the `auxiliaryFunds` capability with `optional: true` to provide metadata to wallets that support this optional capability while maintaining compatibility with wallets that do not.
 
 ## Security Considerations
 
 - Apps MUST NOT make any assumptions about the source of auxiliary funds. Apps' smart contracts should still, as they would today, make appropriate balance checks onchain when processing a transaction.
 - Applications MUST NOT assume that the wallet will always be able to fulfill the asset requirements, and SHOULD handle failures gracefully.
-
 
 ## Copyright
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -125,21 +125,21 @@ type WalletSendCallsRequest = {
 
 The following type definitions specify the structure for each supported token standard:
 
-#### ERC-20
+#### [ERC-20](./eip-20.md)
 ```typescript
 type ERC20Asset = {
   amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
 };
 ```
 
-#### ERC-721
+#### [ERC-721](./eip-721.md)
 ```typescript
 type ERC721Asset = {
   tokenId: `0x${string}`; // Token ID as a hex string
 };
 ```
 
-#### ERC-1155
+#### [ERC-1155](./eip-1155.md)
 ```typescript
 type ERC1155Asset = {
   tokenId: `0x${string}`; // Token ID as a hex string

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -99,14 +99,55 @@ type WalletSendCallsRequest = {
   capabilities?: {
     auxiliaryFunds?: {
       assetsRequiredForExecution?: {
-        [asset: `0x${string}`]: {
-          amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
+        erc20?: {
+          [asset: `0x${string}`]: {
+            amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
+          };
+        };
+        erc721?: {
+          [asset: `0x${string}`]: {
+            tokenId: `0x${string}`; // Token ID as a hex string
+          };
+        };
+        erc1155?: {
+          [asset: `0x${string}`]: {
+            tokenId: `0x${string}`; // Token ID as a hex string
+            amount: `0x${string}`; // Amount required, as a hex string representing the integer value
+          };
         };
       };
     };
   };
 };
 ```
+
+### Token Standard Types
+
+The following type definitions specify the structure for each supported token standard:
+
+#### ERC20
+```typescript
+type ERC20Asset = {
+  amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
+};
+```
+
+#### ERC721
+```typescript
+type ERC721Asset = {
+  tokenId: `0x${string}`; // Token ID as a hex string
+};
+```
+
+#### ERC1155
+```typescript
+type ERC1155Asset = {
+  tokenId: `0x${string}`; // Token ID as a hex string
+  amount: `0x${string}`; // Amount required, as a hex string representing the integer value
+};
+```
+
+Additional token standard types should be specified in subsequent corollary ERCs to maintain modularity and allow for proper standardization of each token type's requirements.
 
 #### Example Scenario: Cross-Chain Deposit to Aave
 
@@ -123,8 +164,10 @@ Suppose a user wants to deposit DAI into Aave on Chain X, but their wallet addre
   "capabilities": {
     "auxiliaryFunds": {
       "assetsRequiredForExecution": {
-        "0x6B175474E89094C44Da98b954EedeAC495271d0F": { // DAI address on Chain X
-          "amount": "0x0de0b6b3a7640000" // 1 DAI
+        "erc20": {
+          "0x6B175474E89094C44Da98b954EedeAC495271d0F": { // DAI address on Chain X
+            "amount": "0x0de0b6b3a7640000" // 1 DAI
+          }
         }
       }
     }

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -145,16 +145,15 @@ Auxiliary funds provisioning (bridging, swapping, or other asset retrieval opera
 
 ### Error Codes
 
-The following error codes are defined for auxiliary funds provisioning failures. These errors follow the JSON-RPC 2.0 specification for error objects, which require a `code` and `message` field.
+The following error codes are defined for auxiliary funds provisioning failures.
 
 | Code     | Message                           | Description |
 |----------|-----------------------------------|-------------|
 | -32080   | Auxiliary funds provisioning failed | Wallet attempted to provision funds but failed (e.g., bridge/swap error). |
 | -32081   | Asset not supported             | The requested asset is not available through the wallet’s auxiliary fund system. |
-| -32082   | Insufficient auxiliary funds    | Wallet supports the asset but cannot fulfill the requested amount. |
-| -32083   | Auxiliary funds timeout         | The provisioning operation took too long or timed out. |
-| -32084   | Auxiliary funds capability not available | The wallet no longer supports auxiliary funds on the requested chain. |
-| -32085   | Invalid assetsRequiredForExecution | The structure of the assetsRequiredForExecution object is malformed. |
+| -32082   | Auxiliary funds timeout         | The provisioning operation took too long or timed out. |
+| -32083   | Auxiliary funds capability not available | The wallet no longer supports auxiliary funds on the requested chain. |
+| -32084   | Invalid assetsRequiredForExecution | The structure of the assetsRequiredForExecution object is malformed. |
 
 Applications SHOULD use the `wallet_getCallsStatus` method to track the status of call bundles that involve auxiliary funds provisioning, as the provisioning process may take time to complete. The status response will indicate whether the auxiliary funds provisioning is in progress, completed, or failed.
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -80,7 +80,9 @@ This parameter is necessary because transaction call data alone does not reliabl
 
 ### `wallet_sendCalls` Extended Parameter
 
-The `assetsRequiredForExecution` parameter MUST be specified at the base level of the `wallet_sendCalls` request, nested within a `capabilities.auxiliaryFunds` object. This allows the application to specify which assets and amounts are required for the successful execution of the requested calls.
+The `assetsRequiredForExecution` parameter MUST be specified within the `capabilities.auxiliaryFunds` object of the `wallet_sendCalls` request. This allows the application to specify which assets and amounts are required for the successful execution of the requested calls.
+
+> **Note**: The `capabilities` object is specified in [EIP-5792](./eip-5792.md) where `wallet_sendCalls` is first defined. As stated in EIP-5792: "The capabilities field is how an app can communicate with a wallet about capabilities a wallet supports. For example, this is where an app can specify a paymaster service URL from which an ERC-4337 wallet can request a paymasterAndData input for a user operation."
 
 ```typescript
 // Example wallet_sendCalls type extension

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -101,7 +101,6 @@ type WalletSendCallsRequest = {
       assetsRequiredForExecution?: Array<{
         asset: `0x${string}`; // Asset address (use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native asset)
         amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
-        decimals: number;      // Number of decimals for the asset (to interpret amount correctly)
       }>;
     };
   };
@@ -125,8 +124,7 @@ Suppose a user wants to deposit DAI into Aave on Chain X, but their wallet addre
       "assetsRequiredForExecution": [
         {
           "asset": "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI address on Chain X
-          "amount": "0x0de0b6b3a7640000", // 1 DAI
-          "decimals": 18
+          "amount": "0x0de0b6b3a7640000" // 1 DAI
         },
       ]
     }
@@ -147,8 +145,13 @@ When an app sees that a connected wallet has access to auxiliary funds via the `
 
 Apps MUST include the `assetsRequiredForExecution` parameter in the `capabilities.auxiliaryFunds` object whenever they rely on the `auxiliaryFunds` capability to fulfill a user action. This ensures the wallet has the necessary information to provision assets as needed for successful execution.
 
-### Decimals Source of Truth
-- Applications and wallets SHOULD verify the `decimals` value for each asset against onchain data or trusted sources to avoid errors from incorrect values.
+### Amount Validation
+
+The `amount` value in `assetsRequiredForExecution` MUST be cross-checked against the asset contract address using the `chainId` specified at the base of the `wallet_sendCalls` request. If no `chainId` is provided in the request, the wallet SHOULD use the currently selected chainId. This validation ensures that the amount is interpreted correctly according to the asset's actual decimal precision on the target chain.
+
+### Asset Decimal Precision
+
+Wallets MUST obtain the decimal precision for each asset by querying the asset contract's `decimals()` function on the target chain. This ensures that the `amount` value is interpreted correctly according to the asset's actual precision, rather than relying on potentially incorrect decimal values provided by applications.
 
 ### Gas Estimation and Native Asset Handling
 - Applications SHOULD include an estimate for the required native asset (e.g., ETH for gas) in `assetsRequiredForExecution` when possible.

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -74,7 +74,7 @@ type AuxiliaryFundsCapability = {
 
 ### Extended Usage: `assetsRequiredForExecution` Parameter
 
-When a wallet indicates support for the `auxiliaryFunds` capability (i.e., `supported: true`), applications that use the [`wallet_sendCalls`](./eip-5792.md#wallet_sendcalls) method MUST include an additional parameter named `assetsRequiredForExecution` in the call. 
+When a wallet indicates support for the `auxiliaryFunds` capability (i.e., `supported: true`), applications that use the [`wallet_sendCalls`](./eip-5792.md#wallet_sendcalls) method MAY include an `assetsRequiredForExecution` parameter in the `capabilities.auxiliaryFunds` object to enable the wallet to leverage this capability.
 
 This parameter is necessary because transaction call data alone does not reliably indicate which assets and amounts are needed for successful execution. Calls may involve complex logic or multiple contracts, making it difficult for wallets to infer requirements. By specifying required assets and amounts explicitly, apps ensure wallets have the information needed to provision, bridge, or swap assets as necessary for the transaction to succeed.
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -139,6 +139,22 @@ The wallet, upon receiving this request, can:
 
 This mechanism allows advanced wallets to abstract away the complexity of cross-chain or offchain funding, enabling seamless user experiences even when the user's onchain balance is insufficient on the target chain.
 
+
+### Error Codes
+
+The following error codes are defined for auxiliary funds provisioning failures. These errors follow the JSON-RPC 2.0 specification for error objects, which require a `code` and `message` field.
+
+| Code     | Message                           | Description |
+|----------|-----------------------------------|-------------|
+| -32080   | Auxiliary funds provisioning failed | Wallet attempted to provision funds but failed (e.g., bridge/swap error). |
+| -32081   | Asset not supported             | The requested asset is not available through the wallet’s auxiliary fund system. |
+| -32082   | Insufficient auxiliary funds    | Wallet supports the asset but cannot fulfill the requested amount. |
+| -32083   | Auxiliary funds timeout         | The provisioning operation took too long or timed out. |
+| -32084   | Auxiliary funds capability not available | The wallet no longer supports auxiliary funds on the requested chain. |
+| -32085   | Invalid assetsRequiredForExecution | The structure of the assetsRequiredForExecution object is malformed. |
+
+Applications SHOULD use the `wallet_getCallsStatus` method to track the status of call bundles that involve auxiliary funds provisioning, as the provisioning process may take time to complete. The status response will indicate whether the auxiliary funds provisioning is in progress, completed, or failed.
+
 ### App Implementation Guidance
 
 When an app sees that a connected wallet has access to auxiliary funds via the `auxiliaryFunds` capability in a `wallet_getCapabilities` response, the app SHOULD NOT block users from taking actions on the basis of asset balance checks.
@@ -171,7 +187,7 @@ The shape of this capability allows for a more advanced extension if apps feel m
 
 - Apps MUST NOT make any assumptions about the source of auxiliary funds. Apps' smart contracts should still, as they would today, make appropriate balance checks onchain when processing a transaction.
 - Applications MUST NOT assume that the wallet will always be able to fulfill the asset requirements, and SHOULD handle failures gracefully.
-- Wallets SHOULD provide clear error messages or status codes if they are unable to fulfill the asset requirements (e.g. bridge/swap failure, or unsupported assets).
+
 
 ## Copyright
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -99,53 +99,15 @@ type WalletSendCallsRequest = {
   capabilities?: {
     auxiliaryFunds?: {
       assetsRequiredForExecution?: {
-        erc20?: {
-          [asset: `0x${string}`]: {
-            amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
-          };
-        };
-        erc721?: {
-          [asset: `0x${string}`]: {
-            tokenIds: `0x${string}`[]; // Array of token IDs as hex strings
-          };
-        };
-        erc1155?: {
-          [asset: `0x${string}`]: {
-            [tokenId: `0x${string}`]: `0x${string}`; // Token ID to amount mapping, where amount is a hex string
-          };
-        };
-      };
+        address: `0x${string}`; // Asset contract address (MUST be checksummed)
+        amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
+        standard: 'erc20' | 'erc721' | 'erc1155'; // Token standard
+        tokenId?: `0x${string}`; // Token ID as a hex string (required for ERC-721 and ERC-1155)
+      }[];
     };
   };
 };
 ```
-
-### Token Standard Types
-
-The following type definitions specify the structure for each supported token standard:
-
-#### [ERC-20](./eip-20.md)
-```typescript
-type ERC20Asset = {
-  amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
-};
-```
-
-#### [ERC-721](./eip-721.md)
-```typescript
-type ERC721Asset = {
-  tokenIds: `0x${string}`[]; // Array of token IDs as hex strings
-};
-```
-
-#### [ERC-1155](./eip-1155.md)
-```typescript
-type ERC1155Asset = {
-  [tokenId: `0x${string}`]: `0x${string}`; // Token ID to amount mapping, where amount is a hex string
-};
-```
-
-Additional token standard types should be specified in subsequent corollary ERCs to maintain modularity and allow for proper standardization of each token type's requirements.
 
 #### Example Scenario: Cross-Chain Deposit to Aave
 
@@ -161,13 +123,13 @@ Suppose a user wants to deposit DAI into Aave on Chain X, but their wallet addre
   ],
   "capabilities": {
     "auxiliaryFunds": {
-      "assetsRequiredForExecution": {
-        "erc20": {
-          "0x6B175474E89094C44Da98b954EedeAC495271d0F": { // DAI address on Chain X
-            "amount": "0x0de0b6b3a7640000" // 1 DAI
-          }
+      "assetsRequiredForExecution": [
+        {
+          "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI address on Chain X
+          "amount": "0x0de0b6b3a7640000", // 1 DAI
+          "standard": "erc20"
         }
-      }
+      ]
     }
   }
 }
@@ -179,6 +141,21 @@ The wallet, upon receiving this request, can:
 - Complete the deposit call to Aave on Chain X
 
 This mechanism allows advanced wallets to abstract away the complexity of cross-chain or offchain funding, enabling seamless user experiences even when the user's onchain balance is insufficient on the target chain.
+
+### Token Standard Extensibility
+
+This specification currently supports three token standards with the following field requirements:
+
+- **ERC-20**: Requires `amount` field only
+- **ERC-721**: Requires both `amount` and `tokenId` fields
+- **ERC-1155**: Requires both `amount` and `tokenId` fields
+
+The `amount` field semantics vary by token standard:
+- **ERC-20**: Represents token quantity in smallest unit (e.g., wei for 18-decimal tokens)
+- **ERC-721**: Represents NFT quantity (typically "0x01" for single NFT instances)
+- **ERC-1155**: Represents quantity of the specified token ID
+
+Future token standards MUST specify additional required fields as properties on the asset object root to maintain extensibility.
 
 ### Auxiliary Funds and Atomic Execution
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -192,10 +192,10 @@ The following error codes are defined for auxiliary funds provisioning failures.
 
 | Code     | Message                           | Description |
 |----------|-----------------------------------|-------------|
-| -32080   | Auxiliary funds provisioning failed | Wallet attempted to provision funds but failed (e.g., bridge/swap error). |
-| -32081   | Asset not supported             | The requested asset is not available through the wallet’s auxiliary fund system. |
-| -32082   | Auxiliary funds capability not available | The wallet no longer supports auxiliary funds on the requested chain. |
-| -32083   | Invalid assetsRequiredForExecution | The structure of the assetsRequiredForExecution object is malformed. |
+| 5770     | Auxiliary funds provisioning failed | Wallet attempted to provision funds but failed (e.g., bridge/swap error). |
+| 5771     | Asset not supported             | The requested asset is not available through the wallet's auxiliary fund system. |
+| 5772     | Auxiliary funds capability not available | The wallet no longer supports auxiliary funds on the requested chain. |
+| 5773     | Invalid assetsRequiredForExecution | The structure of the assetsRequiredForExecution object is malformed. |
 
 Applications SHOULD use the `wallet_getCallsStatus` method to track the status of call bundles that involve auxiliary funds provisioning, as the provisioning process may take time to complete. The status response will indicate whether the auxiliary funds provisioning is in progress, completed, or failed.
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -72,15 +72,15 @@ type AuxiliaryFundsCapability = {
 }
 ```
 
-### Extended Usage: `assetsRequiredForExecution` Parameter
+### Extended Usage: `requiredAssets` Parameter
 
-When a wallet indicates support for the `auxiliaryFunds` capability (i.e., `supported: true`), applications that use the [`wallet_sendCalls`](./eip-5792.md#wallet_sendcalls) method MAY include an `assetsRequiredForExecution` parameter in the `capabilities.auxiliaryFunds` object to enable the wallet to leverage this capability.
+When a wallet indicates support for the `auxiliaryFunds` capability (i.e., `supported: true`), applications that use the [`wallet_sendCalls`](./eip-5792.md#wallet_sendcalls) method MAY include a `requiredAssets` parameter in the `capabilities.auxiliaryFunds` object to enable the wallet to leverage this capability.
 
 This parameter is necessary because transaction call data alone does not reliably indicate which assets and amounts are needed for successful execution. Calls may involve complex logic or multiple contracts, making it difficult for wallets to infer requirements. By specifying required assets and amounts explicitly, apps ensure wallets have the information needed to provision, bridge, or swap assets as necessary for the transaction to succeed.
 
 ### `wallet_sendCalls` Extended Parameter
 
-If included, the `assetsRequiredForExecution` parameter MUST be specified within the `capabilities.auxiliaryFunds` object of the `wallet_sendCalls` request.
+If included, the `requiredAssets` parameter MUST be specified within the `capabilities.auxiliaryFunds` object of the `wallet_sendCalls` request.
 
 > **Note**: The `capabilities` object is specified in [EIP-5792](./eip-5792.md) where `wallet_sendCalls` is first defined: "The capabilities field is how an app can communicate with a wallet about capabilities a wallet supports. For example, this is where an app can specify a paymaster service URL from which an [ERC-4337](./eip-4337.md) wallet can request a paymasterAndData input for a user operation."
 
@@ -98,7 +98,7 @@ type WalletSendCallsRequest = {
   }>;
   capabilities?: {
     auxiliaryFunds?: {
-      assetsRequiredForExecution?: {
+      requiredAssets?: {
         address: `0x${string}`;
         amount: `0x${string}`; // Amount required, as a hex string representing the integer value in the asset's smallest unit
         standard: 'erc20' | 'erc721' | 'erc1155'; // Token standard
@@ -123,7 +123,7 @@ Suppose a user wants to deposit DAI into Aave on Chain X, but their wallet addre
   ],
   "capabilities": {
     "auxiliaryFunds": {
-      "assetsRequiredForExecution": [
+      "requiredAssets": [
         {
           "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI address on Chain X
           "amount": "0x0de0b6b3a7640000", // 1 DAI
@@ -170,7 +170,7 @@ The following error codes are defined for auxiliary funds provisioning failures.
 | 5770     | Auxiliary funds provisioning failed | Wallet attempted to provision funds but failed (e.g., bridge/swap error). |
 | 5771     | Asset not supported             | The requested asset is not available through the wallet's auxiliary fund system. |
 | 5772     | Auxiliary funds capability not available | The wallet no longer supports auxiliary funds on the requested chain. |
-| 5773     | Invalid assetsRequiredForExecution | The structure of the assetsRequiredForExecution object is malformed. |
+| 5773     | Invalid requiredAssets | The structure of the requiredAssets object is malformed. |
 
 Applications SHOULD use the `wallet_getCallsStatus` method to track the status of call bundles that involve auxiliary funds provisioning, as the provisioning process may take time to complete. The status response will indicate whether the auxiliary funds provisioning is in progress, completed, or failed.
 
@@ -178,11 +178,11 @@ Applications SHOULD use the `wallet_getCallsStatus` method to track the status o
 
 When an app sees that a connected wallet has access to auxiliary funds via the `auxiliaryFunds` capability in a `wallet_getCapabilities` response, the app SHOULD NOT block users from taking actions on the basis of asset balance checks.
 
-Apps MAY include the `assetsRequiredForExecution` parameter in the `capabilities.auxiliaryFunds` object to ensure the wallet has the necessary information to provision assets as needed for successful execution.
+Apps MAY include the `requiredAssets` parameter in the `capabilities.auxiliaryFunds` object to ensure the wallet has the necessary information to provision assets as needed for successful execution.
 
 ### Amount Validation
 
-The wallet MUST cross-check the `amount` value in `assetsRequiredForExecution` against the `decimal()` value specified on the `asset`'s contract to ensure that the amount is interpreted correctly according to the asset's decimal precision.
+The wallet MUST cross-check the `amount` value in `requiredAssets` against the `decimal()` value specified on the `asset`'s contract to ensure that the amount is interpreted correctly according to the asset's decimal precision.
 
 ## Rationale
 
@@ -195,7 +195,7 @@ An alternative we considered is defining a way for apps to fetch available auxil
 The shape of this capability allows for a more advanced extension if apps feel more functionality is needed.
 
 ## Backwards Compatibility
-- Applications SHOULD only include the `assetsRequiredForExecution` parameter if the wallet advertises the `auxiliaryFunds` capability.
+- Applications SHOULD only include the `requiredAssets` parameter if the wallet advertises the `auxiliaryFunds` capability.
 
 ## Security Considerations
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -170,8 +170,7 @@ The shape of this capability allows for a more advanced extension if apps feel m
 
 - Apps MUST NOT make any assumptions about the source of auxiliary funds. Apps' smart contracts should still, as they would today, make appropriate balance checks onchain when processing a transaction.
 - Applications MUST NOT assume that the wallet will always be able to fulfill the asset requirements, and SHOULD handle failures gracefully.
-- Wallets SHOULD provide clear error messages or status codes if they are unable to fulfill the asset requirements (e.g., insufficient offchain funds, bridge/swap failure, or unsupported assets).
-- Consider whether specifying asset requirements per call could leak sensitive information about user intent or holdings. Where appropriate, apps and wallets SHOULD follow best practices to minimize privacy risks.
+- Wallets SHOULD provide clear error messages or status codes if they are unable to fulfill the asset requirements (e.g. bridge/swap failure, or unsupported assets).
 
 ## Copyright
 

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -82,7 +82,7 @@ This parameter is necessary because transaction call data alone does not reliabl
 
 The `assetsRequiredForExecution` parameter MUST be specified within the `capabilities.auxiliaryFunds` object of the `wallet_sendCalls` request. This allows the application to specify which assets and amounts are required for the successful execution of the requested calls.
 
-> **Note**: The `capabilities` object is specified in [EIP-5792](./eip-5792.md) where `wallet_sendCalls` is first defined: "The capabilities field is how an app can communicate with a wallet about capabilities a wallet supports. For example, this is where an app can specify a paymaster service URL from which an ERC-4337 wallet can request a paymasterAndData input for a user operation."
+> **Note**: The `capabilities` object is specified in [EIP-5792](./eip-5792.md) where `wallet_sendCalls` is first defined: "The capabilities field is how an app can communicate with a wallet about capabilities a wallet supports. For example, this is where an app can specify a paymaster service URL from which an [ERC-4337](./eip-4337.md) wallet can request a paymasterAndData input for a user operation."
 
 ```typescript
 // Example wallet_sendCalls type extension

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -78,6 +78,8 @@ When a wallet indicates support for the `auxiliaryFunds` capability (i.e., `supp
 
 A wallet's signaling support for the `auxiliaryFunds` capability does not necessarily mean they can interpret or use the `requiredAssets` metadata. The `requiredAssets` parameter is an optional capability that wallets may or may not support, even when they support the base `auxiliaryFunds` capability.
 
+**Native Asset Handling**: Wallets SHOULD deduce native asset requirements (e.g., ETH on Ethereum mainnet) from the `call.value` field in the calls array rather than requiring explicit specification in `requiredAssets`. The `requiredAssets` parameter is primarily intended for token assets that cannot be inferred from call data alone.
+
 This parameter may be necessary because transaction call data alone does not reliably indicate which assets and amounts are needed for successful execution. Calls may involve complex logic or multiple contracts, making it difficult for wallets to infer requirements. By specifying required assets and amounts explicitly, apps ensure wallets have the information needed to provision, bridge, or swap assets as necessary for the transaction to succeed.
 
 ### `wallet_sendCalls` Extended Parameter

--- a/ERCS/erc-7682.md
+++ b/ERCS/erc-7682.md
@@ -82,7 +82,7 @@ This parameter is necessary because transaction call data alone does not reliabl
 
 The `assetsRequiredForExecution` parameter MUST be specified within the `capabilities.auxiliaryFunds` object of the `wallet_sendCalls` request. This allows the application to specify which assets and amounts are required for the successful execution of the requested calls.
 
-> **Note**: The `capabilities` object is specified in [EIP-5792](./eip-5792.md) where `wallet_sendCalls` is first defined. As stated in EIP-5792: "The capabilities field is how an app can communicate with a wallet about capabilities a wallet supports. For example, this is where an app can specify a paymaster service URL from which an ERC-4337 wallet can request a paymasterAndData input for a user operation."
+> **Note**: The `capabilities` object is specified in [EIP-5792](./eip-5792.md) where `wallet_sendCalls` is first defined: "The capabilities field is how an app can communicate with a wallet about capabilities a wallet supports. For example, this is where an app can specify a paymaster service URL from which an ERC-4337 wallet can request a paymasterAndData input for a user operation."
 
 ```typescript
 // Example wallet_sendCalls type extension


### PR DESCRIPTION
This PR extends `ERC-7682` to specify that when a wallet supports the `auxiliaryFunds` capability, applications using `wallet_sendCalls` must include a `assetsRequiredForExecution` parameter nest under `capabilties` -> `auxiliaryFunds`. This parameter explicitly lists the assets and amounts required for successful execution, as transaction call data alone is insufficient for wallets to infer these requirements.
