### PR TITLE
Update ERC-7846: Tweaks

### DIFF
--- a/ERCS/erc-7846.md
+++ b/ERCS/erc-7846.md
@@ -30,7 +30,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 Requests to connect account(s) with optional capabilities.
 
-- An Application MAY provide a list of chain IDs to propose to the wallet to establish an initial connection with. 
+- An Application MAY provide a list of chain IDs (`chainIds`) to propose to the wallet to establish an initial connection with. 
 - The Wallet MUST support at least one of the provided chain IDs. If the Wallet does not support any of the provided chain IDs, then the Wallet MUST reject with an `5710 Unsupported Chain` error.
 - If the Application does not provide any chain IDs, then the Wallet MAY propose any chain ID it supports.
 - If the Application requests to add or switch chain via a `wallet_addEthereumChain` or `wallet_switchEthereumChain` request at a later time, the Wallet MAY switch to the requested chain (even if not one of the chain IDs provided at connection) or reject with an `5710 Unsupported Chain` error if not supported.

--- a/ERCS/erc-7846.md
+++ b/ERCS/erc-7846.md
@@ -2,7 +2,7 @@
 eip: 7846
 title: Wallet Connection API
 description: Adds JSON-RPC method for requesting wallet connection with modular capabilities.
-author: Conner Swenberg (@ilikesymmetry), Jake Moxey (@jxom), Lukas Rosario (@lukasrosario)
+author: Conner Swenberg (@ilikesymmetry), Jake Moxey (@jxom), Lukas Rosario (@lukasrosario), Stephan Cilliers (@stephancill)
 discussions-to: https://ethereum-magicians.org/t/erc-7846-wallet-connection-api/22245
 status: Draft
 type: Standards Track
@@ -30,16 +30,22 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 Requests to connect account(s) with optional capabilities.
 
+- An Application MAY provide a list of chain IDs to propose to the wallet to establish a connection with. 
+- The Wallet MUST support at least one of the provided chain IDs. If the Application does not provide any chain IDs, then the Wallet MAY propose any chain ID it supports.
+
+
 ##### Request
 
 ```ts
 type Request = {
   method: 'wallet_connect',
   params: [{
-    // JSON-RPC method version.
-    version: string;
     // Optional capabilities to request (e.g. Sign In With Ethereum).
     capabilities?: Record<string, unknown>;
+    // Chain IDs to propose to the wallet to connect to.
+    chainIds?: `0x${string}`[];
+    // JSON-RPC method version.
+    version: '1';
   }]
 }
 ```
@@ -65,13 +71,13 @@ type Response = {
 const response = await provider.request({
   method: 'wallet_connect',
   params: [{
-    version: '1',
     capabilities: {
       signInWithEthereum: {
         nonce: '12345678',
-        chainId: '0x1'
       }
-    }
+    },
+    chainIds: ['0x1', '0x2105'],
+    version: '1',
   }]
 })
 /**
@@ -86,7 +92,8 @@ const response = await provider.request({
  *         }
  *       }
  *     }
- *   ]
+ *   ],
+ *   chainIds: ['0x1', '0xa', '0x2105', '0x31b51']
  * }
  */
 ```
@@ -124,10 +131,11 @@ Adds support for offchain authentication using [ERC-4361](./eip-4361.md).
 Same as ERC-4361 specification with minor modifications: 
 * The casing of multi-word fields has been adjusted to camelCase instead of kebab-case. Resources are an array field. 
 * The account address returned by `wallet_connect` MUST match the address inferred in the Sign-In with Ethereum (SIWE) message.
-* `version` is optional and defaults to an accepted version defined in ERC-4361 if not provided.
-* `domain` is optional and defaults to the domain of the requesting app if not provided.
-* `uri` is optional and defaults to the uri of the requesting app if not provided.
-* `issuedAt` is optional and defaults to the current time if not provided.
+* `chainId` is optional. If not provided, the Wallet MUST fill this field with one of the chain IDs requested on the `wallet_connect` request (or any chain ID the account supports if no chain IDs were requested).
+* `version` is optional. If not provided, the Wallet MUST fill this field with an accepted version defined in ERC-4361.
+* `domain` is optional. If not provided, the Wallet MUST fill this field with the domain of the requesting app.
+* `uri` is optional. If not provided, the Wallet MUST fill this field with the uri of the requesting app.
+* `issuedAt` is optional. If not provided, the Wallet MUST fill this field with the current time.
 
 The wallet MUST return a ERC-4361-formatted message that exactly matches the requested parameters and a signature over the [EIP-191](./eip-191.md) `personal_sign` hash of the message. The app SHOULD also verify that the two match for security.
 
@@ -135,17 +143,17 @@ The wallet MUST return a ERC-4361-formatted message that exactly matches the req
 type Parameters = {
   signInWithEthereum: {
     nonce: string;
-    chainId: string; // EIP-155 hex-encoded
-    version?: string;
-    scheme?: string;
+    chainId?: string; // EIP-155 hex-encoded
     domain?: string;
-    uri?: string;
-    statement?: string;
-    issuedAt?: string;
     expirationTime?: string;
+    issuedAt?: string;
     notBefore?: string;
     requestId?: string;
     resources?: string[];
+    scheme?: string;
+    statement?: string;
+    uri?: string;
+    version?: string;
   }
 }
 ```
@@ -171,18 +179,17 @@ type Response = {
 const result = await provider.request({
   method: 'wallet_connect',
   params: [{
-    version: '1',
     capabilities: {
       signInWithEthereum: {
-        nonce: '12345678',
-        chainId: '0x1',
-        version: '1',
         domain: 'app.com',
-        uri: 'https://app.com/connect',
-        issuedAt: '2024-12-35T04:20:00Z',
         expirationTime: '2024-12-35T06:09:00Z'
+        issuedAt: '2024-12-35T04:20:00Z',
+        nonce: '12345678',
+        uri: 'https://app.com/connect',
       }
-    }
+    },
+    chainIds: ['0x1', '0x2105'],
+    version: '1'
   }]
 })
 /**
@@ -197,12 +204,20 @@ const result = await provider.request({
  *         }
  *       }
  *     }
- *   ]
+ *   ],
+ *   chainIds: ['0x1', '0xa', '0x2105', '0x31b51']
  * }
  */
 ```
 
 ## Rationale
+
+### `chainIds` Request Parameter
+
+In an ever-evolving "multichain" ecosystem, it is important for Applications to be able to connect to a Wallet without being constrained to supply a chain (or set of chains) to connect to. This specification allows for this flexibility by making chain IDs optional in the `wallet_connect` request. This allows an Application to 
+more gracefully perform actions on any chain the Wallet supports.
+However, if an Application is designed to support specific chains, the Application MAY provide a `chainIds` parameter to `wallet_connect` to request connection to at least one of the provided chain IDs. This may be
+important for Applications that perform actions with contracts that reside on a chain, or perform [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) verification on Smart Contract Accounts.
 
 ### Multiple Accounts
 

--- a/ERCS/erc-7846.md
+++ b/ERCS/erc-7846.md
@@ -94,7 +94,7 @@ const response = await provider.request({
  *         }
  *       }
  *     }
- *   ],
+ *   ]
  * }
  */
 ```
@@ -205,7 +205,7 @@ const result = await provider.request({
  *         }
  *       }
  *     }
- *   ],
+ *   ]
  * }
  */
 ```

--- a/ERCS/erc-7846.md
+++ b/ERCS/erc-7846.md
@@ -33,7 +33,7 @@ Requests to connect account(s) with optional capabilities.
 - An Application MAY provide a list of chain IDs (`chainIds`) to propose to the wallet to establish an initial connection with. 
 - The Wallet MUST support at least one of the provided chain IDs. If the Wallet does not support any of the provided chain IDs, then the Wallet MUST reject with an `5710 Unsupported Chain` error.
 - If the Application does not provide any chain IDs, then the Wallet MAY propose any chain ID it supports.
-- If the Application requests to add or switch chain via a `wallet_addEthereumChain` or `wallet_switchEthereumChain` request at a later time, the Wallet MAY switch to the requested chain (even if not one of the chain IDs provided at connection) or reject with an `5710 Unsupported Chain` error if not supported.
+- If the Application requests to switch chain via a `wallet_switchEthereumChain` request at a later time, the Wallet MAY switch to the requested chain (even if not one of the chain IDs provided at connection) or reject with an `5710 Unsupported Chain` error if not supported.
 
 
 ##### Request
@@ -58,12 +58,15 @@ List of connected accounts with their associated capabilities.
 
 ```ts
 type Response = {
+  // Accounts established with this connection.
   accounts: {
     // Address of the connected account.
     address: `0x${string}`;
     // Capabilities granted that is associated with this account.
     capabilities: Record<string, unknown>;
-  }[]
+  }[],
+  // Initial chain IDs established with this connection.
+  chainIds: `0x${string}`[]
 }
 ```
 
@@ -94,7 +97,8 @@ const response = await provider.request({
  *         }
  *       }
  *     }
- *   ]
+ *   ],
+ *   chainIds: ['0x1', '0xa', '0x2105', '0x31b51']
  * }
  */
 ```
@@ -205,7 +209,8 @@ const result = await provider.request({
  *         }
  *       }
  *     }
- *   ]
+ *   ],
+ *   chainIds: ['0x1', '0xa', '0x2105', '0x31b51']
  * }
  */
 ```

--- a/ERCS/erc-7846.md
+++ b/ERCS/erc-7846.md
@@ -30,8 +30,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 Requests to connect account(s) with optional capabilities.
 
-- An Application MAY provide a list of chain IDs to propose to the wallet to establish a connection with. 
-- The Wallet MUST support at least one of the provided chain IDs. If the Application does not provide any chain IDs, then the Wallet MAY propose any chain ID it supports.
+- An Application MAY provide a list of chain IDs to propose to the wallet to establish an initial connection with. 
+- The Wallet MUST support at least one of the provided chain IDs. If the Wallet does not support any of the provided chain IDs, then the Wallet MUST reject with an `5710 Unsupported Chain` error.
+- If the Application does not provide any chain IDs, then the Wallet MAY propose any chain ID it supports.
+- If the Application requests to add or switch chain via a `wallet_addEthereumChain` or `wallet_switchEthereumChain` request at a later time, the Wallet MAY switch to the requested chain (even if not one of the chain IDs provided at connection) or reject with an `5710 Unsupported Chain` error if not supported.
 
 
 ##### Request
@@ -42,7 +44,7 @@ type Request = {
   params: [{
     // Optional capabilities to request (e.g. Sign In With Ethereum).
     capabilities?: Record<string, unknown>;
-    // Chain IDs to propose to the wallet to connect to.
+    // Chain IDs to propose to the wallet to establish an initial connection with.
     chainIds?: `0x${string}`[];
     // JSON-RPC method version.
     version: '1';

--- a/ERCS/erc-7846.md
+++ b/ERCS/erc-7846.md
@@ -95,7 +95,6 @@ const response = await provider.request({
  *       }
  *     }
  *   ],
- *   chainIds: ['0x1', '0xa', '0x2105', '0x31b51']
  * }
  */
 ```
@@ -207,7 +206,6 @@ const result = await provider.request({
  *       }
  *     }
  *   ],
- *   chainIds: ['0x1', '0xa', '0x2105', '0x31b51']
  * }
  */
 ```

--- a/ERCS/erc-7846.md
+++ b/ERCS/erc-7846.md
@@ -30,11 +30,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 Requests to connect account(s) with optional capabilities.
 
-- An Application MAY provide a list of chain IDs (`chainIds`) to propose to the wallet to establish an initial connection with. 
-- The Wallet MUST support at least one of the provided chain IDs. If the Wallet does not support any of the provided chain IDs, then the Wallet MUST reject with an `5710 Unsupported Chain` error.
-- If the Application does not provide any chain IDs, then the Wallet MAY propose any chain ID it supports.
-- If the Application requests to switch chain via a `wallet_switchEthereumChain` request at a later time, the Wallet MAY switch to the requested chain (even if not one of the chain IDs provided at connection) or reject with an `5710 Unsupported Chain` error if not supported.
-
+- An Application MAY provide a list of chain IDs (`chainIds`) it supports. The Wallet MUST establish the connection on at least one of the provided chain IDs that it supports, and MUST return the established chain IDs in the response `chainIds`.
+- If the Wallet does not support any of the provided chain IDs, then the Wallet MUST reject with a `5710 Unsupported Chain` error. The Wallet SHOULD include the unsupported chain ID(s) in the error's `data` field.
+- If the Application does not provide `chainIds`, then the Wallet MAY establish the connection on any chain ID(s) it supports, and MUST return them in the response `chainIds`.
 
 ##### Request
 
@@ -44,10 +42,10 @@ type Request = {
   params: [{
     // Optional capabilities to request (e.g. Sign In With Ethereum).
     capabilities?: Record<string, unknown>;
-    // Chain IDs to propose to the wallet to establish an initial connection with.
+    // Chain IDs (hex-encoded) the Application supports.
     chainIds?: `0x${string}`[];
     // JSON-RPC method version.
-    version: '1';
+    version: '0';
   }]
 }
 ```
@@ -65,7 +63,7 @@ type Response = {
     // Capabilities granted that is associated with this account.
     capabilities: Record<string, unknown>;
   }[],
-  // Initial chain IDs established with this connection.
+  // Chain IDs (hex-encoded) established with this connection.
   chainIds: `0x${string}`[]
 }
 ```
@@ -82,7 +80,7 @@ const response = await provider.request({
       }
     },
     chainIds: ['0x1', '0x2105'],
-    version: '1',
+    version: '0',
   }]
 })
 /**
@@ -98,7 +96,7 @@ const response = await provider.request({
  *       }
  *     }
  *   ],
- *   chainIds: ['0x1', '0xa', '0x2105', '0x31b51']
+ *   chainIds: ['0x1', '0x2105']
  * }
  */
 ```
@@ -136,7 +134,7 @@ Adds support for offchain authentication using [ERC-4361](./eip-4361.md).
 Same as ERC-4361 specification with minor modifications: 
 * The casing of multi-word fields has been adjusted to camelCase instead of kebab-case. Resources are an array field. 
 * The account address returned by `wallet_connect` MUST match the address inferred in the Sign-In with Ethereum (SIWE) message.
-* `chainId` is optional. If not provided, the Wallet MUST fill this field with one of the chain IDs requested on the `wallet_connect` request (or any chain ID the account supports if no chain IDs were requested).
+* `chainId` is optional. If not provided, the Wallet MUST fill this field with the first chain ID established for the connection (i.e. the first entry of the response `chainIds`). Applications that require [ERC-1271](./eip-1271.md) verification against a Smart Contract Account SHOULD provide `chainIds` on the `wallet_connect` request so that the SIWE `chainId` resolves to a chain the account is deployed to.
 * `version` is optional. If not provided, the Wallet MUST fill this field with an accepted version defined in ERC-4361.
 * `domain` is optional. If not provided, the Wallet MUST fill this field with the domain of the requesting app.
 * `uri` is optional. If not provided, the Wallet MUST fill this field with the uri of the requesting app.
@@ -149,16 +147,16 @@ type Parameters = {
   signInWithEthereum: {
     nonce: string;
     chainId?: string; // EIP-155 hex-encoded
+    version?: string;
+    scheme?: string;
     domain?: string;
-    expirationTime?: string;
+    uri?: string;
+    statement?: string;
     issuedAt?: string;
+    expirationTime?: string;
     notBefore?: string;
     requestId?: string;
     resources?: string[];
-    scheme?: string;
-    statement?: string;
-    uri?: string;
-    version?: string;
   }
 }
 ```
@@ -194,7 +192,7 @@ const result = await provider.request({
       }
     },
     chainIds: ['0x1', '0x2105'],
-    version: '1'
+    version: '0'
   }]
 })
 /**
@@ -210,7 +208,7 @@ const result = await provider.request({
  *       }
  *     }
  *   ],
- *   chainIds: ['0x1', '0xa', '0x2105', '0x31b51']
+ *   chainIds: ['0x1', '0x2105']
  * }
  */
 ```
@@ -219,10 +217,15 @@ const result = await provider.request({
 
 ### `chainIds` Request Parameter
 
-In an ever-evolving "multichain" ecosystem, it is important for Applications to be able to connect to a Wallet without being constrained to supply a chain (or set of chains) to connect to. This specification allows for this flexibility by making chain IDs optional in the `wallet_connect` request. This allows an Application to 
-more gracefully perform actions on any chain the Wallet supports.
-However, if an Application is designed to support specific chains, the Application MAY provide a `chainIds` parameter to `wallet_connect` to request connection to at least one of the provided chain IDs. This may be
-important for Applications that perform actions with contracts that reside on a chain, or perform [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) verification on Smart Contract Accounts.
+In an ever-evolving "multichain" ecosystem, it is important for Applications to be able to connect to a Wallet without being constrained to supply a chain (or set of chains) to connect to. This specification makes `chainIds` optional so an Application that is agnostic to the connected chain can gracefully operate on any chain the Wallet supports.
+
+If an Application is designed to support specific chains, it MAY provide `chainIds` so the Wallet can short-circuit the connection (rejecting with a `5710 Unsupported Chain` error) when it supports none of them. This is important for Applications that interact with contracts on specific chains, or perform [ERC-1271](./eip-1271.md) verification against Smart Contract Accounts, which must be done on a chain the account is deployed to.
+
+`wallet_connect` establishes the set of chains a connection is scoped to (returned in the response `chainIds`) rather than a single "active" chain. There is intentionally no notion of a "current" chain to switch between; Applications SHOULD specify the target chain explicitly in subsequent requests (for example, via [ERC-5792](./eip-5792.md) `wallet_sendCalls`).
+
+### `chainIds` on the Connection
+
+`chainIds` is returned at the root of the response rather than per-account because a connection's chain scope applies uniformly to all returned accounts. This keeps the common case simple, and there is no expectation that different accounts within a single connection are scoped to different chains.
 
 ### Multiple Accounts
 


### PR DESCRIPTION
A few minor changes:

- Adds a `chainIds` property to the request. Rationale:
  - If an Application provides a set of chain IDs it supports, then we can make `chainId` in request capabilities optional (and also dedupe on it if there are multiple capabilities that have `chainId`) and have the wallet fill in this property with one of the root `chainIds`. 
- Makes `chainId` optional on the `signInWithEthereum` capability. Rationale: 
  - As mentioned above, the wallet will be able to fill `chainId` with one of the root `chainIds`.
  - For the case of Contract Accounts, the SIWE `chainId` must be a chain that the signing Smart Contract Account resides on, so that we can ERC-1271 verify. The Application may not know this in advance because Applications do not (and should not have to) know what chains the SCA lives on. For example, an Application may be set up with JxomChain (`69420`) and Base (`8453`), and set the SIWE `chainId` to `69420` (because the app may just supply the first or active chain). However the Wallet may not support JxomChain and therefore SIWE will fail. If a set of `chainIds` are supported on the root, then the Wallet can pick a supported chain and fill the SIWE `chainId` as Base (`8453`).