### PR TITLE
Add ERC: Dual-Mode Fungible Tokens

### DIFF
--- a/ERCS/erc-8085.md
+++ b/ERCS/erc-8085.md
@@ -13,7 +13,7 @@ requires: 20, 8086
 
 ## Abstract
 
-This EIP defines an interface for fungible tokens that operate in two modes: transparent mode (fully compatible with [ERC-20](./eip-20)) and privacy mode (using `ERC-8086` privacy primitives). Token holders can convert balances between modes. The transparent mode uses account-based balances, while the privacy mode uses the standardized IZRC20 interface from `ERC-8086`. Total supply is maintained as the sum of both modes.
+This EIP defines an interface for fungible tokens that operate in two modes: transparent mode (fully compatible with [ERC-20](./eip-20)) and privacy mode (using [ERC-8086](./eip-8086) privacy primitives). Token holders can convert balances between modes. The transparent mode uses account-based balances, while the privacy mode uses the standardized IZRC20 interface from ERC-8086. Total supply is maintained as the sum of both modes.
 
 ## Motivation
 
@@ -179,14 +179,14 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ```solidity
 /**
  * @title IDualModeToken
- * @notice Interface for dual-mode tokens (ERC-8085) combining ERC-20 and `ERC-8086` (IZRC20)
+ * @notice Interface for dual-mode tokens (ERC-8085) combining ERC-20 and [ERC-8086](./eip-8086) (IZRC20)
  * @dev Implementations MUST inherit both IERC20 and IZRC20
- *      Privacy events and core functions are inherited from IZRC20 (`ERC-8086`)
+ *      Privacy events and core functions are inherited from IZRC20 (ERC-8086)
  *      This interface only defines mode conversion logic - the core value of ERC-8085
  *
  * Architecture:
  *   - Public Mode: Standard ERC-20 (transparent balances and transfers)
- *   - Privacy Mode: `ERC-8086` IZRC20 (ZK-SNARK protected balances and transfers)
+ *   - Privacy Mode: ERC-8086 IZRC20 (ZK-SNARK protected balances and transfers)
  *   - Mode Conversion: toPrivacy (public → private) and toPublic (private → public)
  */
 interface IDualModeToken is IERC20, IZRC20 {
@@ -258,7 +258,7 @@ interface IDualModeToken is IERC20, IZRC20 {
     // ═══════════════════════════════════════════════════════════════════════
 
     // Note: Privacy transfers use IZRC20.transfer(uint8, bytes, bytes[])
-    // which is inherited from IZRC20 (`ERC-8086`)
+    // which is inherited from IZRC20 (ERC-8086)
 
     /**
      * @notice Total supply across both modes (overrides IERC20 and IZRC20)
@@ -395,11 +395,11 @@ This ensures:
 
 ## Backwards Compatibility
 
-This standard is fully backward compatible with [ERC-20](./eip-20) and `ERC-8086`:
+This standard is fully backward compatible with [ERC-20](./eip-20) and [ERC-8086](./eip-8086):
 
 - All ERC-20 functions operate on transparent balances
 - All standard ERC-20 events are emitted
-- All `ERC-8086` (IZRC20) functions and events are supported for privacy mode
+- All ERC-8086 (IZRC20) functions and events are supported for privacy mode
 - Existing DeFi protocols work without modification
 - Privacy mode is additive and optional
 


### PR DESCRIPTION
 ## Summary
  This PR proposes a new ERC standard for dual-mode fungible tokens that support both transparent (ERC-20) and
  privacy-preserving (zk-SNARK) modes within a single token.

  ## Motivation
  Current privacy solutions for tokens require trade-offs:
  - Wrapper-based: Creates two separate tokens, splits liquidity
  - Protocol-level: Requires blockchain forks, multi-year coordination

  This standard provides an integrated approach specifically for **new token deployments** that want privacy as a
  core feature from day one.

  ## Key Features
  - **Unified Token Economics**: One token address, no liquidity fragmentation
  - **Seamless Mode Switching**: Users convert between public and privacy modes
  - **Full ERC-20 Compatibility**: Works with existing DeFi without modification
  - **Transparent Supply Tracking**: Prevents hidden inflation
  - **Application-Layer Deployment**: Deploy today on any EVM chain

  ## Community Discussion
  - Ethereum Magicians:
  https://ethereum-magicians.org/t/erc-8085-dual-mode-fungible-tokens/26592

  ## Current Status
  - [x] Specification complete
  - [x] Interface definitions with detailed event comments
  - [x] Security considerations documented
  - [x] Community discussion initiated
  - [ ] Reference implementation (planned after initial feedback)
  - [ ] Test cases (planned after initial feedback)

  ## Next Steps
  I will add the reference implementation and test cases after receiving initial community feedback on the
  specification.
