### PR TITLE
Update ERC-7730: Update examples according to latest specification

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -698,7 +698,7 @@ It also shows how to describe a more dynamic enumeration, like a list of possibl
 {
   "display": {
     "formats": {
-      "repay(address asset, uint256 amount, uint256 interestRateMode)": {
+      "repay(address asset,uint256 amount,uint256 interestRateMode)": {
         "$id": "repay",
         "intent": "Repay loan",
         "interpolatedIntent": "Repay {amount} of {interestRateMode} rate loan",
@@ -949,7 +949,7 @@ The following ERC-7730 shows examples for the three kinds of `fields` options
 {
     "display": {
         "formats": {
-            "myFunction(address account,uint256 amount,MyParamType param)" : {
+            "myFunction(address account,uint256 amount,(string name,uint256 value) param)" : {
                 "fields": [
                     {
                         "path": "account",
@@ -1138,7 +1138,7 @@ Here is an example of how to format embedded calldata:"
 {
     "display": {
         "formats": {
-            "permitAndCall(bytes permit, bytes action)": {
+            "permitAndCall(bytes permit,bytes action)": {
                 "intent": "Execute with permit",
                 "fields": [
                     {
@@ -1170,7 +1170,7 @@ To handle this, the `amountPath` and/or `spenderPath` parameters can be used to 
 {
     "display": {
         "formats": {
-            "permitAndCall(bytes permit, address target, bytes action)": {
+            "permitAndCall(bytes permit,address target,bytes action)": {
                 "intent": "Execute with permit",
                 "fields": [
                     {


### PR DESCRIPTION
**Summary**

This PR updates examples throughout ERC-7730 that became outdated following the specification changes introduced in [PR #1289](https://github.com/ethereum/ERCs/pull/1289/files#diff-4be5c7ab93c36d831fd790dbc2db4dccdea358a04cb2e64fee220132b700d02cR764). The specification now requires:
> - Keys MUST use canonical Solidity type names: `uint256`, `bytes32`, `address`, `bool`, tuple syntax `(…)`, dynamic arrays `type[]`, and fixed arrays `type[N]`. Aliases (e.g., `uint`) are NOT permitted, commas MUST NOT be followed by spaces, and there MUST be exactly one space between each type and its parameter name.

**Changes**

- Removed spaces after commas in the repay and permitAndCall functions.
- Updated myFunction example to use proper tuple syntax for custom struct types instead of named struct references.