### PR TITLE
Move EIP-8001 to Review

### DIFF
--- a/ERCS/erc-8001.md
+++ b/ERCS/erc-8001.md
@@ -2,9 +2,9 @@
 eip: 8001
 title: Agent Coordination Framework
 description: Minimal, single-chain, multi-party agent coordination using EIP-712 attestations
-author: Kwame Bryan (@kbryan)
+author: Kwame Bryan (@KBryan)
 discussions-to: https://ethereum-magicians.org/t/erc-8001-secure-intents-a-cryptographic-framework-for-autonomous-agent-coordination-draft-erc-8001/24989
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2025-08-02

--- a/ERCS/erc-8001.md
+++ b/ERCS/erc-8001.md
@@ -195,33 +195,36 @@ interface IAgentCoordination {
 
 ### Semantics
 
-- **Participants** MUST be unique and sorted ascending. Implementations MUST reject non-canonical arrays.
 - `proposeCoordination`:
-    - Verifies EIP-712 signature by `agentId` using ECDSA for EOAs or [ERC-1271] for contracts.
-    - Requires `intent.expiry > block.timestamp` and `intent.nonce > agentNonces[agentId]`.
-    - Stores the canonicalised state and sets `agentNonces[agentId] = intent.nonce`.
-    - Emits `CoordinationProposed`.
+  Rejects: invalid signatures, expired intents, non-monotonic nonces, malformed participants
+
+  Accepts valid EIP-712 signed intents and:
+  - Emits `CoordinationProposed`
+  - Makes intent queryable as `Proposed`
+  - Enforces nonce monotonicity for `agentId`
+
 - `acceptCoordination`:
-    - Checks the intent exists and is not expired.
-    - Verifies the participant is listed and has not already accepted.
-    - Verifies the acceptance signature against the typed `AcceptanceAttestation`.
-    - Records acceptance and stores the acceptance `expiry` for that participant.
-    - Emits `CoordinationAccepted` with the typed acceptance hash.
-    - Returns `true` when all required acceptances are present.
+  Rejects: non-existent intents, expired intents, non-participants, duplicate acceptances, invalid signatures
+
+  Accepts valid attestations and:
+  - Emits `CoordinationAccepted`
+  - Adds participant to `acceptedBy` in status
+  - Returns `true` when all required acceptances present
+
 - `executeCoordination`:
-    - Requires the intent to be in an executable state. In [ERC-8001](./eip-8001.md) the policy is **all participants have accepted**.
-    - Requires every stored acceptance to be unexpired at execution time.
-    - Verifies `payloadHash` matches the stored hash.
-    - Emits `CoordinationExecuted`.
+  Rejects: non-ready intents, expired intents or acceptances, payload mismatches
+
+  Executes when all participants accepted and unexpired:
+  - Emits `CoordinationExecuted` with result
+  - Status becomes `Executed`
+  - Returns success and execution result
+
 - `cancelCoordination`:
-    - The proposer MAY cancel before execution. Anyone MAY cancel after expiry.
-    - Emits `CoordinationCancelled`.
-- Status values are implementation-defined but MUST include Proposed, Ready, Executed, Cancelled, Expired.
-- `executeCoordination` MUST:
-     - Verify status == Ready (i.e., every participant has accepted).
-     - Verify `block.timestamp < intent.expiry`.
-     - For each recorded acceptance: verify `block.timestamp < acceptance.expiry`.
-     - Verify `keccak256(abi.encode(payload))` equals the stored `payloadHash`.
+  Proposer MAY cancel before execution; anyone MAY cancel after expiry
+  - Emits `CoordinationCancelled`
+  - Status becomes `Cancelled`
+
+- `getCoordinationStatus` MUST return one of: `None`, `Proposed`, `Ready`, `Executed`, `Cancelled`, `Expired`
 
 ### Nonces
 


### PR DESCRIPTION
Move EIP-8001 to Review

Changes:
- Update status from Draft to Review
- Rewrite function semantics to specify observable behaviour rather than implementation details
- Replace prescriptive storage requirements with interface-based outcomes
- Focus on validation conditions and state transitions per review feedback
- Fix author field to @KBryan for auto-merge compatibility
