### PR TITLE
Add ERC: MultiTrust Credential (MTC) — Verifiable Reputation Interface (Core)

### DIFF
--- a/ERCS/erc-mtc-core.md
+++ b/ERCS/erc-mtc-core.md
@@ -1,0 +1,179 @@
+---
+eip: TBD
+title: MultiTrust Credential (MTC) — Verifiable Reputation Interface (Core)
+description: Minimal ERC interface for non-transferable reputation credentials with typed metrics, lifecycle events, and policy masks, without on-chain PII.
+author: Yuta Hoshino (@YutaHoshino) <y_hoshino@indiesquare.me>
+discussions-to: https://ethereum-magicians.org/t/discussion-erc-multitrust-credential-mtc-core-zk-proof-optional
+status: Draft
+type: Standards Track
+category: ERC
+created: 2025-09-19
+---
+
+## Abstract
+This proposal specifies a minimal, implementation-agnostic ERC interface matching the MultiTrustCredential reference. It standardizes schema registration, role-gated mint/update/revoke, slashing, and validity reads for VC-aligned reputation metrics, while keeping personally identifiable information (PII) off-chain.
+
+## Motivation
+Applications need portable, privacy-preserving ways to check eligibility, reputation, or compliance across dApps and chains. Current solutions rely on bespoke contracts or token-based SBTs, which limit interoperability and indexing. MTC defines canonical events, read APIs, and policy masks so wallets, SDKs, and indexers can integrate reputation data with stable semantics.
+
+## Specification
+The key words “MUST”, “MUST NOT”, “SHOULD”, and “MAY” are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### ERC-165 Compliance (normative)
+Implementations of this standard **MUST** implement ERC-165 and report the interface id for `IMultiTrustCredentialCore`.
+The interface id is the XOR of all function selectors defined in the normative interface.
+Implementations **MUST NOT** change function signatures in a way that alters the interface id.
+
+### Terms
+- **Subject**: Address whose reputation is recorded (one credential token per subject).
+- **Metric Schema**: Typed identifier (bytes32) describing a reputation dimension.
+- **Mask**: Bitmask policy that constrains allowed comparison operators (GTE/LTE/EQ).
+- **Leaf Commitment**: On-chain commitment (e.g., Merkle/poseidon/keccak) to off-chain VC payloads.
+
+### Events (normative)
+```solidity
+event MetricRegistered(bytes32 indexed id, string label, bytes32 role, uint8 mask);
+event MetricUpdated(uint256 indexed tokenId, bytes32 indexed metricId, uint32 newValue, uint256 leafFull);
+event MetricRevoked(uint256 indexed tokenId, bytes32 indexed metricId, uint32 prevValue, uint256 prevLeaf);
+event Slash(uint256 indexed tokenId, bytes32 indexed metricId, uint32 penalty);
+event CompareMaskChanged(bytes32 indexed id, uint8 oldMask, uint8 newMask, address indexed editor);
+/// @dev OPTIONAL: Implementations that integrate a ZK verifier MAY emit this.
+event VerifierSet(address verifier);
+event MaskFrozenSet(bytes32 id, bool frozen);
+```
+
+> Note: The event parameter name `role` corresponds to the `roleName` argument in `registerMetric`.
+
+### Data Structures (normative ABI)
+```solidity
+/**
+* @dev Stored metric (per tokenId, metricId).
+* - `value`     : current numeric value (or placeholder if commitment-only)
+* - `leafFull`  : commitment/hash (circuit-dependent)
+* - `timestamp` : last update time (seconds)
+* - `expiresAt` : deadline of this metric. 0 indicates no expiration date.
+*/
+struct Metric { uint32 value; uint256 leafFull; uint32 timestamp; uint32 expiresAt; }
+
+/**
+* @dev Input for single mint.
+* - `uri` is set as tokenURI on first mint for the address.
+*/
+struct MetricInput  { bytes32 metricId; uint32 value; uint256 leafFull; string uri; uint32 expiresAt; }
+
+/**
+* @dev Input for an update.
+*/
+struct MetricUpdate { bytes32 metricId; uint32 newValue; uint256 leafFull; uint32 expiresAt; }
+
+/**
+* @dev Batch mint item; creates token if absent and sets tokenURI on first write.
+*/
+struct MintItem { address to; bytes32 metricId; uint32 value; uint256 leafFull; string uri; uint32 expiresAt; }
+
+/**
+* @dev Batch update item for an existing token.
+*/
+struct UpdateItem { uint256 tokenId; bytes32 metricId; uint32 newValue; uint256 leafFull; uint32 expiresAt; }
+```
+
+### Compare Mask Domain (normative)
+Valid mask values are limited to the bitwise subset of `{ GT = 1, LT = 2, EQ = 4 }`.
+Implementations **MUST** revert if a mask contains undefined bits.
+After `setMaskFrozen(id, true)` for a given `id`, subsequent `setCompareMask(id, …)` **MUST** revert.
+
+### Interface (normative)
+```solidity
+pragma solidity ^0.8.22;
+
+interface IMultiTrustCredentialCore {
+    /* Schema & Policy */
+    function registerMetric(
+        bytes32 id,
+        string  calldata label,
+        bytes32 roleName,
+        bool    commitment,
+        uint8   mask
+    ) external;
+
+    function setCompareMask(bytes32 id, uint8 mask) external;
+    function setMaskFrozen(bytes32 id, bool frozen) external;
+
+    /* Mint & Update */
+    function mint(address to, MetricInput calldata data) external;
+    function mintBatch(MintItem[] calldata arr) external;
+    function updateMetric(uint256 tokenId, MetricUpdate calldata upd) external;
+    function updateMetricBatch(UpdateItem[] calldata arr) external;
+    function revokeMetric(uint256 tokenId, bytes32 metricId) external;
+    function slash(address offender, bytes32 metricId, uint32 penalty) external;
+
+    /* Read API */
+    function getMetric(uint256 tokenId, bytes32 metricId)
+        external view returns (uint32 value, uint256 leafFull, uint32 timestamp);
+
+    function tokenIdOf(address subject) external pure returns (uint256);
+}
+```
+
+### Revocation Semantics (normative)
+After a metric is revoked for `(tokenId, metricId)`, `getMetric(tokenId, metricId)` **MUST** revert.
+
+### Non-Transferability & One-Token-Per-Subject (normative)
+Implementations **MUST** enforce non-transferability of the credential token.
+There **MUST NOT** exist more than one credential token per subject.
+If a deterministic mapping is used, `tokenId` **SHOULD** equal `uint256(uint160(subject))`, and `tokenIdOf(subject)` **MUST** return that value.
+
+### State-Change Authorization (normative)
+All state-changing functions (`registerMetric`, `setCompareMask`, `setMaskFrozen`, `mint`, `mintBatch`, `updateMetric`, `updateMetricBatch`, `revokeMetric`, `slash`) **MUST** be restricted by implementation-defined roles/policies.
+
+### Function Behavior & Failure Conditions (normative, minimum set)
+- `registerMetric` **MUST** revert if `id` is already registered (unless the implementation explicitly supports updates) and **MUST** revert if `mask` contains undefined bits.
+- `setCompareMask` **MUST** revert if `id` is unknown or if `mask` contains undefined bits.
+- `setMaskFrozen(id, true)` freezes the policy for `id`; subsequent `setCompareMask(id, …)` **MUST** revert.
+- `mint` **MUST** revert if a credential token already exists for `to`, or if `data.metricId` is not registered, or if the caller lacks the required role.
+- `updateMetric` / `updateMetricBatch` **MUST** revert if the metric schema is not registered, or if the caller lacks the required role. `updateMetric` **MUST** enforce the `deadline` rule above.
+- `revokeMetric` **MUST** revert if the metric is not present or if the caller lacks the required role.
+- `slash(offender, …)` **MUST** target the existing credential holder; implementations **SHOULD** derive `tokenId` via `tokenIdOf(offender)` and **MUST** revert if no token exists for `offender`.
+
+### Policy Mask (informative)
+```solidity
+/**
+ * @dev Bit mask for allowed comparison operators in zk checks.
+ * GT=1, LT=2, EQ=4 .. combinations allowed (e.g., 1|4).
+ */
+library CompareMask {
+    // Bit flags (base)
+    uint16 internal constant GT  = 1 << 0; // 0b0001
+    uint16 internal constant LT  = 1 << 1; // 0b0010
+    uint16 internal constant EQ  = 1 << 2; // 0b0100
+    uint16 internal constant IN  = 1 << 3; // 0b1000 (allowlist membership)
+    // Aliases / composites
+    uint16 internal constant NONE = 0;           // KYC-only (no compare)
+    uint16 internal constant NE   = GT | LT;     // not equal
+    uint16 internal constant GTE  = GT | EQ;
+    uint16 internal constant LTE  = LT | EQ;
+    uint16 internal constant ALL  = GT | LT | EQ;
+}
+```
+
+### Rationale
+- **Event stability**: Canonical events enable uniform indexing across chains.
+- **Struct-based ABI**: Minimizes app/SDK glue and preserves upgrade flexibility.
+- **Mask governance**: Freezing masks allows ossifying comparison policies post-audit.
+
+## Backwards Compatibility
+MTC does not conflict with ERC-721/1155 and can co-exist with ERC-4973/5192 when tokens represent badges. This specification does not define transfer or approval events and SHOULD NOT be confused with token transfer standards.
+
+## Reference Implementation
+A non-normative reference will be published (Solidity ≥0.8.22) mirroring the interfaces and events above:  
+- Core contract: `MultiTrustCredential.sol` (https://github.com/hazbase/contracts/blob/main/multi-trust-credential/contracts/MultiTrustCredential.sol)
+
+## Security Considerations
+- **Role-Gated Writes**: Implementations MUST restrict writers per metric (`roleName`) and protect administrative operations.
+- **Non-Transferability**: Implementations MUST prevent transfer of credential tokens.
+- **Privacy**: PII MUST NOT be stored on-chain; `leafFull` SHOULD commit to normalized VC payloads; hash functions SHOULD be collision-resistant.
+- **Replay/Substitution**: Writers SHOULD prevent duplicate digests and bind updates to `(tokenId, metricId)`; clients SHOULD verify event consistency.
+- **Governance**: `CompareMask` freezes SHOULD be used after audits; `VerifierSet` (if any) SHOULD be governed (roles/timelocks).
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-mtc-zk.md
+++ b/ERCS/erc-mtc-zk.md
@@ -1,0 +1,143 @@
+---
+eip: TBD
+title: MTC-ZK — Zero-Knowledge Presentation Interface for MultiTrust Credential
+description: Optional ERC interface to verify ZK proofs against MTC commitments via a fixed Groth16-style ABI, bound to the current anchor and the active comparison policy.
+author: Yuta Hoshino (@YutaHoshino) <y_hoshino@indiesquare.me>
+discussions-to: https://ethereum-magicians.org/t/discussion-erc-multitrust-credential-mtc-core-zk-proof-optional
+status: Draft
+type: Standards Track
+category: ERC
+created: 2025-09-19
+requires: <EIP number of MTC Core>  # set once Core is numbered
+---
+
+## Abstract
+This proposal defines an optional zero-knowledge presentation interface for MTC deployments. It standardizes how contracts verify proofs that a subject’s metric satisfies a predicate without revealing the underlying value, by binding the proof to the current MTC anchor and comparison policy.
+
+## Motivation
+Applications and circuits need a shared, minimal way to verify that a subject’s metric satisfies a policy (e.g., “score ≥ threshold”) without exposing raw values. A common ABI enables wallets, circuits, verifiers, and indexers to interoperate across ecosystems while keeping PII off-chain.
+
+## Specification
+The key words “MUST”, “MUST NOT”, “SHOULD”, and “MAY” are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### ERC-165 Compliance (normative)
+Implementations of this standard **MUST** implement ERC-165 and report the interface id for `IMultiTrustCredentialZK`.  
+The interface id is the XOR of all function selectors defined in this interface.  
+Implementations **MUST NOT** change function signatures in a way that alters the interface id.
+
+### External Verifier (normative)
+```solidity
+pragma solidity ^0.8.22;
+
+/// @notice External circuit verifier (e.g., Groth16 via snarkJS).
+interface IVerifier {
+    /// @dev Circuit-specific verification with fixed-length proof/public inputs.
+    function verifyProof(
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[6] calldata publicSignals
+    ) external view returns (bool);
+}
+```
+
+### ZK Presentation Interface (normative)
+```solidity
+pragma solidity ^0.8.22;
+
+/// @title IMultiTrustCredentialZK
+/// @notice Verify a ZK proof against the current MTC Core anchor and the active comparison policy.
+/// @dev This interface is optional and extends the functionality of MTC Core without changing it.
+interface IMultiTrustCredentialZK {
+    /// @return ok True if proof is valid AND bound to the current anchor/policy for (tokenId, metricId).
+    function proveMetric(
+        uint256 tokenId,
+        bytes32 metricId,
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[6] calldata publicSignals
+    ) external view returns (bool ok);
+}
+```
+
+### Public Signals Mapping (normative)
+This EIP fixes the order of `publicSignals` to match the reference circuit and verifier:
+
+```
+publicSignals[0] = mode        // operator code: 1: > (GT), 2: < (LT), 3: = (EQ); 0 is disallowed
+publicSignals[1] = root        // Merkle root (must equal the Core anchor for the metric)
+publicSignals[2] = nullifier   // circuit-defined nullifier
+publicSignals[3] = addr        // holder address as field element
+publicSignals[4] = threshold   // comparator parameter (e.g., threshold or expected value)
+publicSignals[5] = leaf        // committed value (private); used inside the circuit
+```
+
+### Binding Requirements (normative)
+Implementations of `proveMetric` **MUST** guarantee that a successful proof is **bound to the current MTC anchor and policy** for `(tokenId, metricId)`:
+
+- Implementations **MUST** obtain the **current** `leafFull` by calling the MTC Core contract (e.g., `getMetric(tokenId, metricId)`) and **MUST** verify `publicSignals[1] == leafFull`.
+  If the metric is revoked, per Core specification, `getMetric` **MUST** revert; ZK verification **MUST NOT** succeed for revoked metrics.
+- Implementations **MUST** enforce the **active comparison mask** from Core for the metric schema (CompareMask domain: `GT=1, LT=2, EQ=4`).  
+  The operator encoded by `publicSignals[0]` (**mode**) **MUST** be permitted by the mask; otherwise `proveMetric` **MUST** revert. `mode == 0` **MUST** revert.
+- Implementations **MUST** verify `tokenId == tokenIdOf(address(uint160(publicSignals[3])))`, interpreting `publicSignals[3]` as a **big-endian field element whose lower 160 bits map to the EVM address**. If no token exists for that address, the call **MUST** revert.
+
+### Comparison Semantics (normative)
+Let `value` denote the committed metric value proven inside the circuit. Implementations **MUST** interpret operators as:
+
+- GT (`mode==1`): `value > threshold` (greater than)  
+- LT (`mode==2`): `value < threshold` (lower than)  
+- EQ (`mode==3`): `value == threshold` (exact match)
+
+`value` and `threshold` are treated as **unsigned 256-bit integers**; units/scaling are defined by the metric schema.
+
+### Leaf Construction with Domain Separation (normative)
+To prevent cross-contract / cross-chain replay without changing the public signals arity, this profile **MUST** include a domain separator in the tree leaf construction:
+
+```
+domain := keccak256(abi.encode(chainid(), address(this)))  (reduced mod field)
+treeLeaf := Poseidon(leaf, addr, domain)
+```
+
+- The circuit **MUST** compute `treeLeaf` as above and prove membership in the Merkle tree with `root == publicSignals[1]`.
+- On-chain contracts **MUST** rely on the proof (and current root equality) and **MUST NOT** attempt to reconstruct `leaf` beyond verifying the proof and anchor binding.
+
+### Optional Events
+```solidity
+/// @notice Emitted when the verifier address is configured (e.g., during initialize()).
+event VerifierSet(address verifier);
+
+/// @notice MAY be emitted when a proof is successfully verified.
+event ProofVerified(uint256 tokenId, bytes32 metricId, uint8 mode, uint256 threshold);
+```
+
+### Rationale
+- **Fixed ABI**: A Groth16 tuple is widely supported and keeps calldata minimal; other proving systems MAY adapt behind `IVerifier`.
+- **Separation of Concerns**: ZK remains optional, keeping Core minimal for non-ZK deployments.
+- **Binding over leakage**: By binding proofs to Core’s current anchor and the policy mask, implementations avoid value disclosure while ensuring policy is enforced. Domain separation in the leaf construction prevents cross-contract replay while preserving the 6-signal layout.
+
+## Backwards Compatibility
+MTC-ZK is optional and compatible with any MTC Core implementation that stores a commitment (`leafFull`) and a comparison mask policy.  
+For the reference profile implied by this mapping, **Core SHOULD store the Merkle `root` in `leafFull`**.  
+Gas costs for pairing precompiles vary by platform; implementations SHOULD document expected ranges.
+
+## Reference Implementation
+A non-normative reference will be published with example circuits and an adapter verifier contract demonstrating:
+- Reading Core’s `getMetric` to retrieve the current `leafFull` (root)
+- Enforcing the Core comparison mask against `mode`
+- Mapping `publicSignals` per the order above
+- Domain-separated leaf construction: `treeLeaf = Poseidon(leaf, addr, keccak256(abi.encode(chainid(), address(this))))`
+- Emitting `ProofVerified` on success (optional)
+
+## Security Considerations
+- **Substitution & Replay**: Proofs **MUST** be bound to `(tokenId, metricId, root)` and the **active policy mask**.  
+  The circuit **MUST** include domain separation in the leaf construction as specified above. Sharing identical roots across unrelated contracts **MUST NOT** occur.
+- **Revocation**: Since Core `getMetric` reverts after revocation, ZK verification **MUST NOT** succeed once revoked.
+- **Upgrades/Governance**: Verifier addresses SHOULD be governed (roles/timelocks), and changes SHOULD be auditable.
+- **Malleability**: Implementations SHOULD reject malformed proofs and unexpected `publicSignals` layouts that would bypass policy checks.
+
+## Editorial Notes
+After the MTC Core proposal receives an EIP number, update `requires:` in the preamble to reference it.
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
### Summary
This PR introduces two related ERC drafts:

- **MTC Core**: a minimal ERC interface to issue, update, revoke, and verify non-transferable credentials that anchor verifiable credentials (VC) on-chain. Values are stored as commitments; revocation is immediate; comparison policies are fixed via bitmask and can be frozen.
- **MTC-ZK (optional)**: an extension that defines a fixed Groth16-style ABI (`proveMetric`) to verify that a credential satisfies a predicate (e.g., score ≥ 80, violations ≤ 2) without revealing the raw value. Proofs are bound to the current Core anchor and use domain-separated leaves to prevent replay.

Both files are EIP-1 compliant, marked as Draft, and under discussion at Magicians.

### Files added
- `ERCs/eip-mtc-core.md`
- `ERCs/eip-mtc-zk.md`

### Discussion thread
https://ethereum-magicians.org/t/discussion-erc-multitrust-credential-mtc-core-zk-proof-optional/25526