### PR TITLE
Update ERC-7754: adding details on 'alg' param

### DIFF
--- a/ERCS/erc-7754.md
+++ b/ERCS/erc-7754.md
@@ -66,7 +66,7 @@ We propose to use the dapp's domain certificate of a root of trust to establish 
 
 Attested public keys are necessary for the chain of trust to be established.
 Since this is traditionally done via DNS certificates, we propose the addition of a DNS record containing the public keys.
-This is similar to [RFC-6636](https://www.rfc-editor.org/rfc/rfc6376.html)'s DKIM, but the use of a manifest file provides more flexibility for future improvements, as well as support for multiple algorithm and key pairs.
+This is similar to [RFC-6376](https://www.rfc-editor.org/rfc/rfc6376.html)'s DKIM, but the use of a manifest file provides more flexibility for future improvements, as well as support for multiple algorithm and key pairs.
 
 Similarly to standard [RFC-7519](https://www.rfc-editor.org/rfc/rfc7519.html)'s JWT practices, the wallet could eagerly cache dapp keys.
 However, in the absence of a revocation mechanism, a compromised key could still be used until caches have expired.
@@ -80,18 +80,22 @@ Example DNS record for `my-crypto-dapp.invalid`:
 TXT: TWIST=/.well-known/twist.json
 ```
 
-Example TWIST manifest at `https://my-crypto-dapp.invalid.com/twist.json`:
+Example TWIST manifest at `https://my-crypto-dapp.invalid/.well-known/twist.json`:
 
 ```json
 {
   "publicKeys": [
-    { "id": "1", "alg": "ECDSA", "publicKey": "0xaf34..." },
-    { "id": "2", "alg": "RSA-PSS", "publicKey": "0x98ab..." }
+    { "id": "1", "alg": "ES256", "publicKey": "0xaf34..." },
+    { "id": "2", "alg": "PS256", "publicKey": "0x98ab..." }
   ]
 }
 ```
 
-Dapps SHOULD only rely on algorithms available via [SubtleCrypto](https://www.w3.org/TR/2017/REC-WebCryptoAPI-20170126/), since they are present in every browser.
+Implementers MUST support at least the following "alg" param values, from [RFC 7518 section 3.1](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1): ES256 and EdDSA. Implementers SHOULD support PS256, RS256, ES384, ES512, PS384, PS512, RS384, and RS512.
+
+Implementers SHOULD use [SubtleCrypto](https://www.w3.org/TR/2017/REC-WebCryptoAPI-20170126/), since it is available in modern browsers.
+
+Public keys MUST be encoded using the X.509 SubjectPublicKeyInfo (SPKI) structure in DER format and represented as hex-encoded strings.
 
 #### Manifest schema
 
@@ -195,7 +199,7 @@ async function signedRequest(
 
   let manifestPath = '';
   const dnsResp = await resolver.query(domain, 'TXT');
-  for (record of dnsResp.answers) {
+  for (const record of dnsResp.answers) {
     if (!record.data.startsWith('TWIST=')) continue;
 
     manifestPath = record.data.substring(5); // This should be domain + '/.well-known/twist.json'
@@ -203,12 +207,14 @@ async function signedRequest(
   }
 
   // 3. Parse the manifest and get the key and algo based on `keyId`
-  const manifestReq = await fetch(manifestPath);
-  if(manifestReq.headers['content-type']!=='application/json'){
-    throw new Error('The manifest is not a proper json file')
+  const manifestUrl = `https://${domain}${manifestPath.startsWith('/') ? '' : '/'}${manifestPath}`;
+  const manifestReq = await fetch(manifestUrl, { redirect: 'error' });
+  const contentType = (manifestReq.headers.get('content-type') || '').toLowerCase();
+  if (!contentType.startsWith('application/json')) {
+    throw new Error('The manifest is not a proper JSON file');
   }
   const manifest = await manifestReq.json();
-  const keyData = manifest.publicKeys.filter((x) => x.id == keyId);
+  const keyData = manifest.publicKeys.find((x) => x.id === keyId);
   if (!keyData) {
     throw new Error('Could not find the signing key');
   }

--- a/ERCS/erc-7754.md
+++ b/ERCS/erc-7754.md
@@ -54,7 +54,7 @@ We propose to use the dapp's domain certificate of a root of trust to establish 
 
 1. The user's browser verifies the domain certificate and displays appropriate warnings if overtaken
 2. The DNS record of the dapp hosts a TXT field pointing to a URL where a JSON manifest is hosted
-   - This file SHOULD be at a well known address such as `https://example.com/.well-known/twist.json`
+   - This file SHOULD be at a well known address such as `example[.]com/.well-known/twist.json`
 3. The config file contains an array of objects of the form `{ id, alg, publicKey }`
 4. For signed requests, the dapp first securely signs the payload with a private key, for example by submitting a request to its backend
 5. The original payload, signature, and public key id are sent to the wallet via the `wallet_signedRequest` RPC method
@@ -66,9 +66,9 @@ We propose to use the dapp's domain certificate of a root of trust to establish 
 
 Attested public keys are necessary for the chain of trust to be established.
 Since this is traditionally done via DNS certificates, we propose the addition of a DNS record containing the public keys.
-This is similar to [RFC-6376](https://www.rfc-editor.org/rfc/rfc6376.html)'s DKIM, but the use of a manifest file provides more flexibility for future improvements, as well as support for multiple algorithm and key pairs.
+This is similar to RFC 6376's DKIM, but the use of a manifest file provides more flexibility for future improvements, as well as support for multiple algorithm and key pairs.
 
-Similarly to standard [RFC-7519](https://www.rfc-editor.org/rfc/rfc7519.html)'s JWT practices, the wallet could eagerly cache dapp keys.
+Similarly to standard RFC 7519's JWT practices, the wallet could eagerly cache dapp keys.
 However, in the absence of a revocation mechanism, a compromised key could still be used until caches have expired.
 To mitigate this, wallets SHOULD NOT cache dapp public keys for more than 2 hours.
 This practice establishes a relatively short vulnerability window, and manageable overhead for both wallet and dapp maintainers.
@@ -80,7 +80,7 @@ Example DNS record for `my-crypto-dapp.invalid`:
 TXT: TWIST=/.well-known/twist.json
 ```
 
-Example TWIST manifest at `https://my-crypto-dapp.invalid/.well-known/twist.json`:
+Example TWIST manifest at `my-crypto-dapp[.]invalid/.well-known/twist.json`:
 
 ```json
 {
@@ -91,9 +91,9 @@ Example TWIST manifest at `https://my-crypto-dapp.invalid/.well-known/twist.json
 }
 ```
 
-Implementers MUST support at least the following "alg" param values, from [RFC 7518 section 3.1](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1): ES256 and EdDSA. Implementers SHOULD support PS256, RS256, ES384, ES512, PS384, PS512, RS384, and RS512.
+Implementers MUST support at least the following "alg" param values, from RFC 7518 section 3.1: ES256 and EdDSA. Implementers SHOULD support PS256, RS256, ES384, ES512, PS384, PS512, RS384, and RS512.
 
-Implementers SHOULD use [SubtleCrypto](https://www.w3.org/TR/2017/REC-WebCryptoAPI-20170126/), since it is available in modern browsers.
+Implementers SHOULD use `SubtleCrypto`, since it is available in modern browsers.
 
 Public keys MUST be encoded using the X.509 SubjectPublicKeyInfo (SPKI) structure in DER format and represented as hex-encoded strings.
 
@@ -103,7 +103,6 @@ We propose a simple and extensible schema:
 
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "TWIST manifest",
   "type": "object",
   "properties": {
@@ -191,11 +190,11 @@ async function signedRequest(
   const domain = getDappDomain();
 
   // 2. Get the manifest for the current domain
-  // It's possible to use RFC 8484 for the actual DNS-over-HTTPS specification, see https://datatracker.ietf.org/doc/html/rfc8484.
+  // It's possible to use RFC 8484 for the actual DNS-over-HTTPS specification.
   // However, here we are doing it with DoHjs.
   // This step is optional, and you could go directly to the well-known address first at `domain + '/.well-known/twist.json'`
   const doh = require('dohjs');
-  const resolver = new doh.DohResolver('https://1.1.1.1/dns-query');
+  const resolver = new doh.DohResolver('<doh-endpoint>');
 
   let manifestPath = '';
   const dnsResp = await resolver.query(domain, 'TXT');


### PR DESCRIPTION
### ERC-7754: Specify JOSE `alg` values, key encoding, and manifest URL; minor fixes

- **What changed**
  - Corrects DKIM reference to [RFC-6376](https://www.rfc-editor.org/rfc/rfc6376.html).
  - Updates example manifest URL to `/.well-known/twist.json` and aligns the DNS TXT example.
  - Switches example `alg` values to JOSE names (`ES256`, `PS256`) instead of generic labels.
  - Adds normative requirements:
    - **MUST** support: `ES256`, `EdDSA`.
    - **SHOULD** support: `PS256`, `RS256`, `ES384`, `ES512`, `PS384`, `PS512`, `RS384`, `RS512` (per [RFC 7518 §3.1](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1)).
  - Specifies public key encoding: X.509 SPKI (DER), represented as hex-encoded strings.
  - Recommends using WebCrypto `SubtleCrypto`.
  - Improves code sample