### PR TITLE
Update ERC-7943: Split into separate interfaces

### DIFF
--- a/ERCS/erc-7943.md
+++ b/ERCS/erc-7943.md
@@ -281,22 +281,7 @@ In general, the standard prioritizes error specificity, meaning that specific er
 
 As an example, an AMM pool or a lending protocol can integrate with [ERC-7943](./eip-7943.md) based [ERC-20](./eip-20.md) tokens by calling `isUserAllowed` or `canTransfer` to handle these assets in a compliant manner. Enforcement actions like `forcedTransfer` and `setFrozenTokens` can either be called by third party entities or be integrated by external protocols to allow for automated and programmable compliance. Users can then expand these tokens with additional features to fit the specific needs of individual asset types, either with on-chain identity systems, historical balances tracking for dividend distributions, semi-fungibility with token metadata, and other custom functionalities.
 
-### Notes on naming:
-
-The naming conventions in this ERC were carefully chosen to establish clarity and semantic consistency within the broader RWA ecosystem while maintaining neutrality and broad applicability.
-
-- **`forcedTransfer`**: This term was selected for its neutrality. While names like "confiscation," "revocation," or "recovery" describe specific motivations, `forcedTransfer` purely denotes the direct action of transferring assets, irrespective of the underlying reason. This name was adopted from [ERC-3643](./eip-3643.md) for consistency across RWA specifications.
-- **`canTransfer`**: This name was chosen for consistency with established RWA standards including [ERC-3643](./eip-3643.md) and [ERC-7518](./eip-7518.md). This alignment promotes interoperability and reduces cognitive overhead when working across different RWA tokens.
-- **`setFrozenTokens` / `getFrozenTokens`**: These names were chosen for managing transfer restrictions and align with [ERC-3643](./eip-3643.md) naming patterns.
-    - **Consolidated Approach**: To maintain a lean EIP, a single `setFrozenTokens` function (which overwrites the frozen asset quantity) and one `Frozen` event were favored over distinct `freeze`/`unfreeze` functions and events.
-    - **Terminology**: "Frozen" was selected for its general applicability to both fungible (amount-based) and non-fungible (status-based) assets, as terms like "amount" or "asset(s)" might not be universally fitting.
-- **`ERC7943InsufficientUnfrozenBalance`**: Discussions around "insufficient" being similar to "unavailable" arose, where "unavailable" might have better suggested a temporal condition like a freezing status. However the term "available"/ "unavailable" was also overlapping with "frozen" / "unfrozen" creating more confusion and duality. Finally, coupling "insufficient" with the specified "unfrozen balance" better represents the domain, prefix and subject of the error, according to [ERC-6093](./eip-6093.md) guidelines.
-
-## Backwards Compatibility
-
-This EIP defines a new interface standard and does not alter existing ones like [ERC-20](./eip-20.md), [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md). Standard wallets and explorers can interact with the base token functionality of implementing contracts, subject to the rules enforced by that contract's implementation of `isUserAllowed`, `canTransfer` and `getFrozenTokens` functions. Full support for the [ERC-7943](./eip-7943.md) functions requires explicit integration.
-
-## Extensibility
+### Extensibility
 
 While this ERC provides the necessary primitives for regulated assets, any additional feature can be added through extensions. As an example, if for any administrative function like `setFrozenTokens` a valid legal proof must be provided and attached to the call, the contract can have a function that batches operations like:
 
@@ -312,6 +297,21 @@ contract ComplianceOperator is IERC7943MultiToken {
 ```
 
 Alternatively, developers can also perform several operations through the use of multicall patterns similar to the one defined in [ERC-6357](./eip-6357.md) so that a mix of the given primitives with additional features can be batched in one transaction. Finally, functionalities like pausability can be added on top, either through the use of modifiers or directly within functions implementations.
+
+### Notes on naming:
+
+The naming conventions in this ERC were carefully chosen to establish clarity and semantic consistency within the broader RWA ecosystem while maintaining neutrality and broad applicability.
+
+- **`forcedTransfer`**: This term was selected for its neutrality. While names like "confiscation," "revocation," or "recovery" describe specific motivations, `forcedTransfer` purely denotes the direct action of transferring assets, irrespective of the underlying reason. This name was adopted from [ERC-3643](./eip-3643.md) for consistency across RWA specifications.
+- **`canTransfer`**: This name was chosen for consistency with established RWA standards including [ERC-3643](./eip-3643.md) and [ERC-7518](./eip-7518.md). This alignment promotes interoperability and reduces cognitive overhead when working across different RWA tokens.
+- **`setFrozenTokens` / `getFrozenTokens`**: These names were chosen for managing transfer restrictions and align with [ERC-3643](./eip-3643.md) naming patterns.
+    - **Consolidated Approach**: To maintain a lean EIP, a single `setFrozenTokens` function (which overwrites the frozen asset quantity) and one `Frozen` event were favored over distinct `freeze`/`unfreeze` functions and events.
+    - **Terminology**: "Frozen" was selected for its general applicability to both fungible (amount-based) and non-fungible (status-based) assets, as terms like "amount" or "asset(s)" might not be universally fitting.
+- **`ERC7943InsufficientUnfrozenBalance`**: Discussions around "insufficient" being similar to "unavailable" arose, where "unavailable" might have better suggested a temporal condition like a freezing status. However the term "available"/ "unavailable" was also overlapping with "frozen" / "unfrozen" creating more confusion and duality. Finally, coupling "insufficient" with the specified "unfrozen balance" better represents the domain, prefix and subject of the error, according to [ERC-6093](./eip-6093.md) guidelines.
+
+## Backwards Compatibility
+
+This EIP defines a new interface standard and does not alter existing ones like [ERC-20](./eip-20.md), [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md). Standard wallets and explorers can interact with the base token functionality of implementing contracts, subject to the rules enforced by that contract's implementation of `isUserAllowed`, `canTransfer` and `getFrozenTokens` functions. Full support for the [ERC-7943](./eip-7943.md) functions requires explicit integration.
 
 ## Reference Implementation
 


### PR DESCRIPTION
- Documented that `canTransfer` should return `false` on paused contracts.
- Documented discrepancy of `canTransfer` performing `isUserAllowed` with ERC-3643.
- Split into separate interfaces (fungible, non fungible, multi token)
- Refactored examples
- Changed the "should not allow freezing more assets than balance" to a "should be able to freeze more than that"

Things to review:

- [x] `getFrozenTokens` for ERC-721 should return uint256 or a bool ?

> from ETH Magicians discussion, it is [good](https://ethereum-magicians.org/t/erc-7943-universal-rwa-interface-urwa/23972/76?u=xaler) to leave it as bool.

- [x] Errors should be named the same even if with different parameters across different interfaces ?

> Error renamed in the non-fungible case

- [x] Review correctness of provided examples

> At least [one](https://ethereum-magicians.org/t/erc-7943-universal-rwa-interface-urwa/23972/76?u=xaler) confirmation that those are good.