### PR TITLE
Add ERC: Onchain Metadata for Token Registries

### DIFF
--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -17,7 +17,7 @@ This ERC defines an onchain metadata standard for multi-token and NFT registries
 
 ## Motivation
 
-This ERC addresses the need for fully onchain metadata while maintaining compatibility with existing [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), and [ERC-6909](./eip-6909.md) standards. It has been a long-felt need for developers to store metadata onchain for NFTs and other multitoken contracts; however, there has been no uniform standard way to do this. Some projects have used the tokenURI field to store metadata onchain using Data URLs, which introduces gas inefficiencies and has other downstream effects (for example making storage proofs more complex). This standard provides a uniform way to store metadata onchain, and is backwards compatible with existing [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), and [ERC-6909](./eip-6909.md) standards.
+This ERC addresses the need for fully onchain metadata while maintaining compatibility with existing [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), and [ERC-6909](./eip-6909.md) standards. It has been a long-felt need for developers to store metadata onchain for NFTs and other multitoken contracts; however, there has been no uniform standard way to do this. Some projects have used the `tokenURI` field to store metadata onchain using Data URLs, which introduces gas inefficiencies and has other downstream effects (for example making storage proofs more complex). This standard provides a uniform way to store metadata onchain, and is backwards compatible with existing [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), and [ERC-6909](./eip-6909.md) standards.
 
 ## Specification
 
@@ -67,7 +67,7 @@ The Diamond Storage pattern provides predictable storage locations for data, whi
 
 ### Examples
 
-The inspiration for this standard was trustless AI agents. The registry extends [ERC-721](./eip-721.md) by adding getMetadata and setMetadata functions for optional extra on-chain agent metadata.
+The inspiration for this standard was trustless AI agents. The registry extends [ERC-721](./eip-721.md) by adding `getMetadata` and `setMetadata` functions for optional extra on-chain agent metadata.
 
 #### Example: Context for LLM-Facing Agent Metadata
 


### PR DESCRIPTION
Introduces a new standard for storing arbitrary metadata directly onchain for ERC-721, ERC-1155, ERC-6909, and ERC-8004 registries.

**Key features:**
- Key-value pair interface: string keys mapped to bytes values for each token
- Required `getMetadata()` function and `MetadataSet` event
- Backwards compatible with existing token standards
- Enables trustless AI agents, proof of personhood, and custom metadata

This addresses the long-felt need for uniform onchain metadata storage while avoiding gas inefficiencies.

**Note on Standard History:**

This onchain metadata standard was originally introduced as part of ERC-8041 on **September 30, 2025** (commit `13f11f2`). ERC-8041 later pivoted to focus on fixed-supply agent collections, so this core metadata functionality is being reintroduced as a standalone standard.