### PR TITLE
Add ERC: Transaction Attribution

### DIFF
--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -2,7 +2,7 @@
 eip: 8021
 title: Transaction Attribution
 description: A standardized method for attributing transactions to applications and wallets through data suffixes, enabling interoperable attribution tracking and reward distribution.
-author: Conner Swenberg (@ilikesymmetry)
+author: Conner Swenberg (@ilikesymmetry), Dan Cortes (@dgca)
 discussions-to: https://ethereum-magicians.org/t/erc-8021-transaction-attribution/25561
 status: Draft
 type: Standards Track
@@ -41,15 +41,15 @@ This standard defines a structured data suffix format appended to transaction ca
 2. **schemaId** (1 byte): Schema ID number that declares the schema of proceeding bytes with space for forwards compatibility
 3. **schemaData** (variable bytes): Data to be parsed according to `schemaId`
 
-A `schemaId` MUST have an associated ERC to be considered valid.
+A `schemaId` MUST be defined in an ERC to be considered valid.
 
 ### Multi-Attribution Schemas
 
 Our first schemas enable attributing multiple entities in a single transaction.
 
-Entities are identified by a unique "code" which is a string that follows 7-bit ASCII encoding. A code MUST NOT contain commas (`0x2C`) as this is reserved as a delimitter for attributing multiple codes.
+Entities are identified by a unique "code" which is a string that follows 7-bit ASCII encoding. A code MUST NOT contain commas (`0x2C`) as this is reserved as a delimiter for attributing multiple codes.
 
-Codes MUST also be registered in a Code Regsitry smart contract (interface defined in later section). Chains are encouraged to provide canonical code registries which MAY be defined in this or future ERCs.
+Codes MUST also be registered in a Code Registry smart contract (interface defined in later section). Chains are encouraged to provide canonical code registries which MAY be defined in this or future ERCs.
 
 Schema ID `0` defines the following bytes and assumes chain's canonical Code Registry:
 1. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
@@ -85,7 +85,7 @@ Multiple entity attribution with custom registry:
 
 Offchain parsers SHOULD implement the following algorithm:
 
-1. Extract the last TBD bytes as `ercSuffix` and verify it matches the standard identifier
+1. Extract the last 16 bytes as `ercSuffix` and verify it matches the standard identifier
 2. Extract the previous byte as `schemaId`
 3. If `schemaId` is `0`:
    a. Extract the previous byte as `codesLength`
@@ -132,12 +132,12 @@ interface ICodeRegistry {
 }
 ```
 
-### Code Regsitry Canonical Addresses
+### Code Registry Canonical Addresses
 
 | Chain ID | Code Registry |
 | -------- | ------------- |
-| `8453`   | TBD           |
-| `84532`  | TBD           |
+| `8453`   | [`0x000000bc7e6457e610fe52dcc0ca5b3ce59c8e80`](https://basescan.org/address/0x000000bc7e6457e610fe52dcc0ca5b3ce59c8e80) |
+| `84532`  | [`0xf20b8a32c39f3c56bbd27fe8438090b5a03b6381`](https://sepolia.basescan.org/address/0xf20b8a32c39f3c56bbd27fe8438090b5a03b6381) |
 
 ### Code Metadata
 
@@ -154,18 +154,6 @@ type CodeMetadata = {
 
 Future ERCs can extend this schema.
 
-### ERC-5792 Integration
-
-Applications using ERC-5792's `wallet_sendCalls` RPC method MUST communicate attribution data through a new capability:
-
-```typescript
-interface DataSuffixCapability {
-  dataSuffix: string; // Hex-encoded bytes to append as suffix
-}
-```
-
-Wallets implementing this capability MUST append the provided `dataSuffix` bytes to the transaction calldata. Wallets MAY optionally insert their own attribution code before the application's suffix if they understand this standard.
-
 ### ERC-4337 User Operation Implementation
 
 For ERC-4337 compliant smart accounts, the implementation differs from normal Ethereum transactions:
@@ -181,6 +169,37 @@ When implementing attribution for smart accounts:
 3. Wallets supporting both EOA and smart account transactions MUST handle suffix appending appropriately based on the account type
 
 This ensures attribution data remains accessible and parseable regardless of whether the transaction originates from an externally owned account (EOA) or a smart contract account following ERC-4337.
+
+### App<>Wallet Integration
+
+Apps can append ERC-8021 attribution through multiple methods, but this standard defines integration with two RPCs: 
+1. `eth_sendTransaction`
+2. `wallet_sendCalls`
+
+Regardless of integration method, wallets MAY insert their own attribution code alongside the application-defined codes, provided they understand this standard.
+
+#### `eth_sendTransaction` Integration
+
+This legacy method is supported by all functional Ethereum wallets. Apps can add ERC-8021 attribution to their transactions by directly appending the data suffix to the `data` field.
+
+Note that wallets MAY mutate the transaction, for example in cases where ERC-4337 Smart Accounts are used and a transaction is actually sent from an ERC-4337 Bundler.
+
+#### `wallet_sendCalls` Integration (ERC-5792)
+
+This more modern alternative to `eth_sendTransaction` also has wide adoption across wallets and provided simpler interfaces for batching transactions, sponsoring gas, and more open-ended capabilities.
+
+Applications using ERC-5792's `wallet_sendCalls` RPC method MUST communicate attribution data through a new `dataSuffix` capability:
+
+```typescript
+interface DataSuffixCapability {
+  dataSuffix: {
+    value: string // Hex-encoded bytes to append as suffix
+    optional?: bool // Declare to wallet if adding attribution is optional (reverts if not and wallet does not support)
+  };
+}
+```
+
+Wallets implementing this capability MUST append the provided `dataSuffix` bytes to the proper data location (transaction data for EOAs, user operation callData for ERC-4337 Smart Accounts).
 
 ## Rationale
 

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -1,7 +1,7 @@
 ---
 eip: 8021
 title: Transaction Attribution
-description: A standardized method for attributing transactions to applications and wallets through data suffixes, enabling interoperable attribution tracking and reward distribution.
+description: Leverage data suffixes to enables interoperable transaction attribution for apps, wallets, and more.
 author: Conner Swenberg (@ilikesymmetry), Dan Cortes (@dgca), Ryan Morning (0xClouds), Nick Prince (@nick_prince12)
 discussions-to: https://ethereum-magicians.org/t/erc-8021-transaction-attribution/25561
 status: Draft
@@ -17,7 +17,7 @@ This ERC defines a standardized method for attributing transactions to applicati
 
 ## Motivation
 
-Currently, applications informally append "data suffixes" to transactions to indicate their origin, typically using the first bytes of a hash representing the application name. For example, Coinbase adds `keccak256("CoinbaseSmartWallet")` to transactions from keys.coinbase.com, and apps like Zora and OpenSea employ similar approaches.
+Currently, applications informally append "data suffixes" to transactions to indicate their origin, typically using the first bytes of a hash representing the application name or domain (e.g. `keccak256("AppName")[0:4]`).
 
 This ad-hoc approach presents several limitations:
 
@@ -37,9 +37,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This standard defines a structured data suffix format appended to transaction calldata. The suffix consists of the following components (ordered from end of calldata backwards):
 
-1. **ercSuffix** (16 bytes): A special identifier value indicating use of this standard ("8021" repeated)
-2. **schemaId** (1 byte): Schema ID number that declares the schema of proceeding bytes with space for forwards compatibility
-3. **schemaData** (variable bytes): Data to be parsed according to `schemaId`
+1. **`ercMarker`** (16 bytes): A special identifier value indicating use of this standard ("8021" repeated)
+2. **`schemaId`** (1 byte): Schema ID number that declares the schema of proceeding bytes with space for forwards compatibility
+3. **`schemaData`** (variable bytes): Data to be parsed according to `schemaId`
 
 A `schemaId` MUST be defined in an ERC to be considered valid.
 
@@ -52,15 +52,15 @@ Entities are identified by a unique "code" which is a string that follows 7-bit 
 Codes MUST also be registered in a Code Registry smart contract (interface defined in later section). Chains are encouraged to provide canonical code registries which MAY be defined in this or future ERCs.
 
 Schema ID `0` defines the following bytes and assumes chain's canonical Code Registry:
-1. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
-2. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
+1. **`codesLength`** (1 byte): Length of the codes array in bytes, including delimiters
+2. **`codes`** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
 
 Schema ID `1` builds on top of `0`, but also defines a custom Code Registry chain and address
-1. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
-2. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
-3. **codeRegistryChainIdLength** (1 byte): Length of the chain id hosting the custom Code Registry
-4. **codeRegistryChainId** (variable bytes): Chain id hosting the custom Code Registry
-5. **codeRegistryAddress** (20 bytes): Address of a smart contract implementing `ICodeRegistry`
+1. **`codesLength`** (1 byte): Length of the codes array in bytes, including delimiters
+2. **`codes`** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
+3. **`codeRegistryChainIdLength`** (1 byte): Length of the chain id hosting the custom Code Registry
+4. **`codeRegistryChainId`** (variable bytes): Chain id hosting the custom Code Registry
+5. **`codeRegistryAddress`** (20 bytes): Address of a smart contract implementing `ICodeRegistry`
 
 Custom Code Registries can be referenced across chains for ease of connecting identity for multi-chain apps.
 
@@ -68,26 +68,26 @@ Custom Code Registries can be referenced across chains for ease of connecting id
 
 The complete suffix format is:
 ```
-{txData}{schemaData}{schemaId}{ercSuffix}
-```
+txData||schemaData||schemaId||ercMarker
+``````
 
 Single entity attribution with canonical registry:
 ```
-{txData}{"baseapp"}{7}{0}{0x80218021802180218021802180218021}
+txData||"baseapp"||7||0||0x80218021802180218021802180218021
 ```
 
 Multiple entity attribution with custom registry:
 ```
-{txData}{0xCodeRegistry}{8453}{2}{"baseapp,morpho"}{14}{1}{0x80218021802180218021802180218021}
+txData||0xCodeRegistry||8453||2||"baseapp,morpho"||14||1||0x80218021802180218021802180218021
 ```
 
 ### Parsing Algorithm
 
 Offchain parsers SHOULD implement the following algorithm:
 
-1. Extract the last 16 bytes as `ercSuffix` and verify it matches the standard identifier
-2. Extract the previous byte as `schemaId`
-3. If `schemaId` is `0`:
+1. Extract the last 16 bytes as `ercMarker`` and verify it matches the standard identifier
+2. Extract the previous byte as ``schemaId``
+3. If `schemaId` is `0``:`
    a. Extract the previous byte as `codesLength`
    b. Extract the previous `codesLength` bytes as `codes`
    c. Implicitly set `codeRegistryAddress` as the registry defined by the host chain
@@ -134,10 +134,7 @@ interface ICodeRegistry {
 
 ### Code Registry Canonical Addresses
 
-| Chain ID | Code Registry |
-| -------- | ------------- |
-| `8453`   | [`0x000000bc7e6457e610fe52dcc0ca5b3ce59c8e80`](https://basescan.org/address/0x000000bc7e6457e610fe52dcc0ca5b3ce59c8e80) |
-| `84532`  | [`0xf20b8a32c39f3c56bbd27fe8438090b5a03b6381`](https://sepolia.basescan.org/address/0xf20b8a32c39f3c56bbd27fe8438090b5a03b6381) |
+Schema 0 supports smallest data suffixes by allowing attribution to implicitly use a registry canonically defined by the chain. Chains that offer canonical registries should make their addresses publicly available in their documentation.
 
 ### Code Metadata
 
@@ -154,7 +151,7 @@ type CodeMetadata = {
 
 Future ERCs can extend this schema.
 
-### ERC-4337 User Operation Implementation
+### [ERC-4337](./erc-4337.md) User Operation Implementation
 
 For ERC-4337 compliant smart accounts, the implementation differs from normal Ethereum transactions:
 
@@ -172,7 +169,7 @@ This ensures attribution data remains accessible and parseable regardless of whe
 
 ### App<>Wallet Integration
 
-Apps can append ERC-8021 attribution through multiple methods, but this standard defines integration with two RPCs: 
+Apps can append attribution through multiple methods, but this standard defines integration with two RPCs: 
 1. `eth_sendTransaction`
 2. `wallet_sendCalls`
 
@@ -180,11 +177,11 @@ Regardless of integration method, wallets MAY insert their own attribution code 
 
 #### `eth_sendTransaction` Integration
 
-This legacy method is supported by all functional Ethereum wallets. Apps can add ERC-8021 attribution to their transactions by directly appending the data suffix to the `data` field.
+This legacy method is supported by all functional Ethereum wallets. Apps can add attribution to their transactions by directly appending the data suffix to the `data` field.
 
 Note that wallets MAY mutate the transaction, for example in cases where ERC-4337 Smart Accounts are used and a transaction is actually sent from an ERC-4337 Bundler.
 
-#### `wallet_sendCalls` Integration (ERC-5792)
+#### `wallet_sendCalls` Integration ([ERC-5792](./erc-5792.md))
 
 This more modern alternative to `eth_sendTransaction` also has wide adoption across wallets and provided simpler interfaces for batching transactions, sponsoring gas, and more open-ended capabilities.
 
@@ -221,7 +218,7 @@ Wallets implementing this capability MUST append the provided `dataSuffix` bytes
 
 **Fixed-length codes**: A fixed-length encoding was considered but rejected to allow for flexible, human-readable identifiers.
 
-**ERC-721 dependency**: While codes may be implemented as ERC-721 NFTs, reducing strict dependencies makes this proposal more flexible and clarifies the minimal interface truly required for attribution.
+**[ERC-721](./erc-721.md) dependency**: While codes may be implemented as ERC-721 NFTs, reducing strict dependencies makes this proposal more flexible and clarifies the minimal interface truly required for attribution.
 
 **Structured ERC-5792 capability**: A generic bytes `dataSuffix` minimizes the effort on wallets to integrate and maintain support for new schemaIds, increasing chances of wide adoption.
 
@@ -235,11 +232,11 @@ Existing applications using informal attribution methods can migrate to this sta
 
 ### Parsing Safety
 
-Parsers MUST validate the suffix format before processing to prevent malformed data from causing errors. Invalid suffixes SHOULD be ignored rather than causing parsing failures.
+As mentioned earlier, we recommend parsers validate the suffix format before processing to prevent malformed data from causing errors. Invalid suffixes can be ignored rather than causing parsing failures.
 
 ### Registry Trust
 
-The security of attribution data depends on the trustworthiness of the registry contract. Users and applications SHOULD verify the registry implementation and governance before relying on its data.
+The security of attribution data depends on the trustworthiness of the registry contract. Users and applications are encouraged to verify the registry implementation and governance before relying on its data.
 
 ### Data Integrity
 
@@ -247,7 +244,7 @@ Since attribution data is appended to calldata, it could potentially be modified
 
 ### Privacy Considerations
 
-Attribution data is publicly visible on-chain. Applications handling sensitive user information SHOULD NOT include identifying information in attribution codes.
+Attribution data is publicly visible onchain. Future standards can find ways to standardize privacy-preserving attribution, but this it out of scope for the initial proposal and can be added in the future.
 
 ## Test Cases
 
@@ -277,10 +274,6 @@ Invalid schemaId handling:
 Input: 0xddddddddff80218021802180218021802180218021
 Expected: Parsing stops, unknown schemaId
 ```
-
-## Reference Implementation
-
-A reference implementation including the registry contract and parsing library is available at [implementation link to be added].
 
 ## Copyright
 

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -2,7 +2,7 @@
 eip: 8021
 title: Transaction Attribution
 description: A standardized method for attributing transactions to applications and wallets through data suffixes, enabling interoperable attribution tracking and reward distribution.
-author: Conner Swenberg (@ilikesymmetry), Dan Cortes (@dgca)
+author: Conner Swenberg (@ilikesymmetry), Dan Cortes (@dgca), Ryan Morning (0xClouds), Nick Prince (@nick_prince12)
 discussions-to: https://ethereum-magicians.org/t/erc-8021-transaction-attribution/25561
 status: Draft
 type: Standards Track

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -2,7 +2,7 @@
 eip: 8021
 title: Transaction Attribution
 description: Leverage data suffixes to enables interoperable transaction attribution for apps, wallets, and more.
-author: Conner Swenberg (@ilikesymmetry), Dan Cortes (@dgca), Ryan Morning (0xclouds), Nick Prince
+author: Conner Swenberg (@ilikesymmetry), Dan Cortes (@dgca), Ryan Morning (@0xclouds), Nick Prince
 discussions-to: https://ethereum-magicians.org/t/erc-8021-transaction-attribution/25561
 status: Draft
 type: Standards Track
@@ -228,6 +228,38 @@ This standard is fully backward compatible with existing transaction formats. Tr
 
 Existing applications using informal attribution methods can migrate to this standard while maintaining their current functionality during the transition period.
 
+## Test Cases
+
+Single entity attribution + canonical registry:
+
+```
+Input: 0xdddddddd62617365617070070080218021802180218021802180218021
+Expected: 
+- txData: 0xdddddddd
+- schemaId: 0
+- codes: ["baseapp"]
+- registry: canonical
+```
+
+Multiple entity attribution + custom registry:
+
+```
+Input: 0xddddddddcccccccccccccccccccccccccccccccccccccccc210502626173656170702C6D6F7270686F0E0180218021802180218021802180218021
+Expected:
+- txData: 0xdddddddd
+- schemaId: 1
+- codes: ["baseapp", "morpho"]
+- codeRegistryChainId: 8453
+- codeRegistryAddress: 0xcccccccccccccccccccccccccccccccccccccccc
+```
+
+Invalid schemaId handling:
+
+```
+Input: 0xddddddddff80218021802180218021802180218021
+Expected: Parsing stops, unknown schemaId
+```
+
 ## Security Considerations
 
 ### Parsing Safety
@@ -245,35 +277,6 @@ Since attribution data is appended to calldata, it could potentially be modified
 ### Privacy Considerations
 
 Attribution data is publicly visible onchain. Future standards can find ways to standardize privacy-preserving attribution, but this it out of scope for the initial proposal and can be added in the future.
-
-## Test Cases
-
-Single entity attribution + canonical registry:
-```
-Input: 0xdddddddd62617365617070070080218021802180218021802180218021
-Expected: 
-- txData: 0xdddddddd
-- schemaId: 0
-- codes: ["baseapp"]
-- registry: canonical
-```
-
-Multiple entity attribution + custom registry:
-```
-Input: 0xddddddddcccccccccccccccccccccccccccccccccccccccc210502626173656170702C6D6F7270686F0E0180218021802180218021802180218021
-Expected:
-- txData: 0xdddddddd
-- schemaId: 1
-- codes: ["baseapp", "morpho"]
-- codeRegistryChainId: 8453
-- codeRegistryAddress: 0xcccccccccccccccccccccccccccccccccccccccc
-```
-
-Invalid schemaId handling:
-```
-Input: 0xddddddddff80218021802180218021802180218021
-Expected: Parsing stops, unknown schemaId
-```
 
 ## Copyright
 

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -151,7 +151,7 @@ type CodeMetadata = {
 
 Future ERCs can extend this schema.
 
-### [ERC-4337](./erc-4337.md) User Operation Implementation
+### [ERC-4337](./eip-4337.md) User Operation Implementation
 
 For ERC-4337 compliant smart accounts, the implementation differs from normal Ethereum transactions:
 
@@ -181,7 +181,7 @@ This legacy method is supported by all functional Ethereum wallets. Apps can add
 
 Note that wallets MAY mutate the transaction, for example in cases where ERC-4337 Smart Accounts are used and a transaction is actually sent from an ERC-4337 Bundler.
 
-#### `wallet_sendCalls` Integration ([ERC-5792](./erc-5792.md))
+#### `wallet_sendCalls` Integration ([ERC-5792](./eip-5792.md))
 
 This more modern alternative to `eth_sendTransaction` also has wide adoption across wallets and provided simpler interfaces for batching transactions, sponsoring gas, and more open-ended capabilities.
 
@@ -218,7 +218,7 @@ Wallets implementing this capability MUST append the provided `dataSuffix` bytes
 
 **Fixed-length codes**: A fixed-length encoding was considered but rejected to allow for flexible, human-readable identifiers.
 
-**[ERC-721](./erc-721.md) dependency**: While codes may be implemented as ERC-721 NFTs, reducing strict dependencies makes this proposal more flexible and clarifies the minimal interface truly required for attribution.
+**[ERC-721](./eip-721.md) dependency**: While codes may be implemented as ERC-721 NFTs, reducing strict dependencies makes this proposal more flexible and clarifies the minimal interface truly required for attribution.
 
 **Structured ERC-5792 capability**: A generic bytes `dataSuffix` minimizes the effort on wallets to integrate and maintain support for new schemaIds, increasing chances of wide adoption.
 

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -2,7 +2,7 @@
 eip: 8021
 title: Transaction Attribution
 description: Leverage data suffixes to enables interoperable transaction attribution for apps, wallets, and more.
-author: Conner Swenberg (@ilikesymmetry), Dan Cortes (@dgca), Ryan Morning (0xClouds), Nick Prince (@nick_prince12)
+author: Conner Swenberg (@ilikesymmetry), Dan Cortes (@dgca), Ryan Morning (0xclouds), Nick Prince
 discussions-to: https://ethereum-magicians.org/t/erc-8021-transaction-attribution/25561
 status: Draft
 type: Standards Track

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -1,9 +1,9 @@
 ---
-eip: XXXX
-title: Transaction Attribution Standard
+eip: 8021
+title: Transaction Attribution
 description: A standardized method for attributing transactions to applications and wallets through data suffixes, enabling interoperable attribution tracking and reward distribution.
 author: Conner Swenberg (@ilikesymmetry)
-discussions-to: https://t.me/+eGryX6DeFWMwYmMx
+discussions-to: https://ethereum-magicians.org/t/erc-8021-transaction-attribution/25561
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -55,10 +55,14 @@ Schema ID `0` defines the following bytes and assumes chain's canonical Code Reg
 1. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
 2. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
 
-Schema ID `1` builds on top of `0`, but also defines a custom Code Registry
+Schema ID `1` builds on top of `0`, but also defines a custom Code Registry chain and address
 1. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
 2. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
-3. **codeRegistryAddress** (20 bytes): Address of a smart contract implementing `ICodeRegistry`
+3. **codeRegistryChainIdLength** (1 byte): Length of the chain id hosting the custom Code Registry
+4. **codeRegistryChainId** (variable bytes): Chain id hosting the custom Code Registry
+5. **codeRegistryAddress** (20 bytes): Address of a smart contract implementing `ICodeRegistry`
+
+Custom Code Registries can be referenced across chains for ease of connecting identity for multi-chain apps.
 
 #### Examples
 
@@ -74,7 +78,7 @@ Single entity attribution with canonical registry:
 
 Multiple entity attribution with custom registry:
 ```
-{txData}{0xCodeRegistry}{"baseapp,morpho"}{14}{1}{0x80218021802180218021802180218021}
+{txData}{0xCodeRegistry}{8453}{2}{"baseapp,morpho"}{14}{1}{0x80218021802180218021802180218021}
 ```
 
 ### Parsing Algorithm
@@ -88,14 +92,16 @@ Offchain parsers SHOULD implement the following algorithm:
    b. Extract the previous `codesLength` bytes as `codes`
    c. Implicitly set `codeRegistryAddress` as the registry defined by the host chain
    d. Parse `codes` using `0x2C` (comma) as delimiter between codes
-   e. Query code-related data from `codeRegistryAddress`
-3. If `schemaId` is `1`:
+   e. Query code-related data from `codeRegistryAddress` on host chain
+4. If `schemaId` is `1`:
    a. Extract the previous byte as `codesLength`
    b. Extract the previous `codesLength` bytes as `codes`
-   c. Extract the previous 20 bytes as custom `codeRegistryAddress`
-   d. Parse `codes` using `0x2C` (comma) as delimiter between codes
-   e. Query code-related data from `codeRegistryAddress`
-4. Else `schemaId` does not match, parsing SHOULD terminate (unknown schemaId)
+   c. Extract the previous byte as `codeRegistryChainIdLength`
+   d. Extract the previous `codeRegistryChainIdLength` bytes as `codeRegistryChainId`
+   e. Extract the previous 20 bytes as `codeRegistryAddress`
+   f. Parse `codes` using `0x2C` (comma) as delimiter between codes
+   g. Query code-related data from `codeRegistryAddress` on chain with id `codeRegistryChainId`
+5. Else `schemaId` does not match, parsing SHOULD terminate (unknown schemaId)
 
 ### Code Registry Interface
 
@@ -238,12 +244,13 @@ Expected:
 
 Multiple entity attribution + custom registry:
 ```
-Input: 0xdddddddd626173656170702C6D6F7270686F0Ecccccccccccccccccccccccccccccccccccccccc0180218021802180218021802180218021
+Input: 0xddddddddcccccccccccccccccccccccccccccccccccccccc210502626173656170702C6D6F7270686F0E0180218021802180218021802180218021
 Expected:
 - txData: 0xdddddddd
-- schemaId: 0
+- schemaId: 1
 - codes: ["baseapp", "morpho"]
-- registry: 0xcccccccccccccccccccccccccccccccccccccccc
+- codeRegistryChainId: 8453
+- codeRegistryAddress: 0xcccccccccccccccccccccccccccccccccccccccc
 ```
 
 Invalid schemaId handling:

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -2,7 +2,7 @@
 eip: 8021
 title: Transaction Attribution
 description: A standardized method for attributing transactions to applications and wallets through data suffixes, enabling interoperable attribution tracking and reward distribution.
-author: Conner Swenberg (@ilikesymmetry)
+author: Conner Swenberg (@ilikesymmetry), Kofi (@Jam516)
 discussions-to: https://ethereum-magicians.org/t/erc-8021-transaction-attribution/25561
 status: Draft
 type: Standards Track
@@ -17,7 +17,7 @@ This ERC defines a standardized method for attributing transactions to applicati
 
 ## Motivation
 
-Currently, applications informally append "data suffixes" to transactions to indicate their origin, typically using the first 4 bytes of a hash representing the application name. For example, Coinbase adds `keccak256("CoinbaseSmartWallet")` to transactions from keys.coinbase.com, and platforms like Zora and OpenSea employ similar approaches.
+Currently, applications informally append "data suffixes" to transactions to indicate their origin, typically using the first bytes of a hash representing the application name. For example, Coinbase adds `keccak256("CoinbaseSmartWallet")` to transactions from keys.coinbase.com, and apps like Zora and OpenSea employ similar approaches.
 
 This ad-hoc approach presents several limitations:
 
@@ -37,65 +37,108 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This standard defines a structured data suffix format appended to transaction calldata. The suffix consists of the following components (ordered from end of calldata backwards):
 
-1. **ercSuffix** (TBD bytes): A special identifier value indicating use of this standard
-2. **version** (1 byte): Schema version number enabling forward compatibility
-3. **codeRegistryAddress** (20 bytes): Address of a smart contract implementing `ICodeRegistry` (version 0x00 only)
-4. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
-5. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (0x2C) as delimiter
+1. **ercSuffix** (32 bytes): A special identifier value indicating use of this standard ("8021" repeated)
+2. **schemaId** (1 byte): Schema ID number that declares the schema of proceeding bytes with space for forwards compatibility
+3. **schemaData** (variable bytes): Data to be parsed according to `schemaId`
+
+A `schemaId` MUST have an associated ERC to be considered valid.
+
+### Multi-Attribution Schemas
+
+Our first schemas enable attributing multiple entities in a single transaction.
+
+Entities are identified by a unique "code" which is a string that follows 7-bit ASCII encoding. Every code MUST have an Entity Type associated with it to discern between different kinds of parties that can contribute to a transaction. Entity Types are prepended to each code with a colon (`0x3A`) separator, for example `w:baseapp`.
+
+The following Entity Types are supported:
+1. `w`: Wallet
+2. `a`: App
+3. `r`: Referrer
+
+Codes MUST also be registered in a Code Regsitry smart contract (interface defined in later section). Chains are encouraged to provide canonical code registries which MAY be defined in this or future ERCs.
+
+Schema ID `0` defines the following bytes and assumes chain's canonical Code Registry:
+3. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
+4. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
+
+Schema ID `1` builds on top of `0`, but also defines a custom Code Registry
+3. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
+4. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
+5. **codeRegistryAddress** (20 bytes): Address of a smart contract implementing `ICodeRegistry`
+
+#### Examples
 
 The complete suffix format is:
 ```
-{transaction_calldata}{codes}{codesLength}{codeRegistryAddress}{version}{ercSuffix}
+{txData}{schemaData}{schemaId}{ercSuffix}
 ```
 
 #### Examples
 
-Single entity attribution:
+Single entity attribution with canonical registry:
 ```
-{txData}baseapp{7}{0xCodeRegistry}{0x00}{0xERCSUFFIX}
+{txData}{"w:baseapp"}{9}{0}{0x8021802180218021802180218021802180218021802180218021802180218021}
 ```
 
-Multiple entity attribution:
+Multiple entity attribution with custom registry:
 ```
-{txData}baseapp,morpho{14}{0xCodeRegistry}{0x00}{0xERCSUFFIX}
+{txData}{0xCodeRegistry}{"w:baseapp,a:morpho"}{18}{1}{0x8021802180218021802180218021802180218021802180218021802180218021}
 ```
 
 ### Parsing Algorithm
 
-Offchain parsers MUST implement the following algorithm:
+Offchain parsers SHOULD implement the following algorithm:
 
 1. Extract the last TBD bytes as `ercSuffix` and verify it matches the standard identifier
-2. Extract the previous byte as `version`
-3. If `version` is `0x00`:
-   a. Extract the previous 20 bytes as `codeRegistryAddress`
-   b. Extract the previous byte as `codesLength`
-   c. Extract the previous `codesLength` bytes as `codes`
-   d. Parse `codes` using ASCII decoding with comma (`0x2C`) as delimiter
-   e. For each code, query the registry at `codeRegistryAddress`
-4. If `version` is not `0x00`, parsing SHOULD terminate (unknown version)
+2. Extract the previous byte as `schemaId`
+3. If `schemaId` is `0`:
+   a. Extract the previous byte as `codesLength`
+   b. Extract the previous `codesLength` bytes as `codes`
+   c. Implicitly set `codeRegistryAddress` as the registry defined by the host chain
+   d. Parse `codes` using `0x2C` (comma) as delimiter between codes and `0x3A` (colon) as separator between code and entity type
+   e. Query code-related data from `codeRegistryAddress`
+3. If `schemaId` is `1`:
+   a. Extract the previous byte as `codesLength`
+   b. Extract the previous `codesLength` bytes as `codes`
+   c. Extract the previous 20 bytes as custom `codeRegistryAddress`
+   d. Parse `codes` using `0x2C` (comma) as delimiter between codes and `0x3A` (colon) as separator between code and entity type
+   e. Query code-related data from `codeRegistryAddress`
+4. Else `schemaId` does not match, parsing SHOULD terminate (unknown schemaId)
 
-### ICodeRegistry Interface
+### Code Registry Interface
 
-The `codeRegistryAddress` MUST point to a contract implementing the following interface:
+A Code Registry MUST implement the following interface:
 
 ```solidity
 interface ICodeRegistry {
-    /// @notice Returns the payout address for incentive distribution
-    /// @param code The attribution code to query
+    /// @notice Fetch a code's address to payout incentives
+    /// @param code The code to query
     /// @return The address to receive rewards for this code
     function payoutAddress(string memory code) external view returns (address);
     
-    /// @notice Returns the metadata URI for additional information
-    /// @param code The attribution code to query  
-    /// @return uri The URI pointing to metadata about this code
-    function codeURI(string memory code) external view returns (string memory uri);
+    /// @notice Fetch a code's URI to fetch for additional metadata
+    /// @param code The code to query  
+    /// @return The URI pointing to metadata about this code
+    function codeURI(string memory code) external view returns (string memory);
     
-    /// @notice Checks if a code is valid and registered
-    /// @param code The attribution code to validate
+    /// @notice Check if a code is valid format (characters, length, etc)
+    /// @dev MUST return false if code is empty string
+    /// @param code The code to query
     /// @return True if the code is valid, false otherwise
     function isValidCode(string memory code) external view returns (bool);
+    
+    /// @notice Check if a code is registered
+    /// @param code The code to query
+    /// @return True if the code is registered, false otherwise
+    function isRegistered(string memory code) external view returns (bool);
 }
 ```
+
+### Code Regsitry Canonical Addresses
+
+| Chain ID | Code Registry |
+| -------- | ------------- |
+| `8453`   | TBD           |
+| `84532`  | TBD           |
 
 ### ERC-5792 Integration
 
@@ -131,7 +174,7 @@ This ensures attribution data remains accessible and parseable regardless of whe
 
 **Reverse-order parsing**: The suffix format is designed for parsing from the end of calldata backwards, enabling efficient detection of attribution without requiring knowledge of the original calldata length.
 
-**Version byte**: Including a version field enables future extensions while maintaining backward compatibility with parsers that only understand version 0x00.
+**schemaId byte**: Including a schemaId field enables future extensions and optimizations in minimizing attribution data.
 
 **Registry pattern**: Using a registry contract allows entities to update their payout addresses and metadata without requiring transaction format changes.
 
@@ -141,13 +184,13 @@ This ensures attribution data remains accessible and parseable regardless of whe
 
 ### Alternative Approaches Considered
 
-**Customizable registry**: While a single global registry was considered, the flexible registry approach allows different ecosystems to maintain their own attribution systems.
+**Customizable registry**: While a single global registry is recommended when available for reduced transaction data, the flexible registry approach allows different ecosystems to maintain their own attribution systems.
 
 **Fixed-length codes**: A fixed-length encoding was considered but rejected to allow for flexible, human-readable identifiers.
 
 **ERC-721 dependency**: While codes may be implemented as ERC-721 NFTs, reducing strict dependencies makes this proposal more flexible and clarifies the minimal interface truly required for attribution.
 
-**Structured ERC-5792 capability**: A generic bytes `dataSuffix` minimizes the effort on wallets to integrate and maintain support for new versions, increasing chances of wide adoption.
+**Structured ERC-5792 capability**: A generic bytes `dataSuffix` minimizes the effort on wallets to integrate and maintain support for new schemaIds, increasing chances of wide adoption.
 
 ## Backwards Compatibility
 
@@ -178,28 +221,30 @@ Attribution data is publicly visible on-chain. Applications handling sensitive u
 ### Valid Suffix Parsing
 
 ```
-Input: 0x1234567890baseapp0x07{registry_address}0x00{erc_suffix}
+Input: 0xdddddddd773A6261736561707009008021802180218021802180218021802180218021802180218021802180218021
 Expected: 
-- version: 0x00
-- registry: {registry_address}  
-- codes: ["baseapp"]
+- txData: 0xdddddddd
+- schemaId: 0
+- codes: [{type: "w", code: "baseapp"}]
+- registry: canonical
 ```
 
 ### Multiple Entity Attribution
 
 ```
-Input: 0x1234567890baseapp,zora0x0d{registry_address}0x00{erc_suffix}
+Input: 0xdddddddd773A626173656170702C613A6D6F7270686F12cccccccccccccccccccccccccccccccccccccccc018021802180218021802180218021802180218021802180218021802180218021
 Expected:
-- version: 0x00
-- registry: {registry_address}
-- codes: ["baseapp", "zora"]
+- txData: 0xdddddddd
+- schemaId: 0
+- codes: [{type: "w", code: "baseapp"}, {type: "a", code: "morpho"}]
+- registry: 0xcccccccccccccccccccccccccccccccccccccccc
 ```
 
-### Invalid Version Handling
+### Invalid schemaId Handling
 
 ```
-Input: 0x1234567890somedata0x01{erc_suffix}
-Expected: Parsing stops, unknown version
+Input: 0xddddddddff8021802180218021802180218021802180218021802180218021802180218021
+Expected: Parsing stops, unknown schemaId
 ```
 
 ## Reference Implementation

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -37,7 +37,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This standard defines a structured data suffix format appended to transaction calldata. The suffix consists of the following components (ordered from end of calldata backwards):
 
-1. **ercSuffix** (32 bytes): A special identifier value indicating use of this standard ("8021" repeated)
+1. **ercSuffix** (16 bytes): A special identifier value indicating use of this standard ("8021" repeated)
 2. **schemaId** (1 byte): Schema ID number that declares the schema of proceeding bytes with space for forwards compatibility
 3. **schemaData** (variable bytes): Data to be parsed according to `schemaId`
 
@@ -47,12 +47,7 @@ A `schemaId` MUST have an associated ERC to be considered valid.
 
 Our first schemas enable attributing multiple entities in a single transaction.
 
-Entities are identified by a unique "code" which is a string that follows 7-bit ASCII encoding. Every code MUST have an Entity Type associated with it to discern between different kinds of parties that can contribute to a transaction. Entity Types are prepended to each code with a colon (`0x3A`) separator, for example `w:baseapp`.
-
-The following Entity Types are supported:
-1. `"w"`: Wallet
-2. `"a"`: App
-3. `"r"`: Referrer
+Entities are identified by a unique "code" which is a string that follows 7-bit ASCII encoding. A code MUST NOT contain commas (`0x2C`) as this is reserved as a delimitter for attributing multiple codes.
 
 Codes MUST also be registered in a Code Regsitry smart contract (interface defined in later section). Chains are encouraged to provide canonical code registries which MAY be defined in this or future ERCs.
 
@@ -74,12 +69,12 @@ The complete suffix format is:
 
 Single entity attribution with canonical registry:
 ```
-{txData}{"w:baseapp"}{9}{0}{0x8021802180218021802180218021802180218021802180218021802180218021}
+{txData}{"baseapp"}{7}{0}{0x80218021802180218021802180218021}
 ```
 
 Multiple entity attribution with custom registry:
 ```
-{txData}{0xCodeRegistry}{"w:baseapp,a:morpho"}{18}{1}{0x8021802180218021802180218021802180218021802180218021802180218021}
+{txData}{0xCodeRegistry}{"baseapp,morpho"}{14}{1}{0x80218021802180218021802180218021}
 ```
 
 ### Parsing Algorithm
@@ -92,13 +87,13 @@ Offchain parsers SHOULD implement the following algorithm:
    a. Extract the previous byte as `codesLength`
    b. Extract the previous `codesLength` bytes as `codes`
    c. Implicitly set `codeRegistryAddress` as the registry defined by the host chain
-   d. Parse `codes` using `0x2C` (comma) as delimiter between codes and `0x3A` (colon) as separator between code and entity type
+   d. Parse `codes` using `0x2C` (comma) as delimiter between codes
    e. Query code-related data from `codeRegistryAddress`
 3. If `schemaId` is `1`:
    a. Extract the previous byte as `codesLength`
    b. Extract the previous `codesLength` bytes as `codes`
    c. Extract the previous 20 bytes as custom `codeRegistryAddress`
-   d. Parse `codes` using `0x2C` (comma) as delimiter between codes and `0x3A` (colon) as separator between code and entity type
+   d. Parse `codes` using `0x2C` (comma) as delimiter between codes
    e. Query code-related data from `codeRegistryAddress`
 4. Else `schemaId` does not match, parsing SHOULD terminate (unknown schemaId)
 
@@ -218,27 +213,27 @@ Attribution data is publicly visible on-chain. Applications handling sensitive u
 
 Single entity attribution + canonical registry:
 ```
-Input: 0xdddddddd773A6261736561707009008021802180218021802180218021802180218021802180218021802180218021
+Input: 0xdddddddd62617365617070090080218021802180218021802180218021
 Expected: 
 - txData: 0xdddddddd
 - schemaId: 0
-- codes: [{type: "w", code: "baseapp"}]
+- codes: ["baseapp"]
 - registry: canonical
 ```
 
 Multiple entity attribution + custom registry:
 ```
-Input: 0xdddddddd773A626173656170702C613A6D6F7270686F12cccccccccccccccccccccccccccccccccccccccc018021802180218021802180218021802180218021802180218021802180218021
+Input: 0xdddddddd626173656170702C6D6F7270686F12cccccccccccccccccccccccccccccccccccccccc0180218021802180218021802180218021
 Expected:
 - txData: 0xdddddddd
 - schemaId: 0
-- codes: [{type: "w", code: "baseapp"}, {type: "a", code: "morpho"}]
+- codes: ["baseapp", "morpho"]
 - registry: 0xcccccccccccccccccccccccccccccccccccccccc
 ```
 
 Invalid schemaId handling:
 ```
-Input: 0xddddddddff8021802180218021802180218021802180218021802180218021802180218021
+Input: 0xddddddddff80218021802180218021802180218021
 Expected: Parsing stops, unknown schemaId
 ```
 

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -2,7 +2,7 @@
 eip: 8021
 title: Transaction Attribution
 description: A standardized method for attributing transactions to applications and wallets through data suffixes, enabling interoperable attribution tracking and reward distribution.
-author: Conner Swenberg (@ilikesymmetry), Kofi (@Jam516)
+author: Conner Swenberg (@ilikesymmetry)
 discussions-to: https://ethereum-magicians.org/t/erc-8021-transaction-attribution/25561
 status: Draft
 type: Standards Track
@@ -132,6 +132,21 @@ interface ICodeRegistry {
 | -------- | ------------- |
 | `8453`   | TBD           |
 | `84532`  | TBD           |
+
+### Code Metadata
+
+Querying `CodeRegistry.codeURI(code)` returns a string `uri` to fetch actual metadata, following from NFT patterns. The returned metadata SHOULD include these fields:
+
+```typescript
+type CodeMetadata = {
+    app: {
+      name: string
+      url: string
+    }
+}
+```
+
+Future ERCs can extend this schema.
 
 ### ERC-5792 Integration
 

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -228,7 +228,7 @@ Attribution data is publicly visible on-chain. Applications handling sensitive u
 
 Single entity attribution + canonical registry:
 ```
-Input: 0xdddddddd62617365617070090080218021802180218021802180218021
+Input: 0xdddddddd62617365617070070080218021802180218021802180218021
 Expected: 
 - txData: 0xdddddddd
 - schemaId: 0
@@ -238,7 +238,7 @@ Expected:
 
 Multiple entity attribution + custom registry:
 ```
-Input: 0xdddddddd626173656170702C6D6F7270686F12cccccccccccccccccccccccccccccccccccccccc0180218021802180218021802180218021
+Input: 0xdddddddd626173656170702C6D6F7270686F0Ecccccccccccccccccccccccccccccccccccccccc0180218021802180218021802180218021
 Expected:
 - txData: 0xdddddddd
 - schemaId: 0

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -50,20 +50,20 @@ Our first schemas enable attributing multiple entities in a single transaction.
 Entities are identified by a unique "code" which is a string that follows 7-bit ASCII encoding. Every code MUST have an Entity Type associated with it to discern between different kinds of parties that can contribute to a transaction. Entity Types are prepended to each code with a colon (`0x3A`) separator, for example `w:baseapp`.
 
 The following Entity Types are supported:
-1. `w`: Wallet
-2. `a`: App
-3. `r`: Referrer
+1. `"w"`: Wallet
+2. `"a"`: App
+3. `"r"`: Referrer
 
 Codes MUST also be registered in a Code Regsitry smart contract (interface defined in later section). Chains are encouraged to provide canonical code registries which MAY be defined in this or future ERCs.
 
 Schema ID `0` defines the following bytes and assumes chain's canonical Code Registry:
-3. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
-4. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
+1. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
+2. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
 
 Schema ID `1` builds on top of `0`, but also defines a custom Code Registry
-3. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
-4. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
-5. **codeRegistryAddress** (20 bytes): Address of a smart contract implementing `ICodeRegistry`
+1. **codesLength** (1 byte): Length of the codes array in bytes, including delimiters
+2. **codes** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
+3. **codeRegistryAddress** (20 bytes): Address of a smart contract implementing `ICodeRegistry`
 
 #### Examples
 
@@ -71,8 +71,6 @@ The complete suffix format is:
 ```
 {txData}{schemaData}{schemaId}{ercSuffix}
 ```
-
-#### Examples
 
 Single entity attribution with canonical registry:
 ```
@@ -218,8 +216,7 @@ Attribution data is publicly visible on-chain. Applications handling sensitive u
 
 ## Test Cases
 
-### Valid Suffix Parsing
-
+Single entity attribution + canonical registry:
 ```
 Input: 0xdddddddd773A6261736561707009008021802180218021802180218021802180218021802180218021802180218021
 Expected: 
@@ -229,8 +226,7 @@ Expected:
 - registry: canonical
 ```
 
-### Multiple Entity Attribution
-
+Multiple entity attribution + custom registry:
 ```
 Input: 0xdddddddd773A626173656170702C613A6D6F7270686F12cccccccccccccccccccccccccccccccccccccccc018021802180218021802180218021802180218021802180218021802180218021
 Expected:
@@ -240,8 +236,7 @@ Expected:
 - registry: 0xcccccccccccccccccccccccccccccccccccccccc
 ```
 
-### Invalid schemaId Handling
-
+Invalid schemaId handling:
 ```
 Input: 0xddddddddff8021802180218021802180218021802180218021802180218021802180218021
 Expected: Parsing stops, unknown schemaId

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -43,6 +43,8 @@ This standard defines a structured data suffix format appended to transaction ca
 
 A `schemaId` MUST be defined in an ERC to be considered valid.
 
+All multi-byte integer fields in this specification use big-endian byte order.
+
 ### Multi-Attribution Schemas
 
 Our first schemas enable attributing multiple entities in a single transaction.
@@ -64,21 +66,85 @@ Schema ID `1` builds on top of `0`, but also defines a custom Code Registry chai
 
 Custom Code Registries can be referenced across chains for ease of connecting identity for multi-chain apps.
 
+Schema ID `2` uses [CBOR](https://cbor.io/) encoding for extensible transaction annotation:
+
+- Optional and unknown fields for future extensions
+- Coexistence with other suffix-based systems
+- Arbitrary metadata without requiring new schema IDs
+
+1. **cborLength** (2 bytes): Length of the CBOR-encoded map in bytes
+2. **cborData** (variable length): CBOR-encoded map containing attribution data
+
+The CBOR map MUST use the following key schema. All fields are OPTIONAL. All top-level keys are reserved for this specification.
+
+| Key | Description                                                                                                                                                                      |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `a` | Application code - string value                                                                                                                                                  |
+| `w` | Wallet code - string value                                                                                                                                                       |
+| `r` | Custom registries - sub-map keyed by entity type (`a` for application, `w` for wallet), each containing `c` (chainId as hex string) and `a` (20-byte hex-encoded address string) |
+| `m` | Custom metadata - sub-map of arbitrary key-value pairs                                                                                                                           |
+
+Only the `m` (metadata) field MAY contain arbitrary data defined by consumers of this specification. All other top-level keys are reserved and MUST NOT be used for purposes other than those defined above.
+
+```typescript
+type Schema2Data = {
+  a?: string;
+  w?: string;
+  r?: {
+    a?: { c: Hex; a: Hex };
+    w?: { c: Hex; a: Hex };
+  };
+  m?: Record<string, unknown>;
+};
+```
+
+Note: Schema ID `2` trades minimal byte size for extensibility. Applications prioritizing minimal calldata overhead SHOULD use Schema ID `0` or `1` when their use case does not require extensibility.
+
 #### Examples
 
 The complete suffix format is:
+
 ```
 txData||schemaData||schemaId||ercMarker
 ``````
 
 Single entity attribution with canonical registry:
+
 ```
 txData||"baseapp"||7||0||0x80218021802180218021802180218021
 ```
 
 Multiple entity attribution with custom registry:
+
 ```
 txData||0xCodeRegistry||8453||2||"baseapp,morpho"||14||1||0x80218021802180218021802180218021
+```
+
+Single entity attribution with CBOR (Schema ID 2):
+
+```
+{txData}{"a":"baseapp"}{0x000b}{2}{0x80218021802180218021802180218021}
+```
+
+Multiple entities with wallet, custom registry, and metadata (Schema ID 2):
+
+```
+{txData}{cborData}{0x007b}{2}{0x80218021802180218021802180218021}
+
+{
+  "a": "baseapp",
+  "w": "privy",
+  "r": {
+    "a": {
+      "c": "0x2105",
+      "a": "0xBcf2B9598Ec0781eE49230CaACF0FB3C881B5195"
+    }
+  },
+  "m": {
+    "utm_campaign": "winter-promo",
+    "source": "webapp"
+  }
+}
 ```
 
 ### Parsing Algorithm
@@ -101,7 +167,17 @@ Offchain parsers SHOULD implement the following algorithm:
    e. Extract the previous 20 bytes as `codeRegistryAddress`
    f. Parse `codes` using `0x2C` (comma) as delimiter between codes
    g. Query code-related data from `codeRegistryAddress` on chain with id `codeRegistryChainId`
-5. Else `schemaId` does not match, parsing SHOULD terminate (unknown schemaId)
+5. If `schemaId` is `2`:
+   a. Extract the previous 2 bytes as `cborLength`
+   b. Extract the previous `cborLength` bytes as `cborData`
+   c. Decode `cborData` as a CBOR map
+   d. Extract application code from key `a`
+   e. Extract wallet code from key `w` (if present)
+   f. Extract custom registries from key `r` (if present), containing sub-maps keyed by `a` (application) and/or `w` (wallet), each with `c` (chainId) and `a` (address)
+   g. Extract metadata from key `m` (if present)
+   h. For each code, if no custom registry specified for that entity type, use chain's canonical Code Registry
+   i. Query code-related data from appropriate registry for each code
+6. Else `schemaId` does not match, parsing SHOULD terminate (unknown schemaId)
 
 ### Code Registry Interface
 
@@ -113,18 +189,18 @@ interface ICodeRegistry {
     /// @param code The code to query
     /// @return The address to receive rewards for this code
     function payoutAddress(string memory code) external view returns (address);
-    
+
     /// @notice Fetch a code's URI to fetch for additional metadata
-    /// @param code The code to query  
+    /// @param code The code to query
     /// @return The URI pointing to metadata about this code
     function codeURI(string memory code) external view returns (string memory);
-    
+
     /// @notice Check if a code is valid format (characters, length, etc)
     /// @dev MUST return false if code is empty string
     /// @param code The code to query
     /// @return True if the code is valid, false otherwise
     function isValidCode(string memory code) external view returns (bool);
-    
+
     /// @notice Check if a code is registered
     /// @param code The code to query
     /// @return True if the code is registered, false otherwise
@@ -142,11 +218,11 @@ Querying `CodeRegistry.codeURI(code)` returns a string `uri` to fetch actual met
 
 ```typescript
 type CodeMetadata = {
-    app: {
-      name: string
-      url: string
-    }
-}
+  app: {
+    name: string;
+    url: string;
+  };
+};
 ```
 
 Future ERCs can extend this schema.
@@ -190,8 +266,8 @@ Applications using ERC-5792's `wallet_sendCalls` RPC method MUST communicate att
 ```typescript
 interface DataSuffixCapability {
   dataSuffix: {
-    value: string // Hex-encoded bytes to append as suffix
-    optional?: bool // Declare to wallet if adding attribution is optional (reverts if not and wallet does not support)
+    value: string; // Hex-encoded bytes to append as suffix
+    optional?: bool; // Declare to wallet if adding attribution is optional (reverts if not and wallet does not support)
   };
 }
 ```
@@ -212,6 +288,8 @@ Wallets implementing this capability MUST append the provided `dataSuffix` bytes
 
 **ERC-5792 integration**: The capability-based approach aligns with ERC-5792's extensible design while providing a clean separation of concerns between applications and wallets.
 
+**CBOR encoding for Schema ID 2**: Schema IDs 0 and 1 are optimized for minimal bytes but assume sole ownership of the calldata suffix. Schema ID 2 uses CBOR encoding to enable coexistence with other suffix-based systems, support arbitrary metadata, and allow future extensions without requiring new schema IDs. The tradeoff is increased calldata size and parsing complexity.
+
 ### Alternative Approaches Considered
 
 **Customizable registry**: While a single global registry is recommended when available for reduced transaction data, the flexible registry approach allows different ecosystems to maintain their own attribution systems.
@@ -221,6 +299,11 @@ Wallets implementing this capability MUST append the provided `dataSuffix` bytes
 **[ERC-721](./eip-721.md) dependency**: While codes may be implemented as ERC-721 NFTs, reducing strict dependencies makes this proposal more flexible and clarifies the minimal interface truly required for attribution.
 
 **Structured ERC-5792 capability**: A generic bytes `dataSuffix` minimizes the effort on wallets to integrate and maintain support for new schemaIds, increasing chances of wide adoption.
+
+## Forwards Compatibility
+
+All schemas after schema V2 must follow the following structure: `{schemaData}{schemaDataLength (2 bytes)}{schemaId (1 byte)}{ercSuffix (16 bytes)}`
+This layout ensures the complete dataSuffix for any future schema can be deterministically discovered using the same parsing rules.
 
 ## Backwards Compatibility
 
@@ -234,7 +317,7 @@ Single entity attribution + canonical registry:
 
 ```
 Input: 0xdddddddd62617365617070070080218021802180218021802180218021
-Expected: 
+Expected:
 - txData: 0xdddddddd
 - schemaId: 0
 - codes: ["baseapp"]
@@ -251,6 +334,28 @@ Expected:
 - codes: ["baseapp", "morpho"]
 - codeRegistryChainId: 8453
 - codeRegistryAddress: 0xcccccccccccccccccccccccccccccccccccccccc
+```
+
+Single entity attribution with CBOR (Schema ID 2):
+
+```
+Input: 0xdddddddda161616762617365617070000b0280218021802180218021802180218021
+Expected:
+- txData: 0xdddddddd
+- schemaId: 2
+- cborLength: 0x000b (11 bytes)
+- cborData: {"a": "baseapp"}
+```
+
+Multiple entities with metadata (Schema ID 2):
+
+```
+Input: 0xdddddddda46161676261736561707061776570726976796172a16161a26163663078323130356161782a307842636632423935393845633037383165453439323330436141434630464233433838314235313935616da26c75746d5f63616d706169676e6c77696e7465722d70726f6d6f66736f7572636566776562617070007b0280218021802180218021802180218021
+Expected:
+- txData: 0xdddddddd
+- schemaId: 2
+- cborLength: 0x007b (123 bytes)
+- cborData: {"a":"baseapp","w":"privy","r":{"a":{"c":"0x2105","a":"0xBcf2B9598Ec0781eE49230CaACF0FB3C881B5195"}},"m":{"utm_campaign":"winter-promo","source":"webapp"}}
 ```
 
 Invalid schemaId handling:

--- a/ERCS/erc-8021.md
+++ b/ERCS/erc-8021.md
@@ -54,10 +54,12 @@ Entities are identified by a unique "code" which is a string that follows 7-bit 
 Codes MUST also be registered in a Code Registry smart contract (interface defined in later section). Chains are encouraged to provide canonical code registries which MAY be defined in this or future ERCs.
 
 Schema ID `0` defines the following bytes and assumes chain's canonical Code Registry:
+
 1. **`codesLength`** (1 byte): Length of the codes array in bytes, including delimiters
 2. **`codes`** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
 
 Schema ID `1` builds on top of `0`, but also defines a custom Code Registry chain and address
+
 1. **`codesLength`** (1 byte): Length of the codes array in bytes, including delimiters
 2. **`codes`** (variable length): Array of attribution codes using ASCII encoding with comma (`0x2C`) as delimiter
 3. **`codeRegistryChainIdLength`** (1 byte): Length of the chain id hosting the custom Code Registry
@@ -81,6 +83,7 @@ The CBOR map MUST use the following key schema. All fields are OPTIONAL. All top
 | --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `a` | Application code - string value                                                                                                                                                  |
 | `w` | Wallet code - string value                                                                                                                                                       |
+| `s` | Service codes - array of string values identifying additional service providers (e.g., block builders, relayers, solvers)                                                         |
 | `r` | Custom registries - sub-map keyed by entity type (`a` for application, `w` for wallet), each containing `c` (chainId as hex string) and `a` (20-byte hex-encoded address string) |
 | `m` | Custom metadata - sub-map of arbitrary key-value pairs                                                                                                                           |
 
@@ -90,6 +93,7 @@ Only the `m` (metadata) field MAY contain arbitrary data defined by consumers of
 type Schema2Data = {
   a?: string;
   w?: string;
+  s?: string[];
   r?: {
     a?: { c: Hex; a: Hex };
     w?: { c: Hex; a: Hex };
@@ -106,7 +110,7 @@ The complete suffix format is:
 
 ```
 txData||schemaData||schemaId||ercMarker
-``````
+```
 
 Single entity attribution with canonical registry:
 
@@ -147,12 +151,24 @@ Multiple entities with wallet, custom registry, and metadata (Schema ID 2):
 }
 ```
 
+Multiple entities with services (Schema ID 2):
+
+```
+{txData}{cborData}{0x0026}{2}{0x80218021802180218021802180218021}
+
+{
+  "a": "baseapp",
+  "w": "privy",
+  "s": ["flashbots", "titan"]
+}
+```
+
 ### Parsing Algorithm
 
 Offchain parsers SHOULD implement the following algorithm:
 
 1. Extract the last 16 bytes as `ercMarker`` and verify it matches the standard identifier
-2. Extract the previous byte as ``schemaId``
+2. Extract the previous byte as `schemaId`
 3. If `schemaId` is `0``:`
    a. Extract the previous byte as `codesLength`
    b. Extract the previous `codesLength` bytes as `codes`
@@ -173,10 +189,11 @@ Offchain parsers SHOULD implement the following algorithm:
    c. Decode `cborData` as a CBOR map
    d. Extract application code from key `a`
    e. Extract wallet code from key `w` (if present)
-   f. Extract custom registries from key `r` (if present), containing sub-maps keyed by `a` (application) and/or `w` (wallet), each with `c` (chainId) and `a` (address)
-   g. Extract metadata from key `m` (if present)
-   h. For each code, if no custom registry specified for that entity type, use chain's canonical Code Registry
-   i. Query code-related data from appropriate registry for each code
+   f. Extract service codes from key `s` (if present) as an array of strings
+   g. Extract custom registries from key `r` (if present), containing sub-maps keyed by `a` (application) and/or `w` (wallet), each with `c` (chainId) and `a` (address)
+   h. Extract metadata from key `m` (if present)
+   i. For each code, if no custom registry specified for that entity type, use chain's canonical Code Registry
+   j. Query code-related data from appropriate registry for each code
 6. Else `schemaId` does not match, parsing SHOULD terminate (unknown schemaId)
 
 ### Code Registry Interface
@@ -245,7 +262,8 @@ This ensures attribution data remains accessible and parseable regardless of whe
 
 ### App<>Wallet Integration
 
-Apps can append attribution through multiple methods, but this standard defines integration with two RPCs: 
+Apps can append attribution through multiple methods, but this standard defines integration with two RPCs:
+
 1. `eth_sendTransaction`
 2. `wallet_sendCalls`
 
@@ -356,6 +374,17 @@ Expected:
 - schemaId: 2
 - cborLength: 0x007b (123 bytes)
 - cborData: {"a":"baseapp","w":"privy","r":{"a":{"c":"0x2105","a":"0xBcf2B9598Ec0781eE49230CaACF0FB3C881B5195"}},"m":{"utm_campaign":"winter-promo","source":"webapp"}}
+```
+
+Attribution with services array (Schema ID 2):
+
+```
+Input: 0xdddddddda361616762617365617070617765707269767961738269666c617368626f747365746974616e00260280218021802180218021802180218021
+Expected:
+- txData: 0xdddddddd
+- schemaId: 2
+- cborLength: 0x0026 (38 bytes)
+- cborData: {"a":"baseapp","w":"privy","s":["flashbots","titan"]}
 ```
 
 Invalid schemaId handling:

--- a/ERCS/erc-xxxx.md
+++ b/ERCS/erc-xxxx.md
@@ -17,7 +17,7 @@ This ERC defines a standardized method for attributing transactions to applicati
 
 ## Motivation
 
-Currently, applications informally append "data suffixes" to transactions to indicate their origin, typically using the first 4 bytes of a hash representing the application name. For example, Coinbase Smart Wallet adds `keccak256("CoinbaseSmartWallet")` to transactions from keys.coinbase.com, and platforms like Zora and OpenSea employ similar approaches.
+Currently, applications informally append "data suffixes" to transactions to indicate their origin, typically using the first 4 bytes of a hash representing the application name. For example, Coinbase adds `keccak256("CoinbaseSmartWallet")` to transactions from keys.coinbase.com, and platforms like Zora and OpenSea employ similar approaches.
 
 This ad-hoc approach presents several limitations:
 
@@ -70,7 +70,7 @@ Offchain parsers MUST implement the following algorithm:
    a. Extract the previous 20 bytes as `codeRegistryAddress`
    b. Extract the previous byte as `codesLength`
    c. Extract the previous `codesLength` bytes as `codes`
-   d. Parse `codes` using ASCII decoding with comma (`0x2C`) as separator
+   d. Parse `codes` using ASCII decoding with comma (`0x2C`) as delimiter
    e. For each code, query the registry at `codeRegistryAddress`
 4. If `version` is not `0x00`, parsing SHOULD terminate (unknown version)
 
@@ -188,11 +188,11 @@ Expected:
 ### Multiple Entity Attribution
 
 ```
-Input: 0x1234567890baseapp,wallet0x0d{registry_address}0x00{erc_suffix}
+Input: 0x1234567890baseapp,zora0x0d{registry_address}0x00{erc_suffix}
 Expected:
 - version: 0x00
 - registry: {registry_address}
-- codes: ["baseapp", "wallet"]
+- codes: ["baseapp", "zora"]
 ```
 
 ### Invalid Version Handling

--- a/ERCS/erc-xxxx.md
+++ b/ERCS/erc-xxxx.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2025-09-11
-requires: 5792
+requires: 4337, 5792
 ---
 
 ## Abstract


### PR DESCRIPTION
Introduces a standardized method for attributing transactions to applications and wallets through structured data suffixes. Includes support for both normal transactions and ERC-4337 user operations, with clear implementation guidelines for smart account transactions.