### PR TITLE
 Update ERC-6909: Move to Last Call

### DIFF
--- a/ERCS/erc-6909.md
+++ b/ERCS/erc-6909.md
@@ -4,7 +4,7 @@ title: Minimal Multi-Token Interface
 description: A minimal specification for managing multiple tokens by their id in a single contract.
 author: JT Riley (@jtriley2p), Dillon (@d1ll0n), Sara (@snreynolds), Vectorized (@Vectorized), Neodaoist (@neodaoist)
 discussions-to: https://ethereum-magicians.org/t/erc-6909-multi-token-standard/13891
-status: Review
+status: Last Call
 type: Standards Track
 category: ERC
 created: 2023-04-19


### PR DESCRIPTION
Reasoning: The discussion in the official discussion forum has settled, only window-dressing niceties remain, and there are existing deployments using ERC-6909 interface (Uniswap, 0xSplits, zAMM). At the risk of a production interface being deemed stagnant because of procedure unrelated to application layer, this ERC should moved to Last Call.

https://ethereum-magicians.org/t/erc-6909-multi-token-standard/13891/77?u=z0r0z