### PR TITLE
Update ERC-7955: Fix DUP instruction

### DIFF
--- a/ERCS/erc-7955.md
+++ b/ERCS/erc-7955.md
@@ -242,7 +242,7 @@ The `CREATE2_FACTORY_RUNTIME_CODE` corresponds to the following assembly:
 # CREATE2 reverted, propagate the revert data.
                         # Stack: [address = 0; 0; 32]
 0x0013: RETURNDATASIZE  # Stack: [r.len; 0; 0; 32]              | Push the revert data length onto the stack
-0x0014: DUP1            # Stack: [0; r.len; 0; 0; 32]           | Push 0 on to the stack by duplicating; note that
+0x0014: DUP2            # Stack: [0; r.len; 0; 0; 32]           | Push 0 on to the stack by duplicating; note that
                                                                 # `PUSH0` is intentionally do not used for increased
                                                                 # compatibility with chains that do not implement that
                                                                 # specific opcode


### PR DESCRIPTION
The bytecode is correct but the assembly has an error.