### PR TITLE
Update ERC-7730: add optional integrity field amendment

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1340,30 +1340,30 @@ Sources values are wallet manufacturer specific. Some example values could be:
 
 Wallets MAY extend the specification with wallet specific layout instructions by defining a schema bound to the `display.formats.screens` field.  
 
-## ERC-7730: Optional Integrity Field for Descriptor Tamper-Evidence
+### ERC-7730: Optional Integrity Field for Descriptor Tamper-Evidence
 
-### Abstract
+#### Abstract
 
 This amendment introduces an optional top-level `integrity` object that wallets and tooling can use to detect tampering with ERC-7730 descriptors during storage or transport. The mechanism is transport-agnostic, operates offline, and does not influence descriptor interpretation.
 
-### Motivation
+#### Motivation
 
 Descriptors are frequently distributed from arbitrary locations such as GitHub repositories, content delivery networks, and dapp-hosted domains, which makes byte-level tampering difficult to notice. This amendment focuses solely on byte-integrity so that consumers can surface warnings when the document payload changes; provenance, governance, and trust decisions remain outside its scope.
 
-### Specification
+#### Specification
 
-#### Scope
+##### Scope
 
 * The `integrity` object is optional. Absence is not an error.
 * Implementations MAY validate `integrity` if present; verification outcome affects wallet and tool user experiences only and MUST NOT alter descriptor semantics.
 
-#### Hash Input (canonicalization)
+##### Hash Input (canonicalization)
 
 * Let D be the JSON document with the top-level `integrity` key removed.
 * Canonicalize D using the RFC 8785 JSON Canonicalization Scheme (JCS) with UTF-8 encoding, lexicographic member ordering, and I-JSON constraints.
-* Compute `digest = keccak256(JCS(D))`, where `keccak256` is the Ethereum Keccak-256 function.
+* Compute `digest = keccak256(JCS(D))`, where `keccak256` is the Ethereum Keccak-256 function (distinct from FIPS SHA3-256).
 
-#### Signed Message (exact bytes)
+##### Signed Message (exact bytes)
 
 Implementations MUST construct the exact ASCII (UTF-8) message with line feed newlines, no byte order mark, and no trailing spaces:
 
@@ -1383,7 +1383,7 @@ HEXDIGIT    = %x30-39 / %x61-66     ; 0-9 or a-f (lowercase)
 64HEXDIGIT  = 64*HEXDIGIT
 ```
 
-#### Signature schemes and verification rules
+##### Signature schemes and verification rules
 
 * `sigType: "eip191"`, `signerType: "eoa"`:  
   The signer MUST sign the message defined above using [EIP-191](./eip-191.md) personal signing. Verifiers MUST:  
@@ -1398,11 +1398,11 @@ HEXDIGIT    = %x30-39 / %x61-66     ; 0-9 or a-f (lowercase)
   3. call [EIP-1271](./eip-1271.md) `isValidSignature(bytes32,bytes)` on that account at the chain specified by the CAIP-10 identifier, requiring the magic value `0x1626ba7e`.  
      If chain access is unavailable, implementations SHOULD surface "verification unavailable" and continue according to product policy.
 
-#### Signer identity format (CAIP-10)
+##### Signer identity format (CAIP-10)
 
 The `signer` field MUST be a CAIP-10 account string (e.g., `eip155:1:0xAbc...`), uniquely binding both the chain reference and the account without requiring separate `chainId` properties.
 
-#### `integrity` object (JSON schema fragment)
+##### `integrity` object (JSON schema fragment)
 
 ```json
 "integrity": {
@@ -1414,18 +1414,18 @@ The `signer` field MUST be a CAIP-10 account string (e.g., `eip155:1:0xAbc...`),
 }
 ```
 
-#### Verifier behavior
+##### Verifier behavior
 
 * If `integrity` is present and verification fails (hash mismatch, bad signature, or invalid 1271 response), implementations MUST surface an integrity failure. Whether to block is product policy.
 * If `integrity` is present and verification cannot be performed (for example, offline EIP-1271 lookups), implementations SHOULD surface "verification unavailable."
 * If `integrity` is absent, implementations MUST NOT treat this as an error.
 * Implementations MUST NOT change how they interpret descriptor content based on the verification outcome.
 
-### Rationale
+#### Rationale
 
 JSON canonicalization via RFC 8785 ensures stable bytes across languages and tooling, while Keccak-256 matches existing Ethereum hashing primitives. The explicit message template and ABNF eliminate newline or casing ambiguities. Separating `sigType` from `signerType` avoids assumptions about available chain connectivity and supports future combinations. Encoding the signer as CAIP-10 binds chain and account in one field, removing auxiliary identifiers. Time-based invalidation features are intentionally excluded to keep the surface minimal, and provenance or governance concerns stay intentionally out of scope.
 
-### Security Considerations
+#### Security Considerations
 
 This mechanism only detects tampering of descriptor bytes and does not assert safety or endorsement. Implementations SHOULD reject non-I-JSON inputs (duplicate keys or non-UTF-8 encodings) before canonicalization, MUST enforce low-s ECDSA handling, and MUST ensure the Ethereum Keccak-256 function, not the FIPS SHA3-256 variant, is used throughout verification.
 


### PR DESCRIPTION
  Summary
- introduce an optional top-level `integrity` object that lets wallets and tooling detect descriptor tampering without changing how descriptors are interpreted
- document canonicalization (RFC 8785), message construction, signature validation for EIP-191/1271 with CAIP-10 signer IDs, JSON schema expectations, and explicit verifier UX handling
