### PR TITLE
ERC-8055 Guardianshield security token

### DIFF
--- a/ERCS/guardianshield ERC-8055
+++ b/ERCS/guardianshield ERC-8055
@@ -1,0 +1,86 @@
+---
+eip: 8055
+title: Guardian Shield Security Token
+author: Rexjaden <rexxrog1@gmail.com>
+discussions-to: https://github.com/ethereum/ERCs/issues/8055
+status: Draft
+type: Standard Track
+category: ERC
+created: 2025-10-21
+---
+
+## Abstract
+
+[ERC-8055](https://eips.ethereum.org/EIPS/eip-8055) introduces a security token governed exclusively by Guardian Shield Administration. Designed to combat the escalating threat of theft and fraud in the crypto ecosystem, this token incorporates serialized tracking, verifiable burn protocols, and automated reminting to protect users and preserve tokenomics. It represents a proactive step toward restoring trust and resilience in decentralized finance.
+
+## Motivation
+
+The crypto ecosystem is under constant siege from deceptive actors who exploit vulnerabilities to steal, contaminate, and defraud. Imagine a thief who believes they've succeeded — they've stolen a million tokens, convinced they’ve escaped with someone else's property. But then, without warning, those tokens vanish. Burned. Logged. Reminted into the Guardian Shield Treasury. The thief is left with nothing. The rightful owner, upon presenting irreputable proof, sees their assets restored.
+
+This is the power of [ERC-8055](https://eips.ethereum.org/EIPS/eip-8055).
+
+Guardian Shield tokens are designed to fight back. Each token is serialized, monitored, and protected by a burn-and-remint protocol that activates only upon verified proof of theft, fraud, or contamination. The system doesn’t just react — it anticipates. It logs every action, remints automatically to preserve tokenomics, and ensures that compromised assets are never left in circulation.
+
+[ERC-8055](https://eips.ethereum.org/EIPS/eip-8055) is more than a proposal. It’s a statement: that security, transparency, and justice are not optional in decentralized finance. It’s a step forward in the battle against crypto crime — and a warning to those who think they can get away with it.
+
+## Specification
+
+- **Token Type**: Security token
+- **Serial Tracking**: Each token carries a unique serial number
+- **Burn Mechanism**:
+  - Triggered only upon verifiable proof of:
+    - Theft
+    - Fraudulent acquisition
+    - Contamination
+  - Proof must be logged and validated before burn
+- **Reminting Protocol**:
+  - Burned tokens are reminted and placed in Guardian Shield Treasury
+  - Automatic reminting preserves tokenomics
+  - Tokens returned to rightful owner upon irreputable proof
+- **Treasury Management**:
+  - Maintained by Guardian Shield Administration
+  - Monitored by autonomous agents for security
+- **Batch Minting**:
+  - Tokens minted in batches of 300 million
+  - Each batch assigned a monitoring agent with logging duties
+- **Purchasing Model**:
+  - Guardian Shield tokens are available to anyone
+  - Initial price: $0.005 per token
+  - Purchasable using ETH, BTC, or any token with recognized value
+  - Flexible exchange model allows users to trade diverse assets for Guardian Shield tokens
+- **Liquidity-Based Pricing**:
+  - Token price will fluctuate based on liquidity
+  - As demand and circulation shift, pricing adjusts dynamically like other tradable tokens
+- **Inheritance**:
+  - [ERC-8055](https://eips.ethereum.org/EIPS/eip-8055) inherits core interfaces from [ERC-20](https://eips.ethereum.org/EIPS/eip-20) for fungible token compatibility
+  - Optionally integrates [ERC-721](https://eips.ethereum.org/EIPS/eip-721) traits for unique serial tracking and ownership verification
+
+## Rationale
+
+The design prioritizes security, transparency, and recoverability. Serial tracking enables forensic auditing. The burn/remint cycle ensures that compromised tokens do not disrupt circulation or valuation. Agent-based monitoring adds a layer of real-time oversight.
+
+By inheriting from [ERC-20](https://eips.ethereum.org/EIPS/eip-20), [ERC-8055](https://eips.ethereum.org/EIPS/eip-8055) maintains compatibility with existing wallets, exchanges, and DeFi protocols. Optional integration with [ERC-721](https://eips.ethereum.org/EIPS/eip-721) allows for enhanced traceability and individualized token behavior, supporting hybrid use cases where both fungibility and uniqueness are required.
+
+## Backwards Compatibility
+
+[ERC-8055](https://eips.ethereum.org/EIPS/eip-8055) is a standalone proposal and does not interfere with existing proposals. It may be integrated alongside [ERC-20](https://eips.ethereum.org/EIPS/eip-20) or [ERC-721](https://eips.ethereum.org/EIPS/eip-721) depending on implementation.
+
+## Reference Implementation
+
+The implementation will support open-access purchasing via a decentralized exchange or smart contract interface. Users can acquire Guardian Shield tokens using ETH, BTC, or other recognized tokens. The initial price is set at $0.005 per token, but pricing will fluctuate based on liquidity and market conditions. The system will include:
+
+- A token swap interface supporting multi-token input
+- Price oracle integration for real-time valuation and liquidity tracking
+- Logging of purchase transactions and batch assignments
+- Agent monitoring for each minted batch
+- Treasury reminting logic triggered by verified burn events
+
+## Security Considerations
+
+- Burn triggers require strict validation to prevent abuse
+- Treasury agents must be tamper-proof and auditable
+- Reminting must be rate-limited to avoid inflationary exploits
+
+## Copyright
+
+This EIP is licensed under CC0.


### PR DESCRIPTION
This ERC defines a security token governed by Guardianshield Administration.  It introduces serialized tracking, verifiable burn protocols, and automated reminting to combat theft, fraud, and contamination in the crypto ecosystem. ERC-8055 is designed to protect users, preserve tokenomics, and restore trust in decentralized finance.
