### PR TITLE
Add ERC: Proxy Clear Signing

### DIFF
--- a/ERCS/erc-8009.md
+++ b/ERCS/erc-8009.md
@@ -1,0 +1,200 @@
+---
+eip: 8009
+title: Proxy Clear Signing
+description: Permissionless singleton contract that proxies smart-contract calls and enforces transaction constraints specified by the end user
+author: Mark Virchenko (@borseno), Ilya Kubariev (@gymnasy55), Daniel Nagy (@nagydani)
+discussions-to: https://ethereum-magicians.org/t/erc-8009-proxy-clear-signing/25199
+status: Draft
+type: Standards Track
+category: ERC
+created: 2025-08-19
+requires: 20
+---
+
+## Abstract
+
+Introduce a singleton, stateless contract that proxies arbitrary smart‑contract calls and enforces user‑supplied outcome constraints. The proxy supports **absolute post‑balance thresholds** and **balance‑difference (delta) checks** over native ETH and [ERC-20](./eip-20.md) balances. Calls that violate the declared constraints are reverted.
+
+## Motivation
+
+Current hardware wallets struggle to present meaningful transaction information when interacting with unknown or newly deployed smart contracts. Without prior knowledge of a contract’s ABI or address, these devices can only display raw hexadecimal calldata - an unreadable and unsafe experience for most users. This practice, known as blind signing, leaves users vulnerable to unintentionally approving malicious or incorrect transactions. This vulnerability has already been exploited in high-value attacks.
+
+Instead of parsing transaction calldata, the proposed approach focuses on verifying expected balance differences after execution. This proposal introduces an alternative path to clear signing - defined here as the ability for users to verify the outcome of a transaction before signing, without requiring ABI knowledge. By routing calls through a singleton proxy contract that enforces these expectations on-chain, hardware wallets can reliably display the “balance after transaction” values to the user, taken from the smart-contract parameters. This enables a permissionless, scalable, and understandable transaction confirmation experience, even for unknown contracts.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### Contract Overview
+
+A singleton, stateless permissionless proxy contract deployed once per network.
+
+The contract accepts transaction execution requests containing:
+
+1. **Target call data** — Encoded calldata for the intended interaction.
+2. **Approvals** — Optional [ERC-20](./eip-20.md) instructions executed **before** the target call to either approve the call target to spend proxy-held ERC-20 tokens or transfer proxy-held tokens directly to the call target.
+3. **Withdrawals** — Optional ETH/[ERC-20](./eip-20.md) transfers executed **after** the target call (from the proxy to specified recipients).
+4. **Balance rules** — One of:
+   - **Post‑balance rules:** minimum absolute balances after execution; or
+   - **Balance‑difference rules:** minimum required deltas between pre‑ and post‑execution balances.
+
+The contract MUST NOT store persistent state. Multiple independent users MAY reuse the same instance without interference.
+
+### BalanceProxy
+
+The `BalanceProxy` MUST implement the following interface:
+
+```solidity
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+/// @title IBalanceProxy
+/// @notice Minimal interface for the BalanceProxy core contract
+/// @dev Core is source-agnostic: it never pulls tokens, only uses its own balances
+interface IBalanceProxy {
+    /// @notice Struct to represent balance or value of specific token by target address
+    /// @param target Target address
+    /// @param token Token address (address(0) for ETH)
+    /// @param balance Expected absolute balance (post) or diff (signed)
+    struct Balance {
+        address target;
+        address token;
+        int256 balance;
+    }
+
+    /// @notice Approval instruction: either transfer tokens to target or approve target to spend
+    struct Approval {
+        Balance balance; // token, target, amount(>=0 expected)
+        bool useTransfer; // true: transfer to target; false: approve target
+    }
+
+    /// @notice Error when actual diff != expected
+    error ERC8009BalanceDiffConstraintViolation(
+        address token,
+        address target,
+        int256 expected,
+        int256 actual
+    );
+
+    /// @notice Error thrown when a balance is insufficient
+    error ERC8009BalanceConstraintViolation(
+        address token,
+        address target,
+        int256 balance,
+        uint256 actual
+    );
+
+    /// @notice Error thrown when a call fails
+    error ERC8009CallFailed(address target, bytes data, bytes returnData);
+
+    /// @notice Proxy call to a target contract with specified post-balance checks
+    function proxyCall(
+        Balance[] memory postBalances,
+        Approval[] memory approvals,
+        address target,
+        bytes memory data,
+        Balance[] memory withdrawals
+    ) external payable returns (bytes memory);
+
+    /// @notice Proxy call with balance diffs
+    function proxyCallDiffs(
+        Balance[] memory diffs,
+        Approval[] memory approvals,
+        address target,
+        bytes memory data,
+        Balance[] memory withdrawals
+    ) external payable returns (bytes memory);
+}
+```
+
+This standard defines a singleton, stateless proxy that:
+
+1. Optionally approves or transfers [ERC-20](./eip-20.md) amounts for a designated spender (approvals),
+2. Proxies a call to a target contract,
+3. Optionally performs withdrawals from the proxy (withdrawals),
+4. Enforces user-specified post-execution balance checks (postBalances).
+
+If any check fails or the proxied call fails, the transaction MUST revert.
+
+### Semantics
+
+Execution MUST proceed in this order:
+
+1. Approvals
+2. Target call
+3. Withdrawals
+4. Post-balance checks (if provided) OR diff checks (if provided)
+
+For absolute rules, balances are compared using `actual >= abs(required)`. 
+For diff rules, deltas are computed as `after - before` and compared to the signed requirement.
+
+## Rationale
+
+Several design decisions have been made to maximize reusability, reduce integration overhead, and simplify the verification model:
+
+1. Stateless – The contract holds no persistent state. All parameters, including balance requirements, approvals, and transfers, are supplied per call. This removes per-user deployment and initialization steps, avoids migrations, and keeps the execution path auditable.
+2. Protocol-agnostic – The proxy forwards arbitrary calldata without protocol-specific parsing or allowlists. It applies only generic balance and transfer rules, making it immediately usable with any newly deployed contract that transfers tokenized assets.
+3. Standardized interface and permissionless – While a canonical deployment is expected per network, this ERC primarily standardizes the `IBalanceProxy` interface. This is what makes coordination necessary: hardware wallets, periphery contracts, and other tooling can be built against the interface and interoperate with any conforming implementation. A well-known interface also allows independent implementations to exist for different environments (e.g. testnets, L2s, or alternative security models).
+4. UI-focused — the contract contains enough information in the parameters for hardware wallets to parse and display to the user. This includes, beyond the information required for execution, the token's decimals and symbol, which allow the hardware wallet to display the token name and format the values correctly.
+
+These choices yield a contract that is simple to integrate, predictable to verify, and easy to reuse across applications. 
+
+The limitation of this solution is that enforcement is limited to tokenized balances (ETH or [ERC-20](./eip-20.md)) and cannot apply to non-transferable state stored within other contracts, such as staking positions or lending positions.
+
+An additional "preBalances" parameter was discussed to be introduced into the contract, for the use case when a transaction is only relevant to be executed when an arbitrary address has certain balance. Because of how rare the use case is, it has been decided not to include this parameter into the contract.
+
+A critical vulnerability was identified in the initial design: when users approve tokens to the Proxy, it was possible for an attacker to steal the tokens by crafting a transaction that calls the `transferFrom` function. A malicious actor could exploit the contract by sending a transaction like:
+
+```solidity
+proxy.proxyCall([...], [...], tokenAddress, abi.encodeFunction("transferFrom", ...), [...]);
+```
+
+In response to this vulnerability, we initially considered banning the `transferFrom` function selector, but this approach seemed non-standard and diverged from the usual ERC token handling pattern. Instead, we decided to implement the **Core/Periphery** split. This split allows token transfers, including `transferFrom`, to be handled in the **Periphery**, ensuring that the **Core** contract remains focused on transaction execution and balance validation. This approach maintains ERC compatibility while resolving the security issue effectively.
+
+### Core/Periphery Contract Model
+
+To address concerns around argument handling, user interface display, and support for various hardware wallets, we have split the logic into **Core** and **Periphery contracts**.
+
+1. **Core Contract**: The core contract focuses solely on executing transactions, including transferring tokens, checking balances, and enforcing balance rules. It does not deal with data formatting or UI presentation, ensuring it remains minimal, universal, and focused on performing the actual logic.
+2. **Periphery Contract**: The peripheral contract handles all interaction with the user interface and external hardware wallets. It takes care of token argument handling, including decimals, symbols, and other UI-related data that is specific to the hardware wallet or user preferences.
+
+This separation ensures that the **Core** remains lightweight and adaptable, while the **Periphery** can be customized to match different wallets' needs.
+
+### Safe Multisig Support
+
+`SafeRouter` is a periphery contract that adds support for Safe multisig wallets, used by teams that require multiple signers to authorize transactions. This is a good example of how periphery contracts complement the core: the `BalanceProxy` core remains focused solely on balance enforcement, while `SafeRouter` handles the Safe-specific coordination needed to make that enforcement available to multisig participants.
+
+`SafeRouter` is added as an owner of the Safe, occupying one signing slot in the threshold. When the co-signers have collected their required signatures, they submit the transaction through `SafeRouter`. `SafeRouter` first verifies that the caller is an existing owner of the Safe, then makes a call to `BalanceProxy`, passing `SafeRouter`'s own `executeSafeTransaction` function as the target call. This is because `BalanceProxy` needs to capture balance differences across the execution, which requires recording balances both before and after the target call. At the point of `BalanceProxy` executing the call, `SafeRouter` verifies the callback came from the expected `BalanceProxy` instance, provides its approval for the transaction on the multisig contract, and calls `safe.execTransaction`. Only after the Safe transaction has executed does `BalanceProxy` check the declared post-balance constraints. If any constraint is violated the entire transaction reverts, including the Safe execution.
+
+### Comparison to Other Standards
+
+#### [EIP-6120](./eip-6120.md)
+**[EIP-6120](./eip-6120.md)** imposes a key limitation by requiring that the target contract cannot be a token (such as an [ERC-20](./eip-20.md)), which restricts its use in DeFi applications that involve token transfers. This makes it incompatible with the majority of real-world smart contracts. In contrast, our approach does not have this restriction, allowing the target contract to be any contract, including tokens, making it more flexible and compatible with existing DeFi standards. By separating the transaction logic (**Core**) from the user interface handling (**Periphery**), our solution ensures scalability and adaptability for a wide range of wallets, without compromising functionality or compatibility.
+
+#### Intent-Based State Transition
+
+The **Intent-Based State Transition** proposal introduces a more complex approach to contract interaction, requiring significant changes to how contracts are written and integrated. Unlike our solution, which is plug-and-play and works with existing contracts, intent-based state transitions require a complete rewrite of contracts to be compatible. This makes it less feasible for immediate adoption and integration.
+
+## Backwards Compatibility
+
+This EIP introduces a new contract standard and does not modify existing standards. No backwards-compatibility issues are expected.
+
+## Test Cases
+
+Test cases can be found [here](../assets/eip-8009/test/BalanceProxy.test.ts).
+
+## Reference Implementation
+
+A reference implementation of the **Core** `BalanceProxy` contract can be found [here](../assets/eip-8009/BalanceProxy.sol) and reference implementations of the **Periphery** contracts `ApproveRouter`, `PermitRouter`, and `SafeRouter` can be found [here](../assets/eip-8009/ApproveRouter.sol), [here](../assets/eip-8009/PermitRouter.sol), and [here](../assets/eip-8009/SafeRouter.sol) respectively.
+
+> Please note that the reference implementation depends on the `@openzeppelin/contracts v5.3.0`
+
+## Security Considerations
+
+1. **Third-party funding.** Absolute balance checks only assert that an address holds at least a specified amount after execution. They do not constrain where those funds came from. An attacker (or any third party) can top up the account during the transaction to satisfy the condition. Where provenance matters, balance-difference checks SHOULD be used instead.
+
+2. **Residual balances.** Because the proxy is stateless, any assets transferred into it that are not withdrawn within the same transaction remain stuck in the contract. These residual balances are not tracked or attributed. They may later be withdrawn by anyone, intentionally or otherwise.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/assets/erc-8009/ApproveRouter.sol
+++ b/assets/erc-8009/ApproveRouter.sol
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+import {IBalanceProxy} from "./interfaces/IBalanceProxy.sol";
+import {BalanceMetadata} from "./interfaces/IMetadata.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+/// @title ApproveRouter
+/// @notice Handles allowance + pull tokens then delegates to BalanceProxy core
+contract ApproveRouter {
+    /// @notice Error thrown when metadata and balances array lengths don't match
+    error MetadataBalancesLengthMismatch(
+        uint256 metaLength,
+        uint256 balancesLength
+    );
+
+    /// @notice Error thrown when metadata doesn't match actual token properties
+    error InvalidMetadata(
+        address token,
+        string expectedSymbol,
+        uint8 expectedDecimals,
+        string actualSymbol,
+        uint8 actualDecimals
+    );
+
+    /// @dev Internal function to validate metadata matches actual token properties
+    /// @param meta Metadata array to validate
+    /// @param balances Corresponding balances array
+    function _checkMetadata(
+        BalanceMetadata[] memory meta,
+        IBalanceProxy.Balance[] memory balances
+    ) internal view {
+        if (meta.length != balances.length) {
+            revert MetadataBalancesLengthMismatch(meta.length, balances.length);
+        }
+
+        for (uint256 i = 0; i < meta.length; i++) {
+            string memory actualSymbol;
+            uint8 actualDecimals;
+
+            if (balances[i].token == address(0)) {
+                actualSymbol = "ETH";
+                actualDecimals = 18;
+            } else {
+                actualSymbol = IERC20Metadata(balances[i].token).symbol();
+                actualDecimals = IERC20Metadata(balances[i].token).decimals();
+            }
+
+            if (
+                keccak256(abi.encodePacked(actualSymbol)) !=
+                keccak256(abi.encodePacked(meta[i].symbol)) ||
+                actualDecimals != meta[i].decimals
+            ) {
+                revert InvalidMetadata(
+                    balances[i].token,
+                    meta[i].symbol,
+                    meta[i].decimals,
+                    actualSymbol,
+                    actualDecimals
+                );
+            }
+        }
+    }
+
+    /// @notice Execute proxyCall with pre-approved tokens (router as spender)
+    function approveProxyCall(
+        IBalanceProxy balanceProxy,
+        IBalanceProxy.Balance[] memory postBalances,
+        IBalanceProxy.Approval[] memory approvals,
+        address target,
+        bytes memory data,
+        IBalanceProxy.Balance[] memory withdrawals
+    ) external payable returns (bytes memory) {
+        for (uint256 i = 0; i < approvals.length; i++) {
+            IBalanceProxy.Balance memory bal = approvals[i].balance;
+            uint256 amount = uint256(bal.balance);
+            IERC20(bal.token).transferFrom(
+                msg.sender,
+                address(balanceProxy),
+                amount
+            );
+        }
+        return
+            balanceProxy.proxyCall{value: msg.value}(
+                postBalances,
+                approvals,
+                target,
+                data,
+                withdrawals
+            );
+    }
+
+    /// @notice proxyCallDiffs with pre-approved tokens
+    function approveProxyCallDiffs(
+        IBalanceProxy balanceProxy,
+        IBalanceProxy.Balance[] memory diffs,
+        IBalanceProxy.Approval[] memory approvals,
+        address target,
+        bytes memory data,
+        IBalanceProxy.Balance[] memory withdrawals
+    ) external payable returns (bytes memory) {
+        for (uint256 i = 0; i < approvals.length; i++) {
+            IBalanceProxy.Balance memory bal = approvals[i].balance;
+            uint256 amount = uint256(bal.balance);
+            IERC20(bal.token).transferFrom(
+                msg.sender,
+                address(balanceProxy),
+                amount
+            );
+        }
+        return
+            balanceProxy.proxyCallDiffs{value: msg.value}(
+                diffs,
+                approvals,
+                target,
+                data,
+                withdrawals
+            );
+    }
+
+    /// @notice Execute proxyCall with pre-approved tokens and calldata metadata (metadata is ignored on-chain)
+    function approveProxyCallWithMeta(
+        IBalanceProxy balanceProxy,
+        BalanceMetadata[] memory meta,
+        IBalanceProxy.Balance[] memory balances,
+        IBalanceProxy.Approval[] memory approvals,
+        address target,
+        bytes memory data,
+        IBalanceProxy.Balance[] memory withdrawals
+    ) external payable returns (bytes memory) {
+        // Validate metadata against balances
+        _checkMetadata(meta, balances);
+
+        // Pull tokens for approvals
+        for (uint256 i = 0; i < approvals.length; i++) {
+            IBalanceProxy.Balance memory bal = approvals[i].balance;
+            uint256 amount = uint256(bal.balance);
+            IERC20(bal.token).transferFrom(
+                msg.sender,
+                address(balanceProxy),
+                amount
+            );
+        }
+
+        // Delegate to BalanceProxy
+        return
+            balanceProxy.proxyCall{value: msg.value}(
+                balances,
+                approvals,
+                target,
+                data,
+                withdrawals
+            );
+    }
+
+    /// @notice proxyCallDiffs with pre-approved tokens and calldata metadata (metadata is ignored on-chain)
+    function approveProxyCallDiffsWithMeta(
+        IBalanceProxy balanceProxy,
+        BalanceMetadata[] memory meta,
+        IBalanceProxy.Balance[] memory diffs,
+        IBalanceProxy.Approval[] memory approvals,
+        address target,
+        bytes memory data,
+        IBalanceProxy.Balance[] memory withdrawals
+    ) external payable returns (bytes memory) {
+        // Validate metadata against diffs
+        _checkMetadata(meta, diffs);
+
+        // Pull tokens for approvals
+        for (uint256 i = 0; i < approvals.length; i++) {
+            IBalanceProxy.Balance memory bal = approvals[i].balance;
+            uint256 amount = uint256(bal.balance);
+            IERC20(bal.token).transferFrom(
+                msg.sender,
+                address(balanceProxy),
+                amount
+            );
+        }
+
+        // Delegate to BalanceProxy
+        return
+            balanceProxy.proxyCallDiffs{value: msg.value}(
+                diffs,
+                approvals,
+                target,
+                data,
+                withdrawals
+            );
+    }
+}

--- a/assets/erc-8009/BalanceProxy.sol
+++ b/assets/erc-8009/BalanceProxy.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IBalanceProxy} from "./interfaces/IBalanceProxy.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {SignedMath} from "@openzeppelin/contracts/utils/math/SignedMath.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title BalanceProxy
+/// @notice Proxy contract for calling contracts with specified balances and approvals
+/// @dev This contract is used to proxy calls to a target contract with specified balances and approvals
+contract BalanceProxy is IBalanceProxy, ReentrancyGuard {
+    /// @dev Internal function to check if a balance is sufficient
+    /// @param balance Balance to check
+    function _balanceCheck(Balance memory balance) internal view {
+        uint256 actual = balance.token == address(0)
+            ? balance.target.balance
+            : IERC20(balance.token).balanceOf(balance.target);
+        if (actual < SignedMath.abs(balance.balance)) {
+            revert ERC8009BalanceConstraintViolation(
+                balance.token,
+                balance.target,
+                balance.balance,
+                actual
+            );
+        }
+    }
+
+    /// @dev Calldata version of internal function to check if a balance is sufficient
+    /// @param balance Balance to check
+    function _balanceCheckCalldata(Balance calldata balance) internal view {
+        uint256 actual = balance.token == address(0)
+            ? balance.target.balance
+            : IERC20(balance.token).balanceOf(balance.target);
+        if (actual < SignedMath.abs(balance.balance)) {
+            revert ERC8009BalanceConstraintViolation(
+                balance.token,
+                balance.target,
+                balance.balance,
+                actual
+            );
+        }
+    }
+
+    /// @dev Internal function to apply approval instruction (memory)
+    function _applyApproval(Approval memory approval) internal {
+        Balance memory bal = approval.balance;
+        uint256 amount = uint256(bal.balance);
+        if (approval.useTransfer) {
+            IERC20(bal.token).transfer(bal.target, amount);
+        } else {
+            IERC20(bal.token).approve(bal.target, amount);
+        }
+    }
+
+    /// @dev Internal function to transfer a balance
+    /// @param balance Balance to transfer
+    function _transfer(Balance memory balance) internal {
+        if (balance.token == address(0)) {
+            payable(balance.target).transfer(SignedMath.abs(balance.balance));
+        } else {
+            IERC20(balance.token).transfer(
+                balance.target,
+                SignedMath.abs(balance.balance)
+            );
+        }
+    }
+
+    function _currentBalance(
+        address token,
+        address who
+    ) internal view returns (uint256) {
+        return token == address(0) ? who.balance : IERC20(token).balanceOf(who);
+    }
+
+    function _signedDiff(
+        uint256 afterBalance,
+        uint256 beforeBalance
+    ) internal pure returns (int256) {
+        if (afterBalance >= beforeBalance) {
+            return SafeCast.toInt256(afterBalance - beforeBalance);
+        }
+        return -SafeCast.toInt256(beforeBalance - afterBalance);
+    }
+
+    function proxyCall(
+        Balance[] memory postBalances,
+        Approval[] memory approvals,
+        address target,
+        bytes memory data,
+        Balance[] memory withdrawals
+    ) external payable override nonReentrant returns (bytes memory) {
+        uint256 i;
+        for (i = 0; i < approvals.length; i++) {
+            _applyApproval(approvals[i]);
+        }
+        bytes memory result;
+        if (target != address(0) || data.length > 0 || msg.value > 0) {
+            bool success;
+            (success, result) = target.call{value: msg.value}(data);
+            if (!success) revert ERC8009CallFailed(target, data, result);
+        }
+        for (i = 0; i < withdrawals.length; i++) {
+            _transfer(withdrawals[i]);
+        }
+        for (i = 0; i < postBalances.length; i++) {
+            _balanceCheck(postBalances[i]);
+        }
+        return result;
+    }
+
+    function proxyCallDiffs(
+        Balance[] memory diffs,
+        Approval[] memory approvals,
+        address target,
+        bytes memory data,
+        Balance[] memory withdrawals
+    ) external payable override nonReentrant returns (bytes memory) {
+        uint256 i;
+        uint256 len = diffs.length;
+        uint256[] memory before = new uint256[](len);
+        for (i = 0; i < len; i++)
+            before[i] = _currentBalance(diffs[i].token, diffs[i].target);
+        for (i = 0; i < approvals.length; i++) _applyApproval(approvals[i]);
+        bytes memory result;
+        if (target != address(0) || data.length > 0 || msg.value > 0) {
+            bool success;
+            (success, result) = target.call{value: msg.value}(data);
+            if (!success) revert ERC8009CallFailed(target, data, result);
+        }
+        for (i = 0; i < withdrawals.length; i++) _transfer(withdrawals[i]);
+        for (i = 0; i < len; i++) {
+            uint256 afterBal = _currentBalance(diffs[i].token, diffs[i].target);
+            int256 actualDiff = _signedDiff(afterBal, before[i]);
+            if (actualDiff < diffs[i].balance)
+                revert ERC8009BalanceDiffConstraintViolation(
+                    diffs[i].token,
+                    diffs[i].target,
+                    diffs[i].balance,
+                    actualDiff
+                );
+        }
+        return result;
+    }
+
+    receive() external payable {}
+}

--- a/assets/erc-8009/PermitRouter.sol
+++ b/assets/erc-8009/PermitRouter.sol
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+import {IBalanceProxy} from "./interfaces/IBalanceProxy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IERC20Permit, PermitData} from "./interfaces/IPermit.sol";
+import {BalanceMetadata} from "./interfaces/IMetadata.sol";
+
+/// @title PermitRouter
+/// @notice Handles permit + pull tokens then delegates to BalanceProxy core
+contract PermitRouter {
+    /// @notice Error thrown when metadata and balances array lengths don't match
+    error MetadataBalancesLengthMismatch(
+        uint256 metaLength,
+        uint256 balancesLength
+    );
+
+    /// @notice Error thrown when permits array length doesn't match approvals array length
+    /// @param permitsLength The length of the permits array
+    /// @param approvalsLength The length of the approvals array
+    error PermitsLengthMismatch(uint256 permitsLength, uint256 approvalsLength);
+
+    /// @notice Error thrown when metadata doesn't match actual token properties
+    error InvalidMetadata(
+        address token,
+        string expectedSymbol,
+        uint8 expectedDecimals,
+        string actualSymbol,
+        uint8 actualDecimals
+    );
+
+    /// @dev Internal function to validate metadata matches actual token properties
+    /// @param meta Metadata array to validate
+    /// @param balances Corresponding balances array
+    function _checkMetadata(
+        BalanceMetadata[] memory meta,
+        IBalanceProxy.Balance[] memory balances
+    ) internal view {
+        if (meta.length != balances.length) {
+            revert MetadataBalancesLengthMismatch(meta.length, balances.length);
+        }
+
+        for (uint256 i = 0; i < meta.length; i++) {
+            string memory actualSymbol;
+            uint8 actualDecimals;
+
+            if (balances[i].token == address(0)) {
+                actualSymbol = "ETH";
+                actualDecimals = 18;
+            } else {
+                actualSymbol = IERC20Metadata(balances[i].token).symbol();
+                actualDecimals = IERC20Metadata(balances[i].token).decimals();
+            }
+
+            if (
+                keccak256(abi.encodePacked(actualSymbol)) !=
+                keccak256(abi.encodePacked(meta[i].symbol)) ||
+                actualDecimals != meta[i].decimals
+            ) {
+                revert InvalidMetadata(
+                    balances[i].token,
+                    meta[i].symbol,
+                    meta[i].decimals,
+                    actualSymbol,
+                    actualDecimals
+                );
+            }
+        }
+    }
+
+    /// @notice Execute proxyCall with permits
+    function permitProxyCall(
+        IBalanceProxy balanceProxy,
+        IBalanceProxy.Balance[] memory postBalances,
+        IBalanceProxy.Approval[] memory approvals,
+        PermitData[] memory permits,
+        address target,
+        bytes memory data,
+        IBalanceProxy.Balance[] memory withdrawals
+    ) external payable returns (bytes memory) {
+        uint256 len = approvals.length;
+        if (permits.length != len)
+            revert PermitsLengthMismatch(permits.length, len);
+        for (uint256 i = 0; i < len; i++) {
+            IBalanceProxy.Balance memory bal = approvals[i].balance;
+            uint256 amount = uint256(bal.balance);
+            PermitData memory p = permits[i];
+            IERC20Permit(bal.token).permit(
+                msg.sender,
+                address(this),
+                amount,
+                p.deadline,
+                p.v,
+                p.r,
+                p.s
+            );
+            IERC20(bal.token).transferFrom(
+                msg.sender,
+                address(balanceProxy),
+                amount
+            );
+        }
+        return
+            balanceProxy.proxyCall{value: msg.value}(
+                postBalances,
+                approvals,
+                target,
+                data,
+                withdrawals
+            );
+    }
+
+    /// @notice proxyCallDiffs with permits
+    function permitProxyCallDiffs(
+        IBalanceProxy balanceProxy,
+        IBalanceProxy.Balance[] memory diffs,
+        IBalanceProxy.Approval[] memory approvals,
+        PermitData[] memory permits,
+        address target,
+        bytes memory data,
+        IBalanceProxy.Balance[] memory withdrawals
+    ) external payable returns (bytes memory) {
+        uint256 len = approvals.length;
+        if (permits.length != len)
+            revert PermitsLengthMismatch(permits.length, len);
+        for (uint256 i = 0; i < len; i++) {
+            IBalanceProxy.Balance memory bal = approvals[i].balance;
+            uint256 amount = uint256(bal.balance);
+            PermitData memory p = permits[i];
+            IERC20Permit(bal.token).permit(
+                msg.sender,
+                address(this),
+                amount,
+                p.deadline,
+                p.v,
+                p.r,
+                p.s
+            );
+            IERC20(bal.token).transferFrom(
+                msg.sender,
+                address(balanceProxy),
+                amount
+            );
+        }
+        return
+            balanceProxy.proxyCallDiffs{value: msg.value}(
+                diffs,
+                approvals,
+                target,
+                data,
+                withdrawals
+            );
+    }
+
+    /// @notice Execute proxyCall with permits and calldata metadata (metadata is ignored on-chain)
+    function permitProxyCallWithMeta(
+        IBalanceProxy balanceProxy,
+        BalanceMetadata[] memory meta,
+        IBalanceProxy.Balance[] memory balances,
+        IBalanceProxy.Approval[] memory approvals,
+        PermitData[] memory permits,
+        address target,
+        bytes memory data,
+        IBalanceProxy.Balance[] memory withdrawals
+    ) external payable returns (bytes memory) {
+        // Validate metadata against balances
+        _checkMetadata(meta, balances);
+
+        // Process permits
+        uint256 len = approvals.length;
+        if (permits.length != len)
+            revert PermitsLengthMismatch(permits.length, len);
+        for (uint256 i = 0; i < len; i++) {
+            IBalanceProxy.Balance memory bal = approvals[i].balance;
+            uint256 amount = uint256(bal.balance);
+            PermitData memory p = permits[i];
+            IERC20Permit(bal.token).permit(
+                msg.sender,
+                address(this),
+                amount,
+                p.deadline,
+                p.v,
+                p.r,
+                p.s
+            );
+            IERC20(bal.token).transferFrom(
+                msg.sender,
+                address(balanceProxy),
+                amount
+            );
+        }
+
+        // Delegate to BalanceProxy
+        return
+            balanceProxy.proxyCall{value: msg.value}(
+                balances,
+                approvals,
+                target,
+                data,
+                withdrawals
+            );
+    }
+
+    /// @notice proxyCallDiffs with permits and calldata metadata (metadata is ignored on-chain)
+    function permitProxyCallDiffsWithMeta(
+        IBalanceProxy balanceProxy,
+        BalanceMetadata[] memory meta,
+        IBalanceProxy.Balance[] memory diffs,
+        IBalanceProxy.Approval[] memory approvals,
+        PermitData[] memory permits,
+        address target,
+        bytes memory data,
+        IBalanceProxy.Balance[] memory withdrawals
+    ) external payable returns (bytes memory) {
+        // Validate metadata against diffs
+        _checkMetadata(meta, diffs);
+
+        // Process permits
+        uint256 len = approvals.length;
+        if (permits.length != len)
+            revert PermitsLengthMismatch(permits.length, len);
+        for (uint256 i = 0; i < len; i++) {
+            IBalanceProxy.Balance memory bal = approvals[i].balance;
+            uint256 amount = uint256(bal.balance);
+            PermitData memory p = permits[i];
+            IERC20Permit(bal.token).permit(
+                msg.sender,
+                address(this),
+                amount,
+                p.deadline,
+                p.v,
+                p.r,
+                p.s
+            );
+            IERC20(bal.token).transferFrom(
+                msg.sender,
+                address(balanceProxy),
+                amount
+            );
+        }
+
+        // Delegate to BalanceProxy
+        return
+            balanceProxy.proxyCallDiffs{value: msg.value}(
+                diffs,
+                approvals,
+                target,
+                data,
+                withdrawals
+            );
+    }
+}

--- a/assets/erc-8009/SafeRouter.sol
+++ b/assets/erc-8009/SafeRouter.sol
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+import {IBalanceProxy} from "./interfaces/IBalanceProxy.sol";
+import {BalanceMetadata} from "./interfaces/IMetadata.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {ISafe} from "@safe-global/safe-smart-account/contracts/interfaces/ISafe.sol";
+import {Enum} from "@safe-global/safe-smart-account/contracts/libraries/Enum.sol";
+
+contract SafeRouter {
+    bytes32 private _activeSafeExecution;
+
+    struct SafeTx {
+        address to;
+        uint256 value;
+        bytes data;
+        Enum.Operation operation;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address payable refundReceiver;
+        bytes signatures;
+        uint256 routerSigPosition;
+    }
+
+    error NotSafeOwner(address caller, address safe);
+    error RouterNotSafeOwner(address router, address safe);
+    error SafeExecutionFailed(address safe, address target);
+    error UnsupportedSafeOperation(Enum.Operation operation);
+    error UnauthorizedSafeExecution();
+    error InvalidSignaturesLength(uint256 length);
+    error InvalidRouterSignaturePosition(
+        uint256 position,
+        uint256 signatureCount
+    );
+    error InsufficientSafeSignatures(uint256 provided, uint256 threshold);
+    error InvalidSafeThreshold(uint256 threshold);
+    error MetadataBalancesLengthMismatch(
+        uint256 metaLength,
+        uint256 balancesLength
+    );
+    error InvalidMetadata(
+        address token,
+        string expectedSymbol,
+        uint8 expectedDecimals,
+        string actualSymbol,
+        uint8 actualDecimals
+    );
+
+    function safeExecuteWithPostBalances(
+        IBalanceProxy balanceProxy,
+        IBalanceProxy.Balance[] calldata postBalances,
+        ISafe safe,
+        SafeTx calldata safeTx
+    ) external {
+        _verifySafeContext(safe);
+        _validateSafeTx(safe, safeTx);
+        _executeWithBalanceProxy(
+            balanceProxy,
+            safe,
+            postBalances,
+            safeTx,
+            false
+        );
+    }
+
+    function safeExecuteWithDiffs(
+        IBalanceProxy balanceProxy,
+        IBalanceProxy.Balance[] calldata diffs,
+        ISafe safe,
+        SafeTx calldata safeTx
+    ) external {
+        _verifySafeContext(safe);
+        _validateSafeTx(safe, safeTx);
+        _executeWithBalanceProxy(balanceProxy, safe, diffs, safeTx, true);
+    }
+
+    function safeExecuteWithPostBalancesMeta(
+        IBalanceProxy balanceProxy,
+        BalanceMetadata[] calldata meta,
+        IBalanceProxy.Balance[] calldata postBalances,
+        ISafe safe,
+        SafeTx calldata safeTx
+    ) external {
+        _verifySafeContext(safe);
+        _validateSafeTx(safe, safeTx);
+        _checkMetadata(meta, postBalances);
+        _executeWithBalanceProxy(
+            balanceProxy,
+            safe,
+            postBalances,
+            safeTx,
+            false
+        );
+    }
+
+    function safeExecuteWithDiffsMeta(
+        IBalanceProxy balanceProxy,
+        BalanceMetadata[] calldata meta,
+        IBalanceProxy.Balance[] calldata diffs,
+        ISafe safe,
+        SafeTx calldata safeTx
+    ) external {
+        _verifySafeContext(safe);
+        _validateSafeTx(safe, safeTx);
+        _checkMetadata(meta, diffs);
+        _executeWithBalanceProxy(balanceProxy, safe, diffs, safeTx, true);
+    }
+
+    function executeSafeTransaction(
+        ISafe safe,
+        SafeTx calldata safeTx
+    ) external {
+        bytes memory data = abi.encodeCall(
+            this.executeSafeTransaction,
+            (safe, safeTx)
+        );
+        if (_activeSafeExecution != _safeExecutionHash(msg.sender, data)) {
+            revert UnauthorizedSafeExecution();
+        }
+        _execOriginalTx(safe, safeTx);
+    }
+
+    function _verifySafeContext(ISafe safe) internal view {
+        if (!safe.isOwner(msg.sender))
+            revert NotSafeOwner(msg.sender, address(safe));
+        if (!safe.isOwner(address(this))) {
+            revert RouterNotSafeOwner(address(this), address(safe));
+        }
+    }
+
+    function _execOriginalTx(ISafe safe, SafeTx calldata safeTx) internal {
+        bytes memory signatures = _buildSignatures(
+            safeTx.signatures,
+            safeTx.routerSigPosition,
+            safe.getThreshold() - 1
+        );
+
+        bool success = safe.execTransaction(
+            safeTx.to,
+            safeTx.value,
+            safeTx.data,
+            safeTx.operation,
+            safeTx.safeTxGas,
+            safeTx.baseGas,
+            safeTx.gasPrice,
+            safeTx.gasToken,
+            safeTx.refundReceiver,
+            signatures
+        );
+        if (!success) revert SafeExecutionFailed(address(safe), safeTx.to);
+    }
+
+    function _validateSafeTx(ISafe safe, SafeTx calldata safeTx) internal view {
+        if (safeTx.operation != Enum.Operation.Call) {
+            revert UnsupportedSafeOperation(safeTx.operation);
+        }
+
+        uint256 threshold = safe.getThreshold();
+        if (threshold < 2) {
+            revert InvalidSafeThreshold(threshold);
+        }
+
+        if (safeTx.signatures.length % 65 != 0) {
+            revert InvalidSignaturesLength(safeTx.signatures.length);
+        }
+
+        uint256 requiredHumanSignatures = threshold - 1;
+        uint256 provided = safeTx.signatures.length / 65;
+        if (safeTx.routerSigPosition > requiredHumanSignatures) {
+            revert InvalidRouterSignaturePosition(
+                safeTx.routerSigPosition,
+                provided
+            );
+        }
+        if (provided < requiredHumanSignatures) {
+            revert InsufficientSafeSignatures(
+                provided,
+                requiredHumanSignatures
+            );
+        }
+    }
+
+    function _executeWithBalanceProxy(
+        IBalanceProxy balanceProxy,
+        ISafe safe,
+        IBalanceProxy.Balance[] calldata balances,
+        SafeTx calldata safeTx,
+        bool useDiffs
+    ) internal {
+        bytes memory data = abi.encodeCall(
+            this.executeSafeTransaction,
+            (safe, safeTx)
+        );
+        _activeSafeExecution = _safeExecutionHash(address(balanceProxy), data);
+        if (useDiffs) {
+            balanceProxy.proxyCallDiffs(
+                balances,
+                new IBalanceProxy.Approval[](0),
+                address(this),
+                data,
+                new IBalanceProxy.Balance[](0)
+            );
+        } else {
+            balanceProxy.proxyCall(
+                balances,
+                new IBalanceProxy.Approval[](0),
+                address(this),
+                data,
+                new IBalanceProxy.Balance[](0)
+            );
+        }
+        _activeSafeExecution = bytes32(0);
+    }
+
+    function _safeExecutionHash(
+        address caller,
+        bytes memory data
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(caller, data));
+    }
+
+    function _checkMetadata(
+        BalanceMetadata[] calldata meta,
+        IBalanceProxy.Balance[] calldata balances
+    ) internal view {
+        if (meta.length != balances.length) {
+            revert MetadataBalancesLengthMismatch(meta.length, balances.length);
+        }
+        for (uint256 i = 0; i < meta.length; i++) {
+            string memory actualSymbol;
+            uint8 actualDecimals;
+            if (balances[i].token == address(0)) {
+                actualSymbol = "ETH";
+                actualDecimals = 18;
+            } else {
+                actualSymbol = IERC20Metadata(balances[i].token).symbol();
+                actualDecimals = IERC20Metadata(balances[i].token).decimals();
+            }
+            if (
+                keccak256(abi.encodePacked(actualSymbol)) !=
+                keccak256(abi.encodePacked(meta[i].symbol)) ||
+                actualDecimals != meta[i].decimals
+            ) {
+                revert InvalidMetadata(
+                    balances[i].token,
+                    meta[i].symbol,
+                    meta[i].decimals,
+                    actualSymbol,
+                    actualDecimals
+                );
+            }
+        }
+    }
+
+    function _buildSignatures(
+        bytes calldata existingSigs,
+        uint256 routerSigPosition,
+        uint256 requiredHumanSignatures
+    ) internal view returns (bytes memory) {
+        bytes memory routerSig = abi.encodePacked(
+            bytes32(uint256(uint160(address(this)))),
+            bytes32(0),
+            uint8(1)
+        );
+
+        uint256 humanSignaturesLength = requiredHumanSignatures * 65;
+        return
+            abi.encodePacked(
+                existingSigs[:routerSigPosition * 65],
+                routerSig,
+                existingSigs[routerSigPosition * 65:humanSignaturesLength]
+            );
+    }
+}

--- a/assets/erc-8009/interfaces/IBalanceProxy.sol
+++ b/assets/erc-8009/interfaces/IBalanceProxy.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+/// @title IBalanceProxy
+/// @notice Minimal interface for the BalanceProxy core contract
+/// @dev Core is source-agnostic: it never pulls tokens, only uses its own balances
+interface IBalanceProxy {
+    /// @notice Struct to represent balance or value of specific token by target address
+    /// @param target Target address
+    /// @param token Token address (address(0) for ETH)
+    /// @param balance Expected absolute balance (post) or diff (signed)
+    struct Balance {
+        address target;
+        address token;
+        int256 balance;
+    }
+
+    /// @notice Approval instruction: either transfer tokens to target or approve target to spend
+    struct Approval {
+        Balance balance; // token, target, amount(>=0 expected)
+        bool useTransfer; // true: transfer to target; false: approve target
+    }
+
+    /// @notice Error when actual diff != expected
+    error ERC8009BalanceDiffConstraintViolation(
+        address token,
+        address target,
+        int256 expected,
+        int256 actual
+    );
+
+    /// @notice Error thrown when a balance is insufficient
+    error ERC8009BalanceConstraintViolation(
+        address token,
+        address target,
+        int256 balance,
+        uint256 actual
+    );
+
+    /// @notice Error thrown when a call fails
+    error ERC8009CallFailed(address target, bytes data, bytes returnData);
+
+    /// @notice Proxy call to a target contract with specified post-balance checks
+    function proxyCall(
+        Balance[] memory postBalances,
+        Approval[] memory approvals,
+        address target,
+        bytes memory data,
+        Balance[] memory withdrawals
+    ) external payable returns (bytes memory);
+
+    /// @notice Proxy call with balance diffs
+    function proxyCallDiffs(
+        Balance[] memory diffs,
+        Approval[] memory approvals,
+        address target,
+        bytes memory data,
+        Balance[] memory withdrawals
+    ) external payable returns (bytes memory);
+}

--- a/assets/erc-8009/interfaces/IMetadata.sol
+++ b/assets/erc-8009/interfaces/IMetadata.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+/// @title BalanceMetadata struct used for UI-friendly calldata
+/// @notice Passed as a first argument to router functions for easier off-chain decoding; ignored by contracts logic
+struct BalanceMetadata {
+    string symbol;
+    uint8 decimals;
+}

--- a/assets/erc-8009/interfaces/IPermit.sol
+++ b/assets/erc-8009/interfaces/IPermit.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+/*
+ * solhint: disable mixedCase function name rule for standard constants
+ * Some ERC standards expose functions/variables in SCREAMING_SNAKE_CASE
+ * (for example DOMAIN_SEPARATOR). We intentionally keep the standard
+ * names to match token implementations, so disable the rule for this file.
+ */
+/* solhint-disable func-name-mixedcase */
+
+/**
+ * @title IERC20Permit
+ * @dev Interface for the ERC20 Permit standard (EIP-2612).
+ */
+interface IERC20Permit {
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function nonces(address owner) external view returns (uint256);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}
+
+/**
+ * @title IDaiPermit
+ * @dev Interface for the DAI-style permit.
+ */
+interface IDaiPermit {
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 expiry,
+        bool allowed,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+}
+
+/**
+ * @notice Struct to hold permit data for EIP-2612 tokens.
+ * @param deadline The time at which the signature expires.
+ * @param v The recovery id of the signature.
+ * @param r The r-value of the signature.
+ * @param s The s-value of the signature.
+ */
+struct PermitData {
+    uint256 deadline;
+    uint8 v;
+    bytes32 r;
+    bytes32 s;
+}
+
+/**
+ * @notice Struct to hold permit data for DAI-style tokens.
+ * @param nonce The nonce of the permit.
+ * @param expiry The time at which the signature expires.
+ * @param allowed Whether the spender is allowed to spend the tokens.
+ * @param v The recovery id of the signature.
+ * @param r The r-value of the signature.
+ * @param s The s-value of the signature.
+ */
+struct DaiPermitData {
+    uint256 nonce;
+    uint256 expiry;
+    bool allowed;
+    uint8 v;
+    bytes32 r;
+    bytes32 s;
+}

--- a/assets/erc-8009/test/BalanceProxy.test.ts
+++ b/assets/erc-8009/test/BalanceProxy.test.ts
@@ -1,0 +1,1149 @@
+import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpers';
+import { expect } from 'chai';
+import { viem, ignition } from 'hardhat';
+import { encodeFunctionData, erc20Abi, parseEther } from 'viem';
+
+import BalanceProxyModule from '@/ignition/modules/balance-proxy';
+
+// TargetMock ABI subset used for encoding
+const targetAbi = [
+  {
+    inputs: [{ internalType: 'address', name: '_erc20', type: 'address' }],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'take', type: 'uint256' },
+      { internalType: 'uint256', name: 'give', type: 'uint256' },
+    ],
+    name: 'mint',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'take', type: 'uint256' },
+      { internalType: 'uint256', name: 'give', type: 'uint256' },
+    ],
+    name: 'mintEth',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+] as const;
+
+// ReenterTargetMock ABI subset
+const reenterAbi = [
+  {
+    inputs: [],
+    name: 'attack',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
+function encodeMint(take: bigint, give: bigint) {
+  return encodeFunctionData({
+    abi: targetAbi,
+    functionName: 'mint',
+    args: [take, give],
+  });
+}
+
+function encodeMintEth(take: bigint, give: bigint) {
+  return encodeFunctionData({
+    abi: targetAbi,
+    functionName: 'mintEth',
+    args: [take, give],
+  });
+}
+
+async function deployFixture() {
+  const [owner, user, other] = await viem.getWalletClients();
+  const { balanceProxy } = await ignition.deploy(BalanceProxyModule, {
+    defaultSender: owner.account.address,
+  });
+  const token = await viem.deployContract('ERC20Mock', ['MockToken', 'MTK'], {
+    client: { wallet: owner },
+  });
+  const target = await viem.deployContract('TargetMock', [token.address], {
+    client: { wallet: owner },
+  });
+  const approveRouter = await viem.deployContract('ApproveRouter', [], {
+    client: { wallet: owner },
+  });
+  const permitRouter = await viem.deployContract('PermitRouter', [], {
+    client: { wallet: owner },
+  });
+  const publicClient = await viem.getPublicClient();
+  return {
+    owner,
+    user,
+    other,
+    balanceProxy,
+    token,
+    target,
+    approveRouter,
+    permitRouter,
+    publicClient,
+  };
+}
+
+describe('BalanceProxy + Routers (updated API)', function () {
+  this.timeout(120000);
+  it('deploys core & routers', async () => {
+    const { balanceProxy, approveRouter, permitRouter } =
+      await loadFixture(deployFixture);
+    expect(balanceProxy.address).to.be.a('string');
+    expect(approveRouter.address).to.be.a('string');
+    expect(permitRouter.address).to.be.a('string');
+  });
+
+  it('reverts InsufficientBalance when postBalance (ETH) expects more than actual', async () => {
+    const { owner, user, token, target, balanceProxy, approveRouter } =
+      await loadFixture(deployFixture);
+    const TAKE = parseEther('5');
+    const GIVE_ETH = parseEther('2');
+    await token.write.mint([user.account.address, TAKE]);
+    await owner.sendTransaction({ to: target.address, value: GIVE_ETH });
+    await token.write.approve([approveRouter.address, TAKE], {
+      account: user.account,
+    });
+    await expect(
+      approveRouter.write.approveProxyCall(
+        [
+          balanceProxy.address,
+          [
+            {
+              target: balanceProxy.address,
+              token: '0x0000000000000000000000000000000000000000',
+              balance: GIVE_ETH + 1n,
+            },
+          ],
+          [
+            {
+              balance: {
+                target: target.address,
+                token: token.address,
+                balance: TAKE,
+              },
+              useTransfer: false,
+            },
+          ],
+          target.address,
+          encodeMintEth(TAKE, GIVE_ETH),
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejected;
+  });
+
+  it('withdraws ETH and checks postBalance for ETH', async () => {
+    const { owner, user, other, token, target, balanceProxy, approveRouter } =
+      await loadFixture(deployFixture);
+    const TAKE = parseEther('10');
+    const GIVE_ETH = parseEther('3');
+    await token.write.mint([user.account.address, TAKE]);
+    // fund target so it can pay ETH to proxy
+    await owner.sendTransaction({ to: target.address, value: GIVE_ETH });
+    await token.write.approve([approveRouter.address, TAKE], {
+      account: user.account,
+    });
+    await approveRouter.write.approveProxyCall(
+      [
+        balanceProxy.address,
+        [
+          {
+            target: balanceProxy.address,
+            token: '0x0000000000000000000000000000000000000000',
+            balance: 0n,
+          },
+        ],
+        [
+          {
+            balance: {
+              target: target.address,
+              token: token.address,
+              balance: TAKE,
+            },
+            useTransfer: false,
+          },
+        ],
+        target.address,
+        encodeMintEth(TAKE, GIVE_ETH),
+        [
+          {
+            target: other.account.address,
+            token: '0x0000000000000000000000000000000000000000',
+            balance: GIVE_ETH,
+          },
+        ],
+      ],
+      { account: user.account },
+    );
+    const pc = await viem.getPublicClient();
+    const proxyEth = await pc.getBalance({ address: balanceProxy.address });
+    expect(proxyEth).to.equal(0n);
+  });
+});
+
+describe('PermitRouter.permitProxyCall', () => {
+  // Narrow interfaces to avoid using `any`
+  type PermitToken = {
+    address: `0x${string}`;
+    read: {
+      name: () => Promise<string>;
+      nonces: (args: [`0x${string}`]) => Promise<bigint>;
+    };
+  };
+  type TestWallet = {
+    account: { address: `0x${string}` };
+    getChainId: () => Promise<number>;
+    signTypedData: (args: {
+      domain: {
+        name: string;
+        version: string;
+        chainId: number;
+        verifyingContract: `0x${string}`;
+      };
+      types: {
+        Permit: Array<{ name: string; type: string }>;
+      };
+      primaryType: 'Permit';
+      message: {
+        owner: `0x${string}`;
+        spender: `0x${string}`;
+        value: bigint;
+        nonce: bigint;
+        deadline: bigint;
+      };
+    }) => Promise<`0x${string}`>; // viem wallet client signature helper
+  };
+  async function buildPermit(
+    user: TestWallet,
+    token: PermitToken,
+    spender: `0x${string}`,
+    value: bigint,
+  ) {
+    const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
+    const nonce = await token.read.nonces([user.account.address]);
+    const domain = {
+      name: await token.read.name(),
+      version: '1',
+      chainId: await user.getChainId(),
+      verifyingContract: token.address,
+    };
+    const types = {
+      Permit: [
+        { name: 'owner', type: 'address' },
+        { name: 'spender', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'deadline', type: 'uint256' },
+      ],
+    };
+    const message = {
+      owner: user.account.address,
+      spender,
+      value,
+      nonce,
+      deadline,
+    };
+    const signature = await user.signTypedData({
+      domain,
+      types,
+      primaryType: 'Permit',
+      message,
+    });
+    const r = `0x${signature.slice(2, 66)}` as `0x${string}`;
+    const s = `0x${signature.slice(66, 130)}` as `0x${string}`;
+    const v = parseInt(signature.slice(130, 132), 16);
+    return { deadline, v, r, s };
+  }
+
+  it('approve mode with permit pulls tokens & sets allowance', async () => {
+    const { user, token, target, balanceProxy, permitRouter } =
+      await loadFixture(deployFixture);
+    const AMOUNT = parseEther('25');
+    await token.write.mint([user.account.address, AMOUNT]);
+    const permit = await buildPermit(user, token, permitRouter.address, AMOUNT);
+    await permitRouter.write.permitProxyCall(
+      [
+        balanceProxy.address,
+        [],
+        [
+          {
+            balance: {
+              target: target.address,
+              token: token.address,
+              balance: AMOUNT,
+            },
+            useTransfer: false,
+          },
+        ],
+        [permit],
+        target.address,
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+    const proxyBal = await token.read.balanceOf([balanceProxy.address]);
+    expect(proxyBal).to.equal(AMOUNT);
+    const allowance = await token.read.allowance([
+      balanceProxy.address,
+      target.address,
+    ]);
+    expect(allowance).to.equal(AMOUNT);
+  });
+
+  it('transfer mode with permit moves tokens to target', async () => {
+    const { user, token, target, balanceProxy, permitRouter } =
+      await loadFixture(deployFixture);
+    const AMOUNT = parseEther('40');
+    await token.write.mint([user.account.address, AMOUNT]);
+    const permit = await buildPermit(user, token, permitRouter.address, AMOUNT);
+    await permitRouter.write.permitProxyCall(
+      [
+        balanceProxy.address,
+        [],
+        [
+          {
+            balance: {
+              target: target.address,
+              token: token.address,
+              balance: AMOUNT,
+            },
+            useTransfer: true,
+          },
+        ],
+        [permit],
+        target.address,
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+    const targetBal = await token.read.balanceOf([target.address]);
+    expect(targetBal).to.equal(AMOUNT);
+  });
+});
+
+describe('Error: CallFailed', () => {
+  it('reverts when calling non-existent function on target', async () => {
+    const { user, token, target, balanceProxy, approveRouter } =
+      await loadFixture(deployFixture);
+    const AMOUNT = parseEther('5');
+    await token.write.mint([user.account.address, AMOUNT]);
+    await token.write.approve([approveRouter.address, AMOUNT], {
+      account: user.account,
+    });
+    // encode ERC20 transfer (target does not implement) => should revert
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: 'transfer',
+      args: [target.address, AMOUNT],
+    });
+    await expect(
+      approveRouter.write.approveProxyCall(
+        [
+          balanceProxy.address,
+          [],
+          [
+            {
+              balance: {
+                target: target.address,
+                token: token.address,
+                balance: AMOUNT,
+              },
+              useTransfer: false,
+            },
+          ],
+          target.address,
+          data,
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejectedWith('CallFailed');
+  });
+
+  it('reverts when calling non-existent function on target via proxyCallDiffs', async () => {
+    const { user, target, balanceProxy, approveRouter } =
+      await loadFixture(deployFixture);
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: 'transfer',
+      args: [target.address, 1n],
+    });
+    await expect(
+      approveRouter.write.approveProxyCallDiffs(
+        [
+          balanceProxy.address,
+          [], // diffs
+          [], // approvals
+          target.address,
+          data,
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejectedWith('CallFailed');
+  });
+});
+
+describe('proxyCallDiffs via ApproveRouter', () => {
+  it('checks expected diffs (positive balance increase)', async () => {
+    const { user, token, target, balanceProxy, approveRouter } =
+      await loadFixture(deployFixture);
+    const TAKE = parseEther('10');
+    const GIVE = parseEther('15');
+    await token.write.mint([user.account.address, TAKE]);
+    await token.write.approve([approveRouter.address, TAKE], {
+      account: user.account,
+    });
+    // Expect proxy balance diff >= GIVE (after mint it receives GIVE tokens)
+    await approveRouter.write.approveProxyCallDiffs(
+      [
+        balanceProxy.address,
+        [
+          {
+            target: balanceProxy.address,
+            token: token.address,
+            balance: GIVE - TAKE, // net balance increase expected (GIVE - TAKE)
+          },
+        ],
+        [
+          {
+            balance: {
+              target: target.address,
+              token: token.address,
+              balance: TAKE,
+            },
+            useTransfer: false,
+          },
+        ],
+        target.address,
+        encodeMint(TAKE, GIVE),
+        [],
+      ],
+      { account: user.account },
+    );
+    const bal = await token.read.balanceOf([balanceProxy.address]);
+    expect(bal).to.equal(GIVE); // TAKE was spent, GIVE minted
+  });
+
+  it('handles ETH diff zero success path', async () => {
+    const { user, other, balanceProxy, approveRouter } =
+      await loadFixture(deployFixture);
+    // Target an EOA with empty data so the low-level call succeeds; no state change => diff 0
+    await approveRouter.write.approveProxyCallDiffs(
+      [
+        balanceProxy.address,
+        [
+          {
+            target: balanceProxy.address,
+            token: '0x0000000000000000000000000000000000000000',
+            balance: 0n,
+          },
+        ],
+        [],
+        other.account.address,
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+  });
+});
+
+describe('ApproveRouter WithMeta', () => {
+  it('approveProxyCallWithMeta: pulls tokens and sets allowance (meta ignored)', async () => {
+    const { user, token, target, balanceProxy, approveRouter } =
+      await loadFixture(deployFixture);
+    const AMOUNT = parseEther('33');
+    await token.write.mint([user.account.address, AMOUNT]);
+    await token.write.approve([approveRouter.address, AMOUNT], {
+      account: user.account,
+    });
+
+    const meta = [
+      {
+        symbol: 'MTK',
+        decimals: 18,
+      },
+    ];
+
+    const balances = [
+      {
+        target: balanceProxy.address,
+        token: token.address,
+        balance: AMOUNT,
+      },
+    ];
+
+    await approveRouter.write.approveProxyCallWithMeta(
+      [
+        balanceProxy.address,
+        meta,
+        balances,
+        [
+          {
+            balance: {
+              target: target.address,
+              token: token.address,
+              balance: AMOUNT,
+            },
+            useTransfer: false,
+          },
+        ],
+        target.address,
+        encodeMint(0n, 0n),
+        [],
+      ],
+      { account: user.account },
+    );
+
+    const proxyBal = await token.read.balanceOf([balanceProxy.address]);
+    expect(proxyBal).to.equal(AMOUNT);
+    const allowance = await token.read.allowance([
+      balanceProxy.address,
+      target.address,
+    ]);
+    expect(allowance).to.equal(AMOUNT);
+  });
+
+  it('approveProxyCallDiffsWithMeta: transfer mode sends tokens to EOA target', async () => {
+    const { user, token, other, balanceProxy, approveRouter } =
+      await loadFixture(deployFixture);
+    const AMOUNT = parseEther('21');
+    await token.write.mint([user.account.address, AMOUNT]);
+    await token.write.approve([approveRouter.address, AMOUNT], {
+      account: user.account,
+    });
+
+    const meta = [
+      {
+        symbol: 'MTK',
+        decimals: 18,
+      },
+    ];
+
+    const diffs = [
+      {
+        target: other.account.address,
+        token: token.address,
+        balance: AMOUNT,
+      },
+    ];
+
+    await approveRouter.write.approveProxyCallDiffsWithMeta(
+      [
+        balanceProxy.address,
+        meta,
+        diffs,
+        [
+          {
+            balance: {
+              target: other.account.address,
+              token: token.address,
+              balance: AMOUNT,
+            },
+            useTransfer: true,
+          },
+        ],
+        other.account.address, // EOA target, empty data succeeds
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+
+    const targetBal = await token.read.balanceOf([other.account.address]);
+    expect(targetBal).to.equal(AMOUNT);
+  });
+});
+
+describe('withdrawals loop executes (direct proxyCall)', () => {
+  it('sends ETH via withdrawals and reduces proxy balance', async () => {
+    const { owner, user, other, balanceProxy } =
+      await loadFixture(deployFixture);
+    // fund proxy with 5 wei
+    await owner.sendTransaction({ to: balanceProxy.address, value: 5n });
+    // withdraw 3 wei to `other`
+    await balanceProxy.write.proxyCall(
+      [
+        [],
+        [],
+        other.account.address,
+        '0x',
+        [
+          {
+            target: other.account.address,
+            token: '0x0000000000000000000000000000000000000000',
+            balance: 3n,
+          },
+        ],
+      ],
+      { account: user.account },
+    );
+    const pc = await viem.getPublicClient();
+    const proxyEth = await pc.getBalance({ address: balanceProxy.address });
+    expect(proxyEth).to.equal(2n);
+  });
+
+  it('sends ERC20 via withdrawals from proxy balance', async () => {
+    const { owner, user, token, other, balanceProxy } =
+      await loadFixture(deployFixture);
+    const AMT = parseEther('10');
+    const OUT = parseEther('4');
+    await token.write.mint([balanceProxy.address, AMT], {
+      account: owner.account,
+    });
+    await balanceProxy.write.proxyCall(
+      [
+        [],
+        [],
+        other.account.address,
+        '0x',
+        [
+          {
+            target: user.account.address,
+            token: token.address,
+            balance: OUT,
+          },
+        ],
+      ],
+      { account: user.account },
+    );
+    const proxyBal = await token.read.balanceOf([balanceProxy.address]);
+    const userBal = await token.read.balanceOf([user.account.address]);
+    expect(proxyBal).to.equal(AMT - OUT);
+    expect(userBal).to.equal(OUT);
+  });
+});
+
+describe('withdrawals loop executes (proxyCallDiffs path)', () => {
+  it('sends ETH via withdrawals inside proxyCallDiffs', async () => {
+    const { owner, user, other, balanceProxy } =
+      await loadFixture(deployFixture);
+    const pc = await viem.getPublicClient();
+    // fund proxy with 5 wei
+    await owner.sendTransaction({ to: balanceProxy.address, value: 5n });
+    const beforeProxy = await pc.getBalance({
+      address: balanceProxy.address,
+    });
+    const beforeOther = await pc.getBalance({
+      address: other.account.address,
+    });
+
+    await balanceProxy.write.proxyCallDiffs(
+      [
+        [], // diffs
+        [], // approvals
+        other.account.address, // target: EOA call succeeds
+        '0x',
+        [
+          {
+            target: other.account.address,
+            token: '0x0000000000000000000000000000000000000000',
+            balance: 3n,
+          },
+        ],
+      ],
+      { account: user.account },
+    );
+
+    const afterProxy = await pc.getBalance({
+      address: balanceProxy.address,
+    });
+    const afterOther = await pc.getBalance({
+      address: other.account.address,
+    });
+    expect(beforeProxy - afterProxy).to.equal(3n);
+    expect(afterOther - beforeOther).to.equal(3n);
+  });
+});
+
+describe('PermitRouter WithMeta', () => {
+  // Local helper duplicating buildPermit to keep scope self-contained
+  type PermitToken = {
+    address: `0x${string}`;
+    read: {
+      name: () => Promise<string>;
+      nonces: (args: [`0x${string}`]) => Promise<bigint>;
+    };
+  };
+  type TestWallet = {
+    account: { address: `0x${string}` };
+    getChainId: () => Promise<number>;
+    signTypedData: (args: {
+      domain: {
+        name: string;
+        version: string;
+        chainId: number;
+        verifyingContract: `0x${string}`;
+      };
+      types: {
+        Permit: Array<{ name: string; type: string }>;
+      };
+      primaryType: 'Permit';
+      message: {
+        owner: `0x${string}`;
+        spender: `0x${string}`;
+        value: bigint;
+        nonce: bigint;
+        deadline: bigint;
+      };
+    }) => Promise<`0x${string}`>;
+  };
+  async function buildPermit(
+    user: TestWallet,
+    token: PermitToken,
+    spender: `0x${string}`,
+    value: bigint,
+  ) {
+    const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
+    const nonce = await token.read.nonces([user.account.address]);
+    const domain = {
+      name: await token.read.name(),
+      version: '1',
+      chainId: await user.getChainId(),
+      verifyingContract: token.address,
+    };
+    const types = {
+      Permit: [
+        { name: 'owner', type: 'address' },
+        { name: 'spender', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'deadline', type: 'uint256' },
+      ],
+    };
+    const message = {
+      owner: user.account.address,
+      spender,
+      value,
+      nonce,
+      deadline,
+    };
+    const signature = await user.signTypedData({
+      domain,
+      types,
+      primaryType: 'Permit',
+      message,
+    });
+    const r = `0x${signature.slice(2, 66)}` as `0x${string}`;
+    const s = `0x${signature.slice(66, 130)}` as `0x${string}`;
+    const v = parseInt(signature.slice(130, 132), 16);
+    return { deadline, v, r, s };
+  }
+
+  it('permitProxyCallWithMeta: pulls tokens and sets allowance (meta ignored)', async () => {
+    const { user, token, target, balanceProxy, permitRouter } =
+      await loadFixture(deployFixture);
+    const AMOUNT = parseEther('19');
+    await token.write.mint([user.account.address, AMOUNT]);
+    const permit = await buildPermit(
+      user as unknown as TestWallet,
+      token as unknown as PermitToken,
+      permitRouter.address,
+      AMOUNT,
+    );
+
+    const meta = [
+      {
+        symbol: 'MTK',
+        decimals: 18,
+      },
+    ];
+
+    const balances = [
+      {
+        target: balanceProxy.address,
+        token: token.address,
+        balance: AMOUNT,
+      },
+    ];
+
+    await permitRouter.write.permitProxyCallWithMeta(
+      [
+        balanceProxy.address,
+        meta,
+        balances,
+        [
+          {
+            balance: {
+              target: target.address,
+              token: token.address,
+              balance: AMOUNT,
+            },
+            useTransfer: false,
+          },
+        ],
+        [permit],
+        target.address,
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+
+    const proxyBal = await token.read.balanceOf([balanceProxy.address]);
+    expect(proxyBal).to.equal(AMOUNT);
+    const allowance = await token.read.allowance([
+      balanceProxy.address,
+      target.address,
+    ]);
+    expect(allowance).to.equal(AMOUNT);
+  });
+
+  it('permitProxyCallDiffsWithMeta: transfer mode sends tokens to EOA target', async () => {
+    const { user, token, other, balanceProxy, permitRouter } =
+      await loadFixture(deployFixture);
+    const AMOUNT = parseEther('13');
+    await token.write.mint([user.account.address, AMOUNT]);
+    const permit = await buildPermit(
+      user as unknown as TestWallet,
+      token as unknown as PermitToken,
+      permitRouter.address,
+      AMOUNT,
+    );
+
+    const meta = [
+      {
+        symbol: 'MTK',
+        decimals: 18,
+      },
+    ];
+
+    const diffs = [
+      {
+        target: other.account.address,
+        token: token.address,
+        balance: AMOUNT,
+      },
+    ];
+
+    await permitRouter.write.permitProxyCallDiffsWithMeta(
+      [
+        balanceProxy.address,
+        meta,
+        diffs,
+        [
+          {
+            balance: {
+              target: other.account.address,
+              token: token.address,
+              balance: AMOUNT,
+            },
+            useTransfer: true,
+          },
+        ],
+        [permit],
+        other.account.address,
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+
+    const targetBal = await token.read.balanceOf([other.account.address]);
+    expect(targetBal).to.equal(AMOUNT);
+  });
+
+  it('permitProxyCallWithMeta: reverts on PermitsLengthMismatch', async () => {
+    const { user, token, target, balanceProxy, permitRouter } =
+      await loadFixture(deployFixture);
+    const AMOUNT = parseEther('7');
+    await token.write.mint([user.account.address, AMOUNT]);
+
+    const meta = [
+      {
+        symbol: 'MTK',
+        decimals: 18,
+      },
+    ];
+
+    const balances = [
+      {
+        target: balanceProxy.address,
+        token: token.address,
+        balance: AMOUNT,
+      },
+    ];
+
+    await expect(
+      permitRouter.write.permitProxyCallWithMeta(
+        [
+          balanceProxy.address,
+          meta,
+          balances,
+          [
+            {
+              balance: {
+                target: target.address,
+                token: token.address,
+                balance: AMOUNT,
+              },
+              useTransfer: false,
+            },
+          ],
+          [], // permits empty => mismatch
+          target.address,
+          '0x',
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejectedWith('PermitsLengthMismatch');
+  });
+
+  it('permitProxyCallDiffsWithMeta: reverts on PermitsLengthMismatch', async () => {
+    const { user, token, other, balanceProxy, permitRouter } =
+      await loadFixture(deployFixture);
+    const AMOUNT = parseEther('5');
+    await token.write.mint([user.account.address, AMOUNT]);
+
+    const meta = [
+      {
+        symbol: 'MTK',
+        decimals: 18,
+      },
+    ];
+
+    const diffs = [
+      {
+        target: other.account.address,
+        token: token.address,
+        balance: AMOUNT,
+      },
+    ];
+
+    await expect(
+      permitRouter.write.permitProxyCallDiffsWithMeta(
+        [
+          balanceProxy.address,
+          meta,
+          diffs,
+          [
+            {
+              balance: {
+                target: other.account.address,
+                token: token.address,
+                balance: AMOUNT,
+              },
+              useTransfer: true,
+            },
+          ],
+          [], // permits empty => mismatch
+          other.account.address,
+          '0x',
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejectedWith('PermitsLengthMismatch');
+  });
+});
+
+describe('internal _balanceCheckCalldata via tester', () => {
+  it('covers ETH path (sufficient balance: no revert)', async () => {
+    const { owner, user } = await loadFixture(deployFixture);
+    // deploy tester
+    const tester = await viem.deployContract('BalanceProxyTester', [], {
+      client: { wallet: owner },
+    });
+    // fund user with a bit of ETH
+    await owner.sendTransaction({ to: user.account.address, value: 10n });
+    // call with token=address(0), target=user, expected <= actual
+    await tester.read.exposeBalanceCheckCalldata([
+      {
+        target: user.account.address,
+        token: '0x0000000000000000000000000000000000000000',
+        balance: 1n,
+      },
+    ]);
+  });
+
+  it('covers ETH path (insufficient balance: revert)', async () => {
+    const { owner } = await loadFixture(deployFixture);
+    const tester = await viem.deployContract('BalanceProxyTester', [], {
+      client: { wallet: owner },
+    });
+    // tester has 0 ETH; expect revert when requiring > 0
+    await expect(
+      tester.read.exposeBalanceCheckCalldata([
+        {
+          target: tester.address,
+          token: '0x0000000000000000000000000000000000000000',
+          balance: 1n,
+        },
+      ]),
+    ).to.be.rejected;
+  });
+
+  it('covers ERC20 path (insufficient balance: revert)', async () => {
+    const { owner, user, token } = await loadFixture(deployFixture);
+    const tester = await viem.deployContract('BalanceProxyTester', [], {
+      client: { wallet: owner },
+    });
+    await expect(
+      tester.read.exposeBalanceCheckCalldata([
+        {
+          target: user.account.address,
+          token: token.address,
+          balance: 1n, // user has 0 tokens
+        },
+      ]),
+    ).to.be.rejected;
+  });
+
+  it('covers ERC20 path (sufficient balance: no revert)', async () => {
+    const { owner, user, token } = await loadFixture(deployFixture);
+    const tester = await viem.deployContract('BalanceProxyTester', [], {
+      client: { wallet: owner },
+    });
+    // mint token to user so balance >= expected
+    await token.write.mint([user.account.address, 5n]);
+    await tester.read.exposeBalanceCheckCalldata([
+      {
+        target: user.account.address,
+        token: token.address,
+        balance: 1n,
+      },
+    ]);
+  });
+});
+
+describe('BalanceProxy core error paths', () => {
+  it('reverts on NegativeApprovalAmount via direct proxyCall', async () => {
+    const { user, balanceProxy, target } = await loadFixture(deployFixture);
+    await expect(
+      balanceProxy.write.proxyCall(
+        [
+          [],
+          [
+            {
+              balance: {
+                target: target.address,
+                token: '0x0000000000000000000000000000000000000000',
+                balance: -1n,
+              },
+              useTransfer: false,
+            },
+          ],
+          target.address,
+          '0x',
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejected;
+  });
+
+  it('reverts UnexpectedBalanceDiff when expected diff not met', async () => {
+    const { user, balanceProxy, target } = await loadFixture(deployFixture);
+    await expect(
+      balanceProxy.write.proxyCallDiffs(
+        [
+          [
+            {
+              target: balanceProxy.address,
+              token: '0x0000000000000000000000000000000000000000',
+              balance: 1n,
+            },
+          ],
+          [],
+          target.address,
+          '0x',
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejected;
+  });
+
+  it('reverts when ETH withdrawal cannot be paid (negative withdrawal from empty proxy)', async () => {
+    const { user, other, balanceProxy } = await loadFixture(deployFixture);
+    // Call succeeds (EOA target), then withdrawal tries to send 1 wei from proxy (has 0) => revert
+    await expect(
+      balanceProxy.write.proxyCall(
+        [
+          [],
+          [],
+          other.account.address,
+          '0x',
+          [
+            {
+              target: user.account.address,
+              token: '0x0000000000000000000000000000000000000000',
+              balance: -1n,
+            },
+          ],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejected;
+  });
+
+  it('reverts on reentrancy (nonReentrant guard)', async () => {
+    const { owner, user, balanceProxy } = await loadFixture(deployFixture);
+    const reenter = await viem.deployContract(
+      'ReenterTargetMock',
+      [balanceProxy.address],
+      {
+        client: { wallet: owner },
+      },
+    );
+    const attackData = encodeFunctionData({
+      abi: reenterAbi,
+      functionName: 'attack',
+      args: [],
+    });
+    await expect(
+      balanceProxy.write.proxyCall(
+        [
+          [], // postBalances
+          [], // approvals
+          reenter.address,
+          attackData,
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejectedWith('CallFailed');
+  });
+
+  it('reverts on reentrancy in proxyCallDiffs (nonReentrant guard)', async () => {
+    const { owner, user, balanceProxy } = await loadFixture(deployFixture);
+    const reenter = await viem.deployContract(
+      'ReenterDiffsTargetMock',
+      [balanceProxy.address],
+      {
+        client: { wallet: owner },
+      },
+    );
+    const attackData = encodeFunctionData({
+      abi: reenterAbi,
+      functionName: 'attack',
+      args: [],
+    });
+    await expect(
+      balanceProxy.write.proxyCallDiffs(
+        [
+          [], // diffs
+          [], // approvals
+          reenter.address,
+          attackData,
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejectedWith('CallFailed');
+  });
+});

--- a/assets/erc-8009/test/DirectTransferFromAttack.test.ts
+++ b/assets/erc-8009/test/DirectTransferFromAttack.test.ts
@@ -1,0 +1,306 @@
+import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpers';
+import { expect } from 'chai';
+import { viem, ignition } from 'hardhat';
+import { parseEther } from 'viem';
+
+import BalanceProxyModule from '@/ignition/modules/balance-proxy';
+
+describe('✅ BalanceProxy: Token Transfer Integration', function () {
+  async function deployFixture() {
+    const [owner, user] = await viem.getWalletClients();
+
+    const { balanceProxy } = await ignition.deploy(BalanceProxyModule, {
+      defaultSender: owner.account.address,
+    });
+
+    const token = await viem.deployContract('ERC20Mock', ['Test', 'TST'], {
+      client: { wallet: owner },
+    });
+
+    const targetContract = await viem.deployContract(
+      'TargetMock',
+      [token.address],
+      {
+        client: { wallet: owner },
+      },
+    );
+
+    const approveRouter = await viem.deployContract('ApproveRouter', [], {
+      client: { wallet: owner },
+    });
+    const permitRouter = await viem.deployContract('PermitRouter', [], {
+      client: { wallet: owner },
+    });
+
+    return {
+      owner,
+      user,
+      balanceProxy,
+      token,
+      targetContract,
+      approveRouter,
+      permitRouter,
+    };
+  }
+
+  it('✅ Should work with useTransfer=false (approve mode)', async function () {
+    const { user, balanceProxy, token, targetContract, approveRouter } =
+      await loadFixture(deployFixture);
+
+    const AMOUNT = parseEther('100');
+
+    // Mint tokens to user
+    await token.write.mint([user.account.address, AMOUNT]);
+
+    await token.write.approve([approveRouter.address, AMOUNT], {
+      account: user.account,
+    });
+
+    await approveRouter.write.approveProxyCall(
+      [
+        balanceProxy.address,
+        [],
+        [
+          {
+            balance: {
+              token: token.address,
+              target: targetContract.address,
+              balance: AMOUNT,
+            },
+            useTransfer: false,
+          },
+        ],
+        targetContract.address,
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+
+    // Check: proxy should have the tokens (pulled from user), and approval should be cleared
+    const proxyBalance = await token.read.balanceOf([balanceProxy.address]);
+    expect(proxyBalance).to.equal(AMOUNT); // Proxy holds tokens
+
+    // User should have 0 tokens left (all transferred to proxy)
+    const userBalance = await token.read.balanceOf([user.account.address]);
+    expect(userBalance).to.equal(0n);
+
+    // Target allowance should still be set (target hasn't spent tokens yet)
+    const allowance = await token.read.allowance([
+      balanceProxy.address,
+      targetContract.address,
+    ]);
+    expect(allowance).to.equal(AMOUNT); // Approval set for target
+  });
+
+  it('✅ Should work with useTransfer=true (transfer mode)', async function () {
+    const { user, balanceProxy, token, targetContract, approveRouter } =
+      await loadFixture(deployFixture);
+
+    const AMOUNT = parseEther('100');
+
+    // Mint tokens to user
+    await token.write.mint([user.account.address, AMOUNT]);
+
+    await token.write.approve([approveRouter.address, AMOUNT], {
+      account: user.account,
+    });
+    await approveRouter.write.approveProxyCall(
+      [
+        balanceProxy.address,
+        [],
+        [
+          {
+            balance: {
+              token: token.address,
+              target: targetContract.address,
+              balance: AMOUNT,
+            },
+            useTransfer: true,
+          },
+        ],
+        targetContract.address,
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+
+    // Check that tokens were transferred directly to target
+    const targetBalance = await token.read.balanceOf([targetContract.address]);
+    expect(targetBalance).to.equal(AMOUNT);
+
+    // User should have 0 tokens left
+    const userBalance = await token.read.balanceOf([user.account.address]);
+    expect(userBalance).to.equal(0n);
+  });
+
+  it('✅ Should work with permitProxyCall and useTransfer=false (approve mode with permit)', async function () {
+    const { user, balanceProxy, token, targetContract, permitRouter } =
+      await loadFixture(deployFixture);
+
+    const AMOUNT = parseEther('100');
+
+    // Mint tokens to user
+    await token.write.mint([user.account.address, AMOUNT]);
+
+    // Get permit signature data
+    const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600); // 1 hour from now
+    const nonce = await token.read.nonces([user.account.address]);
+
+    // For this test, we'll use signTypedData to create a proper permit signature
+    const domain = {
+      name: await token.read.name(),
+      version: '1',
+      chainId: await user.getChainId(),
+      verifyingContract: token.address,
+    };
+
+    const types = {
+      Permit: [
+        { name: 'owner', type: 'address' },
+        { name: 'spender', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'deadline', type: 'uint256' },
+      ],
+    };
+
+    const message = {
+      owner: user.account.address,
+      spender: permitRouter.address,
+      value: AMOUNT,
+      nonce,
+      deadline,
+    };
+
+    const signature = await user.signTypedData({
+      domain,
+      types,
+      primaryType: 'Permit',
+      message,
+    });
+
+    // Split signature into v, r, s
+    const r = `0x${signature.slice(2, 66)}` as `0x${string}`;
+    const s = `0x${signature.slice(66, 130)}` as `0x${string}`;
+    const v = parseInt(signature.slice(130, 132), 16);
+
+    await permitRouter.write.permitProxyCall(
+      [
+        balanceProxy.address,
+        [],
+        [
+          {
+            balance: {
+              token: token.address,
+              target: targetContract.address,
+              balance: AMOUNT,
+            },
+            useTransfer: false,
+          },
+        ],
+        [{ deadline, v, r, s }],
+        targetContract.address,
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+
+    // Check: proxy should have the tokens
+    const proxyBalance = await token.read.balanceOf([balanceProxy.address]);
+    expect(proxyBalance).to.equal(AMOUNT);
+
+    // User should have 0 tokens left
+    const userBalance = await token.read.balanceOf([user.account.address]);
+    expect(userBalance).to.equal(0n);
+
+    // Target allowance should be set
+    const allowance = await token.read.allowance([
+      balanceProxy.address,
+      targetContract.address,
+    ]);
+    expect(allowance).to.equal(AMOUNT);
+  });
+
+  it('✅ Should work with permitProxyCall and useTransfer=true (transfer mode with permit)', async function () {
+    const { user, balanceProxy, token, targetContract, permitRouter } =
+      await loadFixture(deployFixture);
+
+    const AMOUNT = parseEther('100');
+
+    // Mint tokens to user
+    await token.write.mint([user.account.address, AMOUNT]);
+
+    // Get permit signature data
+    const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
+    const nonce = await token.read.nonces([user.account.address]);
+
+    const domain = {
+      name: await token.read.name(),
+      version: '1',
+      chainId: await user.getChainId(),
+      verifyingContract: token.address,
+    };
+
+    const types = {
+      Permit: [
+        { name: 'owner', type: 'address' },
+        { name: 'spender', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'deadline', type: 'uint256' },
+      ],
+    };
+
+    const message = {
+      owner: user.account.address,
+      spender: permitRouter.address,
+      value: AMOUNT,
+      nonce,
+      deadline,
+    };
+
+    const signature = await user.signTypedData({
+      domain,
+      types,
+      primaryType: 'Permit',
+      message,
+    });
+
+    const r = `0x${signature.slice(2, 66)}` as `0x${string}`;
+    const s = `0x${signature.slice(66, 130)}` as `0x${string}`;
+    const v = parseInt(signature.slice(130, 132), 16);
+
+    await permitRouter.write.permitProxyCall(
+      [
+        balanceProxy.address,
+        [],
+        [
+          {
+            balance: {
+              token: token.address,
+              target: targetContract.address,
+              balance: AMOUNT,
+            },
+            useTransfer: true,
+          },
+        ],
+        [{ deadline, v, r, s }],
+        targetContract.address,
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+
+    // Check that tokens were transferred directly to target
+    const targetBalance = await token.read.balanceOf([targetContract.address]);
+    expect(targetBalance).to.equal(AMOUNT);
+
+    // User should have 0 tokens left
+    const userBalance = await token.read.balanceOf([user.account.address]);
+    expect(userBalance).to.equal(0n);
+  });
+});

--- a/assets/erc-8009/test/PermitRouter.test.ts
+++ b/assets/erc-8009/test/PermitRouter.test.ts
@@ -1,0 +1,329 @@
+import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpers';
+import { expect } from 'chai';
+import { viem, ignition } from 'hardhat';
+import { encodeFunctionData, parseEther } from 'viem';
+
+import BalanceProxyModule from '@/ignition/modules/balance-proxy';
+
+const targetAbi = [
+  {
+    inputs: [{ internalType: 'address', name: '_erc20', type: 'address' }],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'take', type: 'uint256' },
+      { internalType: 'uint256', name: 'give', type: 'uint256' },
+    ],
+    name: 'mint',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
+function encodeMint(take: bigint, give: bigint) {
+  return encodeFunctionData({
+    abi: targetAbi,
+    functionName: 'mint',
+    args: [take, give],
+  });
+}
+
+describe('PermitRouter', function () {
+  type PermitToken = {
+    address: `0x${string}`;
+    read: {
+      name: () => Promise<string>;
+      nonces: (args: [`0x${string}`]) => Promise<bigint>;
+    };
+  };
+  type TestWallet = {
+    account: { address: `0x${string}` };
+    getChainId: () => Promise<number>;
+    signTypedData: (args: {
+      domain: {
+        name: string;
+        version: string;
+        chainId: number;
+        verifyingContract: `0x${string}`;
+      };
+      types: { Permit: Array<{ name: string; type: string }> };
+      primaryType: 'Permit';
+      message: {
+        owner: `0x${string}`;
+        spender: `0x${string}`;
+        value: bigint;
+        nonce: bigint;
+        deadline: bigint;
+      };
+    }) => Promise<`0x${string}`>;
+  };
+
+  async function buildPermit(
+    user: TestWallet,
+    token: PermitToken,
+    spender: `0x${string}`,
+    value: bigint,
+  ) {
+    const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
+    const nonce = await token.read.nonces([user.account.address]);
+    const domain = {
+      name: await token.read.name(),
+      version: '1',
+      chainId: await user.getChainId(),
+      verifyingContract: token.address,
+    };
+    const types = {
+      Permit: [
+        { name: 'owner', type: 'address' },
+        { name: 'spender', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'deadline', type: 'uint256' },
+      ],
+    };
+    const message = {
+      owner: user.account.address,
+      spender,
+      value,
+      nonce,
+      deadline,
+    };
+    const signature = await user.signTypedData({
+      domain,
+      types,
+      primaryType: 'Permit',
+      message,
+    });
+    const r = `0x${signature.slice(2, 66)}` as `0x${string}`;
+    const s = `0x${signature.slice(66, 130)}` as `0x${string}`;
+    const v = parseInt(signature.slice(130, 132), 16);
+    return { deadline, v, r, s };
+  }
+
+  async function deployFixture() {
+    const [owner, user, other] = await viem.getWalletClients();
+
+    const { balanceProxy } = await ignition.deploy(BalanceProxyModule, {
+      defaultSender: owner.account.address,
+    });
+
+    const token = await viem.deployContract('ERC20Mock', ['MockToken', 'MTK'], {
+      client: { wallet: owner },
+    });
+
+    const target = await viem.deployContract('TargetMock', [token.address], {
+      client: { wallet: owner },
+    });
+
+    const permitRouter = await viem.deployContract('PermitRouter', [], {
+      client: { wallet: owner },
+    });
+
+    return { owner, user, other, balanceProxy, token, target, permitRouter };
+  }
+
+  it('reverts on permits length mismatch in permitProxyCall', async () => {
+    const { user, balanceProxy, token, target, permitRouter } =
+      await loadFixture(deployFixture);
+
+    const AMOUNT = parseEther('10');
+    await token.write.mint([user.account.address, AMOUNT]);
+
+    const approval = {
+      balance: {
+        target: target.address,
+        token: token.address,
+        balance: AMOUNT,
+      },
+      useTransfer: false,
+    };
+
+    await expect(
+      permitRouter.write.permitProxyCall(
+        [
+          balanceProxy.address,
+          [],
+          [approval],
+          [], // permits empty -> mismatch
+          target.address,
+          '0x',
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejectedWith('PermitsLengthMismatch');
+  });
+
+  it('reverts on permits length mismatch in permitProxyCallDiffs', async () => {
+    const { user, balanceProxy, token, target, permitRouter } =
+      await loadFixture(deployFixture);
+
+    const AMOUNT = parseEther('10');
+    await token.write.mint([user.account.address, AMOUNT]);
+
+    const approval = {
+      balance: {
+        target: target.address,
+        token: token.address,
+        balance: AMOUNT,
+      },
+      useTransfer: false,
+    };
+
+    await expect(
+      permitRouter.write.permitProxyCallDiffs(
+        [
+          balanceProxy.address,
+          [],
+          [approval],
+          [], // permits empty -> mismatch
+          target.address,
+          '0x',
+          [],
+        ],
+        { account: user.account },
+      ),
+    ).to.be.rejectedWith('PermitsLengthMismatch');
+  });
+
+  it('supports permitProxyCallDiffs success path (net positive diff)', async () => {
+    const { user, balanceProxy, token, target, permitRouter } =
+      await loadFixture(deployFixture);
+
+    const TAKE = parseEther('10');
+    const GIVE = parseEther('25');
+
+    await token.write.mint([user.account.address, TAKE]);
+
+    const permit = await buildPermit(
+      user,
+      token as unknown as PermitToken,
+      permitRouter.address,
+      TAKE,
+    );
+
+    await permitRouter.write.permitProxyCallDiffs(
+      [
+        balanceProxy.address,
+        [
+          {
+            target: balanceProxy.address,
+            token: token.address,
+            balance: GIVE - TAKE, // expect at least GIVE - TAKE net increase
+          },
+        ],
+        [
+          {
+            balance: {
+              target: target.address,
+              token: token.address,
+              balance: TAKE,
+            },
+            useTransfer: false,
+          },
+        ],
+        [permit],
+        target.address,
+        encodeMint(TAKE, GIVE),
+        [],
+      ],
+      { account: user.account },
+    );
+
+    const bal = await token.read.balanceOf([balanceProxy.address]);
+    expect(bal).to.equal(GIVE);
+  });
+
+  it('handles multiple approvals and permits', async () => {
+    const { user, balanceProxy, token, target, permitRouter } =
+      await loadFixture(deployFixture);
+
+    const A1 = parseEther('7');
+    const A2 = parseEther('5');
+    await token.write.mint([user.account.address, A1 + A2]);
+
+    // Build two permits with sequential nonces for the same owner/spender
+    const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
+    const baseNonce = await (token as unknown as PermitToken).read.nonces([
+      user.account.address,
+    ]);
+    const domain = {
+      name: await (token as unknown as PermitToken).read.name(),
+      version: '1',
+      chainId: await user.getChainId(),
+      verifyingContract: token.address as `0x${string}`,
+    };
+    const types: { Permit: Array<{ name: string; type: string }> } = {
+      Permit: [
+        { name: 'owner', type: 'address' },
+        { name: 'spender', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'deadline', type: 'uint256' },
+      ],
+    };
+    const sign = async (value: bigint, nonce: bigint) => {
+      const signature = await user.signTypedData({
+        domain,
+        types,
+        primaryType: 'Permit',
+        message: {
+          owner: user.account.address,
+          spender: permitRouter.address,
+          value,
+          nonce,
+          deadline,
+        },
+      });
+      const r = `0x${signature.slice(2, 66)}` as `0x${string}`;
+      const s = `0x${signature.slice(66, 130)}` as `0x${string}`;
+      const v = parseInt(signature.slice(130, 132), 16);
+      return { deadline, v, r, s };
+    };
+
+    const p1 = await sign(A1, baseNonce);
+    const p2 = await sign(A2, baseNonce + 1n);
+
+    await permitRouter.write.permitProxyCall(
+      [
+        balanceProxy.address,
+        [],
+        [
+          {
+            balance: {
+              target: target.address,
+              token: token.address,
+              balance: A1,
+            },
+            useTransfer: false, // set allowance on proxy for target
+          },
+          {
+            balance: {
+              target: target.address,
+              token: token.address,
+              balance: A2,
+            },
+            useTransfer: true, // direct transfer to target
+          },
+        ],
+        [p1, p2],
+        target.address,
+        '0x',
+        [],
+      ],
+      { account: user.account },
+    );
+
+    const targetBal = await token.read.balanceOf([target.address]);
+    expect(targetBal).to.equal(A2);
+
+    const allowance = await token.read.allowance([
+      balanceProxy.address,
+      target.address,
+    ]);
+    expect(allowance).to.equal(A1);
+  });
+});

--- a/assets/erc-8009/test/SafeRouter.test.ts
+++ b/assets/erc-8009/test/SafeRouter.test.ts
@@ -1,0 +1,1190 @@
+import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpers';
+import safeProxyArtifact from '@safe-global/safe-smart-account/build/artifacts/contracts/proxies/SafeProxy.sol/SafeProxy.json';
+import safeArtifact from '@safe-global/safe-smart-account/build/artifacts/contracts/Safe.sol/Safe.json';
+import { expect } from 'chai';
+import { ignition, viem } from 'hardhat';
+import {
+  encodeFunctionData,
+  padHex,
+  parseEther,
+  type Abi,
+  type Address,
+  type GetContractReturnType,
+  type Hex,
+  zeroAddress,
+} from 'viem';
+
+import BalanceProxyModule from '@/ignition/modules/balance-proxy';
+
+const ZERO_ADDRESS = zeroAddress;
+
+const mintAbi = [
+  {
+    name: 'mint',
+    type: 'function',
+    inputs: [
+      { type: 'uint256', name: 'take' },
+      { type: 'uint256', name: 'give' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+] as const;
+
+const mintEthAbi = [
+  {
+    name: 'mintEth',
+    type: 'function',
+    inputs: [
+      { type: 'uint256', name: 'take' },
+      { type: 'uint256', name: 'give' },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+] as const;
+
+type SafeTx = {
+  to: Address;
+  value: bigint;
+  data: Hex;
+  operation: number;
+  safeTxGas: bigint;
+  baseGas: bigint;
+  gasPrice: bigint;
+  gasToken: Address;
+  refundReceiver: Address;
+  signatures: Hex;
+  routerSigPosition: bigint;
+};
+
+function safeTx(params: {
+  to: Address;
+  data: Hex;
+  value?: bigint;
+  operation?: number;
+  signatures?: Hex;
+  routerSigPosition?: bigint;
+  safeTxGas?: bigint;
+  baseGas?: bigint;
+  gasPrice?: bigint;
+  gasToken?: Address;
+  refundReceiver?: Address;
+}): SafeTx {
+  return {
+    to: params.to,
+    value: params.value ?? 0n,
+    data: params.data,
+    operation: params.operation ?? 0,
+    safeTxGas: params.safeTxGas ?? 0n,
+    baseGas: params.baseGas ?? 0n,
+    gasPrice: params.gasPrice ?? 0n,
+    gasToken: params.gasToken ?? ZERO_ADDRESS,
+    refundReceiver: params.refundReceiver ?? ZERO_ADDRESS,
+    signatures: params.signatures ?? '0x',
+    routerSigPosition: params.routerSigPosition ?? 0n,
+  };
+}
+
+function approvedHashSignature(owner: Address): Hex {
+  return `${padHex(owner, { size: 32 })}${'0'.repeat(64)}01` as Hex;
+}
+
+function sortOwners(owners: Address[]): Address[] {
+  return [...owners].sort((left, right) =>
+    BigInt(left) < BigInt(right) ? -1 : 1,
+  );
+}
+
+function routerSignaturePosition(humanOwners: Address[], router: Address) {
+  const routerValue = BigInt(router);
+  return BigInt(
+    humanOwners.filter((owner) => BigInt(owner) < routerValue).length,
+  );
+}
+
+function approvedHashSignatures(owners: Address[]): Hex {
+  return `0x${sortOwners(owners)
+    .map((owner) => approvedHashSignature(owner).slice(2))
+    .join('')}` as Hex;
+}
+
+async function getSafeTxHash(
+  safe: GetContractReturnType<Abi>,
+  tx: SafeTx,
+): Promise<Hex> {
+  const nonce = await safe.read.nonce();
+  return await safe.read.getTransactionHash([
+    tx.to,
+    tx.value,
+    tx.data,
+    tx.operation,
+    tx.safeTxGas,
+    tx.baseGas,
+    tx.gasPrice,
+    tx.gasToken,
+    tx.refundReceiver,
+    nonce,
+  ]);
+}
+
+async function safeTxWithApprovals(
+  safe: GetContractReturnType<Abi>,
+  tx: SafeTx,
+  router: Address,
+  owners: Array<{ account: { address: Address } }>,
+): Promise<SafeTx> {
+  const safeTxHash = await getSafeTxHash(safe, tx);
+  for (const owner of owners) {
+    await safe.write.approveHash([safeTxHash], { account: owner.account });
+  }
+
+  const ownerAddresses = owners.map((owner) => owner.account.address);
+  const requiredHumanSignatures = Number((await safe.read.getThreshold()) - 1n);
+  const selectedOwners = sortOwners(ownerAddresses).slice(
+    0,
+    requiredHumanSignatures,
+  );
+
+  return {
+    ...tx,
+    signatures: approvedHashSignatures(ownerAddresses),
+    routerSigPosition: routerSignaturePosition(selectedOwners, router),
+  };
+}
+
+async function deployFixture() {
+  const [owner, signer, executor, stranger] = await viem.getWalletClients();
+  const publicClient = await viem.getPublicClient();
+
+  const { balanceProxy } = await ignition.deploy(BalanceProxyModule, {
+    defaultSender: owner.account.address,
+  });
+
+  const token = await viem.deployContract('ERC20Mock', ['MockToken', 'MTK']);
+  const target = await viem.deployContract('TargetMock', [token.address]);
+  const safe = await viem.deployContract('SafeMock', []);
+  const safeRouter = await viem.deployContract('SafeRouter', []);
+
+  await safe.write.addOwner([owner.account.address]);
+  await safe.write.addOwner([signer.account.address]);
+  await safe.write.addOwner([safeRouter.address]);
+  await safe.write.setThreshold([2n]);
+
+  return {
+    owner,
+    signer,
+    executor,
+    stranger,
+    publicClient,
+    balanceProxy,
+    token,
+    target,
+    safe,
+    safeRouter,
+  };
+}
+
+async function deployRealSafeFixture() {
+  const base = await deployFixture();
+  const { owner, signer, executor, publicClient, safeRouter } = base;
+
+  const singletonHash = await owner.deployContract({
+    abi: safeArtifact.abi,
+    bytecode: safeArtifact.bytecode as Hex,
+  });
+  const singletonReceipt = await publicClient.waitForTransactionReceipt({
+    hash: singletonHash,
+  });
+  if (!singletonReceipt.contractAddress) {
+    throw new Error('Safe singleton deployment did not return an address');
+  }
+
+  const proxyHash = await owner.deployContract({
+    abi: safeProxyArtifact.abi,
+    bytecode: safeProxyArtifact.bytecode as Hex,
+    args: [singletonReceipt.contractAddress],
+  });
+  const proxyReceipt = await publicClient.waitForTransactionReceipt({
+    hash: proxyHash,
+  });
+  if (!proxyReceipt.contractAddress) {
+    throw new Error('Safe proxy deployment did not return an address');
+  }
+
+  const realSafe = await viem.getContractAt(
+    'ISafe',
+    proxyReceipt.contractAddress,
+  );
+
+  await realSafe.write.setup(
+    [
+      [signer.account.address, executor.account.address, safeRouter.address],
+      3n,
+      ZERO_ADDRESS,
+      '0x',
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      0n,
+      ZERO_ADDRESS,
+    ],
+    { account: owner.account },
+  );
+
+  return { ...base, realSafe };
+}
+
+describe('SafeRouter', function () {
+  this.timeout(120_000);
+
+  it('executes original tx via Safe then verifies post-balances via BalanceProxy', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const GIVE = parseEther('100');
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, GIVE],
+    });
+
+    await safeRouter.write.safeExecuteWithPostBalances(
+      [
+        balanceProxy.address,
+        [{ target: safe.address, token: token.address, balance: GIVE }],
+        safe.address,
+        await safeTxWithApprovals(
+          safe,
+          safeTx({ to: target.address, data: swapData }),
+          safeRouter.address,
+          [owner],
+        ),
+      ],
+      { account: owner.account },
+    );
+
+    expect(await token.read.balanceOf([safe.address])).to.equal(GIVE);
+    expect(await safe.read.lastSignaturesLength()).to.equal(130n);
+  });
+
+  it('trims over-threshold human signatures before adding the router marker', async () => {
+    const { owner, signer, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const GIVE = parseEther('5');
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, GIVE],
+    });
+
+    await safeRouter.write.safeExecuteWithPostBalances(
+      [
+        balanceProxy.address,
+        [{ target: safe.address, token: token.address, balance: GIVE }],
+        safe.address,
+        await safeTxWithApprovals(
+          safe,
+          safeTx({ to: target.address, data: swapData }),
+          safeRouter.address,
+          [owner, signer],
+        ),
+      ],
+      { account: owner.account },
+    );
+
+    expect(await token.read.balanceOf([safe.address])).to.equal(GIVE);
+    expect(await safe.read.lastSignaturesLength()).to.equal(130n);
+  });
+
+  it('executes original tx via Safe then verifies balance diffs for that tx', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const GIVE = parseEther('25');
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, GIVE],
+    });
+
+    await safeRouter.write.safeExecuteWithDiffs(
+      [
+        balanceProxy.address,
+        [{ target: safe.address, token: token.address, balance: GIVE }],
+        safe.address,
+        await safeTxWithApprovals(
+          safe,
+          safeTx({ to: target.address, data: swapData }),
+          safeRouter.address,
+          [owner],
+        ),
+      ],
+      { account: owner.account },
+    );
+
+    expect(await token.read.balanceOf([safe.address])).to.equal(GIVE);
+  });
+
+  it('executes ETH flow: Safe receives ETH, BalanceProxy verifies post-balance', async () => {
+    const { owner, balanceProxy, publicClient, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const GIVE_ETH = parseEther('2');
+    await owner.sendTransaction({ to: target.address, value: GIVE_ETH });
+
+    const swapData = encodeFunctionData({
+      abi: mintEthAbi,
+      functionName: 'mintEth',
+      args: [0n, GIVE_ETH],
+    });
+
+    await safeRouter.write.safeExecuteWithPostBalances(
+      [
+        balanceProxy.address,
+        [{ target: safe.address, token: ZERO_ADDRESS, balance: GIVE_ETH }],
+        safe.address,
+        await safeTxWithApprovals(
+          safe,
+          safeTx({ to: target.address, data: swapData }),
+          safeRouter.address,
+          [owner],
+        ),
+      ],
+      { account: owner.account },
+    );
+
+    expect(await publicClient.getBalance({ address: safe.address })).to.equal(
+      GIVE_ETH,
+    );
+  });
+
+  it('reverts and rolls back original tx when post-balance check fails', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const GIVE = parseEther('100');
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, GIVE],
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithPostBalances(
+        [
+          balanceProxy.address,
+          [{ target: safe.address, token: token.address, balance: GIVE + 1n }],
+          safe.address,
+          await safeTxWithApprovals(
+            safe,
+            safeTx({ to: target.address, data: swapData }),
+            safeRouter.address,
+            [owner],
+          ),
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('ERC8009BalanceConstraintViolation');
+
+    expect(await token.read.balanceOf([safe.address])).to.equal(0n);
+  });
+
+  it('reverts and rolls back original tx when diff check fails', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const GIVE = parseEther('100');
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, GIVE],
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithDiffs(
+        [
+          balanceProxy.address,
+          [{ target: safe.address, token: token.address, balance: GIVE + 1n }],
+          safe.address,
+          await safeTxWithApprovals(
+            safe,
+            safeTx({ to: target.address, data: swapData }),
+            safeRouter.address,
+            [owner],
+          ),
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('ERC8009BalanceDiffConstraintViolation');
+
+    expect(await token.read.balanceOf([safe.address])).to.equal(0n);
+  });
+
+  it('reverts with NotSafeOwner when caller is not a Safe owner', async () => {
+    const { stranger, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, parseEther('1')],
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithPostBalances(
+        [
+          balanceProxy.address,
+          [
+            {
+              target: safe.address,
+              token: token.address,
+              balance: parseEther('1'),
+            },
+          ],
+          safe.address,
+          safeTx({ to: target.address, data: swapData }),
+        ],
+        { account: stranger.account },
+      ),
+    ).to.be.rejectedWith('NotSafeOwner');
+  });
+
+  it('reverts with RouterNotSafeOwner when Safe did not install the router owner', async () => {
+    const { owner, token, target, balanceProxy } =
+      await loadFixture(deployFixture);
+    const safeWithoutRouter = await viem.deployContract('SafeMock', []);
+    const safeRouter = await viem.deployContract('SafeRouter', []);
+    await safeWithoutRouter.write.addOwner([owner.account.address]);
+
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, parseEther('1')],
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithPostBalances(
+        [
+          balanceProxy.address,
+          [
+            {
+              target: safeWithoutRouter.address,
+              token: token.address,
+              balance: parseEther('1'),
+            },
+          ],
+          safeWithoutRouter.address,
+          await safeTxWithApprovals(
+            safeWithoutRouter,
+            safeTx({ to: target.address, data: swapData }),
+            safeRouter.address,
+            [owner],
+          ),
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('RouterNotSafeOwner');
+
+    expect(await token.read.balanceOf([safeWithoutRouter.address])).to.equal(
+      0n,
+    );
+  });
+
+  it('reverts before Safe execution when only one human approved a 2-human Safe', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+    await safe.write.setThreshold([3n]);
+
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, parseEther('1')],
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithPostBalances(
+        [
+          balanceProxy.address,
+          [
+            {
+              target: safe.address,
+              token: token.address,
+              balance: parseEther('1'),
+            },
+          ],
+          safe.address,
+          await safeTxWithApprovals(
+            safe,
+            safeTx({ to: target.address, data: swapData }),
+            safeRouter.address,
+            [owner],
+          ),
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('InsufficientSafeSignatures');
+  });
+
+  it('reverts through Safe when the router marker is used as a human signature', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, parseEther('1')],
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithPostBalances(
+        [
+          balanceProxy.address,
+          [
+            {
+              target: safe.address,
+              token: token.address,
+              balance: parseEther('1'),
+            },
+          ],
+          safe.address,
+          safeTx({
+            to: target.address,
+            data: swapData,
+            signatures: approvedHashSignature(safeRouter.address),
+          }),
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('ERC8009CallFailed');
+  });
+
+  it('reverts before Safe execution when signatures are not 65-byte aligned', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, parseEther('1')],
+    });
+    const approvedTx = await safeTxWithApprovals(
+      safe,
+      safeTx({ to: target.address, data: swapData }),
+      safeRouter.address,
+      [owner],
+    );
+
+    await expect(
+      safeRouter.write.safeExecuteWithPostBalances(
+        [
+          balanceProxy.address,
+          [
+            {
+              target: safe.address,
+              token: token.address,
+              balance: parseEther('1'),
+            },
+          ],
+          safe.address,
+          {
+            ...approvedTx,
+            signatures: `${approvedTx.signatures}00` as Hex,
+          },
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('InvalidSignaturesLength');
+  });
+
+  it('reverts before Safe execution when router signature position is outside the used human signatures', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, parseEther('1')],
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithPostBalances(
+        [
+          balanceProxy.address,
+          [
+            {
+              target: safe.address,
+              token: token.address,
+              balance: parseEther('1'),
+            },
+          ],
+          safe.address,
+          {
+            ...(await safeTxWithApprovals(
+              safe,
+              safeTx({ to: target.address, data: swapData }),
+              safeRouter.address,
+              [owner],
+            )),
+            routerSigPosition: 2n,
+          },
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('InvalidRouterSignaturePosition');
+  });
+
+  it('reverts before Safe execution when operation is not Call', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const GIVE = parseEther('1');
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, GIVE],
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithPostBalances(
+        [
+          balanceProxy.address,
+          [{ target: safe.address, token: token.address, balance: GIVE }],
+          safe.address,
+          safeTx({ to: target.address, data: swapData, operation: 1 }),
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('UnsupportedSafeOperation');
+
+    expect(await token.read.balanceOf([safe.address])).to.equal(0n);
+  });
+
+  it('validates metadata, executes tx, verifies via BalanceProxy', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const GIVE = parseEther('50');
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, GIVE],
+    });
+
+    await safeRouter.write.safeExecuteWithPostBalancesMeta(
+      [
+        balanceProxy.address,
+        [{ symbol: 'MTK', decimals: 18 }],
+        [{ target: safe.address, token: token.address, balance: GIVE }],
+        safe.address,
+        await safeTxWithApprovals(
+          safe,
+          safeTx({ to: target.address, data: swapData }),
+          safeRouter.address,
+          [owner],
+        ),
+      ],
+      { account: owner.account },
+    );
+
+    expect(await token.read.balanceOf([safe.address])).to.equal(GIVE);
+  });
+
+  it('reverts with InvalidMetadata on symbol mismatch', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, parseEther('1')],
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithPostBalancesMeta(
+        [
+          balanceProxy.address,
+          [{ symbol: 'WRONG', decimals: 18 }],
+          [
+            {
+              target: safe.address,
+              token: token.address,
+              balance: parseEther('1'),
+            },
+          ],
+          safe.address,
+          await safeTxWithApprovals(
+            safe,
+            safeTx({ to: target.address, data: swapData }),
+            safeRouter.address,
+            [owner],
+          ),
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('InvalidMetadata');
+  });
+
+  it('reverts with InvalidMetadata on decimals mismatch', async () => {
+    const { owner, balanceProxy, token, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, parseEther('1')],
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithPostBalancesMeta(
+        [
+          balanceProxy.address,
+          [{ symbol: 'MTK', decimals: 6 }],
+          [
+            {
+              target: safe.address,
+              token: token.address,
+              balance: parseEther('1'),
+            },
+          ],
+          safe.address,
+          await safeTxWithApprovals(
+            safe,
+            safeTx({ to: target.address, data: swapData }),
+            safeRouter.address,
+            [owner],
+          ),
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('InvalidMetadata');
+  });
+
+  it('ETH metadata flow via BalanceProxy skip', async () => {
+    const { owner, balanceProxy, publicClient, target, safe, safeRouter } =
+      await loadFixture(deployFixture);
+
+    const GIVE_ETH = parseEther('1');
+    await owner.sendTransaction({ to: target.address, value: GIVE_ETH });
+
+    const swapData = encodeFunctionData({
+      abi: mintEthAbi,
+      functionName: 'mintEth',
+      args: [0n, GIVE_ETH],
+    });
+
+    await safeRouter.write.safeExecuteWithPostBalancesMeta(
+      [
+        balanceProxy.address,
+        [{ symbol: 'ETH', decimals: 18 }],
+        [{ target: safe.address, token: ZERO_ADDRESS, balance: GIVE_ETH }],
+        safe.address,
+        await safeTxWithApprovals(
+          safe,
+          safeTx({ to: target.address, data: swapData }),
+          safeRouter.address,
+          [owner],
+        ),
+      ],
+      { account: owner.account },
+    );
+
+    expect(await publicClient.getBalance({ address: safe.address })).to.equal(
+      GIVE_ETH,
+    );
+  });
+
+  it('reverts through the real Safe when only one human approved before wrapping', async () => {
+    const {
+      signer,
+      executor,
+      balanceProxy,
+      token,
+      target,
+      safeRouter,
+      realSafe,
+    } = await loadFixture(deployRealSafeFixture);
+
+    const GIVE = parseEther('77');
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, GIVE],
+    });
+    const nonce = await realSafe.read.nonce();
+    const safeTxHash = await realSafe.read.getTransactionHash([
+      target.address,
+      0n,
+      swapData,
+      0,
+      0n,
+      0n,
+      0n,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      nonce,
+    ]);
+
+    await realSafe.write.approveHash([safeTxHash], {
+      account: signer.account,
+    });
+
+    await expect(
+      safeRouter.write.safeExecuteWithDiffs(
+        [
+          balanceProxy.address,
+          [{ target: realSafe.address, token: token.address, balance: GIVE }],
+          realSafe.address,
+          safeTx({
+            to: target.address,
+            data: swapData,
+            signatures: approvedHashSignature(signer.account.address),
+            routerSigPosition: routerSignaturePosition(
+              [signer.account.address],
+              safeRouter.address,
+            ),
+          }),
+        ],
+        { account: executor.account },
+      ),
+    ).to.be.rejectedWith('InsufficientSafeSignatures');
+
+    expect(await token.read.balanceOf([realSafe.address])).to.equal(0n);
+    expect(await realSafe.read.nonce()).to.equal(nonce);
+  });
+
+  it('prevents leaked human signatures from executing directly through Safe', async () => {
+    const {
+      signer,
+      executor,
+      stranger,
+      balanceProxy,
+      token,
+      target,
+      safeRouter,
+      realSafe,
+    } = await loadFixture(deployRealSafeFixture);
+
+    const GIVE = parseEther('33');
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, GIVE],
+    });
+    const nonce = await realSafe.read.nonce();
+    const safeTxHash = await realSafe.read.getTransactionHash([
+      target.address,
+      0n,
+      swapData,
+      0,
+      0n,
+      0n,
+      0n,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      nonce,
+    ]);
+
+    await realSafe.write.approveHash([safeTxHash], {
+      account: signer.account,
+    });
+    await realSafe.write.approveHash([safeTxHash], {
+      account: executor.account,
+    });
+
+    const humanOwners = [signer.account.address, executor.account.address];
+    const humanSignatures = approvedHashSignatures(humanOwners);
+
+    await expect(
+      realSafe.write.execTransaction(
+        [
+          target.address,
+          0n,
+          swapData,
+          0,
+          0n,
+          0n,
+          0n,
+          ZERO_ADDRESS,
+          ZERO_ADDRESS,
+          humanSignatures,
+        ],
+        { account: stranger.account },
+      ),
+    ).to.be.rejected;
+
+    await expect(
+      safeRouter.write.safeExecuteWithDiffs(
+        [
+          balanceProxy.address,
+          [
+            {
+              target: realSafe.address,
+              token: token.address,
+              balance: GIVE + 1n,
+            },
+          ],
+          realSafe.address,
+          safeTx({
+            to: target.address,
+            data: swapData,
+            signatures: humanSignatures,
+            routerSigPosition: routerSignaturePosition(
+              humanOwners,
+              safeRouter.address,
+            ),
+          }),
+        ],
+        { account: executor.account },
+      ),
+    ).to.be.rejectedWith('ERC8009BalanceDiffConstraintViolation');
+
+    expect(await token.read.balanceOf([realSafe.address])).to.equal(0n);
+    expect(await realSafe.read.nonce()).to.equal(nonce);
+
+    await expect(
+      realSafe.write.execTransaction(
+        [
+          target.address,
+          0n,
+          swapData,
+          0,
+          0n,
+          0n,
+          0n,
+          ZERO_ADDRESS,
+          ZERO_ADDRESS,
+          humanSignatures,
+        ],
+        { account: stranger.account },
+      ),
+    ).to.be.rejected;
+
+    await safeRouter.write.safeExecuteWithDiffs(
+      [
+        balanceProxy.address,
+        [{ target: realSafe.address, token: token.address, balance: GIVE }],
+        realSafe.address,
+        safeTx({
+          to: target.address,
+          data: swapData,
+          signatures: humanSignatures,
+          routerSigPosition: routerSignaturePosition(
+            humanOwners,
+            safeRouter.address,
+          ),
+        }),
+      ],
+      { account: executor.account },
+    );
+
+    expect(await token.read.balanceOf([realSafe.address])).to.equal(GIVE);
+    expect(await realSafe.read.nonce()).to.equal(nonce + 1n);
+  });
+
+  it('supports a 3-of-5 Safe policy without counting the router owner as a human approval', async () => {
+    const {
+      owner,
+      signer,
+      executor,
+      stranger,
+      publicClient,
+      balanceProxy,
+      token,
+      target,
+      safeRouter,
+    } = await loadFixture(deployFixture);
+    const [, , , , fifthOwner] = await viem.getWalletClients();
+
+    const singletonHash = await owner.deployContract({
+      abi: safeArtifact.abi,
+      bytecode: safeArtifact.bytecode as Hex,
+    });
+    const singletonReceipt = await publicClient.waitForTransactionReceipt({
+      hash: singletonHash,
+    });
+    if (!singletonReceipt.contractAddress) {
+      throw new Error('Safe singleton deployment did not return an address');
+    }
+
+    const proxyHash = await owner.deployContract({
+      abi: safeProxyArtifact.abi,
+      bytecode: safeProxyArtifact.bytecode as Hex,
+      args: [singletonReceipt.contractAddress],
+    });
+    const proxyReceipt = await publicClient.waitForTransactionReceipt({
+      hash: proxyHash,
+    });
+    if (!proxyReceipt.contractAddress) {
+      throw new Error('Safe proxy deployment did not return an address');
+    }
+
+    const realSafe = await viem.getContractAt(
+      'ISafe',
+      proxyReceipt.contractAddress,
+    );
+    const humanOwners = [
+      owner.account.address,
+      signer.account.address,
+      executor.account.address,
+      stranger.account.address,
+      fifthOwner.account.address,
+    ];
+
+    await realSafe.write.setup(
+      [
+        [...humanOwners, safeRouter.address],
+        4n,
+        ZERO_ADDRESS,
+        '0x',
+        ZERO_ADDRESS,
+        ZERO_ADDRESS,
+        0n,
+        ZERO_ADDRESS,
+      ],
+      { account: owner.account },
+    );
+
+    const GIVE = parseEther('19');
+    const swapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, GIVE],
+    });
+    const nonce = await realSafe.read.nonce();
+    const safeTxHash = await realSafe.read.getTransactionHash([
+      target.address,
+      0n,
+      swapData,
+      0,
+      0n,
+      0n,
+      0n,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      nonce,
+    ]);
+
+    for (const account of [owner.account, signer.account]) {
+      await realSafe.write.approveHash([safeTxHash], { account });
+    }
+
+    const twoHumanOwners = [owner.account.address, signer.account.address];
+    await expect(
+      safeRouter.write.safeExecuteWithDiffs(
+        [
+          balanceProxy.address,
+          [{ target: realSafe.address, token: token.address, balance: GIVE }],
+          realSafe.address,
+          safeTx({
+            to: target.address,
+            data: swapData,
+            signatures: approvedHashSignatures(twoHumanOwners),
+            routerSigPosition: routerSignaturePosition(
+              twoHumanOwners,
+              safeRouter.address,
+            ),
+          }),
+        ],
+        { account: owner.account },
+      ),
+    ).to.be.rejectedWith('InsufficientSafeSignatures');
+
+    await realSafe.write.approveHash([safeTxHash], {
+      account: executor.account,
+    });
+
+    const threeHumanOwners = [
+      owner.account.address,
+      signer.account.address,
+      executor.account.address,
+    ];
+
+    await safeRouter.write.safeExecuteWithDiffs(
+      [
+        balanceProxy.address,
+        [{ target: realSafe.address, token: token.address, balance: GIVE }],
+        realSafe.address,
+        safeTx({
+          to: target.address,
+          data: swapData,
+          signatures: approvedHashSignatures(threeHumanOwners),
+          routerSigPosition: routerSignaturePosition(
+            threeHumanOwners,
+            safeRouter.address,
+          ),
+        }),
+      ],
+      { account: owner.account },
+    );
+
+    expect(await token.read.balanceOf([realSafe.address])).to.equal(GIVE);
+    expect(await realSafe.read.nonce()).to.equal(nonce + 1n);
+
+    const EXTRA_GIVE = parseEther('7');
+    const extraSwapData = encodeFunctionData({
+      abi: mintAbi,
+      functionName: 'mint',
+      args: [0n, EXTRA_GIVE],
+    });
+    const extraNonce = await realSafe.read.nonce();
+    const extraSafeTxHash = await realSafe.read.getTransactionHash([
+      target.address,
+      0n,
+      extraSwapData,
+      0,
+      0n,
+      0n,
+      0n,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      extraNonce,
+    ]);
+
+    for (const account of [
+      owner.account,
+      signer.account,
+      executor.account,
+      stranger.account,
+    ]) {
+      await realSafe.write.approveHash([extraSafeTxHash], { account });
+    }
+
+    const fourHumanOwners = [
+      owner.account.address,
+      signer.account.address,
+      executor.account.address,
+      stranger.account.address,
+    ];
+    const selectedOwners = sortOwners(fourHumanOwners).slice(0, 3);
+
+    await safeRouter.write.safeExecuteWithDiffs(
+      [
+        balanceProxy.address,
+        [
+          {
+            target: realSafe.address,
+            token: token.address,
+            balance: EXTRA_GIVE,
+          },
+        ],
+        realSafe.address,
+        safeTx({
+          to: target.address,
+          data: extraSwapData,
+          signatures: approvedHashSignatures(fourHumanOwners),
+          routerSigPosition: routerSignaturePosition(
+            selectedOwners,
+            safeRouter.address,
+          ),
+        }),
+      ],
+      { account: owner.account },
+    );
+
+    expect(await token.read.balanceOf([realSafe.address])).to.equal(
+      GIVE + EXTRA_GIVE,
+    );
+    expect(await realSafe.read.nonce()).to.equal(nonce + 2n);
+  });
+});


### PR DESCRIPTION
This standard introduces an alternative solution to the blind-signing problem on dedicated hardware devices, by routing transactions through a proxy contract which enforces transaction constraints. The solution is split into core/periphery contracts, with the core contract being the standard.

[Discussion](https://ethereum-magicians.org/t/erc-8009-proxy-clear-signing/25199)