### PR TITLE
Update ERC-7683: Remove order structs, extend resolved order

### DIFF
--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -36,9 +36,25 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 - **Raw order**: an order specific to an origin settler, in an implementation-specific encoding
 - **Resolved order**: an order in a standardized representation
 
+### Filler Procedure
+
+Once a filler receives an order for an origin settler it proceeds as follows:
+
+1. Resolves the payload with the origin settler.
+2. Resolves the destination payload with the destination settler(s).
+3. Decodes and processes all extended attributes in the resolved order.
+    - Checks that all attributes are either known or marked informational.
+4. Computes profitability and sufficient liquidity.
+5. Ensures input assets are exclusively allocated until the settlement deadline.
+    - If the order is marked for escrow, opens the order.
+    - If the order uses resource locks funds, validates lock parameters.
+6. Ensures the settlement deadline is sufficient for fill propagation.
+7. Fills the order.
+8. Settles the order.
+
 ### ResolvedCrossChainOrder struct
 
-The raw orders accepted by compliant origin settlers MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that they must be decoded into the information needed to populate the `ResolvedCrossChainOrder` struct. Additionally, `orderData` SHOULD be decodable into a sub-type, which can be used for further functionality such as cross-chain calldata execution (see the examples section for an example of this). It is the responsibility of the `user` and the `filler` to ensure that the `originSettler` supports their order's contained sub-type.
+The raw orders accepted by compliant origin settlers MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that they must be decoded into the information needed to populate the `ResolvedCrossChainOrder` struct.
 
 ```solidity
 /// @title ResolvedCrossChainOrder type
@@ -50,18 +66,11 @@ struct ResolvedCrossChainOrder {
 	address user;
 	/// @dev The chainId of the origin chain
 	uint256 originChainId;
-	/// @dev The timestamp by which the order must be opened. If zero, the open step is not necesary.
-	uint32 openDeadline;
-	/// @dev The timestamp by which the order must be filled on the destination chain(s)
-	uint32 fillDeadline;
 	/// @dev The timestamp by which the order must be settled on the origin chain
 	uint32 settlementDeadline;
 	/// @dev The unique identifier for this order within this settlement system
 	bytes32 orderId;
 
-	/// @dev The max outputs that the filler will send. It's possible the actual amount depends on the state of the destination
-	///      chain (destination dutch auction, for instance), so these outputs should be considered a cap on filler liabilities.
-	Output[] maxSpent;
 	/// @dev The minimum outputs that must be given to the filler as part of order settlement. Similar to maxSpent, it's possible
 	///      that special order types may not be able to guarantee the exact amount at open time, so this should be considered
 	///      a floor on filler receipts. Setting the `recipient` of an `Output` to address(0) indicates that the filler is not
@@ -73,6 +82,17 @@ struct ResolvedCrossChainOrder {
 
 	/// @dev Implementation-specific extensions with additional information or instructions about the order
 	Extension[] extensions;
+}
+
+/// @notice Additional information or instructions about the order
+struct Extension {
+	/// @dev A human-readable ABI description of a function, without the `function` keyword.
+	///      E.g., "dutchAuction(uint256 startTime, uint256 endTime, uint256 startPrice, uint256 endPrice)"
+	string abiDescription;
+	/// @dev The extension parameters ABI-encoded according to `abiDescription`
+	bytes data;
+	/// @dev Whether this extension can be safely ignored.
+	bool informational;
 }
 
 /// @notice Tokens that must be received for a valid order fulfillment
@@ -98,18 +118,16 @@ struct FillInstruction {
 	bytes32 destinationSettler;
 	/// @dev The data generated on the origin chain needed by the destinationSettler to process the fill
 	bytes originData;
-	/// @dev The format in which the filler must encode `fillerData`
-	///      [TODO: elaborate specifics]
-	string fillerDataFormat;
 }
 
-/// @notice Additional information or instructions about the order
-struct Extension {
-	/// @dev A human-readable ABI description of a function, without the `function` keyword.
-	///      E.g., "dutchAuction(uint256 startTime, uint256 endTime, uint256 startPrice, uint256 endPrice)"
-	string abiDescription;
-	/// @dev The extension parameters ABI-encoded according to `abiDescription`
-	bytes data;
+struct ResolvedFillInstructions {
+	/// @dev The timestamp by which the order must be filled
+	uint32 fillDeadline;
+	/// @dev The data that must be submitted to process the fill
+	bytes resolvedData;
+	/// @dev The ABI description with which the filler must encode `fillerData`.
+	///      E.g., "(address repaymentRecipient)"
+	string fillerDataAbi;
 }
 ```
 
@@ -132,19 +150,6 @@ A compliant origin settler contract implementation MUST implement the `IOriginSe
 /// @title IOriginSettler
 /// @notice Standard interface for settlement contracts on the origin chain
 interface IOriginSettler {
-	/// @notice Opens a gasless cross-chain order on behalf of a user.
-	/// @dev This method must emit the Open event
-	/// @param order The order in raw encoding
-	/// @param user The user's address
-	/// @param signature The user's signature over the order
-	function openFor(bytes calldata order, address user, bytes calldata signature) external;
-
-	/// @notice Opens a cross-chain order
-	/// @dev To be called by the user
-	/// @dev This method must emit the Open event
-	/// @param order The order in raw encoding
-	function open(bytes calldata order) external;
-
 	/// @notice Resolves a specific GaslessCrossChainOrder into a generic ResolvedCrossChainOrder
 	/// @dev Intended to improve standardized integration of various order types and settlement contracts
 	/// @param order The order in raw encoding
@@ -164,8 +169,13 @@ interface IDestinationSettler {
 	/// @notice Fills a single leg of a particular order on the destination chain
 	/// @param orderId Unique order identifier for this order
 	/// @param originData Data emitted on the origin to parameterize the fill
+	function resolveFill(bytes32 orderId, bytes calldata originData) external view returns (ResolvedFillInstructions memory);
+
+	/// @notice Fills a single leg of a particular order on the destination chain
+	/// @param orderId Unique order identifier for this order
+	/// @param originData Data emitted on the origin to parameterize the fill
 	/// @param fillerData Data provided by the filler to inform the fill or express their preferences
-	function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) external;
+	function fill(bytes32 orderId, bytes calldata resolvedData, bytes calldata fillerData) external;
 }
 ```
 
@@ -174,6 +184,27 @@ interface IDestinationSettler {
 Cross-chain execution systems implementing this standard SHOULD use a sub-type that can be parsed from the arbitrary `fillerData` field. This may include information such as the desired timing or form of payment for the filler
 
 All sub-types SHOULD be registered in a subtypes repository to encourage sharing of sub-types based on their functionality.
+
+### Escrow Extension
+
+If a resolved order contains the extension `escrow(uint48 openDeadline)`, a filler MUST open the order on the origin settler prior to filling.
+
+```solidity
+interface IOriginSettlerEscrow {
+	/// @notice Opens a gasless cross-chain order on behalf of a user.
+	/// @dev This method must emit the Open event
+	/// @param order The order in raw encoding
+	/// @param user The user's address
+	/// @param signature The user's signature over the order
+	function openFor(bytes calldata order, address user, bytes calldata signature) external;
+
+	/// @notice Opens a cross-chain order
+	/// @dev To be called by the user
+	/// @dev This method must emit the Open event
+	/// @param order The order in raw encoding
+	function open(bytes calldata order) external;
+}
+```
 
 ## Rationale
 

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -33,58 +33,12 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 - **Settlement System**: a system that custodies user deposits, verifies fills, and pays fillers for the purpose of facilitating intents.
 - **Settler**: a contract that implements part of the settlement system on a particular chain.
 - **User**: for the purposes of this document, the user is the end-user who is sending the order.
-
-### Order structs
-
-A compliant cross-chain order type MUST be ABI decodable into either `GaslessCrossChainOrder` or `OnchainCrossChainOrder` type.
-
-```solidity
-/// @title GaslessCrossChainOrder CrossChainOrder type
-/// @notice Standard order struct to be signed by users, disseminated to fillers, and submitted to origin settler contracts by fillers
-struct GaslessCrossChainOrder {
-	/// @dev The contract address that the order is meant to be settled by.
-	/// Fillers send this order to this contract address on the origin chain
-	address originSettler;
-	/// @dev The address of the user who is initiating the swap,
-	/// whose input tokens will be taken and escrowed
-	address user;
-	/// @dev Nonce to be used as replay protection for the order
-	uint256 nonce;
-	/// @dev The chainId of the origin chain
-	uint256 originChainId;
-	/// @dev The timestamp by which the order must be opened
-	uint32 openDeadline;
-	/// @dev The timestamp by which the order must be filled on the destination chain
-	uint32 fillDeadline;
-	/// @dev Type identifier for the order data. This is an EIP-712 typehash.
-	bytes32 orderDataType;
-	/// @dev Arbitrary implementation-specific data
-	/// Can be used to define tokens, amounts, destination chains, fees, settlement parameters,
-	/// or any other order-type specific information
-	bytes orderData;
-}
-
-/// @title OnchainCrossChainOrder CrossChainOrder type
-/// @notice Standard order struct for user-opened orders, where the user is the one submitting the order creation transaction
-struct OnchainCrossChainOrder {
-	/// @dev The timestamp by which the order must be filled on the destination chain
-	uint32 fillDeadline;
-	/// @dev Type identifier for the order data. This is an EIP-712 typehash.
-	bytes32 orderDataType;
-	/// @dev Arbitrary implementation-specific data
-	/// Can be used to define tokens, amounts, destination chains, fees, settlement parameters,
-	/// or any other order-type specific information
-	bytes orderData;
-}
-```
-
-Cross-chain execution systems implementing this standard SHOULD use a sub-type that can be parsed from the arbitrary `orderData` field. This may include information such as the tokens involved in the transfer, the destination chain IDs, fulfillment constraints or settlement oracles.
-
-All sub-types SHOULD be registered in a subtypes repository to encourage sharing of sub-types based on their functionality. See the examples section for an example of how sub-types can be used to support behavior like executing calldata on a target contract of the user's choice on the destination chain.
+- **Raw order**: an order specific to an origin settler, in an implementation-specific encoding
+- **Resolved order**: an order in a standardized representation
 
 ### ResolvedCrossChainOrder struct
 
-A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that the `orderData` must be decoded into the information needed to populate the `ResolvedCrossChainOrder` struct. Additionally, `orderData` SHOULD be decodable into a sub-type, which can be used for further functionality such as cross-chain calldata execution (see the examples section for an example of this). It is the responsibility of the `user` and the `filler` to ensure that the `originSettler` supports their order's contained sub-type.
+The raw orders accepted by compliant origin settlers MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that they must be decoded into the information needed to populate the `ResolvedCrossChainOrder` struct. Additionally, `orderData` SHOULD be decodable into a sub-type, which can be used for further functionality such as cross-chain calldata execution (see the examples section for an example of this). It is the responsibility of the `user` and the `filler` to ensure that the `originSettler` supports their order's contained sub-type.
 
 ```solidity
 /// @title ResolvedCrossChainOrder type
@@ -92,14 +46,16 @@ A compliant cross-chain order type MUST be convertible into the `ResolvedCrossCh
 /// @dev Defines all requirements for filling an order by unbundling the implementation-specific orderData.
 /// @dev Intended to improve integration generalization by allowing fillers to compute the exact input and output information of any order
 struct ResolvedCrossChainOrder {
-	/// @dev The address of the user who is initiating the transfer
+	/// @dev The address of the user account where funds are sourced from
 	address user;
 	/// @dev The chainId of the origin chain
 	uint256 originChainId;
-	/// @dev The timestamp by which the order must be opened
+	/// @dev The timestamp by which the order must be opened. If zero, the open step is not necesary.
 	uint32 openDeadline;
 	/// @dev The timestamp by which the order must be filled on the destination chain(s)
 	uint32 fillDeadline;
+	/// @dev The timestamp by which the order must be settled on the origin chain
+	uint32 settlementDeadline;
 	/// @dev The unique identifier for this order within this settlement system
 	bytes32 orderId;
 
@@ -114,6 +70,9 @@ struct ResolvedCrossChainOrder {
 	/// @dev Each instruction in this array is parameterizes a single leg of the fill. This provides the filler with the information
 	///      necessary to perform the fill on the destination(s).
 	FillInstruction[] fillInstructions;
+
+	/// @dev Implementation-specific extensions with additional information or instructions about the order
+	Extension[] extensions;
 }
 
 /// @notice Tokens that must be received for a valid order fulfillment
@@ -139,6 +98,18 @@ struct FillInstruction {
 	bytes32 destinationSettler;
 	/// @dev The data generated on the origin chain needed by the destinationSettler to process the fill
 	bytes originData;
+	/// @dev The format in which the filler must encode `fillerData`
+	///      [TODO: elaborate specifics]
+	string fillerDataFormat;
+}
+
+/// @notice Additional information or instructions about the order
+struct Extension {
+	/// @dev A human-readable ABI description of a function, without the `function` keyword.
+	///      E.g., "dutchAuction(uint256 startTime, uint256 endTime, uint256 startPrice, uint256 endPrice)"
+	string abiDescription;
+	/// @dev The extension parameters ABI-encoded according to `abiDescription`
+	bytes data;
 }
 ```
 
@@ -149,8 +120,8 @@ A compliant `Open` event MUST adhere to the following abi:
 ```solidity
 /// @notice Signals that an order has been opened
 /// @param orderId a unique order identifier within this settlement system
-/// @param resolvedOrder resolved order that would be returned by resolve if called instead of Open
-event Open(bytes32 indexed orderId, ResolvedCrossChainOrder resolvedOrder);
+/// @param order raw order in implementation-specific encoding
+event Open(bytes32 indexed orderId, bytes order);
 ```
 
 ### Settlement interfaces
@@ -162,31 +133,25 @@ A compliant origin settler contract implementation MUST implement the `IOriginSe
 /// @notice Standard interface for settlement contracts on the origin chain
 interface IOriginSettler {
 	/// @notice Opens a gasless cross-chain order on behalf of a user.
-	/// @dev To be called by the filler.
 	/// @dev This method must emit the Open event
-	/// @param order The GaslessCrossChainOrder definition
+	/// @param order The order in raw encoding
+	/// @param user The user's address
 	/// @param signature The user's signature over the order
-	/// @param originFillerData Any filler-defined data required by the settler
-	function openFor(GaslessCrossChainOrder calldata order, bytes calldata signature, bytes calldata originFillerData) external;
+	function openFor(bytes calldata order, address user, bytes calldata signature) external;
 
 	/// @notice Opens a cross-chain order
 	/// @dev To be called by the user
 	/// @dev This method must emit the Open event
-	/// @param order The OnchainCrossChainOrder definition
-	function open(OnchainCrossChainOrder calldata order) external;
+	/// @param order The order in raw encoding
+	function open(bytes calldata order) external;
 
 	/// @notice Resolves a specific GaslessCrossChainOrder into a generic ResolvedCrossChainOrder
 	/// @dev Intended to improve standardized integration of various order types and settlement contracts
-	/// @param order The GaslessCrossChainOrder definition
-	/// @param originFillerData Any filler-defined data required by the settler
+	/// @param order The order in raw encoding
+	/// @param user The user's address
+	/// @param signature The user's signature over the order (optional)
 	/// @return ResolvedCrossChainOrder hydrated order data including the inputs and outputs of the order
-	function resolveFor(GaslessCrossChainOrder calldata order, bytes calldata originFillerData) external view returns (ResolvedCrossChainOrder memory);
-
-	/// @notice Resolves a specific OnchainCrossChainOrder into a generic ResolvedCrossChainOrder
-	/// @dev Intended to improve standardized integration of various order types and settlement contracts
-	/// @param order The OnchainCrossChainOrder definition
-	/// @return ResolvedCrossChainOrder hydrated order data including the inputs and outputs of the order
-	function resolve(OnchainCrossChainOrder calldata order) external view returns (ResolvedCrossChainOrder memory);
+	function resolveFor(bytes calldata order, address user, bytes calldata signature) external view returns (ResolvedCrossChainOrder memory);
 }
 ```
 


### PR DESCRIPTION
This is part of an ongoing conversation about modifying aspects of ERC-7683 that implementers consider need to be improved.

### Current Problems

- Gas inefficiencies
    - Full resolved order in `Open` event
    - Redundant `originSettler`, `originChainId` in `openFor(GaslessCrossChainOrder, ...)`
    - Parameters in calldata that may not be needed by some protocols
- Unclear criteria for standardized fields vs `orderData`
- Designed primarily for escrow
    - `openDeadline` is not needed in resource locks
- Asset recovery timelines for unfilled intents (escrow refunds, resource lock forced withdrawals) have implications for solvers but are not legible in `ResolvedCrossChainOrder`
- Non-standard chain id and address encoding outside of EVM

### This Proposal

The central change is to move everything into opaque `orderData` and lean more heavily on `resolve`. This allows protocols to encode orders as efficiently as they can.

Additionally:
- Resource locks are supported by making `open` optional.
- A settlement deadline is added, after which escrowed assets may be reclaimed by the user.
- The resolved order is extensible so protocols can encode implementation-specific important information, such as external trust/security assumptions implied by the order.
- The supported filler data format is described in resolved orders.

### Pending Issues

- Some protocols are not able to give a reasonable `maxSpent` bound on output tokens based on the order from the origin settler, or at all.
- Addresses in resolved orders should be given as ERC-7930 Interoperable Addresses.
