### PR TITLE
Add ERC: Self-Describing Bytes via EIP-712 Selectors

### DIFF
--- a/ERCS/erc-8074.md
+++ b/ERCS/erc-8074.md
@@ -97,9 +97,9 @@ Existing contracts that already accept arbitrary `bytes` remain compatible. Cont
 
 ## Security Considerations
 
-- **Payload bounds:** When parsing `DataList`, consumers SHOULD limit `items.length` and total payload size (for example ≤ 8 items and ≤ 8 KB).
-- **Early exit:** Consumers SHOULD stop scanning once all expected selectors are found.
-- **Unknown data:** Unrecognized items MUST be ignored safely.
+- **Payload bounds:** When parsing `DataList`, consumers should limit `items.length` and total payload size (for example ≤ 8 items and ≤ 8 KB).
+- **Early exit:** Consumers should stop scanning once all expected selectors are found.
+- **Unknown data:** Unrecognized items must be ignored safely.
 
 ## Copyright
 


### PR DESCRIPTION
This ERC defines a convention for encoding self-describing structured data within `bytes` parameters, using a 4-byte selector derived from an EIP-712 type string. It specifies a formula for encoding a single payload, as well as a canonical multi-payload wrapper, allowing multiple typed structures to coexist in a single bytes argument.