### PR TITLE
Add ERC: Fixed-Supply Agent NFT Collections

### DIFF
--- a/ERCS/erc-8041.md
+++ b/ERCS/erc-8041.md
@@ -48,10 +48,11 @@ Compliant collection contracts MUST implement the `IERC8041Collection` interface
 pragma solidity ^0.8.25;
 
 interface IERC8041Collection {
-    /// @notice Emitted when the collection is created
+    /// @notice Emitted when the collection is created or updated
     /// @param maxSupply Maximum number of agents in the collection
     /// @param startBlock Block number when minting becomes available
-    event CollectionCreated(uint256 maxSupply, uint256 startBlock);
+    /// @param open Whether the collection is open for minting
+    event CollectionUpdated(uint256 maxSupply, uint256 startBlock, bool open);
 
     /// @notice Emitted when an agent is minted in the collection
     /// @param agentId The ERC-8004 token ID of the agent in the registry
@@ -65,17 +66,9 @@ interface IERC8041Collection {
     ///         Returns 0 if the agent was not minted through this collection
     function getAgentMintNumber(uint256 agentId) external view returns (uint256 mintNumber);
 
-    /// @notice Get the details of the collection
-    /// @return maxSupply Maximum number of agents that can be minted
+    /// @notice Get the current supply of the collection
     /// @return currentSupply Current number of agents minted
-    /// @return startBlock Block number when minting becomes available
-    /// @return open Whether the collection is currently open for minting
-    function getCollectionDetails() external view returns (
-        uint256 maxSupply,
-        uint256 currentSupply,
-        uint256 startBlock,
-        bool open
-    );
+    function getCollectionSupply() external view returns (uint256 currentSupply);
 }
 ```
 
@@ -84,14 +77,14 @@ interface IERC8041Collection {
 Every compliant collection contract MUST implement the following functions:
 
 - `function getAgentMintNumber(uint256 agentId) external view returns (uint256 mintNumber)` - Returns the mint number for a given agent ID (0 if not in collection)
-- `function getCollectionDetails() external view returns (uint256 maxSupply, uint256 currentSupply, uint256 startBlock, bool open)` - Returns the collection's configuration and current state
+- `function getCollectionSupply() external view returns (uint256 currentSupply)` - Returns the current supply of the collection
 
 ### Required Events
 
 Every compliant collection contract MUST emit the following events:
 
+- `event CollectionUpdated(uint256 maxSupply, uint256 startBlock, bool open)` - MUST be emitted when the collection is created and whenever collection details are changed
 - `event AgentMinted(uint256 indexed agentId, uint256 mintNumber, address indexed owner)` - MUST be emitted when an agent is added to the collection
-- `event CollectionCreated(uint256 maxSupply, uint256 startBlock)` - MUST be emitted when the collection is created/initialized
 
 ### Required Behavior
 
@@ -161,7 +154,7 @@ The URI should point to a JSON file following the [ERC-7572](./eip-7572.md) meta
 
 ## Rationale
 
-[ERC-8004](./eip-8004.md) provides an open mint registry where anyone can register agent identities without restrictions. While this unlimited minting model serves many use cases, there is a clear need for limited-supply collections of agents. This interface addresses this by defining a standard for creating fixed-supply collections that leverage the existing [ERC-8004](./eip-8004.md) registry infrastructure while adding collection-specific constraints, metadata, and provenance tracking through mint numbers.
+[ERC-8004](./eip-8004.md) agents are unlimited mint NFTs; this ERC was created to enable verifiable fixed-supply collections of agents. This standard attempts to make minting fixed-supply [ERC-8004](./eip-8004.md) agents as convenient as possible. The `getCollectionSupply()` function allows clients to query current supply without relying on an indexer. Collection configuration (maxSupply, startBlock, open) is communicated via the `CollectionUpdated` event, which is emitted at creation and whenever these values change.
 
 ## Backwards Compatibility
 
@@ -188,14 +181,14 @@ import {IERC8041Collection} from "./interfaces/IERC8041Collection.sol";
  */
 contract ERC8041MinimalCollection is IERC8041Collection {
     IERC8004AgentRegistry public immutable agentRegistry;
-    
-    uint256 public immutable maxSupply;
+
+    uint256 public maxSupply;
     uint256 public currentSupply;
-    uint256 public immutable startBlock;
-    bool public constant open = true;
-    
+    uint256 public startBlock;
+    bool public open;
+
     mapping(uint256 agentId => uint256 mintNumber) private _agentMintNumber;
-    
+
     constructor(
         IERC8004AgentRegistry _agentRegistry,
         uint256 _maxSupply
@@ -203,10 +196,11 @@ contract ERC8041MinimalCollection is IERC8041Collection {
         agentRegistry = _agentRegistry;
         maxSupply = _maxSupply;
         startBlock = block.number;
-        
-        emit CollectionCreated(_maxSupply, block.number);
+        open = true;
+
+        emit CollectionUpdated(_maxSupply, block.number, true);
     }
-    
+
     /**
      * @notice Add an existing agent to the collection
      * @param agentId The ID of an agent already registered in ERC-8004
@@ -215,11 +209,11 @@ contract ERC8041MinimalCollection is IERC8041Collection {
         require(currentSupply < maxSupply, "Supply exceeded");
         require(agentRegistry.ownerOf(agentId) == msg.sender, "Not agent owner");
         require(_agentMintNumber[agentId] == 0, "Already in collection");
-        
+
         currentSupply++;
         uint256 mintNumber = currentSupply;
         _agentMintNumber[agentId] = mintNumber;
-        
+
         // Store collection metadata in the agent's onchain metadata
         bytes memory mintNumberBytes = abi.encode(mintNumber);
         uint8 mintNumberLength = uint8(mintNumberBytes.length);
@@ -228,27 +222,22 @@ contract ERC8041MinimalCollection is IERC8041Collection {
             mintNumberLength,   // 1 byte: length of mint number bytes
             mintNumberBytes     // variable: the mint number (compact encoding)
         );
-        
+
         IERC8004AgentRegistry(address(agentRegistry)).setMetadata(
             agentId,
             "agent-collection",
             collectionMetadata
         );
-        
+
         emit AgentMinted(agentId, mintNumber, msg.sender);
     }
-    
+
     function getAgentMintNumber(uint256 agentId) external view returns (uint256) {
         return _agentMintNumber[agentId];
     }
-    
-    function getCollectionDetails() external view returns (
-        uint256 _maxSupply,
-        uint256 _currentSupply,
-        uint256 _startBlock,
-        bool _open
-    ) {
-        return (maxSupply, currentSupply, startBlock, open);
+
+    function getCollectionSupply() external view returns (uint256) {
+        return currentSupply;
     }
 }
 ```
@@ -257,7 +246,6 @@ This implementation demonstrates:
 
 - **Single collection per contract**: Simplest deployment model
 - **No access control**: Anyone can add their agents to the collection
-- **Always open**: Collection is permanently open once deployed
 - **Bring-your-own-agent model**: Users register agents separately, then add them to the collection
 - **Full mint number tracking**: Each agent receives a sequential position number
 - **Automatic start block**: Collection starts at deployment block


### PR DESCRIPTION
## Add ERC-8041: Fixed-Supply Agent NFT Collections

### Summary
This PR introduces ERC-8041, a standard for creating fixed-supply collections of ERC-8004 Agent NFTs with mint number tracking.

### Motivation
While ERC-8004 provides unlimited minting for AI Agent identities, many use cases require limited collections (e.g., "Genesis 100", "Season 1"). ERC-8041 addresses this need by defining a standard interface for fixed-supply collections.

### Key Features
- **Fixed Supply Limits**: Define maximum number of agents per collection
- **Mint Number Tracking**: Permanent tracking of each agent's position (e.g., "5 of 1000")
- **Onchain Collection Metadata**: Links agents to their collections via the `"agent-collection"` metadata key
- **Time-Gated Releases**: Collections can activate at specific block numbers

### Technical Details
Core interface includes:
- `getAgentMintNumber(uint256 agentId)` - Returns agent's position in collection
- `getCollectionDetails()` - Returns supply info and collection status
- Events: `CollectionCreated`, `AgentMinted`

### Compatibility
- **Requires**: ERC-8004
- **Compatible with**: ERC-721

---

### Note on Direction Change
This ERC represents a strategic shift in approach. Originally, ERC-8041 was planned as a standalone contract-level metadata standard. We've pivoted to instead leverage the existing Onchain Metadata functionality of ERC-8004, focusing on a specific application (fixed-supply agent collections) rather than the underlying metadata infrastructure.

This decision prioritizes implementation speed by repurposing the existing ERC number rather than submitting a new proposal and going through the numbering process again. This allows immediate adoption of onchain metadata capabilities using ERC-8004 registries with the `agent-collection` metadata key. A future ERC will standardize the Onchain Metadata interface itself.

