### PR TITLE
Update ERC-7828: fix typo

### DIFF
--- a/ERCS/erc-7828.md
+++ b/ERCS/erc-7828.md
@@ -66,7 +66,7 @@ Where:
 
 - `<raw-chain>`, `<raw-address>` and `<checksum>` are defined to maintain backwards compatibility with [ERC-7930], and their semantics remain the same.
 - `<chain-name>`: A human-readable chain label within the reserved `<namespace>.eth` domain. This standard uses `<namespace>.eth` to provide a consistent abstraction for chain identity, mapping these labels to their corresponding canonical chain identifiers.
-- `<ens-name>`: An ENS name, which should be resolved following the appropiate ENSIPs (which this standard does not aim to overwrite). It's grammar definition is slightly different than that of ENSIP-1, as this standard does not support names consisting of only a TLD, since they'd be of limited usefulness.
+- `<ens-name>`: An ENS name, which should be resolved following the appropriate ENSIPs (which this standard does not aim to overwrite). It's grammar definition is slightly different than that of ENSIP-1, as this standard does not support names consisting of only a TLD, since they'd be of limited usefulness.
 - `<label>`: Any valid string label per UTS46, as defined in ENSIP-1.
 
 This allows for Interoperable Addresses' text representation to mix and match 'resolved' and 'unresolved' usages in both the chain and address parts.


### PR DESCRIPTION
appropiate -> appropriate