### PR TITLE
Update ERC-7943: Align with ERC-3643 naming conventions and remove ERC7943NotAllowedTransfer

### DIFF
--- a/ERCS/erc-7943.md
+++ b/ERCS/erc-7943.md
@@ -52,7 +52,7 @@ interface IERC7943 /*is IERC165*/ {
     /// @param to The address to which seized tokens were transferred.
     /// @param tokenId The ID of the token being transferred.
     /// @param amount The amount seized.
-    event ForcedTransfer(address indexed from, address indexed to, uint256 tokenId, uint256 amount);
+    event ForcedTransfer(address indexed from, address indexed to, uint256 indexed tokenId, uint256 amount);
 
     /// @notice Emitted when `setFrozenTokens` is called, changing the frozen `amount` of `tokenId` tokens for `user`.
     /// @param user The address of the user whose tokens are being frozen.


### PR DESCRIPTION
Aligned ERC-7943 with ERC-3643 naming conventions for better RWA ecosystem compatibility:

- Renamed `isTransferAllowed` → `canTransfer` (matches ERC-3643, ERC-7518, ERC-7751)
- Renamed `forceTransfer` → `forcedTransfer` (matches ERC-3643)
- Renamed `getFrozen` → `getFrozenTokens` (matches ERC-3643)
- Renamed `setFrozen` → `setFrozenTokens` (for consistency)
- Removed generic `ERC7943NotAllowedTransfer` error to encourage specific error handling

Updated all specifications, examples, and documentation. No breaking changes to core functionality, only improved naming consistency across RWA ERCs.