### PR TITLE
Add ERC: Encode chain id with transaction hash

### DIFF
--- a/ERCS/erc-7950.md
+++ b/ERCS/erc-7950.md
@@ -6,6 +6,8 @@ author: Lauri Peltonen (@microbecode)
 discussions-to: https://ethereum-magicians.org/t/a-new-standard-for-encoding-chain-id-transaction-hash/23782
 status: Last Call
 last-call-deadline: 2025-10-01
+type: Standards Track
+category: ERC
 created: 2025-05-22
 requires: 155
 ---


### PR DESCRIPTION
After discussing with editors in https://github.com/ethereum/EIPs/pull/10210 , this proposal is better suited as an ERC.

Continuing the process where it left at the EIP side.

This proposal was already once an ERC before it was moved to be an EIP (https://github.com/ethereum/ERCs/pull/1036).