### PR TITLE
Fix typos in ERC-7092 documentation

### DIFF
--- a/ERCS/erc-7092.md
+++ b/ERCS/erc-7092.md
@@ -13,7 +13,7 @@ requires: 165
 
 ## Abstract
 
-This proposal introduces fixed-income financial bonds with key characteristics defined to facilitate bond issuance in the primary market and enable buying or selling bonds in the secondary market. The standard also provides cross-chain functionalities for bonds operations and management accross multiple blockchains.
+This proposal introduces fixed-income financial bonds with key characteristics defined to facilitate bond issuance in the primary market and enable buying or selling bonds in the secondary market. The standard also provides cross-chain functionalities for bonds operations and management across multiple blockchains.
 
 ## Motivation
 
@@ -118,7 +118,7 @@ interface IERC7092 /** is ERC165 */ {
     function issueDate() external view returns(uint256);
 
     /**
-    * @notice Returns the bond maturity date, i.e, the date when the pricipal is repaid. This is a Unix Timestamp like the one returned by block.timestamp
+    * @notice Returns the bond maturity date, i.e, the date when the principal is repaid. This is a Unix Timestamp like the one returned by block.timestamp
     *         The maturity date MUST be greater than the issue date
     */
     function maturityDate() external view returns(uint256);
@@ -131,7 +131,7 @@ interface IERC7092 /** is ERC165 */ {
 
     /**
     * @notice Returns the amount of tokens the `_spender` account has been authorized by the `_owner``
-    *         acount to manage their bonds
+    *         account to manage their bonds
     * @param _owner the bondholder address
     * @param _spender the address that has been authorized by the bondholder
     */


### PR DESCRIPTION


## Description

This PR fixes minor spelling errors in the ERC-7092 documentation:

- **Abstract section**: Fixed "accross" → "across"
- **Function comments**: Fixed "pricipal" → "principal" 
- **Authorization comments**: Fixed "acount" → "account"

