### PR TITLE
Update ERC-6123: Fix spelling errors in ERC-6123 documentation

### DIFF
--- a/ERCS/erc-6123.md
+++ b/ERCS/erc-6123.md
@@ -107,7 +107,7 @@ function cancelTrade(address withParty, string memory tradeData, int position, i
 
 #### Trade Termination: `requestTermination`
 
-Allows an eligible party to request a mutual termination of the trade with the correspondig `tradeId` with a termination amount she is willing to pay and provide further termination terms (e.g. an XML)
+Allows an eligible party to request a mutual termination of the trade with the corresponding `tradeId` with a termination amount she is willing to pay and provide further termination terms (e.g. an XML)
 
 ```solidity
 function requestTradeTermination(string memory tradeId, int256 terminationPayment, string memory terminationTerms) external;
@@ -182,7 +182,7 @@ function afterSettlement() external;
 
 #### Settlement Phase: `afterTransfer`
 
-This method is called back from a settlement token or from an eligible address if the transfer of the settlment
+This method is called back from a settlement token or from an eligible address if the transfer of the settlement
 amount was successful. - completes the settlement transfer.
 The transactionData is emitted as part of the corresponding event: `SettlementTransferred` or `SettlementFailed`
 This might result in a termination or start of the next settlement phase, depending on the provided success flag.
@@ -270,7 +270,7 @@ Emitted when a settlement is requested (via `initiateSettlement`). May trigger t
 
 The argument `lastSettlementData` is the one that was passed upon a previous settlement
 in `performSettlement` (under the name `settlementData`). It may be used to pass updated settlement
-specific information calcualted during the previous settlement, e.g., when margin buffer amounts are a function
+specific information calculated during the previous settlement, e.g., when margin buffer amounts are a function
 of market parameters. In case of an external oracle it can pass the `settlementData` via `performSettlement`
 and pick it up in the `SettlementRequested` event (allows for stateless external oracles).
 


### PR DESCRIPTION

## Summary

This PR fixes three spelling errors in the ERC-6123 Smart Derivative Contract specification:

- `correspondig` → `corresponding` 
- `settlment` → `settlement` 
- `calcualted` → `calculated` 

