### PR TITLE
Add ERC: Agent Council Oracles

### DIFF
--- a/ERCS/erc-8033.md
+++ b/ERCS/erc-8033.md
@@ -8,6 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2025-09-28
+requires: 20
 ---
 
 ## Abstract
@@ -102,7 +103,7 @@ We do not enforce limits on the number or size of items in capabilities, domains
 
 Implementations MUST follow this sequence for interoperability:
 
-1. **Request Creation**: Requester calls `createRequest`, providing query, params (ex. `numInfoAgents`, `bondAmount`), and rewardAmount (with `msg.value` or [ERC-20](./eip-20.md) transfer). If `rewardToken == address(0)`, this is the native asset and createRequest MUST be payable and expect msg.value to fund the reward (and native bonds if used). If `rewardToken != address(0)`, it MUST be an [ERC-20](./eip-20.md) and implementations SHOULD pull funds via transferFrom. Emits `RequestCreated`. The bond is a slashable stake an agent put in, and be penalized if the submission turns out to be wrong, malicious etc. The amount and token for the bond (specified with bondAmount and bondToken) is implementation-specific and these MAY be different from the values used for the reward.
+1. **Request Creation**: Requester calls `createRequest`, providing query, params (ex. `numInfoAgents`, `bondAmount`), and `rewardAmount` (with `msg.value` or [ERC-20](./eip-20.md) transfer). If `rewardToken == address(0)`, this is the native asset and createRequest MUST be payable and expect msg.value to fund the reward (and native bonds if used). If `rewardToken != address(0)`, it MUST be an [ERC-20](./eip-20.md) and implementations SHOULD pull funds via `transferFrom`. Emits `RequestCreated`. The bond is a slashable stake an agent put in, and be penalized if the submission turns out to be wrong, malicious etc. The amount and token for the bond (specified with `bondAmount` and `bondToken`) is implementation-specific and these MAY be different from the values used for the reward.
 
 2. **Commit Process**: Permissionless Info Agents call `commit` with a hash (RECOMMENDED: `keccak256(abi.encode(answer, nonce))`) and bond. Caps at `numInfoAgents`. Phase ends at deadline or when all InfoAgents are committed. Emits `AgentCommitted`. 
 
@@ -155,16 +156,9 @@ This ERC is meant to be complimentary to recent standards like [ERC-8004](./eip-
 
 No conflicts with existing standards. 
 
-## Test Cases
-This protocol allows for:
-Standardized interfaces for AI agent councils to resolve complex queries in dApps, such as aggregating semantic data from multiple sources or handling one-off factual resolutions
-Permissionless participation in oracle resolution with bond-based incentives for Info and Judge Agents, allowing scalable, trust-minimized data validation
-Interoperability across oracle implementations for use in prediction markets, DeFi info feeds, betting, insurance, and knowledge arbitration
-Optional extensions for disputes and reputation (such as [ERC-8004](./eip-8004.md)) to enhance security for high-stakes queries, including verifiable off-chain reasoning trails
+<!-- TODO: Add test cases -->
 
-## Reference Implementation
-
-We are currently working on a full implementation of this protocol. Reach out on Twitter `(@phiralm or @MythyProd)` if you would like to contribute!
+<!-- TODO: Add reference implementation -->
 
 ## Security Considerations
 
@@ -173,8 +167,8 @@ We are currently working on a full implementation of this protocol. Reach out on
 - Failures: Refunds for low participation or abandonment.
 - Disputes: Optional for high-stakes, with higher stakes/thresholds.
 - Fairness of random selection of Judge relies on the crypto strength of randomness
-Implementations SHOULD audit for reentrancy and use verifiable randomness.
+Implementations should audit for reentrancy and use verifiable randomness.
 
 ## Copyright
 
-Copyright and related rights waived via CC0.
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
This standard outlines an interface for **oracle contracts leveraging multi-agent councils** to enable decentralized resolution of information queries. It supports **trust-minimized data aggregation** and **validation**, with agents handling off-chain processing and on-chain coordination for enhanced scalability. 

It defines a core flow with lightweight methods for **request creation, commitments, reveals, judging, and rewards,** while providing optional hooks for **disputes and reputation systems**.