### PR TITLE
Update ERC-7760: update storage slot in beacon proxy note

### DIFF
--- a/ERCS/erc-7760.md
+++ b/ERCS/erc-7760.md
@@ -129,7 +129,7 @@ Runtime bytecode:
 
 ### Minimal ERC-1967 beacon proxy
 
-As this proxy does not contain upgrading logic, the initialization code MUST store the implementation at the ERC-1967 implementation storage slot `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`.
+As this proxy does not contain upgrading logic, the initialization code MUST store the implementation beacon at the ERC-1967 beacon storage slot `0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50`.
 
 #### Minimal ERC-1967 beacon proxy (basic variant)
 


### PR DESCRIPTION
Update incorrect storage slot in the section on "Minimal ERC-1967 beacon proxy". Likely was incorrectly copy-pasted from the "Minimal ERC-1967 UUPS proxy" section