### PR TITLE
Update ERC-7730: Add interoperableAddress format to support erc-7930 interoperable addresses

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1316,7 +1316,7 @@ Formats usable for bytes
 
 | **`interoperableAddress`** |                    |
 |----------------------------|--------------------|
-| *Description*              | Display bytes as an [ERC-7930](./erc-7930.md) Interoperable Name. The wallet SHOULD parse the binary format, extract the target address and chain, and display it in the standard `<address> @ <chain> # <checksum>` format. |
+| *Description*              | Display bytes as an [ERC-7930](https://eips.ethereum.org/EIPS/eip-7930) Interoperable Name. The wallet SHOULD parse the binary format, extract the target address and chain, and display it in the standard `<address> @ <chain> # <checksum>` format. |
 | *Parameters*            | None |
 | *Examples*              | ---  |
 | `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C` | Field Value = `0x00010000010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045` |


### PR DESCRIPTION
# Abstract

This pull request extends ERC-7730 by introducing support for [EIP-7930 Interoperable Addresses](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-7930.md). The goal is to enable wallets to safely parse and display chain-specific addresses, improving security for cross-chain interactions.

# Specification

A new format specifier, `` interoperableAddress ``, has been added to the "Bytes formats" section. This instructs wallets to interpret a bytes value as an EIP-7930 binary payload and display it in its human-readable "Interoperable Name" format.

# Open for Discussion

Once an `` interoperableAddress `` is parsed to reveal a standard address, how should we best leverage the rich features of the existing `` addressName `` formatter?


