### PR TITLE
ERC-8004 v1

### DIFF
--- a/ERCS/erc-8004.md
+++ b/ERCS/erc-8004.md
@@ -2,9 +2,9 @@
 eip: 8004
 title: Trustless Agents
 description: Discover agents and establish trust through reputation and validation
-author: Marco De Rossi (@MarcoMetaMask), Davide Crapis (@dcrapis) <davide@ethereum.org>, Jordan Ellis (@jorellis)
+author: Marco De Rossi (@MarcoMetaMask), Davide Crapis (@dcrapis) <davide@ethereum.org>, Jordan Ellis <jordanellis@google.com>, Erik Reppel <erik.reppel@coinbase.com>
 discussions-to: https://ethereum-magicians.org/t/erc-8004-trustless-agents/25098
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2025-08-13
@@ -12,211 +12,339 @@ created: 2025-08-13
 
 ## Abstract
 
-This ERC extends the Agent‑to‑Agent (A2A) Protocol <!-- TODO: where is the A2A protocol defined? --> with a trust layer that allows participants to **discover, choose, and interact with agents across organizational boundaries** without pre‑existing trust.  
+This protocol proposes to use blockchains to **discover, choose, and interact with agents across organizational boundaries** without pre-existing trust, thus **enabling open-ended agent economies**.
 
-It introduces three **lightweight, on‑chain registries**—Identity, Reputation, and Validation—and leaves application‑specific logic to off‑chain components.
-
-Trust models are pluggable and tiered, with security proportional to value at risk—from low-stake tasks like ordering pizza to high-stake tasks like medical diagnosis. Developers can choose from three trust models: reputation-based systems using client feedback, stake-secured inference validation (crypto-economics), and attestations for agents running in TEEs (crypto-verifiability).
-
-<!-- TODO: Your abstract is missing a high-level technical overview of _how_ your proposal accomplishes its goals. -->
+Trust models are pluggable and tiered, with security proportional to value at risk, from low-stake tasks like ordering pizza to high-stake tasks like medical diagnosis. Developers can choose from three trust models: reputation systems using client feedback, validation via stake-secured re-execution, zkML proofs, or TEE oracles.
 
 ## Motivation
 
-The existing A2A protocol handles agent authentication, skills advertisement via AgentCards<!-- TODO: what's an AgentCard -->, direct messaging, and complete task-lifecycle orchestration. Its adoption by leading technology firms demonstrates clear market demand. However, the protocol currently operates within organizational boundaries and **assumes trust between Server Agent and Client Agent**.
+MCP allows servers to list and offer their capabilities (prompts, resources, tools, and completions), while A2A handles agent authentication, skills advertisement via AgentCards, direct messaging, and complete task-lifecycle orchestration. However, these agent communication protocols don't inherently cover agent discovery and trust.
 
-To foster an open, cross-organizational agent economy, we need mechanisms for discovering and trusting agents in untrusted settings. This ERC addresses this need through three core components, which can be deployed on any L2 or on Mainnet:
+To foster an open, cross-organizational agent economy, we need mechanisms for discovering and trusting agents in untrusted settings. This ERC addresses this need through three lightweight registries, which can be deployed on any L2 or on Mainnet as per-chain singletons:
 
-**1\. Identity Registry** \- A minimal on-chain handle that resolves to an agent's off-chain AgentCard, providing every agent with a portable, censorship-resistant identifier.
+**Identity Registry** \- A minimal on-chain handle based on ERC-721 with URIStorage extension that resolves to an agent's registration file, providing every agent with a portable, censorship-resistant identifier.
 
-**2\. Reputation Registry** \- A standard interface for posting and fetching attestations. Scoring and aggregation will likely occur off-chain, enabling an ecosystem of specialized services for agent scoring, auditor networks, and insurance pools.
+**Reputation Registry** \- A standard interface for posting and fetching feedback signals. Scoring and aggregation occur both on-chain (for composability) and off-chain (for sophisticated algorithms), enabling an ecosystem of specialized services for agent scoring, auditor networks, and insurance pools.
 
-**3\. Validation Registry** \- Generic hooks for requesting and recording independent checks through economic staking (validators re-running the job) or cryptographic proofs (TEEs attestations). The ERC defines only the interface, allowing any validation protocol to integrate seamlessly.
+**Validation Registry** \- Generic hooks for requesting and recording independent validators checks (e.g. stakers re-running the job, zkML verifiers, TEE oracles, trusted judges).
 
-Payment layers <!-- Editor's Note: we prefer avoiding specific products in proposals. Since ERCs eventually become immutable, any products mentioned in them get an unfair advantage over products released after finalization. -->are orthogonal to this protocol and not covered here. However, payment proofs can enrich feedback attestations.
-
-This ERC builds on approaches that the Web3 industry is already experimenting with, providing a unified interface and a comprehensive stack to accelerate ecosystem adoption of trustless agents.
+Payments are orthogonal to this protocol and not covered here. However, examples are provided showing how **x402 payment proofs** can enrich feedback signals.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
 
-### Participants
-
-<!-- TODO: define "participant"; does it mean a human, contract, etc.? -->
-
-All participants MUST register with the Identity Registry as a generic agent. Agents can have three roles: 
-
-* Server Agent (A2A Server): Offers services and executes tasks  
-* Client Agent (A2A Client): Assigns tasks to Server Agents and provides feedback  
-* Validator Agent (Optional): Validates tasks through crypto-economic staking mechanisms (staking validators re-executing the inference) or cryptographic verification
-
-Agents may fulfill multiple roles simultaneously without restriction.
-
 ### Identity Registry
 
-All participants register on a smart contract on an EVM chain, which acts as a single entry point. Each agent is uniquely identified by:
+The Identity Registry uses ERC-721 with the URIStorage extension for agent registration, making **all agents immediately browsable and transferable with NFTs-compliant apps**. Each agent is uniquely identified globally by:
 
-* **AgentID:** Global identifier on the blockchain, assigned incrementally by the registry  
-* **AgentDomain:** Following [RFC 8615](https://www.rfc-editor.org/rfc/rfc8615) principles, an Agent Card MUST be available at `https://{AgentDomain}/.well-known/agent-card.json`  
-* **AgentAddress:** EVM-compatible address identifying the agent
+* *namespace:* eip155 for EVM chains  
+* *chainId*: The blockchain network identifier  
+* *identityRegistry*: The address where the ERC-721 registry contract is deployed  
+* *agentId*: The ERC-721 tokenId assigned incrementally by the registry
 
-#### **Write Endpoints**
+Throughout this document, ERC-721's *tokenId* is referred to as *agentId*. The owner of the ERC-721 token is the owner of the agent and can transfer ownership or delegate management (e.g., updating the registration file) to operators, as supported by ERC721URIStorage.
 
-```
-New(AgentDomain, AgentAddress) → AgentID
-Update(AgentID, Optional NewAgentDomain, Optional NewAgentAddress) → Boolean
-```
+#### Token URI and Agent Registration File
 
-All write operations require the transaction sender to be `AgentAddress`.
+The *tokenURI* MUST resolve to the agent registration file. It MAY use any URI scheme such as `ipfs://` (e.g., ipfs://cid) or `https://` (e.g., [https://domain.com/agent3.json](https://domain.com/registration.json)).  When the registration data changes, it can be updated with *\_setTokenURI()* as per ERC721URIStorage.
 
-#### **Public Resolvers**
-
-```
-Get(AgentID) → AgentID, AgentDomain, AgentAddress
-ResolveByDomain(AgentDomain) → AgentID, AgentDomain, AgentAddress
-ResolveByAddress(AgentAddress) → AgentID, AgentDomain, AgentAddress
-```
-
-#### **Agent Card Structure**
-
-Using the concept of "Extension" as defined in the A2A Protocol specs, the Agent Card at the well-known URI SHOULD include a `registrations` array listing all blockchain registries:
+The registration file MUST have the following structure:
 
 ```jsonc
-"registrations": [
-    { "agentId": 12345,
-      "agentAddress": "eip155:1:0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb7",
-      "signature": "...proof of ownership of the address..."
-      },
-    { "agentId": 67890,
-      "agentAddress": "eip155:59144:0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb7",
-      "signature": "...proof of ownership of the address..."
-      }
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "myAgentName",
+  "description": "A natural language description of the Agent, which MAY include what it does, how it works, pricing, and interaction methods",
+  "image": "https://example.com/agentimage.png",
+  "endpoints": [
+    {
+      "name": "A2A",
+      "endpoint": "https://agent.example/.well-known/agent-card.json",
+      "version": "0.3.0"
+    },
+    {
+      "name": "MCP",
+      "endpoint": "https://mcp.agent.eth/",
+      "capabilities": {}, // OPTIONAL, as per MCP spec
+      "version": "2025-06-18"
+    },
+    {
+      "name": "OASF",
+      "endpoint": "ipfs://{cid}",
+      "version": "0.7" // https://github.com/agntcy/oasf/tree/v0.7.0
+    },
+    {
+      "name": "ENS",
+      "endpoint": "vitalik.eth",
+      "version": "v1"
+    },
+    {
+      "name": "DID",
+      "endpoint": "did:method:foobar",
+      "version": "v1"
+    },
+    {
+      "name": "agentWallet",
+      "endpoint": "eip155:1:0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb7"
+    }
+  ],
+  "registrations": [
+    {
+      "agentId": 22,
+      "agentRegistry": "eip155:1:{identityRegistry}"
+    }
+  ],
+  "supportedTrust": [
+    "reputation",
+    "crypto-economic",
+    "tee-attestation"
   ]
+}
 ```
 
-The `agentAddress` field follows the [CAIP 10](https://github.com/ChainAgnostic/CAIPs/blob/b23e772369f2bc885c2ab70af4f0a0ec6bff6631/CAIPs/caip-10.md) account identifier standard: `{namespace}:{reference}:{address}`.
+The *type*, *name*, *description*, and *image* fields at the top SHOULD ensure compatibility with ERC-721 apps. The number and type of *endpoints* are fully customizable, allowing developers to add as many as they wish. The *version* field in endpoints is a SHOULD, not a MUST.
 
-Additionally, following the A2A extensions pattern, the Agent Card SHOULD describe which trust models are supported when the agent acts as a Server Agent:
+Agents MAY advertise their endpoints, which point to an A2A agent card, an MCP endpoint, an ENS agent name, DIDs, or the agent's wallets on any chain (even chains where the agent is not registered).
 
-```json
-"trustModels": ["feedback", "inference-validation", "tee-attestation"]
+Agents SHOULD have at least one registration (multiple are possible), and all fields in the registration are mandatory.  
+The *supportedTrust* field is OPTIONAL. If absent or empty, ERC-8004 is used only for discovery, not for trust.
+
+#### Onchain metadata
+
+The registry extends ERC-721 by adding *getMetadata(uint256 agentId, string key)* and *setMetadata(uint256 agentId, string key, bytes value)* functions for optional extra on-chain agent metadata.  
+Examples of keys are “agentWallet” or “agentName”.
+
+When metadata is set, the following event is emitted:
+
+```javascript
+event MetadataSet(uint256 indexed agentId, string indexed indexedKey, string key, bytes value)
+```
+
+#### Registration
+
+New agents can be minted by calling one of these functions:
+
+```javascript
+struct MetadataEntry {
+string key;
+bytes value;
+}
+
+function register(string tokenURI, MetadataEntry[] calldata metadata) returns (uint256 agentId)
+
+function register(string tokenURI) returns (uint256 agentId)
+
+// tokenURI is added later with _setTokenURI()
+function register() returns (uint256 agentId)
+```
+
+This emits one Transfer event, one MetadataSet event for each metadata entry, if any, and
+
+```javascript
+event Registered(uint256 indexed agentId, string tokenURI, address indexed owner)
 ```
 
 ### Reputation Registry
 
-The Registry provides a **lightweight entry point for task feedback between agents through off-chain attestations**.
+When the Reputation Registry is deployed, the *identityRegistry* address is passed to the constructor and publicly visible by calling:
 
-To minimize on-chain costs, only essential data is stored on-chain. The registry exposes a single endpoint:
-
-```
-AcceptFeedback(AgentClientID, AgentServerID) → emits AuthFeedback event
+```javascript
+function getIdentityRegistry() external view returns (address identityRegistry)
 ```
 
-This emits an `AuthFeedback` event with parameters `(AgentClientID, AgentServerID, FeedbackAuthID)`.
+**As an agent accepts a task, it's expected to sign a *feedbackAuth* to authorize the *clientAddress* (human or agent) to give feedback**. The feedback consists of a *score* (0-100), *tag1* and *tag2* (left to developers' discretion to provide maximum on-chain composability and filtering), a file uri pointing to an off-chain JSON containing additional information, and its KECCAK-256 file hash to guarantee integrity. We suggest using IPFS or equivalent services to make feedback easily indexed by subgraphs or similar technologies. For IPFS uris, the hash is not required.  
+All fields except the *score* are OPTIONAL, so the off-chain file is not required and can be omitted.
 
-**Authorization Flow:** When a Server Agent accepts a task, it pre-authorizes the Client Agent to provide feedback upon task completion.
+#### Giving Feedback
 
-#### **Feedback Data Structure**
+New feedback can be added by any *clientAddress* calling:
 
-Each feedback-providing Client Agent’s Agent Card MUST extend A2A by including a `FeedbackDataURI` that points to a JSON file containing a list of objects like the following:
+```javascript
+function giveFeedback(uint256 agentId, uint8 score, bytes32 tag1, bytes32 tag2, string calldata fileuri, bytes32 calldata filehash, bytes memory feedbackAuth) external
+```
+
+The *agentId* must be a validly registered agent. The *score* MUST be between 0 and 100\. *tag1*, *tag2*, and *uri* are OPTIONAL.
+
+*feedbackAuth* is a tuple with the structure (*agentId*, *clientAddress*, *indexLimit*, *expiry*, *chainId*, *identityRegistry*, *signerAddress*) signed using EIP-191 or ERC-1271 (if *clientAddress* is a smart contract). The *signerAddress* field identifies the agent owner or operator who signed.  
+Verification succeeds only if: *agentId*, *clientAddress*, *chainId* and *identityRegistry* are correct, blocktime \< *expiry* and *indexLimit* is greater than the last index of feedback received by that client for that *agentId*. While in most cases *indexLimit* is simply lastIndex \+ 1, it can be much higher. This allows *agentId* to pre-authorize multiple feedback submissions, useful for agent watch tower use cases.
+
+If the procedure succeeds, an event is emitted:
+
+```javascript
+event NewFeedback(uint256 indexed agentId, address indexed clientAddress, uint8 score, bytes32 indexed tag1, bytes32 tag2, string fileuri, bytes32 filehash)
+```
+
+The feedback fields, except *fileuri* and *filehash*, are stored in the contract storage along with the feedbackIndex (the number of feedback submissions that *clientAddress* has given to *agentId*). This exposes reputation signals to any smart contract, enabling on-chain composability.
+
+When the feedback is given by an agent (i.e., the client is an agent), the agent SHOULD use the address set in the on-chain optional walletAddress metadata as the clientAddress, to facilitate reputation aggregation.
+
+#### Revoking Feedback
+
+*clientAddress* can revoke feedback by calling:
+
+```javascript
+function revokeFeedback(uint256 agentId, uint64 feedbackIndex) external
+```
+
+This emits:
+
+```javascript
+event FeedbackRevoked(uint256 indexed agentId, address indexed clientAddress, uint64 indexed feedbackIndex)
+```
+
+Appending Responses
+
+Anyone (e.g., the *agentId* showing a refund, any off-chain data intelligence aggregator tagging feedback as spam) can call:
+
+```javascript
+function appendResponse(uint256 agentId, address clientAddress, uint64 feedbackIndex, string calldata responseUri, bytes32 calldata responseHash) external
+```
+
+Where *responseHash* is the KECCAK-256 file hash of the *responseUri* file content to guarantee integrity. This field is OPTIONAL for IPFS URIs.
+
+This emits:
+
+```javascript
+event ResponseAppended(uint256 indexed agentId, address indexed clientAddress, uint64 feedbackIndex, address indexed responder, string responseUri)
+```
+
+#### Read Functions
+
+```javascript
+function getSummary(uint256 agentId, address[] calldata clientAddresses, bytes32 tag1, bytes32 tag2) external view returns (uint64 count, uint8 averageScore)
+//agentId is the only mandatory parameter; others are optional filters.
+//Without filtering by clientAddresses, results are subject to Sybil/spam attacks. See Security Considerations for details
+
+function readFeedback(uint256 agentId, address clientAddress, uint64 index) external view returns (uint8 score, bytes32 tag1, bytes32 tag2, bool isRevoked)
+
+function readAllFeedback(uint256 agentId, address[] calldata clientAddresses, bytes32 tag1, bytes32 tag2, bool includeRevoked) external view returns (address[] memory clientAddresses, uint8[] memory scores, bytes32[] memory tag1s, bytes32[] memory tag2s, bool[] memory revokedStatuses)
+//agentId is the only mandatory parameter; others are optional filters. Revoked feedback are omitted.
+
+function getResponseCount(uint256 agentId, address clientAddress, uint64 feedbackIndex, address[] responders) external view returns (uint64)
+//agentId is the only mandatory parameter; others are optional filters.
+
+function getClients(uint256 agentId) external view returns (address[] memory)
+
+function getLastIndex(uint256 agentId, address clientAddress) external view returns (uint64)
+```
+
+We expect reputation systems around reviewers/clientAddresses to emerge. **While simple filtering by reviewer (useful to mitigate spam) and by tag are enabled on-chain, more complex reputation aggregation will happen off-chain**.
+
+#### Off-Chain Feedback File Structure
+
+The OPTIONAL file at the URI could look like:
 
 ```jsonc
 {
-  "FeedbackAuthID": "eip155:1:{FeedbackAuthID}",  // Mandatory, CAIP 10 format
-  "AgentSkillId": "string",         // Optional, as per A2A spec
-  "TaskId": "string",         // Optional, as per A2A spec
-  "contextId": "string",         // Optional, as per A2A spec
-  "Rating": 95,            // Optional, Int
-  "ProofOfPayment": {},      // Optional, Object
-  "Data": {}                 // Optional, Object
+  //MUST FIELDS
+  "agentRegistry": "eip155:1:{identityRegistry}",
+  "agentId": 22,
+  "clientAddress": "eip155:1:{clientAddress}",
+  "createdAt": "2025-09-23T12:00:00Z",
+  "feedbackAuth": "...",
+  "score": 100,
+
+  //MAY FIELDS
+  "tag1": "foo",
+  "tag2": "bar",
+  "skill": "as-defined-by-A2A",
+  "context": "as-defined-by-A2A",
+  "task": "as-defined-by-A2A",
+  "capability": "tools", // As per MCP: "prompts", "resources", "tools" or "completions"
+  "name": "Put the name of the MCP tool you liked!", // As per MCP: the name of the prompt, resource or tool
+  "proof_of_payment": {
+	"fromAddress": "0x00...",
+	"toAddress": "0x00...",
+	"chainId": "1",
+	"txHash": "0x00..." 
+   }, // this can be used for x402 proof of payment
+ 
+ // Other fields
+  " ... ": { " ... " } // MAY
 }
 ```
 
-Multiple entries with the same `FeedbackAuthID` enable multidimensional feedback for a single task.
-
 ### Validation Registry
 
-The Validation Registry provides two endpoints:
+**This registry enables agents to request verification of their work and allows validator smart contracts to provide responses that can be tracked on-chain**. Validator smart contracts could use, for example, stake-secured inference re-execution, zkML verifiers or TEE oracles to validate or reject requests.
 
+When the Validation Registry is deployed, the *identityRegistry* address is passed to the constructor and is visible by calling getIdentityRegistry(), as described above.
+
+#### Validation Request
+
+Agents request validation by calling:
+
+```javascript
+function validationRequest(address validatorAddress, uint256 agentId, string requestUri, bytes32 requestHash) external
 ```
-ValidationRequest(AgentValidatorID, AgentServerID, DataHash)
-ValidationResponse(DataHash, Response)
+
+This function MUST be called by the owner or operator of *agentId*. The *requestUri* points to off-chain data containing all information needed for the validator to validate, including inputs and outputs needed for the verification. The *requestHash* is a commitment to this data, which is OPTIONAL if *requestUri* is a content addressable storage uri (e.g. IPFS). All other fields are mandatory.
+
+A ValidationRequest event is emitted:
+
+```javascript
+event ValidationRequest(address indexed validatorAddress, uint256 indexed agentId, string requestUri, bytes32 indexed requestHash)
 ```
 
-`ValidationRequest(AgentValidatorID, AgentServerID, DataHash)` emits an event with parameters `(AgentValidatorID, AgentServerID, DataHash)`.
+#### Validation Response
 
-The smart contract stores the tuples `(AgentValidatorID, AgentServerID, DataHash)` of pending requests in contract memory for X seconds.
+Validators respond by calling:
 
-##### **In the crypto-economic scenario:**
+```javascript
+function validationResponse(bytes32 requestHash, uint8 response, string responseUri, bytes32 responseHash, bytes32 tag) external
+```
 
-* The **DataHash** commits to all information needed to re-run the job, including the input and output to be verified  
-* **AgentValidator** can be a single centralized trusted agent, a threshold committee (k-of-n) managed by a smart contract, a stake-secured service, or any other kind of programmable governance which calls `ValidationResponse` at the end of the validation process
+Only *requestHash* and *response* are mandatory; *responseUri*, *responseHash* and *tag* are optional. This function MUST be called by the *validatorAddress* specified in the original request. The *response* is a value between 0 and 100, which can be used as binary (0 for failed, 100 for passed) or with intermediate values for validations with a spectrum of outcomes. The optional *responseUri* points to off-chain evidence or audit of the validation, *responseHash* is its commitment (in case the resource is not on IPFS), while *tag* allows for custom categorization or additional data.
 
-##### **In the crypto-verification scenario:**
+validationResponse() can be called multiple times for the same *requestHash*, enabling use cases like progressive validation states (e.g., “soft finality” and “hard finality” using *tag*) or updates to validation status.
 
-* The **DataHash** commits to all information needed to create the TEE attestation proof or the zkTLS <!-- TODO: expand this abbreviation --> proof  
-* **AgentValidator** is a verifier smart contract which checks the proof on-chain and calls `ValidationResponse` if successful
+Upon successful execution, a *ValidationResponse* event is emitted with all function parameters:
 
-#### **Validation Requests**
+```javascript
+event ValidationResponse(address indexed validatorAddress, uint256 indexed agentId, bytes32 indexed requestHash, uint8 response, string responseUri, bytes32 tag)
+```
 
-The Server Agent, in its AgentCard, SHOULD extend the A2A specs by including a  `ValidationRequestsURI`. The file can be hosted on centralized systems or IPFS. The JSON file should contain a dictionary `DataHash => DataURI` with an entry for each validation. The structure of the single DataURI file depends on the validation service.
+The contract stores *requestHash*, *validatorAddress*, *agentId*, *response*, *lastUpdate*, and *tag* in its memory for on-chain querying and composability.
 
-#### **Validation Responses**
+#### Read Functions
 
-When validation is completed, `AgentValidatorAddress` calls or subcalls `ValidationResponse(DataHash, Response)`. Response is an Int `0 ≤ x ≤ 100` and can be used both as binary (0, 100\) or with any value between 0 and 100 for validations with a spectrum of outputs.
+```javascript
+function getValidationStatus(bytes32 requestHash) external view returns (address validatorAddress, uint256 agentId, uint8 response, bytes32 tag, uint256 lastUpdate)
 
-The smart contract checks if `DataHash` is still in the memory of the contract, and fails if it's not. If successful, a `ValidationResponse` event is emitted with parameters `(AgentValidatorID, AgentServerID, DataHash, Response)`.
+function getSummary(uint256 agentId, address[] calldata validatorAddresses, bytes32 tag) external view returns (uint64 count, uint8 avgResponse)
+//Returns aggregated validation statistics for an agent. agentId is the only mandatory parameter; validatorAddresses and tag are optional filters
 
-Symmetrically to the ValidationRequests structure, the Validator Agent, in its AgentCard, COULD extend the A2A specs by including a `ValidationResponsesURI` value. The file can be hosted on centralized systems or IPFS. The JSON file should contain a dictionary `DataHash => DataURI` with an entry for each validation response. The structure of the single DataURI file, which can for example include evidence of the validation, depends on the validation service.
+function getAgentValidations(uint256 agentId) external view returns (bytes32[] memory requestHashes)
 
-Both the Validation Requests and Validation Responses JSON files MIGHT include `AgentSkillId`, `TaskId`, or `contextId` references, following A2A specs naming conventions.
+function getValidatorRequests(address validatorAddress) external view returns (bytes32[] memory requestHashes)
+```
 
-Incentives and slashing related to validation and verification are managed by the specific protocol.
+Incentives and slashing related to validation are managed by the specific validation protocol and are outside the scope of this registry.
 
 ## Rationale
 
-**Off-chain Infrastructure**
-
-The protocol deliberately delegates complex operations off-chain to enable:
-
-* Sophisticated reputation algorithms and aggregation services  
-* Flexible validation protocols with custom incentive mechanisms  
-* Scalable data storage and retrieval systems
-
-**Interoperability**
-
-* CAIP 10 standard ensures chain-agnostic addressing  
-* RFC 8615 compliance enables standard web discovery  
-* Modular design allows integration with existing payment and validation systems
-
-**Possible future directions**
-
-* Cross-chain identifiers  
-* Use NFT interface for agent minting, ownership and transfer  
-* ENS support  
-* Integrations with A2A's extensions managing payments  
-* Incentives to provide feedback or guarantee the off-chain data availability of feedback and validations
-* Verify AgentDomain in the Identity Registry
+* **Agent communication protocols**: MCP and A2A are popular, and other protocols could emerge. For this reason, this protocol links from the blockchain to a flexible registration file including a list where endpoints can be added at will, combining AI primitives (MCP, A2A) and Web3 primitives such as wallet addresses, DIDs, and ENS names.  
+* **Feedback**: The protocol combines the leverage of nomenclature already established by A2A (such as tasks and skills) and MCP (such as tools and prompts) with complete flexibility in the feedback signal structure.  
+* **Gas Sponsorship**: Since clients don't need to be registered anymore, any application can implement frictionless feedback leveraging EIP-7702.  
+* **Indexing**: Since feedback data is saved on-chain and we suggest using IPFS for full data, it's easy to leverage subgraphs to create indexers and improve UX.  
+* **Deployment**: We expect ERC-8004 to be deployed with singletons per chain. Note that an agent registered and receiving feedback on chain A can still operate and transact on other chains. Agents can also be registered on multiple chains if desired.
 
 ## Test Cases
 
 This protocol enables:
 
-- Crawling all Agent Cards starting from a logically centralized endpoint  
-- Easy discovery of which trust models an agent supports (feedback, inference validation, TEE <!-- TOOD: expand this abbreviation --> attestation) for agent selection criteria  
-- Development of protocols and applications to browse and discover trustless agents  
-- Access to complete feedback and validation history for building sophisticated reputation systems
+* Crawling all agents starting from a logically centralized endpoint and discover agent information (name, image, services), capabilities, communication endpoints (MCP, A2A, others), ENS names, wallet addresses and which trust models they support (reputation, validation, TEE attestation)  
+* Building agent explorers and marketplaces using any ERC-721 compatible application to browse, transfer, and manage agents  
+* Building reputation systems with on-chain aggregation (average scores for smart contract composability) or sophisticated off-chain analysis. All reputation signals are public good.  
+* Discovering which agents support stake-secured or zkML validation and how to request it through a standardized interface
 
-<!-- Editor's Note: Proposals should be written as if they are already final. It's too easy to forget to update in-progress text and then you get stuck with a weird looking note when the proposal becomes immutable. -->
+##  Security Considerations
 
-## Security Considerations
-
-* Pre-authorization requirements for feedback  
-* On-chain pointers cannot be deleted, ensuring audit trail integrity  
+* Pre-authorization for feedback only partially mitigates spam, as Sybil attacks are still possible, inflating the reputation of fake agents. The protocol's contribution is to make signals public and use the same schema. We expect many players to build reputation systems, for example, trusting or giving reputation to reviewers (and therefore filtering by reviewer, as the protocol already enables).  
+* On-chain pointers and hashes cannot be deleted, ensuring audit trail integrity  
 * Validator incentives and slashing are managed by specific validation protocols  
-* Verifying that the AgentDomain in the on-chain Registry actually corresponds to the one of the Agent Card is left to the user of the protocol (that's to avoid the involvement of an oracle network)
-
-<!-- TODO: these bullet points are okay for a draft, but should be fleshed out more before going into Review -->
+* While ERC-8004 cryptographically ensures the registration file corresponds to the on-chain agent, it cannot cryptographically guarantee that advertised capabilities are functional and non-malicious. The three trust models (reputation, validation, and TEE attestation) are designed to support this verification need
 
 ## Copyright
 


### PR DESCRIPTION
Main changes:
- Less friction. Clients and Validators don't need to register anymore. This facilitates gas sponsorship of feedback.
- Identity 721-compliant. Agents can be displayed (with title, image, and description of their services) and traded in any 721-compatible app.
- Not just A2A. 8004 now supports also MCP (e.g. tools) and shows examples of usage of ENS, x402, and DIDs.
- More data on-chain to enable on-chain composability for feedback and validation ("information lego" with reputation)
- More IPFS usage, also to enable subgraph indexing -> Better UX
- Added a cosigner
- Moving from Draft to Review