### PR TITLE
Update ERC-8004: Add Requires field

### DIFF
--- a/ERCS/erc-8004.md
+++ b/ERCS/erc-8004.md
@@ -8,6 +8,7 @@ status: Review
 type: Standards Track
 category: ERC
 created: 2025-08-13
+requires: 155, 721
 ---
 
 ## Abstract


### PR DESCRIPTION
Add requires field to header table in accordance to ERC-1.

From what I saw in the specification section EIP-155 and ERC-721 are required.