### PR TITLE
Update ERC-7417: fix spelling errors in documentation

### DIFF
--- a/ERCS/erc-7417.md
+++ b/ERCS/erc-7417.md
@@ -251,7 +251,7 @@ It was considered that events are not an important part of the standard as these
 
 The main existing method of introspection is currently [ERC-165](./eip-165.md) which inspects the signatures of functions implemented in a contract. It is not possible to differentiate an [ERC-20](./eip-20.md) token from an [ERC-223](./eip-223.md) token by just browsing functions that they implement without digging their internal logic.
 
-Here is a token and it is not possible to identify if it should be dealt with as [ERC-20](./eip-20.md) or [ERC-223](./eip-223.md) because it depends on the actual implemenation of it's `transfer` function logic.
+Here is a token and it is not possible to identify if it should be dealt with as [ERC-20](./eip-20.md) or [ERC-223](./eip-223.md) because it depends on the actual implementation of it's `transfer` function logic.
 
 ```solidity
 abstract contract Token {
@@ -291,7 +291,7 @@ In case of this implementation the token will behave as [ERC-223](./eip-223.md):
 }
 ```
 
-Also, there are plenty of tokens that do not implement [ERC-165](./eip-165.md) introspection at all. As the result it was decided to implement a special `standard() returns (uint32)` function in all [ERC-223](./eip-223.md) wrappers created by the Converter and assume that original [ERC-223](./eip-223.md) tokens may explicityly declare themselves as [ERC-223](./eip-223.md) by implementing the same function too. It is assumed that if a token does not implement this function then it is [ERC-20](./eip-20.md).
+Also, there are plenty of tokens that do not implement [ERC-165](./eip-165.md) introspection at all. As the result it was decided to implement a special `standard() returns (uint32)` function in all [ERC-223](./eip-223.md) wrappers created by the Converter and assume that original [ERC-223](./eip-223.md) tokens may explicitly declare themselves as [ERC-223](./eip-223.md) by implementing the same function too. It is assumed that if a token does not implement this function then it is [ERC-20](./eip-20.md).
 
 This method of token standard introspection is more precise than [ERC-165](./eip-165.md).
 


### PR DESCRIPTION

This PR fixes two spelling errors in the ERC-7417 Token Converter specification document.

Fixed "implemenation" → "implementation" 
Fixed "explicityly" → "explicitly"

