### PR TITLE
Update ERC-7955: Propagate CREATE2 Reverts

### DIFF
--- a/ERCS/erc-7955.md
+++ b/ERCS/erc-7955.md
@@ -13,7 +13,7 @@ requires: 1014, 7702
 
 ## Abstract
 
-This ERC defines a permissionless and deterministic deployment mechanism across all EVM-compatible chains. It uses the [EIP-7702](./eip-7702.md) `Set Code for EOAs (0x4)` transaction type to deploy a universal CREATE2 factory contract to a fixed address (`0xC0DE207acb0888c5409E51F27390Dad75e4ECbe7`) with known bytecode. The factory can then create any new contract to a deterministic address using the [EIP-1014](./eip-1014.md) `CREATE2 (0xf5)` opcode. It does not require preinstalls, secret keys, or chain-specific infrastructure.
+This ERC defines a permissionless and deterministic deployment mechanism across all EVM-compatible chains. It uses the [EIP-7702](./eip-7702.md) `Set Code for EOAs (0x4)` transaction type to deploy a universal CREATE2 factory contract to a fixed address (`0xC0DEb853af168215879d284cc8B4d0A645fA9b0E`) with known bytecode. The factory can then create any new contract to a deterministic address using the [EIP-1014](./eip-1014.md) `CREATE2 (0xf5)` opcode. It does not require preinstalls, secret keys, or chain-specific infrastructure.
 
 ## Motivation
 
@@ -71,20 +71,20 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Parameters
 
-| Parameter                   | Value                                                                |
-| --------------------------- | -------------------------------------------------------------------- |
-| `DEPLOYER_PRIVATE_KEY`      | `0x942ba639ec667bdded6d727ad2e483648a34b584f916e6b826fdb7b512633731` |
-| `CREATE2_FACTORY_INIT_CODE` | `0x7760203d3d3582360380843d373d34f580601457fd5b3d52f33d5260186008f3` |
-| `CREATE2_FACTORY_SALT`      | `0x000000000000000000000000000000000000000000000000000000000019e078` |
+| Parameter                   | Value                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------ |
+| `DEPLOYER_PRIVATE_KEY`      | `0x942ba639ec667bdded6d727ad2e483648a34b584f916e6b826fdb7b512633731`           |
+| `CREATE2_FACTORY_INIT_CODE` | `0x7c60203d3d3582360380843d373d34f5806019573d813d933efd5b3d52f33d52601d6003f3` |
+| `CREATE2_FACTORY_SALT`      | `0x000000000000000000000000000000000000000000000000000000000001bec5`           |
 
 ### Derived Parameters
 
 | Derived Parameter              | Value                                                                |
 | ------------------------------ | -------------------------------------------------------------------- |
 | `DEPLOYER_ADDRESS`             | `0x962560A0333190D57009A0aAAB7Bfa088f58461C`                         |
-| `CREATE2_FACTORY_ADDRESS`      | `0xC0DE945918F144DcdF063469823a4C51152Df05D`                         |
-| `CREATE2_FACTORY_RUNTIME_CODE` | `0x60203d3d3582360380843d373d34f580601457fd5b3d52f3`                 |
-| `CREATE2_FACTORY_CODE_HASH`    | `0xeac13dde1a2c9b8dc8a7aded29ad0af5d57c811b746f7909ea841cbfc6ef3adc` |
+| `CREATE2_FACTORY_ADDRESS`      | `0xC0DEb853af168215879d284cc8B4d0A645fA9b0E`                         |
+| `CREATE2_FACTORY_RUNTIME_CODE` | `0x60203d3d3582360380843d373d34f5806019573d813d933efd5b3d52f3`       |
+| `CREATE2_FACTORY_CODE_HASH`    | `0x2ad75e1e9642e6fce7d293d52fa5a8f62a79a2079abb7402256add02d6e8bc30` |
 
 ### Definitions
 
@@ -116,7 +116,7 @@ The _bootstrap contract_ MAY implement additional features such as:
 
 1. Deploy a _bootstrap contract_ described in the previous section.
 2. Sign an EIP-7702 authorization using the `DEPLOYER_PRIVATE_KEY` delegating to the _bootstrap contract_.
-3. Execute an EIP-7702 type `0x4` transaction with the authorization from setup 2; the transaction MUST call `DEPLOYER_ADDRESS` (**either** directly or indirectly) which delegates to the _bootstrap contract_ and MUST perform the `CREATE2 (0xf5)` of the `CREATE2_FACTORY_INIT_CODE` with `CREATE2_FACTORY_SALT` in the _bootstrapping code_.
+3. Execute an EIP-7702 type `0x4` transaction with the authorization from step 2; the transaction MUST call `DEPLOYER_ADDRESS` (**either** directly or indirectly) which delegates to the _bootstrap contract_ and MUST perform the `CREATE2 (0xf5)` of the `CREATE2_FACTORY_INIT_CODE` with `CREATE2_FACTORY_SALT` in the _bootstrapping code_.
 
 Assuming successful execution of the _bootstrapping code_ without reverting in the context of the _deployer_, the _CREATE2 factory contract_ will be deployed to `CREATE2_FACTORY_ADDRESS` with code `CREATE2_FACTORY_RUNTIME_CODE` and code hash `CREATE2_FACTORY_CODE_HASH`.
 
@@ -126,15 +126,15 @@ Assuming successful execution of the _bootstrapping code_ without reverting in t
 
 The deployment mechanism was chosen such that it is uniquely parameterized by the `DEPLOYER_ADDRESS` (which itself is derived from the `DEPLOYER_PRIVATE_KEY` and is therefore deterministic), the `CREATE2_FACTORY_INIT_CODE` and the `CREATE2_FACTORY_SALT` which are both fixed and deterministic. Additionally, since the `DEPLOYER_ADDRESS` will deploy the CREATE2 factory contract with the `CREATE2 (0xf5)` opcode, this guarantees that the address and code of the contract are deterministic.
 
-The use of a publicly known private key enables this mechanism, as anyone can permissionlessly generate a delegation signature to **any** bootstrap contract that would cause the `DEPLOYER_ADDRESS` to execute the specified `CREATE2 (0xf5)` operation and deploy the factory contract to a completely deterministic address. Because of the use of `CREATE2 (0xf5)`, the CREATE2 factory will be deployed to `CREATE2_FACTORY_ADDRESS` if and only if it is deployed with `CREATE2_FACTORY_INIT_CODE`, thus guaranteeing a deployed code hash of `CREATE2_FACTORY_CODE_HASH`. Additionally, the semantics of `CREATE2 (0xf5)` make it so no transaction executed by `DEPLOYER_ADDRESS` can permanently block the deployment of the CREATE2 factory contract.
+The use of a publicly known private key enables this mechanism, as anyone can permissionlessly generate a delegation signature to **any** bootstrap contract that would cause the `DEPLOYER_ADDRESS` to execute the specified `CREATE2 (0xf5)` operation and deploy the factory contract to a completely deterministic address. Because of the use of `CREATE2 (0xf5)`, the CREATE2 factory will be deployed to `CREATE2_FACTORY_ADDRESS` if and only if it is deployed with `CREATE2_FACTORY_INIT_CODE`, thus guaranteeing a deployed code hash of `CREATE2_FACTORY_CODE_HASH`. Additionally, the semantics of `CREATE2 (0xf5)` make it so no transaction executed by `DEPLOYER_ADDRESS` can permanently block the deployment of the CREATE2 factory contract to `CREATE2_FACTORY_ADDRESS`.
 
-One issue with this method is that because the `DEPLOYER_PRIVATE_KEY` is public, anyone can sign alternative delegations or transactions and front-run a legitimate CREATE2 factory deployment. The front-running would increase the nonce of the `DEPLOYER_ADDRESS` account and render the EIP-7702 authorization in the legitimate CREATE2 factory deployment transaction invalid, causing the deployment to potentially fail. We consider this to not be a serious issue, however, as:
+One issue with this method is that because the `DEPLOYER_PRIVATE_KEY` is public, anyone can sign alternative delegations or transactions and front-run a legitimate CREATE2 factory deployment. The front-running would increase the nonce of the `DEPLOYER_ADDRESS` account and render the EIP-7702 authorization in the legitimate CREATE2 factory deployment transaction invalid, causing the deployment to potentially fail. This is not considered to be a serious issue, however, as:
 
 1. Doing so does not prevent future deployments - meaning that an attacker can only delay the deployment of the CREATE2 factory with a sustained attack at a gas cost to the attacker, but not permanently prevent it from happening.
 2. The damage is limited to gas griefing for accounts that are legitimately trying to deploy the CREATE2 factory contract. Furthermore, the reference implementation was coded to minimize the gas griefing damage.
 3. In the case of a very persistent malicious actor, their attack can be circumvented by either making use of private transactions or working directly with block builders.
 
-Another known issue with this method is that a future network upgrade may introduce new mechanisms (such as a new opcode or transaction type) to permanently set an account's code. If this were to happen, and since the `DEPLOYER_PRIVATE_KEY` is publicly known, the `DEPLOYER_ADDRESS` account's code could be mistakenly or maliciously set to something that does not execute the necessary bootstrapping code, permanently preventing any future deployment of the CREATE2 factory contract. If this ERC were to gain sufficient adoption, then we believe this will not be an issue as:
+Another known issue with this method is that a future network upgrade may introduce new mechanisms (such as a new opcode or transaction type) to permanently set an account's code. If this were to happen, and since the `DEPLOYER_PRIVATE_KEY` is publicly known, the `DEPLOYER_ADDRESS` account's code could be mistakenly or maliciously set to something that does not execute the necessary bootstrapping code, permanently preventing any future deployment of the CREATE2 factory contract. If this ERC were to gain sufficient adoption, this is not believed to be an issue as:
 
 1. The deployment on Ethereum Mainnet would already exist, and the `DEPLOYER_PRIVATE_KEY` would no longer have any value on Ethereum Mainnet.
 2. An RIP can be adopted to ensure that `CREATE2_FACTORY_ADDRESS` has code `CREATE2_FACTORY_RUNTIME_CODE`.
@@ -150,7 +150,7 @@ However, in order for Nick's method to work, the EIP-7702 authorization message 
 This mechanism allows the `DEPLOYER_ADDRESS` to do any `CREATE2 (0xf5)` deployment, so it would be possible to forgo the intermediary CREATE2 factory contract and use the deployer technique for all deployments. There are multiple downsides to this, however:
 
 - All contract deployments are subject to the front-running issue described above, which could become an annoyance
-- Concurrent deployments from the deployer are subject to race conditions since EIP-7702 authorizations increase the account nonce. This means that if two deployments are submitted to the mem-pool without knowing about each other, only the first one will actually succeed, because the EIP-7702 authorization in the second transaction is for an outdated nonce. This is not an issue when deployers are trying to deploy the same contract as we propose in this ERC since even if the second delegation and transaction fails, the contract would have been deployed as desired.
+- Concurrent deployments from the deployer are subject to race conditions since EIP-7702 authorizations increase the account nonce. This means that if two deployments are submitted to the mempool without knowing about each other, only the first one will actually succeed, because the EIP-7702 authorization in the second transaction is for an outdated nonce. This is not an issue when deployers are trying to deploy the same contract as proposed in this ERC since even if the second delegation and transaction fails, the contract would have been deployed as desired.
 
 ### Multiple Transaction Procedure
 
@@ -166,34 +166,38 @@ The `CREATE2_FACTORY_SALT` was chosen as the **first** salt value starting from 
 
 ### CREATE2 Factory Bytecode
 
-The CREATE2 factory has a similar interface to existing implementations. Namely, it accepts `salt || init_code` as input, which is a 32-byte `salt` value concatenated with the `init_code` of the contract to deploy. It will execute a `CREATE2` with the specified `salt` and `init_code`, deploying a contract with `init_code` to `keccak256(0xff || CREATE2_FACTORY_ADDRESS || salt || keccak256(init_code))[12:]`.
+The CREATE2 factory has a similar interface to existing implementations. Namely, it accepts `salt || init_code` as input, which is a 32-byte `salt` value concatenated with the `init_code` of the contract to deploy. It will execute a `CREATE2` with the specified `salt` and `init_code`, deploying a contract with `init_code` to `keccak256(0xff || CREATE2_FACTORY_ADDRESS || salt || keccak256(init_code))[12:]`. This contract returns the address of the created contract padded to 32 bytes. This differs from some existing implementations, but was done to maintain consistency with the 32-byte word size on the EVM (same encoding as `ecrecover` precompile for example). A product of this is that the return data from CREATE2 factory is compatible with the Solidity ABI. In the case where the execution of `init_code` were to fail, any revert data is propagated to the caller.
 
-Note that this contract returns the address of the created contract padded to 32 bytes. This differs from some existing implementations, but was done to maintain consistency with the 32-byte word size on the EVM (same encoding as `ecrecover` precompile for example). A product of this is that the return data from CREATE2 factory is compatible with the Solidity ABI.
-
-Throughout both the CREATE2 factory contract initialization and runtime code, we use `RETURNDATASIZE (0x3d)` to push `0` onto the stack instead of the dedicated `PUSH0 (0x5f)` opcode. This is done to increase compatibility with chains that support EIP-7702 but not [EIP-3855](./eip-3855.md), while remaining a 1-byte and 2-gas opcode.
+Throughout both the CREATE2 factory contract initialization and runtime code, `RETURNDATASIZE (0x3d)` is used to push `0` onto the stack instead of the dedicated `PUSH0 (0x5f)` opcode. This is done to increase compatibility with chains that support EIP-7702 but not [EIP-3855](./eip-3855.md), while remaining a 1-byte and 2-gas opcode.
 
 The `CREATE2_FACTORY_INIT_CODE` corresponds to the following assembly:
 
 ```
+# SPDX-License-Identifier: CC0-1.0
+
 ### Constructor Code ###
 
-0x0000: PUSH24 0x60203d3d3582360380843d373d34f580601457fd5b3d52f3
-                        # Stack: [runcode]                      | Push the CREATE2 factory runtime code
-0x0019: RETURNDATASIZE  # Stack: [0; runcode]                   | Push the offset in memory to store the code
-0x001a: MSTORE          # Stack: []                             | The runtime code is now in `memory[8:32]`
-0x001b: PUSH1 25        # Stack: [24]                           | Push the code length
-0x001d: PUSH1 7         # Stack: [8; 24]                        | Push the memory offset of the start of code
-0x001f: RETURN          # Stack: []                             | Return the runtime code
+0x0000: PUSH29 0x60203d3d3582360380843d373d34f5806019573d813d933efd5b3d52f3
+                        # Stack: [runcode]                      | Push the CREATE2 factory runtime code, left padded
+                                                                # with three 0 bytes
+0x001e: RETURNDATASIZE  # Stack: [0; runcode]                   | Push the offset in memory to store the code
+0x001f: MSTORE          # Stack: []                             | The runtime code is now in `memory[3:32]`, because of
+                                                                # the 3 bytes of 0-padding
+0x0020: PUSH1 29        # Stack: [29]                           | Push the code length
+0x0022: PUSH1 3         # Stack: [3; 29]                        | Push the memory offset of the start of code
+0x0024: RETURN          # Stack: []                             | Return the runtime code
 ```
 
 The `CREATE2_FACTORY_RUNTIME_CODE` corresponds to the following assembly:
 
 ```
+# SPDX-License-Identifier: CC0-1.0
+
 ### Runtime Code ###
 
-# Prepare our stack, push 32, a value we will use a lot and can summon with
-# `DUP*` to save on one byte of code (over `PUSH1 32`), and a 0 which will
-# be used by either the `RETURN` or `REVERT` branches at the end.
+# Prepare the stack, push 32, a value that will used a lot and can summon with
+# `DUP*` to save on one byte of code (over `PUSH1 32`), and a 0 which will be
+# used by either the `RETURN` or `REVERT` branches at the end.
 0x0000: PUSH1 32        # Stack: [32]
 0x0002: RETURNDATASIZE  # Stack: [0; 32]
 
@@ -207,7 +211,9 @@ The `CREATE2_FACTORY_RUNTIME_CODE` corresponds to the following assembly:
 0x0007: SUB             # Stack: [code.len; salt; 0; 32]        | Compute `msg.data.length - 32`, which is the length of
                                                                 # the init `code`
 
-# Copy the init code to memory offset 0.
+# Copy the init code to memory offset 0. Note that if the call to the contract
+# incorrectly encoded, this will revert with "out of gas", as it will attempt
+# to copy ~2**256 bytes of calldata to memory.
                         # Stack: [code.len; salt; 0; 32]
 0x0008: DUP1            # Stack: [code.len; .; salt; 0; 32]     | Duplicate the length of the init code
 0x0009: DUP5            # Stack: [32; code.len; ...]            | Push the offset in calldata of the code, which is 32
@@ -229,22 +235,33 @@ The `CREATE2_FACTORY_RUNTIME_CODE` corresponds to the following assembly:
 # Verify the deployment was successful and return the address.
                         # Stack: [address; 0; 32]
 0x000f: DUP1            # Stack: [address; .; 0; 32]            | Duplicate the address value
-0x0010: PUSH1 0x14      # Stack: [0x0014; address; .; 0; 32]    | Push the jump destination offset for the code which
+0x0010: PUSH1 0x19      # Stack: [0x0019; address; .; 0; 32]    | Push the jump destination offset for the code which
                                                                 # handles successful deployments
 0x0012: JUMPI           # Stack: [address; 0; 32]               | Jump if `address != 0`, i.e. `CREATE2` succeeded
 
-# CREATE2 reverted.
+# CREATE2 reverted, propagate the revert data.
                         # Stack: [address = 0; 0; 32]
-0x0013: REVERT          # Stack: []                             | Revert with empty data `memory[0:0]`
+0x0013: RETURNDATASIZE  # Stack: [r.len; 0; 0; 32]              | Push the revert data length onto the stack
+0x0014: DUP1            # Stack: [0; r.len; 0; 0; 32]           | Push 0 on to the stack by duplicating; note that
+                                                                # `PUSH0` is intentionally do not used for increased
+                                                                # compatibility with chains that do not implement that
+                                                                # specific opcode
+0x0015: RETURNDATASIZE  # Stack: [r.len; 0; r.len; 0; 0; 32]    | Push the revert data length onto the stack again
+0x0016: SWAP4           # Stack: [0; 0; r.len; 0; r.len; 32]    | Reorder the stack so that both `RETURNDATACOPY` and
+                                                                # `REVERT` can be called; this is done by swapping the
+                                                                # revert data length on the top of the stack with the
+                                                                # bottom-most 0
+0x0017: RETURNDATACOPY  # Stack: [0; r.len; 32]                 | Copy the revert data to `memory[0:r.len]`
+0x0018: REVERT          # Stack: [32]                           | Revert with `memory[0:r.len]`
 
 # CREATE2 succeeded.
-0x0014: JUMPDEST        # Stack: [address; 0; 32]
-0x0015: RETURNDATASIZE  # Stack: [0; address; 0; 32]            | Push the memory offset (0) to store return data at,
-                                                                # we use `RETURNDATASIZE` because contract creation was
+0x0019: JUMPDEST        # Stack: [address; 0; 32]
+0x001a: RETURNDATASIZE  # Stack: [0; address; 0; 32]            | Push the memory offset (0) to store return data at,
+                                                                # `RETURNDATASIZE` is used as contract creation was
                                                                 # successful, and therefore the return data has size 0
-0x0016: MSTORE          # Stack: [0; 32]                        | Store the address in memory, `memory[0:32]` contains
+0x001b: MSTORE          # Stack: [0; 32]                        | Store the address in memory, `memory[0:32]` contains
                                                                 # the `address` left padded to 32-bytes
-0x0017: RETURN          # Stack: []                             | Return `memory[0:32]`, i.e. the address
+0x001c: RETURN          # Stack: []                             | Return `memory[0:32]`, i.e. the address
 ```
 
 ## Backwards Compatibility
@@ -254,21 +271,22 @@ There are a few backwards compatibility considerations with the new proposal:
 1. It requires an EVM chain with EIP-7702 enabled. This means not all chains can use this deployment method.
 2. It would deploy yet another CREATE2 factory contract that would need to be adopted by tooling.
 3. The proposed CREATE2 factory implementation returns the newly created contract address padded to 32 bytes. This is different to some existing contracts that return unpadded 20-byte address value.
+4. The proposed CREATE2 factory implementation propagates revert data. This is different to some existing contracts that just revert with empty data in case executing the CREATE2 initialization code fails.
 
 ## Reference Implementation
 
-We include a reference implementation of a bootstrap contract to which the deployer account can delegate. The reference implementation expects a call to `Bootstrap` to the function `deploy()` in an EIP-7702 type `0x4` transaction including the EIP-7702 authorization delegating `DEPLOYER_ADDRESS` to `Bootstrap` (NOTE: the `Bootstrap` is called as an entry point, instead of calling `DEPLOYER_ADDRESS` directly which allows the contract to do some up-front checks to minimize gas griefing risk):
+This proposal includes a reference implementation of a bootstrap contract to which the deployer account can delegate. The reference implementation expects a call to `Bootstrap` to the function `deploy()` in an EIP-7702 type `0x4` transaction including the EIP-7702 authorization delegating `DEPLOYER_ADDRESS` to `Bootstrap` (NOTE: the `Bootstrap` is called as an entry point, instead of calling `DEPLOYER_ADDRESS` directly which allows the contract to do some up-front checks to minimize gas griefing risk):
 
 ```solidity
-// SPDX-License-Identifier: CC0
+// SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.29;
 
 contract Bootstrap {
     address private constant _DEPLOYER_ADDRESS = 0x962560A0333190D57009A0aAAB7Bfa088f58461C;
-    address private constant _CREATE2_FACTORY_ADDRESS = 0xC0DE945918F144DcdF063469823a4C51152Df05D;
-    bytes32 private constant _CREATE2_FACTORY_CODE_HASH = hex"eac13dde1a2c9b8dc8a7aded29ad0af5d57c811b746f7909ea841cbfc6ef3adc";
-    bytes private constant _CREATE2_FACTORY_INIT_CODE = hex"7760203d3d3582360380843d373d34f580601457fd5b3d52f33d5260186008f3";
-    bytes32 private constant _CREATE2_FACTORY_SALT = hex"000000000000000000000000000000000000000000000000000000000019e078";
+    address private constant _CREATE2_FACTORY_ADDRESS = 0xC0DEb853af168215879d284cc8B4d0A645fA9b0E;
+    bytes32 private constant _CREATE2_FACTORY_CODE_HASH = hex"2ad75e1e9642e6fce7d293d52fa5a8f62a79a2079abb7402256add02d6e8bc30";
+    bytes private constant _CREATE2_FACTORY_INIT_CODE = hex"7c60203d3d3582360380843d373d34f5806019573d813d933efd5b3d52f33d52601d6003f3";
+    bytes32 private constant _CREATE2_FACTORY_SALT = hex"000000000000000000000000000000000000000000000000000000000001bec5";
 
     error InvalidDelegation();
     error CreationFailed();
@@ -301,17 +319,17 @@ contract Bootstrap {
 A minimal bootstrap contract implementation is also possible (although this has a higher potential for gas griefing). The minimal bootstrap contract expects a call directly to the `DEPLOYER_ADDRESS` in an EIP-7702 type `0x4` transaction including the EIP-7702 authorization delegating `DEPLOYER_ADDRESS` to `MiniBootstrap`:
 
 ```solidity
-// SPDX-License-Identifier: CC0
+// SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.29;
 
 contract MiniBootstrap {
-    bytes32 private constant _CREATE2_FACTORY_INIT_CODE = hex"7760203d3d3582360380843d373d34f580601457fd5b3d52f33d5260186008f3";
-    bytes32 private constant _CREATE2_FACTORY_SALT = hex"000000000000000000000000000000000000000000000000000000000019e078";
+    bytes private constant _CREATE2_FACTORY_INIT_CODE = hex"7c60203d3d3582360380843d373d34f5806019573d813d933efd5b3d52f33d52601d6003f3";
+    bytes32 private constant _CREATE2_FACTORY_SALT = hex"000000000000000000000000000000000000000000000000000000000001bec5";
 
     fallback() external {
+        bytes memory initCode = _CREATE2_FACTORY_INIT_CODE;
         assembly ("memory-safe") {
-            mstore(0, _CREATE2_FACTORY_INIT_CODE)
-            pop(create2(0, 0, 32, _CREATE2_FACTORY_SALT))
+            pop(create2(0, add(initCode, 32), mload(initCode), _CREATE2_FACTORY_SALT))
         }
     }
 }


### PR DESCRIPTION
This PR updates ERC-7955 to propagate CREATE2 reverts as was suggested in the [EIP-7997 discussion](https://ethereum-magicians.org/t/eip-7997-deterministic-factory-predeploy/24998/3).
