### PR TITLE
Update ERC-7828 to reflect ChainRegistry implementation

### DIFF
--- a/ERCS/erc-7828.md
+++ b/ERCS/erc-7828.md
@@ -18,14 +18,15 @@ This proposal extends [ERC-7930](./eip-7930.md) (Interoperable Addresses & Names
 - A unified format for accounts that specifies, together with the address, the chain where the address lives.
 - The use of human-readable chain names, with resolution to chain identifiers via ENS.
 - The use of human-readable account names, with resolution to addresses via ENS.
-- An on-chain registry mapping chain names to identifiers, enabling decentralized resolution of chain metadata. 
+- An on-chain registry mapping chain names to identifiers, enabling decentralized resolution of chain metadata.
 - The ENS domain suffix used for chain names SHALL be abstracted from users for readability, ensuring a simpler display format.
 
 ## Motivation
 
-The current Ethereum address landscape is leading to an ecosystem that will have hundreds and eventually thousands of L2s that use the same address format as Ethereum mainnet. This means an address by itself is not enough information to know which chain the address is related to. This can be problematic if funds are sent to an unreachable address on the incorrect chain. From the user account it should be possible to obtain the right chain identifier (chainID) to include in a transaction. 
+The current Ethereum address landscape is leading to an ecosystem that will have hundreds and eventually thousands of L2s that use the same address format as Ethereum mainnet. This means an address by itself is not enough information to know which chain the address is related to. This can be problematic if funds are sent to an unreachable address on the incorrect chain. From the user account it should be possible to obtain the right chain identifier (chainID) to include in a transaction.
 
 The mapping from chain names to identifiers has, since [EIP-155](./eip-155.md), been maintained off chain using a centralized list. This solution has a few shortcomings:
+
 - It does not scale with the growing number of L2s.
 - The list maintainer is a trusted centralized entity.
 - It does not (currently) support non-EVM chains, even when naming systems (such as ENS, since ENSIP-9) do.
@@ -37,6 +38,7 @@ In the same spirit, the address could be a human-readable name as well, which is
 Moreover, the above can be leveraged to allow for a name to represent the same entity corresponding to different addresses on different chains, mitigating the risk of sending funds to an address the intended recipient doesn't actually control.
 
 Desired properties:
+
 - Backwards compatibility with [ERC-7930]
 - The chain portion can be an [ERC-7785](./eip-7785.md) domain name when that standard is productive.
 - The address portion can be either the appropriate type of address for the chain, or a domain name.
@@ -58,7 +60,7 @@ This standard defines a sub-syntax with extra semantics on top of the Interopera
 
 <raw-address>:         := [-:_%a-zA-Z0-9]+
 <raw-chain>:           := [-:_a-zA-Z0-9]+
-<chain-name>           := (<label> ".")* "<namespace>.eth"  
+<chain-name>           := (<label> ".")* "<namespace>.eth"
 <ens-name>:            := (<label> .)+ <label>
 ```
 
@@ -117,6 +119,7 @@ Wallets MAY display the checksum when formatting addresses, and MAY accept input
 Chain names without a dot (.) are interpreted as labels under a reserved ENS second-level domain <namespace>.eth and resolved via a wildcard resolver contract. This resolver acts as a single source of truth for mapping human-readable chain names to their corresponding chain identifiers encoded in the [ERC-7930] binary format.
 
 To enable onchain resolution between chain names and chain identifiers, a minimal L2Resolver contract SHOULD implement the following methods. The examples below assume the <namespace>.eth name to be l2.eth.
+
 - `function chainId(bytes32 _node) returns (bytes memory _chainBytes)` which resolves a chain `l2.eth` name to its [ERC-7930] chain identifier representation.
 - `function chainName(bytes calldata _chainIdBytes) returns (string memory _chainName)` which resolves an [ERC-7930] chain identifier to a human-readable chain name.
 
@@ -140,7 +143,6 @@ To obtain the **chain identifier** corresponding to a human-readable chain name,
 6.  ABI-decode `result` as `(bytes chainBytes)`.
     • If `chainBytes` is empty → no mapping exists; treat the label as unknown.
 
-
 #### Supported CASA namespaces
 
 While currently only `eip155` chains are supported, the on-chain registry could start listing other chains in order to make human-readable names for non-evm chains possible.
@@ -163,11 +165,9 @@ Reverse resolution (Interoperable Name -> Interoperable Address): [EIP-155](./ei
 
 - Using ENS as the only resolving method means it's enough to use the same Interoperable Addresses v1 for this standard, without extending it to also store the name resolver used. This means however that wallets are free to show users both resolved and unresolved (raw) Interoperable Names.
 
-
 ## Backwards Compatibility
 
 The naming scheme herein defined can represent all names supported by [ERC-7930] by displaying raw addresses without resolution
-
 
 ## Reference Implementation
 
@@ -178,58 +178,76 @@ This section is non-normative, as future ENSIPs can modify the way in which ENS 
 1. Let the user input an address name. Assume it's `alice.eth`.
 2. Let the user select a chain. Assume it's `optimism`. The `l2.eth` suffix is implicit and hidden from end users.
 3. Append `l2.eth` and compute the ENS namehash as per ENSIP-1: `namehash("optimism.l2.eth")`.
-4. Call `L2Resolver.chainId(bytes32 _node)` with the result of step 3 as input, which returns the chain ID in [ERC-7930] byte format.
-5. Convert the returned chain identifier into the CAIP-2 format, as specified by [ERC-7930].
-6. As per ENSIP-11, convert the [EIP-155](./eip-155.md) `chainId` into an ENSIP-11-specific `coinType`: `0x80000000 & 0x0000000A == 0x8000000A`.
-7. Compute the namehash of the result of step 1, according to ENSIP-1.
-8. Query the ENS registry for the appropriate resolver by calling `resolver(bytes32 node)` with the result of the step above.
-9. Call `addr(bytes32 node, uint256 coinType)` on the contract returned on the step above with the results of steps 6 and 5, respectively. This will return the 20 bytes of alice's OP Mainnet address, assume it's `0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa`
-    - Failure mode: if result is address zero, that means the name is not registered and resolution can't be finished.
-10. Serialize `ChainType`, `ChainReferenceLength`, `ChainReference`, `AddressLength` and `Address` according to [ERC-7930] (Interoperable Address v1): `[ 0002 0000 01 0A 14 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA ]`
-11. Interoperable Address is complete: `0x00020000010A14AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`
-12. Compute the checksum as described in [ERC-7930]: `0xC69BEB13` and display it to the user.
+4. Call `ChainResolver.resolve()` with the ENS node to get the chain ID:
+   - Use the `text(bytes32,string)` selector with key `"chain-id"`
+   - This returns the ERC-7785 derived chain ID for the chain (e.g., Optimism's chain ID)
+5. Call `ChainRegistry.coinType(bytes32 chainId)` with the chain ID from step 4:
+   - This returns the ENS coin type for the chain
+   - For Optimism, this would return the appropriate coin type
+6. Compute the namehash of the result of step 1, according to ENSIP-1.
+7. Query the ENS registry for the appropriate resolver by calling `resolver(bytes32 node)` with the result of the step above.
+8. Call `addr(bytes32 node, uint256 coinType)` on the contract returned on the step above with the results of steps 6 and 5, respectively. This will return the 20 bytes of alice's OP Mainnet address, assume it's `0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa`
+   - Failure mode: if result is address zero, that means the name is not registered and resolution can't be finished.
+9. Serialize `ChainType`, `ChainReferenceLength`, `ChainReference`, `AddressLength` and `Address` according to [ERC-7930] (Interoperable Address v1): `[ 0002 0000 01 0A 14 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA ]`
+10. Interoperable Address is complete: `0x00020000010A14AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`
+11. Compute the checksum as described in [ERC-7930]: `0xC69BEB13` and display it to the user.
 
-### Reverse Resolution step-by-step example
+### Chain Information Extraction from Interoperable Address step-by-step example
 
 Starting from the Interoperable Address serialized above: `0x00010000010A14AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`
 
 1. Pick the first two bytes corresponding to the version: `0x0001`. Remaining payload: `0000010A14AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA00010002`
 2. Parse the `ChainType`, `ChainReferenceLength`, `ChainReference`, `AddressLength` and `Address` according to [ERC-7930]. Remaining payload `00010002`
-    1. `ChainType`: `0x0000` -> `eip155`
-    2. `ChainReferenceLength`: `0x01` -> 1
-    3. `ChainReference`: `0x0A` -> 10 (optimism)
-    4. `AddressLength`: `0x14` -> 20 bytes, consistent with `eip155`
-    5. `Address`: `0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa` -> alice's address
-3. Call `L2Resolver.chainName(bytes calldata _chainIdBytes)` with `0x00000000010A00` as the input. The resolver will return the corresponding ENS name, in this case `optimism.l2.eth`.
-4. Compute `coinTypeAsHex` for ENSIP-19:
-    - Check if `ChainType == 0x0000`, as ENSIP-19 does not support non-EVM chains.
-    - Check if `ChainReference & 0xFFFFFFFF == ChainReference`, meaning, all 28 most significant bytes are zero. If this is not the case, fail resolution as ENSIP-19 does not support chainids larger than 4 bytes.
-    - Truncate the `ChainReference` to its 4 least significant bytes: `0x000000A`
-    - Set the `ChainReference`'s MSB to 1: `0x000000A | 0x8000000`: `0x8000000A`
-    - Convert to a lowercase-hexadecimal string without `0x` prefix: `8000000a`
-5. Compute the address as ENSIP-19 expects it, by producing the lowercase-hexadecimal string without `0x` prefix of `Address`: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
-6. Convert the output from two steps above to a reverse lookup string of the form `<address>.<coinType>.reverse` for ENSIP-19: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.8000000a.reverse`
-7.  Find resolver to use for address according to ENS wildcard resolution.
-    1. Call `resolver(namehash(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.8000000a.reverse))` on the mainnet ENS registry. It'll return the zero address, since there is no resolver registered on that address specifically.
-    2. Call `resolver(namehash(8000000a.reverse))` on the mainnet ENS registry. It'll return `0x00000beef055f7934784d6d81b6bc86665630dba`, the address of the `L2ReverseRegistrar` *on the network with chainid 10*.
-8.  Verify the return of the `coinType` method of the `L2ReverseRegistrar` matches the coinType as serialized in step 7.
-9.  Call `nameForAddr(bytes address)` with the address as serialized in step 8. This will return the human-readable name `alice.eth`.
-10.  Check forward resolution of the name as described in ENSIP-11 and repeated in the section above.
-    - If it resolves to the same address, then proceed normally.
-    - If forward resolution of the ENS name returns an address different from the original, or returns an empty byte array, the wallet MUST display the raw, human-readable [ERC-7930] serialized address, indicating the address is unresolved. The wallet SHOULD also warn the user of the mismatch to prevent potential spoofing or confusion.
-11.  Compute the checksum as described in [ERC-7930]: `0xC69BEB13`.
-12.  Format the address in the format `<address>@<chain>#<checksum>` by removing `l2.eth` from step 3 and display it to the user: `alice.eth@optimism#C69BEB13`
+   1. `ChainType`: `0x0000` -> `eip155`
+   2. `ChainReferenceLength`: `0x01` -> 1
+   3. `ChainReference`: `0x0A` -> 10 (optimism)
+   4. `AddressLength`: `0x14` -> 20 bytes, consistent with `eip155`
+   5. `Address`: `0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa` -> alice's address
+3. Convert the `ChainType` to its string namespace representation using an external mapping:
+
+   - `ChainType: 0x0000` maps to namespace `"eip155"`
+   - This mapping follows the [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md) standard that maps namespace strings to their byte representations
+
+4. Call `ChainRegistry.chainDataFromCaip2(string memory namespace, string memory chainReference)` with the CAIP-2 components:
+
+   - `namespace` is `"eip155"` (derived from the mapping above)
+   - `chainReference` is the decimal string representation of `ChainReference: 0x0A` (i.e., `"10"`)
+
+   The registry will return a tuple `(bool exists, ChainData memory chainData)` where:
+
+   - `exists` indicates if the chain was found
+   - `chainData` contains the chain information as defined in `IChainRegistry.ChainData`:
+
+   ```json
+   {
+     "chainName": "optimism",
+     "settlementChainId": 1,
+     "version": "1.0.0",
+     "rollupContract": "0x49048044D57E1c92A77F79988D20FA4a5Fd25F65",
+     "chainNamespace": "eip155",
+     "chainReference": "10",
+     "coinType": 614
+   }
+   ```
+
+5. The chain information extraction is now complete. The address `0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa` has been identified as belonging to the "optimism" chain, providing the necessary chain metadata for further processing.
+
+6. Compute the checksum as described in [ERC-7930]: `0xC69BEB13`.
+
+7. Format the address in the format `<address>@<chain>#<checksum>` for human-readable display:
+   - Result: `0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa@optimism#C69BEB13`
 
 ## Security Considerations
 
 - Wallet developers should be aware of possible unicode glyph collisions in resolved names and warn users about them in order to keep checksums effective, since an attacker could, in order to impersonate `alice.eth@chain.<<namespace>.eth#00112233`:
-    - Mine an address on `chain.<namespace>.eth` such that the checksum of the Interoperable Address is `00112233`.
-    - Register `аlice.eth` (using the russian vowel `а` instead of the latin `a`), and point it to the address above.
+  - Mine an address on `chain.<namespace>.eth` such that the checksum of the Interoperable Address is `00112233`.
+  - Register `аlice.eth` (using the russian vowel `а` instead of the latin `a`), and point it to the address above.
 - ENSIP-19 introduces trust assumptions when resolving reverse records offchain:
-    - ZK-rollups may offer trust-minimized resolution via on-chain proofs.
-    - Sidechains may rely on centralized CCIP-read gateways or signature authorities.
 
-    Wallets MUST surface whether reverse resolution was trust-minimized or trusted.
+  - ZK-rollups may offer trust-minimized resolution via on-chain proofs.
+  - Sidechains may rely on centralized CCIP-read gateways or signature authorities.
+
+  Wallets MUST surface whether reverse resolution was trust-minimized or trusted.
 
 ## Copyright
 


### PR DESCRIPTION
- Fix forward resolution flow to use ChainResolver.resolve() + ChainRegistry.coinType()
- Correct chain information extraction steps to match CAIP-2 lookup