### PR TITLE
Update ERC-7580: Fix typos

### DIFF
--- a/ERCS/erc-7580.md
+++ b/ERCS/erc-7580.md
@@ -17,15 +17,15 @@ This ERC proposes a standard interface for advertisement clients to track user a
 
 ## Motivation
 
-Dapps would propsper due to mass adoption and there emerges surging demands for advertisement on chain. Compared with advertisements in web2, web3 has tremendous advantages on delivery and many other fields. We do need a set of standard tracking interfaces to facilitate advertisement related developments, which could create new economic cycles on chain, further boost dapp prosperity and ultimately benefit on chain users.
+Dapps would prosper due to mass adoption and there emerges surging demands for advertisement on chain. Compared with advertisements in web2, web3 has tremendous advantages on delivery and many other fields. We do need a set of standard tracking interfaces to facilitate advertisement related developments, which could create new economic cycles on chain, further boost dapp prosperity and ultimately benefit on chain users.
 
 Tracking interface standard should be designed with essential & universal support for tracking user actions, and minimum restriction, which could leave most innovative space for airdrop (or advertisement) protocol. The general routine would work like this:
 1. projects get a seed id (hash) from promotion side
 2. before the target promotion action starts, project contracts called the interface `onTrackStart(id, contract_address, function_hash)`
-3. after the target promotion action ends, project contracts called the inferface `onTrackEnd(id, contract_address, function_hash)`
+3. after the target promotion action ends, project contracts called the interface `onTrackEnd(id, contract_address, function_hash)`
 4. promotion contract collect the project action info and distribute the rewards back to projects
 
-For example, we have two entities holding their respective contracts: contract A and contract B. Contract A targets on users who did specific key moves(eg. commit specific functions) in contract B and would give bonus/airdrop to these users. Sure B would also get incentives in the meanwhile. To connect all these dots, B needs to identity these users, verify they're coming for the A's bonus. Hence, we need a track mechanism to facilitate such business.
+For example, we have two entities holding their respective contracts: contract A and contract B. Contract A targets on users who did specific key moves(eg. commit specific functions) in contract B and would give bonus/airdrop to these users. Sure B would also get incentives in the meanwhile. To connect all these dots, B needs to identify these users, verify they're coming for the A's bonus. Hence, we need a track mechanism to facilitate such business.
 
 ## Specification
 


### PR DESCRIPTION
### Details

- Corrected misspellings:
  - `propsper` → `prosper`
  - `inferface` → `interface`
  - `identity` → `identify`