### PR TITLE
Update ERC-3770: fix inconsistent author formatting in metadata

### DIFF
--- a/ERCS/erc-3770.md
+++ b/ERCS/erc-3770.md
@@ -2,7 +2,7 @@
 eip: 3770
 title: Chain-specific addresses
 description: Prepending chain-specific addresses with a human-readable chain identifier
-author: Lukas Schor (@lukasschor), Richard Meissner (@rmeissner), Pedro Gomes (@pedrouid), ligi <ligi@ligi.de>
+author: Lukas Schor (@lukasschor), Richard Meissner (@rmeissner), Pedro Gomes (@pedrouid), ligi (@ligi)
 discussions-to: https://ethereum-magicians.org/t/chain-specific-addresses/6449
 status: Draft
 type: Standards Track


### PR DESCRIPTION
noticed that one of the author entries didn’t follow the same format as the others - added the missing GitHub handle for consistency.