### PR TITLE
Add ERC: Dual-Mode Fungible Tokens

### DIFF
--- a/ERCS/erc-8085.md
+++ b/ERCS/erc-8085.md
@@ -76,7 +76,7 @@ DeFi/DEX Trading          Private Holdings
    - Simplified token distribution and airdrops
 
 2. **Seamless Mode Switching**
-   - Convert to privacy mode for holdings: `toPrivacy()`
+   - Convert to privacy mode for holdings: `toPrivate()`
    - Convert to public mode for DeFi: `toPublic()`
    - Users choose privacy per transaction, not per token
 
@@ -186,37 +186,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
  * Architecture:
  *   - Public Mode: Standard ERC-20 (transparent balances and transfers)
  *   - Privacy Mode: ERC-8086 IZRC20 (ZK-SNARK protected balances and transfers)
- *   - Mode Conversion: toPrivacy (public → private) and toPublic (private → public)
+ *   - Mode Conversion: toPrivate (public → private) and toPublic (private → public)
  */
 interface IDualModeToken is IERC20, IZRC20 {
-
-    // ═══════════════════════════════════════════════════════════════════════
-    // Events (Mode Conversion Specific)
-    // ═══════════════════════════════════════════════════════════════════════
-
-    /// @notice Emitted when value is converted from transparent to privacy mode
-    /// @param account The address converting tokens
-    /// @param amount The amount converted
-    /// @param commitment The cryptographic commitment created
-    /// @param timestamp Block timestamp of conversion
-    event ConvertToPrivacy(
-        address indexed account,
-        uint256 amount,
-        bytes32 indexed commitment,
-        uint256 timestamp
-    );
-
-    /// @notice Emitted when value is converted from privacy to transparent mode
-    /// @param initiator The address initiating the conversion
-    /// @param recipient The address receiving transparent tokens
-    /// @param amount The amount converted
-    /// @param timestamp Block timestamp of conversion
-    event ConvertToPublic(
-        address indexed initiator,
-        address indexed recipient,
-        uint256 amount,
-        uint256 timestamp
-    );
 
     // ═══════════════════════════════════════════════════════════════════════
     // Mode Conversion Functions (Core of ERC-8085)
@@ -230,7 +202,7 @@ interface IDualModeToken is IERC20, IZRC20 {
      * @param proof ZK-SNARK proof of valid commitment creation
      * @param encryptedNote Encrypted note data for recipient wallet
      */
-    function toPrivacy(
+    function toPrivate(
         uint256 amount,
         uint8 proofType,
         bytes calldata proof,
@@ -283,7 +255,7 @@ interface IDualModeToken is IERC20, IZRC20 {
 ```
 
 ### Proof Type Parameter
-The `proofType` parameter in `toPrivacy`, `toPublic`, and `privacyTransfer` functions allows implementations to support multiple proof strategies.
+The `proofType` parameter in `toPrivate`, `toPublic`, and `privacyTransfer` functions allows implementations to support multiple proof strategies.
 
 **Purpose**: Different proof types may be needed for:
 - Different data structures (e.g., active vs. archived state in dual-tree implementations)
@@ -303,6 +275,10 @@ Implementations MUST implement the [ERC-20](./eip-20) interface. All ERC-20 func
 
 Implementations MUST emit standard [ERC-20](./eip-20) `Transfer` events for transparent mode operations.
 
+For mode conversions:
+- `toPrivate()`: MUST emit `Transfer(account, address(0), amount)`
+- `toPublic()`: MUST emit `Transfer(address(0), recipient, amount)`
+
 ### Supply Invariant
 
 Implementations MUST maintain the following invariant at all times:
@@ -315,7 +291,7 @@ Where:
 - `totalSupply()`: Inherited from [ERC-20](./eip-20), represents total token supply across both modes
 - `sum(all balanceOf(account))`: Sum of all transparent mode balances
 - `totalPrivacySupply()`: Aggregate privacy mode supply, tracked by:
-  - Incrementing on `toPrivacy()` (public → private conversion)
+  - Incrementing on `toPrivate()` (public → private conversion)
   - Decrementing on `toPublic()` (private → public conversion)
   - NOT computed from Merkle tree (commitment values are encrypted)
 

--- a/ERCS/erc-8085.md
+++ b/ERCS/erc-8085.md
@@ -116,8 +116,8 @@ This standard is **not** a universal solution. Key constraints:
 
 ### Real-World Use Cases
 
-**1. DAO Governance Token**
-```
+#### DAO Governance Token
+
 Public Mode:
   - Treasury management (transparent)
   - Grant distributions (auditable)
@@ -127,10 +127,10 @@ Privacy Mode:
   - Anonymous voting (no vote buying)
   - Private delegation (confidential strategy)
   - Personal holdings (no public scrutiny)
-```
 
-**2. Privacy-Aware Business Token**
-```
+
+#### Privacy-Aware Business Token
+
 Public Mode:
   - Investor reporting (compliance)
   - Exchange listings (liquidity)
@@ -140,10 +140,10 @@ Privacy Mode:
   - Employee compensation (confidential)
   - Supplier payments (competitive advantage)
   - Strategic reserves (private holdings)
-```
 
-**3. Protocol Token with Optional Privacy**
-```
+
+#### Protocol Token with Optional Privacy
+
 Public Mode:
   - Staking (DeFi integration)
   - Liquidity provision (AMM pools)
@@ -153,7 +153,7 @@ Privacy Mode:
   - Long-term holdings (privacy)
   - Over-the-counter transfers (confidential)
   - Strategic positions (no front-running)
-```
+
 
 ### Design Philosophy
 

--- a/ERCS/erc-8085.md
+++ b/ERCS/erc-8085.md
@@ -13,7 +13,9 @@ requires: 20, 8086
 
 ## Abstract
 
-This EIP defines an interface for fungible tokens that operate in two modes: transparent mode (fully compatible with [ERC-20](./eip-20)) and privacy mode (using [ERC-8086](./eip-8086) privacy primitives). Token holders can convert balances between modes. The transparent mode uses account-based balances, while the privacy mode uses the standardized IZRC20 interface from ERC-8086. Total supply is maintained as the sum of both modes.
+This EIP defines a **permissionless** interface for fungible tokens that operate in two modes: transparent mode (fully compatible with [ERC-20](./eip-20)) and privacy mode (using [ERC-8086](./eip-8086) privacy primitives). Token holders can convert balances between modes. The transparent mode uses account-based balances, while the privacy mode uses the standardized IZRC20 interface from ERC-8086. Total supply is maintained as the sum of both modes.
+
+**Permissionless Nature**: Anyone can implement and deploy dual-mode tokens using this standard without intermediaries, governance approval, or restrictions.
 
 ## Motivation
 
@@ -93,10 +95,11 @@ DeFi/DEX Trading          Private Holdings
    - Prevents hidden inflation
    - Regulatory visibility into aggregate metrics
 
-5. **Application-Layer Deployment**
+5. **Permissionless Application-Layer Deployment**
    - Deploy today on any EVM chain (Ethereum, L2s, sidechains)
    - No protocol changes or governance votes required
    - No coordination with core developers needed
+   - Complete freedom to implement without intermediaries or restrictions
 
 ### Honest Limitations
 

--- a/ERCS/erc-8085.md
+++ b/ERCS/erc-8085.md
@@ -403,6 +403,9 @@ This standard is fully backward compatible with [ERC-20](./eip-20) and [ERC-8086
 - Existing DeFi protocols work without modification
 - Privacy mode is additive and optional
 
+## Reference Implementation
+
+[ERC-8085 Reference Implementation](../assets/erc-8085/README.md)
 
 ## Security Considerations
 

--- a/ERCS/erc-8085.md
+++ b/ERCS/erc-8085.md
@@ -39,9 +39,7 @@ Existing solutions require trade-offs that limit adoption.
 
 **Mechanism**: Wrap existing tokens (DAI, ETH) into a privacy pool contract.
 
-```
 DAI (public) → deposit → Privacy Pool → withdraw → DAI (public)
-```
 
 **Strengths**:
 - ✅ Works with any existing [ERC-20](./eip-20) token
@@ -327,50 +325,8 @@ Where:
 
 ## Rationale
 
-### Why Integrated Dual-Mode Architecture?
 
-This ERC combines the best aspects of both approaches while avoiding their primary limitations:
-
-**Single Token, Dual Capability**:
-```
-Traditional: Token A (public) + Token B (private wrapper) = 2 assets
-This Standard: Token C (public mode ↔ private mode) = 1 asset
-```
-
-**Key Advantages**:
-
-1. **Unified Liquidity**
-   - DEXs only need one trading pair
-   - No fragmentation between "public version" and "private version"
-   - Full liquidity available regardless of current mode
-
-2. **Bidirectional Flexibility**
-   - Users can freely switch: `public → private → public → private`
-   - Unlike wrappers (require unwrapping to access public features)
-   - Unlike protocol-level (often irreversible)
-
-3. **Capital Efficiency**
-   - Can convert to public mode for DeFi, back to private for holdings
-   - No need to maintain separate balances in both forms
-   - Mode conversion is internal (no external token transfers)
-
-4. **Simplified User Experience**
-   - Single token address to track
-   - No "wrapping" concept to understand
-   - Mode switching feels like a native feature, not a workaround
-
-5. **Immediate Deployability**
-   - Application-layer standard (no protocol changes)
-   - Can be deployed today on any EVM chain
-   - No coordination with core developers required
-
-6. **Regulatory Adaptability**
-   - Transparent mode satisfies compliance requirements
-   - Privacy mode available when legally permitted
-   - Can respond to changing jurisdictional rules by adjusting mode usage
-
-
-### BURN_ADDRESS Requirement for toPublic
+### `BURN_ADDRESS` Requirement for `toPublic`
 
 **Problem**: When converting privacy-to-transparent, the ZK circuit enforces value conservation:
 
@@ -402,7 +358,7 @@ This standard is fully backward compatible with [ERC-20](./eip-20) and [ERC-8086
 
 - All ERC-20 functions operate on transparent balances
 - All standard ERC-20 events are emitted
-- All ERC-8086 (IZRC20) functions and events are supported for privacy mode
+- All ERC-8086 (`IZRC20`) functions and events are supported for privacy mode
 - Existing DeFi protocols work without modification
 - Privacy mode is additive and optional
 
@@ -416,7 +372,6 @@ This standard is fully backward compatible with [ERC-20](./eip-20) and [ERC-8086
 
 **Attack Vector**: If the contract does not verify BURN_ADDRESS, an attacker can:
 
-```
 1. Hold Note A (100 privacy balance)
 2. Call toPublic(50) with proof sending output to attacker's own privacy address
 3. If contract skips BURN_ADDRESS check:
@@ -424,7 +379,6 @@ This standard is fully backward compatible with [ERC-20](./eip-20) and [ERC-8086
    - Note B (50) sent to attacker's privacy address ← Still spendable in privacy mode!
    - Note C (50 change)
    Result: 50 + 50 + 50 = 150 (created 50 out of thin air!)
-```
 
 **Mitigation**: Implementations MUST ensure the converted value cannot be spent in privacy mode. For BURN_ADDRESS approach:
 ```solidity

--- a/ERCS/erc-8085.md
+++ b/ERCS/erc-8085.md
@@ -62,13 +62,11 @@ This standard provides a alternative option specifically designed for **new toke
 **Target Use Case**: Projects launching new tokens (governance tokens, protocol tokens, app tokens) that need both DeFi integration and optional privacy.
 
 **Mechanism**:
-```
 Single Token Contract
   ↓
 Public Mode (ERC-20) ←→ Privacy Mode (ZK-SNARK)
   ↓                           ↓
 DeFi/DEX Trading          Private Holdings
-```
 
 **Key Advantages**:
 
@@ -330,21 +328,17 @@ Where:
 
 **Problem**: When converting privacy-to-transparent, the ZK circuit enforces value conservation:
 
-```
 input_amount = output_amount
-```
 
 But we need to "convert" value from privacy mode to public mode. The circuit doesn't know that the contract will create public balance, so we must ensure the converted value doesn't remain spendable in privacy mode.
 
 **Solution**: Force the first output to an unspendable address (BURN_ADDRESS):
 
-```
 Input:  Note A (100)
 Output: Note B → BURN_ADDRESS (50)  ← Provably unspendable
         Note C → User (50, change)  ← Remains private
 
 Contract: Creates 50 public balance for user
-```
 
 This ensures:
 - ✅ Circuit value conservation: 100 = 50 + 50

--- a/ERCS/erc-8085.md
+++ b/ERCS/erc-8085.md
@@ -1,0 +1,451 @@
+---
+eip: 8085
+title: Dual-Mode Fungible Tokens
+description: Fungible tokens supporting both transparent (ERC-20) and privacy-preserving (zk-SNARK) modes with seamless conversion
+author: Rowan (@0xRowan)
+discussions-to: https://ethereum-magicians.org/t/erc-8085-dual-mode-fungible-tokens/26592
+status: Draft
+type: Standards Track
+category: ERC
+created: 2025-11-15
+requires: 20, 8086
+---
+
+## Abstract
+
+This EIP defines an interface for fungible tokens that operate in two modes: transparent mode (fully compatible with [ERC-20](./eip-20)) and privacy mode (using [ERC-8086](./eip-8086) privacy primitives). Token holders can convert balances between modes. The transparent mode uses account-based balances, while the privacy mode uses the standardized IZRC20 interface from ERC-8086. Total supply is maintained as the sum of both modes.
+
+## Motivation
+
+### The Privacy Dilemma for New Token Projects
+
+When launching a new token, projects face a fundamental choice:
+
+1. **[ERC-20](./eip-20)**: Full DeFi composability but zero privacy
+2. **Pure privacy protocols**: Strong privacy but limited ecosystem integration
+
+This creates real-world problems:
+- **DAOs** need public treasury transparency but want anonymous governance voting
+- **Businesses** require auditable accounting but need private payroll transactions
+- **Users** want DeFi participation but need privacy for personal holdings
+
+Existing solutions require trade-offs that limit adoption.
+
+### Current Approaches and Their Limitations
+
+#### Wrapper-Based Privacy (e.g.,   Privacy Pools)
+
+**Mechanism**: Wrap existing tokens (DAI, ETH) into a privacy pool contract.
+
+```
+DAI (public) → deposit → Privacy Pool → withdraw → DAI (public)
+```
+
+**Strengths**:
+- ✅ Works with any existing [ERC-20](./eip-20) token
+- ✅ Permissionless deployment
+- ✅ No changes to underlying token required
+
+**Limitations for New Token Projects**:
+- ❌ Creates two separate tokens (Token A vs. Wrapped Token B)
+- ❌ Splits liquidity between public and wrapped versions
+- ❌ Requires managing two separate contract addresses
+- ❌ Users must unwrap to access DeFi (additional friction)
+
+**Best suited for**: Adding privacy to existing deployed tokens (DAI, USDC, etc.)
+
+
+### Our Approach: Integrated Dual-Mode for New Tokens
+
+This standard provides a alternative option specifically designed for **new token deployments** that want privacy as a core feature from day one.
+
+**Target Use Case**: Projects launching new tokens (governance tokens, protocol tokens, app tokens) that need both DeFi integration and optional privacy.
+
+**Mechanism**:
+```
+Single Token Contract
+  ↓
+Public Mode (ERC-20) ←→ Privacy Mode (ZK-SNARK)
+  ↓                           ↓
+DeFi/DEX Trading          Private Holdings
+```
+
+**Key Advantages**:
+
+1. **Unified Token Economics**
+   - No liquidity split between public/private versions
+   - One token address, one market price
+   - Simplified token distribution and airdrops
+
+2. **Seamless Mode Switching**
+   - Convert to privacy mode for holdings: `toPrivacy()`
+   - Convert to public mode for DeFi: `toPublic()`
+   - Users choose privacy per transaction, not per token
+
+3. **Full [ERC-20](./eip-20) Compatibility**
+   - Works with existing wallets, DEXs, and DeFi protocols
+   - No special support needed for public mode operations
+   - Standard `totalSupply()` accounting tracks both modes
+
+4. **Transparent Supply Tracking**
+   - `totalSupply()` includes both public and privacy mode balances
+   - `totalPrivacySupply()` reveals aggregate privacy supply (no individual balances)
+   - Prevents hidden inflation
+   - Regulatory visibility into aggregate metrics
+
+5. **Application-Layer Deployment**
+   - Deploy today on any EVM chain (Ethereum, L2s, sidechains)
+   - No protocol changes or governance votes required
+   - No coordination with core developers needed
+
+### Honest Limitations
+
+This standard is **not** a universal solution. Key constraints:
+
+1. **New Tokens Only**
+   - Designed for new token deployments with privacy built-in
+   - Cannot add privacy to existing tokens (use wrapper-based solutions for that)
+
+2. **Privacy-to-DeFi Requires Conversion**
+   - Privacy mode balances cannot directly interact with DEXs/DeFi
+   - Users must `toPublic()` before DeFi operations
+   - Conversion reveals amounts on-chain (privacy-to-public events)
+
+### Real-World Use Cases
+
+**1. DAO Governance Token**
+```
+Public Mode:
+  - Treasury management (transparent)
+  - Grant distributions (auditable)
+  - DEX trading (liquidity)
+
+Privacy Mode:
+  - Anonymous voting (no vote buying)
+  - Private delegation (confidential strategy)
+  - Personal holdings (no public scrutiny)
+```
+
+**2. Privacy-Aware Business Token**
+```
+Public Mode:
+  - Investor reporting (compliance)
+  - Exchange listings (liquidity)
+  - Public fundraising (transparency)
+
+Privacy Mode:
+  - Employee compensation (confidential)
+  - Supplier payments (competitive advantage)
+  - Strategic reserves (private holdings)
+```
+
+**3. Protocol Token with Optional Privacy**
+```
+Public Mode:
+  - Staking (DeFi integration)
+  - Liquidity provision (AMM pools)
+  - Trading (price discovery)
+
+Privacy Mode:
+  - Long-term holdings (privacy)
+  - Over-the-counter transfers (confidential)
+  - Strategic positions (no front-running)
+```
+
+### Design Philosophy
+
+This standard embraces a core principle: **"Privacy is a mode, not a separate token."**
+
+Rather than forcing users to choose between incompatible assets (Token A vs. Privacy Token B), we enable contextual privacy within a single fungible token. Users select the appropriate mode for each use case, maintaining capital efficiency and unified liquidity.
+
+This approach acknowledges that privacy and composability serve different purposes, and most users need both at different times—not a forced choice between them.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### Definitions
+
+- **Transparent Mode**: Token balance stored using standard [ERC-20](./eip-20) accounting, publicly visible and queryable via `balanceOf()`
+- **Privacy Mode**: Token value hidden using cryptographic commitments in an authenticated data structure
+- **Commitment**: A cryptographic binding of value and ownership that hides both the amount and recipient identity
+- **Nullifier**: A unique identifier proving a commitment has been spent, preventing double-spending
+- **Mode Conversion**: The process of moving value between transparent and privacy modes
+- **Privacy State**: An authenticated data structure (e.g., Merkle tree, accumulator) tracking privacy mode commitments
+- **BURN_ADDRESS**: A provably unspendable elliptic curve point used to ensure privacy-to-transparent conversions are secure
+
+### Interface
+
+```solidity
+/**
+ * @title IDualModeToken
+ * @notice Interface for dual-mode tokens (ERC-8085) combining ERC-20 and [ERC-8086](./eip-8086) (IZRC20)
+ * @dev Implementations MUST inherit both IERC20 and IZRC20
+ *      Privacy events and core functions are inherited from IZRC20 (ERC-8086)
+ *      This interface only defines mode conversion logic - the core value of ERC-8085
+ *
+ * Architecture:
+ *   - Public Mode: Standard ERC-20 (transparent balances and transfers)
+ *   - Privacy Mode: ERC-8086 IZRC20 (ZK-SNARK protected balances and transfers)
+ *   - Mode Conversion: toPrivacy (public → private) and toPublic (private → public)
+ */
+interface IDualModeToken is IERC20, IZRC20 {
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Events (Mode Conversion Specific)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @notice Emitted when value is converted from transparent to privacy mode
+    /// @param account The address converting tokens
+    /// @param amount The amount converted
+    /// @param commitment The cryptographic commitment created
+    /// @param timestamp Block timestamp of conversion
+    event ConvertToPrivacy(
+        address indexed account,
+        uint256 amount,
+        bytes32 indexed commitment,
+        uint256 timestamp
+    );
+
+    /// @notice Emitted when value is converted from privacy to transparent mode
+    /// @param initiator The address initiating the conversion
+    /// @param recipient The address receiving transparent tokens
+    /// @param amount The amount converted
+    /// @param timestamp Block timestamp of conversion
+    event ConvertToPublic(
+        address indexed initiator,
+        address indexed recipient,
+        uint256 amount,
+        uint256 timestamp
+    );
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Mode Conversion Functions (Core of ERC-8085)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Convert transparent balance to privacy mode
+     * @dev Burns ERC-20 tokens and creates privacy commitment via IZRC20
+     * @param amount Amount to convert (must match proof)
+     * @param proofType Type of proof to support multiple proof strategies.
+     * @param proof ZK-SNARK proof of valid commitment creation
+     * @param encryptedNote Encrypted note data for recipient wallet
+     */
+    function toPrivacy(
+        uint256 amount,
+        uint8 proofType,
+        bytes calldata proof,
+        bytes calldata encryptedNote
+    ) external;
+
+    /**
+     * @notice Convert privacy balance to transparent mode
+     * @dev Spends privacy notes and mints ERC-20 tokens to recipient
+     * @param recipient Address to receive public tokens
+     * @param proofType Type of proof to support multiple proof strategies.
+     * @param proof ZK-SNARK proof of note ownership and spending
+     * @param encryptedNotes Encrypted notes for change outputs (if any)
+     */
+    function toPublic(
+        address recipient,
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) external;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Supply Tracking
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // Note: Privacy transfers use IZRC20.transfer(uint8, bytes, bytes[])
+    // which is inherited from IZRC20 (ERC-8086)
+
+    /**
+     * @notice Total supply across both modes (overrides IERC20 and IZRC20)
+     * @return Total supply = publicSupply + privacySupply
+     */
+    function totalSupply() external view override(IERC20, IZRC20) returns (uint256);
+
+    /**
+     * @notice Get total supply in privacy mode
+     * @dev Tracked by increments/decrements during mode conversions
+     * @return Total privacy supply
+     */
+    function totalPrivacySupply() external view returns (uint256);
+
+    /**
+     * @notice Check if a nullifier has been spent
+     * @dev Alias for IZRC20.nullifiers() with different naming convention
+     * @param nullifier The nullifier hash to check
+     * @return True if spent, false otherwise
+     */
+    function isNullifierSpent(bytes32 nullifier) external view returns (bool);
+}
+```
+
+### Proof Type Parameter
+The `proofType` parameter in `toPrivacy`, `toPublic`, and `privacyTransfer` functions allows implementations to support multiple proof strategies.
+
+**Purpose**: Different proof types may be needed for:
+- Different data structures (e.g., active vs. archived state in dual-tree implementations)
+- Different optimization strategies (e.g., activeTree proofs vs. finalizedTree proofs)
+
+### [ERC-20](./eip-20) Compatibility
+
+Implementations MUST implement the [ERC-20](./eip-20) interface. All ERC-20 functions operate exclusively on transparent mode balances:
+
+- `balanceOf(account)` MUST return the transparent mode balance only
+  - Privacy mode balances are NOT included (they are hidden by design)
+- `transfer(to, amount)` MUST transfer transparent balance only
+- `approve(spender, amount)` MUST approve transparent balance spending
+- `transferFrom(from, to, amount)` MUST transfer transparent balance with allowance
+- `totalSupply()` MUST return the sum of all public balances plus `totalPrivacySupply()`
+  - This represents the total token supply across both modes
+
+Implementations MUST emit standard [ERC-20](./eip-20) `Transfer` events for transparent mode operations.
+
+### Supply Invariant
+
+Implementations MUST maintain the following invariant at all times:
+
+```solidity
+totalSupply() == sum(all balanceOf(account)) + totalPrivacySupply()
+```
+
+Where:
+- `totalSupply()`: Inherited from [ERC-20](./eip-20), represents total token supply across both modes
+- `sum(all balanceOf(account))`: Sum of all transparent mode balances
+- `totalPrivacySupply()`: Aggregate privacy mode supply, tracked by:
+  - Incrementing on `toPrivacy()` (public → private conversion)
+  - Decrementing on `toPublic()` (private → public conversion)
+  - NOT computed from Merkle tree (commitment values are encrypted)
+
+**Note**: The public mode supply can be derived as `totalSupply() - totalPrivacySupply()` if needed, eliminating the need for a separate `totalPublicSupply()` function.
+
+## Rationale
+
+### Why Integrated Dual-Mode Architecture?
+
+This ERC combines the best aspects of both approaches while avoiding their primary limitations:
+
+**Single Token, Dual Capability**:
+```
+Traditional: Token A (public) + Token B (private wrapper) = 2 assets
+This Standard: Token C (public mode ↔ private mode) = 1 asset
+```
+
+**Key Advantages**:
+
+1. **Unified Liquidity**
+   - DEXs only need one trading pair
+   - No fragmentation between "public version" and "private version"
+   - Full liquidity available regardless of current mode
+
+2. **Bidirectional Flexibility**
+   - Users can freely switch: `public → private → public → private`
+   - Unlike wrappers (require unwrapping to access public features)
+   - Unlike protocol-level (often irreversible)
+
+3. **Capital Efficiency**
+   - Can convert to public mode for DeFi, back to private for holdings
+   - No need to maintain separate balances in both forms
+   - Mode conversion is internal (no external token transfers)
+
+4. **Simplified User Experience**
+   - Single token address to track
+   - No "wrapping" concept to understand
+   - Mode switching feels like a native feature, not a workaround
+
+5. **Immediate Deployability**
+   - Application-layer standard (no protocol changes)
+   - Can be deployed today on any EVM chain
+   - No coordination with core developers required
+
+6. **Regulatory Adaptability**
+   - Transparent mode satisfies compliance requirements
+   - Privacy mode available when legally permitted
+   - Can respond to changing jurisdictional rules by adjusting mode usage
+
+
+### BURN_ADDRESS Requirement for toPublic
+
+**Problem**: When converting privacy-to-transparent, the ZK circuit enforces value conservation:
+
+```
+input_amount = output_amount
+```
+
+But we need to "convert" value from privacy mode to public mode. The circuit doesn't know that the contract will create public balance, so we must ensure the converted value doesn't remain spendable in privacy mode.
+
+**Solution**: Force the first output to an unspendable address (BURN_ADDRESS):
+
+```
+Input:  Note A (100)
+Output: Note B → BURN_ADDRESS (50)  ← Provably unspendable
+        Note C → User (50, change)  ← Remains private
+
+Contract: Creates 50 public balance for user
+```
+
+This ensures:
+- ✅ Circuit value conservation: 100 = 50 + 50
+- ✅ Security: Note B can never be spent (no private key exists)
+- ✅ Supply invariant: totalSupply unchanged, just redistributed between modes
+
+
+## Backwards Compatibility
+
+This standard is fully backward compatible with [ERC-20](./eip-20) and [ERC-8086](./eip-8086):
+
+- All ERC-20 functions operate on transparent balances
+- All standard ERC-20 events are emitted
+- All ERC-8086 (IZRC20) functions and events are supported for privacy mode
+- Existing DeFi protocols work without modification
+- Privacy mode is additive and optional
+
+
+## Security Considerations
+
+### Critical: toPublic Conversion Mechanism
+
+**Attack Vector**: If the contract does not verify BURN_ADDRESS, an attacker can:
+
+```
+1. Hold Note A (100 privacy balance)
+2. Call toPublic(50) with proof sending output to attacker's own privacy address
+3. If contract skips BURN_ADDRESS check:
+   - Attacker receives 50 public balance (converted from privacy mode)
+   - Note B (50) sent to attacker's privacy address ← Still spendable in privacy mode!
+   - Note C (50 change)
+   Result: 50 + 50 + 50 = 150 (created 50 out of thin air!)
+```
+
+**Mitigation**: Implementations MUST ensure the converted value cannot be spent in privacy mode. For BURN_ADDRESS approach:
+```solidity
+// Example for implementations using unspendable public key
+require(isUnspendableAddress(recipientPublicKey), "toPublic: output must be unspendable");
+```
+
+This verification is critical—failure to prevent double-spending across modes would allow minting tokens out of thin air.
+
+### Double-Spending Prevention
+
+**Transparent Mode**: Standard [ERC-20](./eip-20) balance checking prevents double-spending.
+
+**Privacy Mode**: Nullifier uniqueness enforced on-chain:
+```solidity
+require(!nullifiers[nullifier], "Nullifier already spent");
+nullifiers[nullifier] = true;
+```
+
+Each commitment can only be spent once, as nullifiers are deterministically derived from commitments and private keys.
+
+### Supply Inflation
+
+**Attack**: Malicious proof claiming incorrect values.
+
+**Mitigation**: ZK circuits enforce value conservation. Verifier contracts validate proofs on-chain before state changes. The invariant `totalSupply() == sum(balanceOf) + totalPrivacySupply()` must hold after every operation.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-8085.md
+++ b/ERCS/erc-8085.md
@@ -405,7 +405,7 @@ This standard is fully backward compatible with [ERC-20](./eip-20) and [ERC-8086
 
 ## Reference Implementation
 
-[ERC-8085 Reference Implementation](../assets/erc-8085/README.md)
+[ERC-8085 Reference Implementation](../assets/eip-8085/README.md)
 
 ## Security Considerations
 

--- a/ERCS/erc-8085.md
+++ b/ERCS/erc-8085.md
@@ -13,7 +13,7 @@ requires: 20, 8086
 
 ## Abstract
 
-This EIP defines a **permissionless** interface for fungible tokens that operate in two modes: transparent mode (fully compatible with [ERC-20](./eip-20)) and privacy mode (using [ERC-8086](./eip-8086) privacy primitives). Token holders can convert balances between modes. The transparent mode uses account-based balances, while the privacy mode uses the standardized IZRC20 interface from ERC-8086. Total supply is maintained as the sum of both modes.
+This EIP defines a **permissionless** interface for fungible tokens that operate in two modes: transparent mode (fully compatible with [ERC-20](./eip-20)) and privacy mode (using [ERC-8086](./eip-8086) privacy primitives). Token holders can convert balances between modes. The transparent mode uses account-based balances, while the privacy mode uses the standardized `IZRC20` interface from ERC-8086. Total supply is maintained as the sum of both modes.
 
 **Permissionless Nature**: Anyone can implement and deploy dual-mode tokens using this standard without intermediaries, governance approval, or restrictions.
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -107,7 +107,8 @@ interface IZRC20 {
      * @param leafIndex Position within subtree (or global index)
      * @param timestamp Block timestamp of insertion
      * @dev For single-tree: subtreeIndex SHOULD be 0, leafIndex is global position
-     * @dev For dual-tree: subtreeIndex identifies which subtree, leafIndex is position within it     */
+     * @dev For dual-tree: subtreeIndex identifies which subtree, leafIndex is position within it
+     */
     event CommitmentAppended(
         uint32 indexed subtreeIndex,
         bytes32 commitment,
@@ -224,19 +225,25 @@ interface IZRC20 {
     ) external;
 
     // ═══════════════════════════════════════════════════════════════════════
-    // Query Functions (OPTIONAL but RECOMMENDED)
+    // Query Functions
     // ═══════════════════════════════════════════════════════════════════════
 
     /**
      * @notice Check if a nullifier has been spent
      * @param nullifier The nullifier to check
      * @return True if nullifier spent, false otherwise
-     * @dev OPTIONAL but RECOMMENDED for client-side validation before proof generation
-     *      Implementations using `mapping(bytes32 => bool) public nullifiers`
+     * @dev Implementations using `mapping(bytes32 => bool) public nullifiers`
      *      will auto-generate this function.
      */
     function nullifiers(bytes32 nullifier) external view returns (bool);
 
+    /**
+     * @notice Returns the current active subtree Merkle root
+     * @return The root hash of the active subtree
+     * @dev The active subtree stores recent commitments for faster proof computation.
+     *      For dual-tree implementations, this is the root of the current working subtree.
+     */
+    function activeSubtreeRoot() external view returns (bytes32);
 }
 ```
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -368,7 +368,7 @@ The configuration file MUST be a valid JSON document. The following shows the sc
 
 **Format**: URL string pointing to the specification version.
 
-**Example**: `"https://eips.ethereum.org/EIPS/eip-8086#privacy-config-v1"`
+**Example**: `https:// ... #privacy-config-v1`
 
 **Client Usage**: Clients SHOULD check this field first to ensure they can parse the configuration format. Unknown types SHOULD be rejected.
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -75,8 +75,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 - **Note**: Off-chain encrypted data `(amount, publicKey, randomness)` for recipient
 - **Merkle Tree**: Authenticated structure storing commitments for zero-knowledge membership proofs
 - **Proof Type**: Parameter routing different proof strategies
-- **View Tag**: Single-byte scanning optimization (OPTIONAL but RECOMMENDED)
-- **Stealth Address**: One-time recipient address from ephemeral keys (OPTIONAL)
 
 ### Core Interface
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -421,13 +421,6 @@ This standard defines a minimal interface for native privacy assets. It is an **
 As described in the Motivation section, this standard serves as a **foundational building block** for higher-level protocols to rapidly implement privacy capabilities:
 
 
-## Reference Implementation
-
-A reference implementation is available at:
-  - **Repository**: [erc-8086-reference](https://github.com/0xRowan/erc-8086-reference)
-  - **Testnet Deployment**: Base Sepolia (Chain ID: 84532)
-  - **Demo Application**: https://testnative.zkprotocol.xyz/
-
 
 ## Security Considerations
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -31,21 +31,26 @@ By unifying the native privacy token interface, we facilitate the development of
 While building privacy solutions for Ethereum, we identified recurring patterns:
 
 **Wrapper Protocols** ([ERC-20](./eip-20) → Privacy → ERC-20):
+
 ```
 DAI (transparent) → zDAI (private) → DAI (transparent)
 ```
+
 - Each protocol implements custom privacy token logic
 - No interoperability between different privacy implementations
 - Duplicated effort, increased security risks
 
 **Dual-Mode Tokens** (Public ↔ Private in one token):
+
 ```
 Single Token: Public mode (ERC-20) ↔ Private mode (ZK-based)
 ```
+
 - Needs a privacy primitive as foundation
 - Current implementations reinvent the wheel
 
 **The Solution**: Standardize the privacy primitive to enable:
+
 - Consistent wrapper protocol implementations
 - Reusable dual-mode token architectures
 - Faster ecosystem development
@@ -246,15 +251,409 @@ interface IZRC20 {
      *      For dual-tree implementations, this is the root of the current working subtree.
      */
     function activeSubtreeRoot() external view returns (bytes32);
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Privacy Configuration (OPTIONAL but RECOMMENDED for client interoperability)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Returns the URI pointing to the Privacy Configuration File
+     * @return URI string (e.g., "ipfs://Qm..." or "https://...")
+     * @dev OPTIONAL but RECOMMENDED for client interoperability
+     *      The configuration file contains implementation-specific parameters
+     *      See specification for the full Privacy Configuration File schema
+     */
+    function privacyConfigURI() external view returns (string memory);
+
+    /**
+     * @notice Sets the Privacy Configuration File URI
+     * @param configURI The configuration URI (can be set multiple times to update)
+     * @dev OPTIONAL - Implementation may restrict access (e.g., onlyOwner)
+     *      Each call overwrites the previous URI
+     */
+    function setPrivacyConfigURI(string calldata configURI) external;
 }
+```
+
+### Privacy Configuration File
+
+Since this standard defines a **minimal interface**, different implementations may use different:
+
+- Proof systems (Groth16, PLONK, STARK, etc.)
+- Circuit implementations (different WASM/ZKEY files)
+- Note encryption algorithms
+- Tree structures (single vs. dual-layer)
+- Public signals schemas
+
+To enable **client interoperability** across different implementations, this standard defines an **OPTIONAL but RECOMMENDED** Privacy Configuration File mechanism, inspired by [ERC-8004](./eip-8004)'s Agent Registration File pattern.
+
+#### Configuration URI Functions
+
+Implementations SHOULD provide:
+
+- `privacyConfigURI()`: Returns the URI pointing to the configuration file
+- `setPrivacyConfigURI(string)`: Sets/updates the configuration URI (typically owner-restricted)
+
+#### Privacy Configuration File Schema
+
+The configuration file MUST be a valid JSON document. The following shows the schema structure with field descriptions:
+
+```json
+{
+  "type": "<schema-identifier-url>",
+  "version": "<semver>",
+  "name": "<token-name>",
+  "symbol": "<token-symbol>",
+
+  "proofSystem": {
+    "protocol": "<protocol-name>",
+    "curve": "<curve-name>",
+    "fieldSize": "<field-prime-decimal>"
+  },
+
+  "treeConfig": {
+    "type": "<tree-type>",
+    "levels": "<tree-height>",
+    "subtreeLevels": "<subtree-height>",
+    "rootTreeLevels": "<root-tree-height>"
+  },
+
+  "circuits": {
+    "<CIRCUIT_NAME>": {
+      "proofType": "<uint8>",
+      "wasmUrl": "<circuit-wasm-url>",
+      "zkeyUrl": "<proving-key-url>",
+      "publicSignals": "<signal-count>",
+      "publicSignalsSchema": [
+        { "name": "<signal-name>", "type": "<solidity-type>", "index": "<position>" }
+      ]
+    }
+  },
+
+  "noteEncryption": {
+    "algorithm": "<encryption-algorithm-chain>",
+    "curve": "<ecdh-curve-name>",
+    "curveParams": {
+      "subgroupOrder": "<curve-subgroup-order-decimal>",
+      "baseField": "<base-field-name>"
+    },
+    "domainSeparator": "<ecdh-domain-string>",
+    "aadTag": "<aes-gcm-aad-string>",
+    "noteFormat": "<format-identifier>",
+    "noteSchema": { }
+  },
+
+  "hashFunction": {
+    "name": "<hash-function-name>",
+    "parameters": { }
+  },
+
+  "keyDerivation": {
+    "method": "<derivation-method>",
+    "addressFormat": "<stealth-address-format>"
+  },
+
+  "endpoints": {
+    "indexer": "<indexer-api-url>",
+    "relayer": "<relayer-api-url>"
+  }
+}
+```
+
+#### Field Specifications
+
+##### `type` (REQUIRED)
+
+**Purpose**: Schema identifier URL for version detection and format validation.
+
+**Format**: URL string pointing to the specification version.
+
+**Example**: `"https://eips.ethereum.org/EIPS/eip-8086#privacy-config-v1"`
+
+**Client Usage**: Clients SHOULD check this field first to ensure they can parse the configuration format. Unknown types SHOULD be rejected.
+
+---
+
+##### `version` (REQUIRED)
+
+**Purpose**: Semantic version of this specific configuration file.
+
+**Format**: Semantic versioning string (MAJOR.MINOR.PATCH).
+
+**Example**: `"1.0.0"`
+
+**Client Usage**: Clients MAY cache configurations and use version for cache invalidation.
+
+---
+
+##### `proofSystem` (REQUIRED)
+
+**Purpose**: Specifies the zero-knowledge proof system parameters.
+
+| Subfield      | Required | Description                                                                                  |
+| ------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `protocol`  | YES      | ZK protocol name. Common values:`groth16`, `plonk`, `fflonk`, `stark`                |
+| `curve`     | YES      | Elliptic curve for the proof system. Common values:`bn128` (alt_bn128), `bls12-381`      |
+| `fieldSize` | YES      | The scalar field prime as a decimal string. This is the maximum value for any public signal. |
+
+**Example**:
+
+```json
+{
+  "protocol": "groth16",
+  "curve": "bn128",
+  "fieldSize": "21888242871839275222246405745257275088548364400416034343698204186575808495617"
+}
+```
+
+**How to obtain `fieldSize`**:
+
+- For `bn128`: This is the BN254 scalar field prime (Fr), a 254-bit prime
+- For `bls12-381`: Use the BLS12-381 scalar field prime
+- Can be obtained from cryptographic libraries (e.g., `snarkjs`, `circomlibjs`)
+
+**Client Usage**: Clients MUST validate that all public signals are less than `fieldSize`. The `protocol` determines which proof verification library to use.
+
+---
+
+##### `treeConfig` (REQUIRED)
+
+**Purpose**: Specifies the Merkle tree structure for storing commitments.
+
+| Subfield           | Required    | Description                                              |
+| ------------------ | ----------- | -------------------------------------------------------- |
+| `type`           | YES         | Tree architecture:`single` or `dual-layer`           |
+| `levels`         | CONDITIONAL | Total tree height (required for `single` type)         |
+| `subtreeLevels`  | CONDITIONAL | Active subtree height (required for `dual-layer` type) |
+| `rootTreeLevels` | CONDITIONAL | Root tree height (required for `dual-layer` type)      |
+
+**Example (single tree)**:
+
+```json
+{
+  "type": "single",
+  "levels": 20
+}
+```
+
+**Example (dual-layer tree)**:
+
+```json
+{
+  "type": "dual-layer",
+  "subtreeLevels": 16,
+  "rootTreeLevels": 20
+}
+```
+
+**Client Usage**: Clients use this to build correct Merkle proofs. Tree capacity = 2^levels (or 2^subtreeLevels × 2^rootTreeLevels for dual-layer).
+
+---
+
+##### `circuits` (REQUIRED)
+
+**Purpose**: Maps operation types to their circuit artifacts and public signal schemas.
+
+Each circuit entry contains:
+
+| Subfield                | Required | Description                                                                         |
+| ----------------------- | -------- | ----------------------------------------------------------------------------------- |
+| `proofType`           | YES      | The `uint8` value to pass to the contract's `mint()` or `transfer()` function |
+| `wasmUrl`             | YES      | URL to the circuit's WASM file for proof generation                                 |
+| `zkeyUrl`             | YES      | URL to the proving key file                                                         |
+| `vkeyUrl`             | NO       | URL to the verification key (optional, verification happens on-chain)               |
+| `publicSignals`       | YES      | Number of public signals in the proof                                               |
+| `publicSignalsSchema` | YES      | Array describing each public signal's name, type, and position                      |
+
+**Example**:
+
+```json
+{
+  "MINT": {
+    "proofType": 0,
+    "wasmUrl": "ipfs://Qm.../Mint.wasm",
+    "zkeyUrl": "ipfs://Qm.../Mint_final.zkey",
+    "publicSignals": 4,
+    "publicSignalsSchema": [
+      { "name": "merkleRoot", "type": "bytes32", "index": 0 },
+      { "name": "commitment", "type": "bytes32", "index": 1 },
+      { "name": "amount", "type": "uint256", "index": 2 },
+      { "name": "timestamp", "type": "uint256", "index": 3 }
+    ]
+  },
+  "TRANSFER": {
+    "proofType": 1,
+    "wasmUrl": "ipfs://Qm.../Transfer.wasm",
+    "zkeyUrl": "ipfs://Qm.../Transfer_final.zkey",
+    "publicSignals": 8,
+    "publicSignalsSchema": [
+      { "name": "nullifier", "type": "bytes32", "index": 0 },
+      { "name": "newCommitment", "type": "bytes32", "index": 1 }
+    ]
+  }
+}
+```
+
+**Client Usage**:
+
+1. Download WASM and ZKEY files for required operations
+2. Use `publicSignalsSchema` to correctly encode/decode proof public inputs
+3. Pass `proofType` value to contract function calls
+
+---
+
+##### `noteEncryption` (REQUIRED)
+
+**Purpose**: Specifies the encryption algorithm and parameters for encrypted notes.
+
+| Subfield                      | Required | Description                                             |
+| ----------------------------- | -------- | ------------------------------------------------------- |
+| `algorithm`                 | YES      | Encryption algorithm chain (e.g.,`ECDH+HKDF+AES-GCM`) |
+| `curve`                     | YES      | Elliptic curve for ECDH key exchange                    |
+| `curveParams`               | YES      | Curve-specific parameters                               |
+| `curveParams.subgroupOrder` | YES      | The curve's subgroup order as decimal string            |
+| `curveParams.baseField`     | NO       | The base field the curve is defined over                |
+| `domainSeparator`           | YES      | Domain separator string for HKDF salt                   |
+| `aadTag`                    | YES      | Additional Authenticated Data tag for AES-GCM           |
+| `noteFormat`                | YES      | Format identifier for serialized encrypted notes        |
+| `noteSchema`                | NO       | Schema describing the plaintext note structure          |
+
+**Example**:
+
+```json
+{
+  "algorithm": "BJJ-ECDH+HKDF-SHA256+AES-256-GCM",
+  "curve": "BabyJubjub",
+  "curveParams": {
+    "subgroupOrder": "2736030358979909402780800718157159386076813972158567259200215660948447373041",
+    "baseField": "bn128"
+  },
+  "domainSeparator": "pv1|bjj-ecdh|v1",
+  "aadTag": "pv1|note|v1",
+  "noteFormat": "BJJ"
+}
+```
+
+**Algorithm Format**: `<ECDH-variant>+<KDF>+<AEAD>`
+
+- ECDH variant: `BJJ-ECDH` (Baby Jubjub), `secp256k1-ECDH`, etc.
+- KDF: `HKDF-SHA256`, `HKDF-SHA512`, etc.
+- AEAD: `AES-256-GCM`, `ChaCha20-Poly1305`, etc.
+
+**How to obtain `subgroupOrder`**:
+
+- For Baby Jubjub: This is the order of the prime-order subgroup (~251 bits)
+- Can be obtained from `circomlibjs`: `babyJub.subOrder`
+
+**Client Usage**:
+
+1. Use `curve` and `curveParams` for ECDH key exchange
+2. Use `domainSeparator` as HKDF salt
+3. Use `aadTag` as AES-GCM additional authenticated data
+4. Use `noteFormat` to identify encrypted note serialization format
+
+---
+
+##### `hashFunction` (REQUIRED)
+
+**Purpose**: Specifies the hash function used for commitments, nullifiers, and Merkle tree.
+
+| Subfield       | Required | Description                                                   |
+| -------------- | -------- | ------------------------------------------------------------- |
+| `name`       | YES      | Hash function name:`Poseidon`, `MiMC`, `Pedersen`, etc. |
+| `parameters` | NO       | Hash-specific parameters (e.g., number of rounds, t-value)    |
+
+**Example**:
+
+```json
+{
+  "name": "Poseidon",
+  "parameters": {
+    "t": 3,
+    "nRoundsF": 8,
+    "nRoundsP": 57
+  }
+}
+```
+
+**Client Usage**: Clients use this hash function for computing commitments, nullifiers, and Merkle tree nodes locally.
+
+---
+
+##### `keyDerivation` (OPTIONAL)
+
+**Purpose**: Describes how users derive privacy keys from their wallet.
+
+| Subfield          | Required | Description                                                   |
+| ----------------- | -------- | ------------------------------------------------------------- |
+| `method`        | NO       | Key derivation method:`EIP-712-Signature`, `BIP-32`, etc. |
+| `addressFormat` | NO       | Stealth address format:`PV1`, custom format identifier      |
+
+**Example**:
+
+```json
+{
+  "method": "EIP-712-Signature",
+  "addressFormat": "PV1"
+}
+```
+
+**Client Usage**: Guides wallet integration for key derivation. This is informational and clients MAY use different methods.
+
+---
+
+##### `endpoints` (OPTIONAL)
+
+**Purpose**: Service discovery for auxiliary infrastructure.
+
+| Subfield    | Required | Description                             |
+| ----------- | -------- | --------------------------------------- |
+| `indexer` | NO       | URL to transaction indexing service API |
+| `relayer` | NO       | URL to gas relayer service API          |
+
+**Example**:
+
+```json
+{
+  "indexer": "https://indexer.example.com/api/v1",
+  "relayer": "https://relayer.example.com/api/v1"
+}
+```
+
+**Client Usage**: Clients MAY use these endpoints for enhanced functionality (faster sync, gas-free transfers).
+
+---
+
+#### URI Schemes
+
+The `privacyConfigURI()` function MAY return URIs using these schemes:
+
+- `ipfs://` - IPFS content addressing (RECOMMENDED for immutability)
+- `https://` - HTTPS URLs (for dynamic updates)
+- `ar://` - Arweave permanent storage
+- `data:` - Base64 encoded inline data (for small configs)
+
+#### Client Integration Flow
+
+```
+1. Client discovers privacy token at address 0x...
+2. Client calls privacyConfigURI() → "ipfs://Qm..."
+3. Client fetches and parses configuration JSON
+4. Client validates `type` field matches supported schema version
+5. Client downloads circuit artifacts (WASM, ZKEY) from specified URLs
+6. Client can now:
+   - Generate proofs using correct circuits and public signals schema
+   - Encrypt notes using specified algorithm and parameters
+   - Compute hashes using specified hash function
+   - Interact with the token contract using correct proofType values
 ```
 
 ### Proof Types
 
 **Purpose**: Different proof types may be needed for:
+
 - Different data structures (e.g., active vs. archived state in dual-tree implementations)
 - Different optimization strategies (e.g., activeTree proofs vs. finalizedTree proofs)
-
 
 ### Privacy Guarantees
 
@@ -265,16 +664,17 @@ Implementations MUST ensure:
 3. **Recipient Privacy**: Recipient addresses not publicly visible
 4. **Balance Privacy**: No `balanceOf(address)` queries (completely private)
 
-
 ### State Management Options
 
 **Option 1: Single Merkle Tree**
+
 - One tree storing all commitments chronologically
 - Simpler implementation
 - Higher proof generation cost for large trees
 - `subtreeIndex = 0` in events
 
 **Option 2: Dual-Layer Tree** (RECOMMENDED for scalability)
+
 - Active subtree (e.g., height 16): Recent commitments, fast proofs
 - Root tree (e.g., height 20): Finalized subtree roots, archival
 - Better performance for common operations (2-3x faster proofs)
@@ -282,15 +682,16 @@ Implementations MUST ensure:
 
 Implementations MUST document their architecture choice.
 
-
 ### Metadata Functions
 
 `name()`, `symbol()`, `decimals()` are OPTIONAL but RECOMMENDED for:
+
 - User interface display
 - Wallet integration
 - Ecosystem interoperability
 
 `totalSupply()` is OPTIONAL:
+
 - Required for fixed-cap verification
 - Privacy trade-off: reveals aggregate supply (but not individual balances)
 - Can be omitted for maximum privacy
@@ -302,16 +703,18 @@ Implementations MUST document their architecture choice.
 Let's consider the privacy scenarios needed on Ethereum:
 
 1. **Existing tokens need privacy**: Through wrapper protocols
+
    ```
    [ERC-20](./eip-20) (DAI, USDC) → Privacy Layer → ERC-20
    ```
-
 2. **Future dual-mode tokens**: Built-in privacy from genesis
+
    ```
    Dual-Mode Token (ERC-20 + Privacy in one contract)
    ```
 
 **With this standard as the unified privacy foundation**:
+
 - **Dual-Mode Protocols** focus on mode conversion logic (their core value)
 - **Wrapper Protocols** focus on wrapping/unwrapping logic (their core value)
 - **Privacy layer uses unified interface** (this standard)
@@ -322,23 +725,25 @@ Let's consider the privacy scenarios needed on Ethereum:
 `name()`, `symbol()`, `decimals()` are marked OPTIONAL but RECOMMENDED.
 
 **Ecosystem Benefits**:
+
 - **Wallet Integration**: Existing wallets can display privacy tokens without special handling
 - **Explorer Compatibility**: Block explorers show meaningful token information
 - **Developer Familiarity**: Matches [ERC-20](./eip-20) conventions, reducing learning curve
 - **Interoperability**: Higher-level protocols can query token metadata consistently
-
 
 ### Why Optional `totalSupply()`?
 
 Different use cases have different transparency requirements.
 
 **Use Cases Requiring `totalSupply()`**:
+
 - Fixed-cap tokens (verify no hidden inflation)
 - DAO treasuries (aggregate holdings visible)
 - Regulatory compliance (prove total supply matches expectations)
 - Wrapper protocols (track total wrapped amount)
 
 **Design Decision**: Make it OPTIONAL—let each implementation choose based on:
+
 - Target use case requirements
 - Regulatory environment
 - Privacy vs. transparency trade-offs
@@ -352,6 +757,7 @@ The `proofType` parameter is a key design decision for **interface stability** a
 **The Challenge**:
 
 Different implementations may need different proof strategies:
+
 - Simple single-tree implementations: One proof type for all operations
 - Optimized dual-layer implementations: Different proofs for active vs. archived state
 - Future optimizations: New proof types without breaking existing contracts
@@ -363,6 +769,63 @@ function mint(uint8 proofType, bytes proof, ...) external;
 function transfer(uint8 proofType, bytes proof, ...) external;
 ```
 
+### Why Privacy Configuration File?
+
+This standard intentionally defines a **minimal interface** to maximize implementation flexibility. However, this creates a challenge:
+
+**The Problem**:
+
+```
+Different implementations may use:
+- Different proof systems (Groth16 vs PLONK vs STARK)
+- Different circuit designs (different public signals)
+- Different encryption algorithms
+- Different tree structures
+- Different proof encoding formats
+```
+
+**Without standardization**:
+
+- Clients must be custom-built for each token implementation
+- No universal privacy wallet possible
+- Ecosystem fragmentation
+
+**The Solution**: Privacy Configuration File (inspired by [ERC-8004](./eip-8004))
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  On-chain (IZRC20 Contract)                                 │
+│  - Minimal interface                                        │
+│  - privacyConfigURI() → "ipfs://Qm..."                     │
+└────────────────────────┬────────────────────────────────────┘
+                         │ points to
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Off-chain (Privacy Configuration File)                     │
+│  - Complete implementation details                          │
+│  - Circuit artifacts (WASM, ZKEY)                          │
+│  - Public signals schema                                    │
+│  - Encryption algorithm                                     │
+│  - Tree structure                                           │
+│  - All client-needed parameters                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Benefits**:
+
+1. **Interface stability**: Core IZRC20 interface remains minimal and stable
+2. **Implementation flexibility**: Each project can use different proof systems
+3. **Client interoperability**: Universal clients can support any compliant token
+4. **Upgradability**: Configuration can be updated without contract changes
+5. **Discoverability**: Clients automatically learn how to interact with any token
+
+**Design Choices**:
+
+- **OPTIONAL but RECOMMENDED**: Not mandatory for simple implementations
+- **URI-based**: Supports IPFS (immutable), HTTPS (dynamic), Arweave, etc.
+- **JSON schema**: Easy to parse and validate
+- **Complete schema**: Includes everything clients need to interact
+
 ### Why Standardize Encrypted Notes and View Tags?
 
 These fields appear in the `Transaction` event, which is emitted for all privacy transfers.
@@ -370,6 +833,7 @@ These fields appear in the `Transaction` event, which is emitted for all privacy
 **The Client Synchronization Challenge**:
 
 For privacy tokens to work, clients must:
+
 1. Monitor blockchain events to detect received payments
 2. Decrypt note data to learn amounts and spending keys
 3. Build local state to construct future transactions
@@ -377,14 +841,16 @@ For privacy tokens to work, clients must:
 Without standardization, each implementation would use incompatible formats, fragmenting the ecosystem.
 
 **Encrypted Notes**:
+
 - **Required for privacy**: Notes contain amounts and secrets that must stay private
 - **Standardizing the concept**: Enables wallets to support multiple implementations
 - **Not mandating the algorithm**: Implementations can use different encryption schemes
 - **Event carries the ciphertext**: Clients know where to find their data
 
 **View Tags** (OPTIONAL but RECOMMENDED):
+
 - **Problem**: Scanning requires trial-decryption of every transaction (expensive)
-- **Solution**: Small tag allows fast pre-filtering 
+- **Solution**: Small tag allows fast pre-filtering
 - **Trade-off**: Minimal metadata leakage vs. practical usability
 - **Standardizing usage**: Wallets can optimize scanning across implementations
 
@@ -395,6 +861,7 @@ This standard is designed as a **foundation layer**, enabling higher-level proto
 **Wrapper Protocols**: Add privacy to existing [ERC-20](./eip-20) tokens
 
 Conceptual pattern:
+
 ```
 1. User deposits DAI into wrapper contract
 2. Wrapper mints privacy token (using IZRC20.mint)
@@ -403,6 +870,7 @@ Conceptual pattern:
 ```
 
 Benefits of standardization:
+
 - All wrapper protocols use the same privacy interface
 - Wallets support all wrappers without custom integration
 - Security audits focus on the wrapper logic, not reinventing privacy primitives
@@ -410,6 +878,7 @@ Benefits of standardization:
 **Dual-Mode Tokens Protocols**: Single token with both modes
 
 Conceptual pattern:
+
 ```solidity
 contract DualModeToken is ERC20, IZRC20 {
     // Inherits both standards
@@ -418,10 +887,10 @@ contract DualModeToken is ERC20, IZRC20 {
 ```
 
 Benefits of standardization:
+
 - Public mode: Standard ERC-20 (works with all DeFi)
 - Private mode: Standard IZRC20 (works with all privacy wallets)
 - Higher-level protocols can focus more on specific business scenarios and solving concrete problems—this is the advantage of a unified privacy asset interface.
-
 
 ## Backwards Compatibility
 
@@ -440,6 +909,7 @@ As described in the Motivation section, this standard serves as a **foundational
 **Attack Vector**: Reusing the same nullifier allows spending a commitment multiple times (double-spending).
 
 **Example**:
+
 ```
 1. Attacker has Note A (100 tokens)
 2. Creates valid proof spending Note A → generates Nullifier N
@@ -450,6 +920,7 @@ As described in the Motivation section, this standard serves as a **foundational
 ```
 
 **Mitigation**: Implementations MUST permanently track spent nullifiers and reject duplicates:
+
 ```solidity
 require(!nullifiers[nullifier], "Nullifier already spent");
 nullifiers[nullifier] = true;
@@ -462,6 +933,7 @@ Each nullifier can only be used once. Nullifiers MUST never expire or be removed
 **Attack**: Submitting invalid proofs to create unauthorized commitments or spend notes without proper authorization.
 
 **Mitigation**: Implementations MUST:
+
 - Verify all zero-knowledge proofs on-chain before any state changes
 - Use verifier contracts (generated by trusted ZK frameworks)
 - Validate all public signals match current contract state
@@ -472,6 +944,7 @@ Each nullifier can only be used once. Nullifiers MUST never expire or be removed
 **Attack**: Modifying or deleting commitments from the Merkle tree breaks proof validity and allows erasing transaction history.
 
 **Mitigation**: Implementations MUST:
+
 - Use append-only commitment trees (no deletions or modifications)
 - Atomically update roots when adding commitments
 - Verify old roots in proofs match current state before acceptance
@@ -484,6 +957,7 @@ Any modification to historical commitments would invalidate all proofs referenci
 **Attack**: Malicious circuits that don't enforce proper constraints allow minting tokens or stealing funds.
 
 **Critical Requirements**: Zero-knowledge circuits MUST enforce:
+
 - **Value conservation**: `Σ input amounts = Σ output amounts`
 - **Merkle membership**: Input commitments exist in the tree
 - **Nullifier binding**: Nullifiers are derived from commitments and private keys (prevents theft)

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -1,9 +1,9 @@
 ---
-eip: 8099
-title: Native Privacy Token Interface
+eip: 8086
+title: Privacy Token
 description: A minimal interface for native privacy-preserving fungible tokens on Ethereum
 author: Rowan (@0xRowan)
-discussions-to: https://ethereum-magicians.org/t/draft-native-privacy-token-interface/26623
+discussions-to: https://ethereum-magicians.org/t/erc-8086-privacy-token/26623
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -12,7 +12,7 @@ created: 2025-11-19
 
 ## Abstract
 
-This EIP defines a minimal interface standard for native privacy tokens on Ethereum.
+This EIP defines a minimal, **permissionless** interface standard for native privacy tokens on Ethereum.
 
 While developing privacy solutions for the Ethereum ecosystem—including wrapper protocols (converting [ERC-20](./eip-20) ↔ privacy tokens) and dual-mode tokens (combining public and private balances)—we identified a recurring need for standardized privacy primitives. Without a common interface, each implementation reinvents commitments, nullifiers, and note encryption, leading to ecosystem fragmentation.
 
@@ -21,6 +21,8 @@ This standard provides that common foundation. It enables:
 - **Dual-mode tokens protocols**: Combine standards via `contract DMT is ERC20, IZRC20`
 
 By unifying the native privacy token interface, we facilitate the development of wrapper and dual-mode protocols, accelerating Ethereum's privacy ecosystem growth.
+
+**Permissionless Nature**: This is a foundational interface standard—anyone can implement, deploy, and build upon it without intermediaries, governance approval, or restrictions.
 
 ## Motivation
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -12,13 +12,9 @@ created: 2025-11-19
 
 ## Abstract
 
-This standard provides that common foundation. It enables:
-- **Wrapper protocols**: Implement this interface for their privacy layer
-- **Dual-mode tokens protocols**: Combine standards via `contract DMT is ERC20, IZRC20`
+This standard defines `IZRC20`, a minimal interface for privacy-preserving fungible tokens on Ethereum. It uses zero-knowledge proofs to enable confidential transfers where transaction amounts, sender, and recipient identities remain hidden. The core mechanism relies on cryptographic commitments stored in a Merkle tree, with nullifiers preventing double-spending.
 
-By unifying the native privacy token interface, we facilitate the development of wrapper and dual-mode protocols, accelerating Ethereum's privacy ecosystem growth.
-
-**Permissionless Nature**: This is a foundational interface standard—anyone can implement, deploy, and build upon it without intermediaries, governance approval, or restrictions.
+This interface serves as a foundational building block for both wrapper protocols (adding privacy to existing [ERC-20](./eip-20) tokens) and dual-mode tokens (single tokens supporting both transparent and private transfers).
 
 ## Motivation
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -586,7 +586,7 @@ Each circuit entry contains:
 
 | Subfield          | Required | Description                                                   |
 | ----------------- | -------- | ------------------------------------------------------------- |
-| `method`        | NO       | Key derivation method:`EIP-712-Signature`, `BIP-32`, etc. |
+| `method`        | NO       | Key derivation method:`[EIP-712](./eip-712)-Signature`, `BIP-32`, etc. |
 | `addressFormat` | NO       | Stealth address format:`PV1`, custom format identifier      |
 
 **Example**:

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -394,7 +394,7 @@ The configuration file MUST be a valid JSON document. The following shows the sc
 
 - For `bn128`: This is the BN254 scalar field prime (Fr), a 254-bit prime
 - For `bls12-381`: Use the BLS12-381 scalar field prime
-- Can be obtained from cryptographic libraries (e.g., `snarkjs`, `circomlibjs`)
+- Can be obtained from ZK cryptographic libraries or computed directly from curve parameters
 
 **Client Usage**: Clients MUST validate that all public signals are less than `fieldSize`. The `protocol` determines which proof verification library to use.
 
@@ -521,7 +521,7 @@ Each circuit entry contains:
 **How to obtain `subgroupOrder`**:
 
 - For Baby Jubjub: This is the order of the prime-order subgroup (~251 bits)
-- Can be obtained from `circomlibjs`: `babyJub.subOrder`
+- Can be obtained from elliptic curve libraries or the Baby Jubjub curve specification
 
 **Client Usage**:
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -230,10 +230,12 @@ interface IZRC20 {
     /**
      * @notice Check if a nullifier has been spent
      * @param nullifier The nullifier to check
-     * @return spent True if nullifier spent, false otherwise
+     * @return True if nullifier spent, false otherwise
      * @dev OPTIONAL but RECOMMENDED for client-side validation before proof generation
+     *      Implementations using `mapping(bytes32 => bool) public nullifiers`
+     *      will auto-generate this function.
      */
-    function isNullifierSpent(bytes32 nullifier) external view returns (bool spent);
+    function nullifiers(bytes32 nullifier) external view returns (bool);
 
 }
 ```

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -586,7 +586,7 @@ Each circuit entry contains:
 
 | Subfield          | Required | Description                                                   |
 | ----------------- | -------- | ------------------------------------------------------------- |
-| `method`        | NO       | Key derivation method:`[EIP-712](./eip-712)-Signature`, `BIP-32`, etc. |
+| `method`        | NO       | Key derivation method: [EIP-712](./eip-712) Signature , `BIP-32`, etc. |
 | `addressFormat` | NO       | Stealth address format:`PV1`, custom format identifier      |
 
 **Example**:

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -1,7 +1,7 @@
 ---
 eip: 8086
 title: Privacy Token
-description: A minimal interface for native privacy-preserving fungible tokens on Ethereum
+description: An abstract privacy foundation layer that can be used in both dual-mode tokens and wrapped tokens
 author: Rowan (@0xRowan)
 discussions-to: https://ethereum-magicians.org/t/erc-8086-privacy-token/26623
 status: Draft
@@ -11,10 +11,6 @@ created: 2025-11-19
 ---
 
 ## Abstract
-
-This EIP defines a minimal, **permissionless** interface standard for native privacy tokens on Ethereum.
-
-While developing privacy solutions for the Ethereum ecosystem—including wrapper protocols (converting [ERC-20](./eip-20) ↔ privacy tokens) and dual-mode tokens (combining public and private balances)—we identified a recurring need for standardized privacy primitives. Without a common interface, each implementation reinvents commitments, nullifiers, and note encryption, leading to ecosystem fragmentation.
 
 This standard provides that common foundation. It enables:
 - **Wrapper protocols**: Implement this interface for their privacy layer
@@ -59,7 +55,6 @@ Single Token: Public mode (ERC-20) ↔ Private mode (ZK-based)
 
 This standard is **not** a replacement for Wrapper Protocols or Dual-Mode Protocol. It is the **privacy foundation** they can build upon:
 
-```
 Ecosystem Stack:
 ┌─────────────────────────────────────┐
 │  Applications (DeFi, DAO, Gaming)   │
@@ -71,7 +66,6 @@ Ecosystem Stack:
 ├─────────────────────────────────────┤
 │  Ethereum L1 / L2s                  │
 └─────────────────────────────────────┘
-```
 
 ## Specification
 
@@ -635,7 +629,6 @@ The `privacyConfigURI()` function MAY return URIs using these schemes:
 
 #### Client Integration Flow
 
-```
 1. Client discovers privacy token at address 0x...
 2. Client calls privacyConfigURI() → "ipfs://Qm..."
 3. Client fetches and parses configuration JSON
@@ -646,7 +639,6 @@ The `privacyConfigURI()` function MAY return URIs using these schemes:
    - Encrypt notes using specified algorithm and parameters
    - Compute hashes using specified hash function
    - Interact with the token contract using correct proofType values
-```
 
 ### Proof Types
 
@@ -698,31 +690,7 @@ Implementations MUST document their architecture choice.
 
 ## Rationale
 
-### Why Do We Need This Standard?
-
-Let's consider the privacy scenarios needed on Ethereum:
-
-1. **Existing tokens need privacy**: Through wrapper protocols
-
-   ```
-   [ERC-20](./eip-20) (DAI, USDC) → Privacy Layer → ERC-20
-   ```
-2. **Future dual-mode tokens**: Built-in privacy from genesis
-
-   ```
-   Dual-Mode Token (ERC-20 + Privacy in one contract)
-   ```
-
-**With this standard as the unified privacy foundation**:
-
-- **Dual-Mode Protocols** focus on mode conversion logic (their core value)
-- **Wrapper Protocols** focus on wrapping/unwrapping logic (their core value)
-- **Privacy layer uses unified interface** (this standard)
-- Result: Faster ecosystem expansion in the privacy direction
-
 ### Why Include Metadata Functions?
-
-`name()`, `symbol()`, `decimals()` are marked OPTIONAL but RECOMMENDED.
 
 **Ecosystem Benefits**:
 
@@ -775,14 +743,12 @@ This standard intentionally defines a **minimal interface** to maximize implemen
 
 **The Problem**:
 
-```
 Different implementations may use:
 - Different proof systems (Groth16 vs PLONK vs STARK)
 - Different circuit designs (different public signals)
 - Different encryption algorithms
 - Different tree structures
 - Different proof encoding formats
-```
 
 **Without standardization**:
 
@@ -792,7 +758,6 @@ Different implementations may use:
 
 **The Solution**: Privacy Configuration File (inspired by [ERC-8004](./eip-8004))
 
-```
 ┌─────────────────────────────────────────────────────────────┐
 │  On-chain (IZRC20 Contract)                                 │
 │  - Minimal interface                                        │
@@ -809,7 +774,6 @@ Different implementations may use:
 │  - Tree structure                                           │
 │  - All client-needed parameters                             │
 └─────────────────────────────────────────────────────────────┘
-```
 
 **Benefits**:
 
@@ -862,12 +826,10 @@ This standard is designed as a **foundation layer**, enabling higher-level proto
 
 Conceptual pattern:
 
-```
 1. User deposits DAI into wrapper contract
 2. Wrapper mints privacy token (using IZRC20.mint)
 3. User transfers privately (using IZRC20.transfer)
 4. User withdraws to get DAI back
-```
 
 Benefits of standardization:
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -429,7 +429,7 @@ As described in the Motivation section, this standard serves as a **foundational
 
 ## Reference Implementation
 
-[ERC-8086 Reference Implementation](../assets/erc-8086/README.md)
+[ERC-8086 Reference Implementation](../assets/eip-8086/README.md)
 
 ## Security Considerations
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -360,8 +360,6 @@ The configuration file MUST be a valid JSON document. The following shows the sc
 
 **Client Usage**: Clients SHOULD check this field first to ensure they can parse the configuration format. Unknown types SHOULD be rejected.
 
----
-
 ##### `version` (REQUIRED)
 
 **Purpose**: Semantic version of this specific configuration file.
@@ -371,8 +369,6 @@ The configuration file MUST be a valid JSON document. The following shows the sc
 **Example**: `"1.0.0"`
 
 **Client Usage**: Clients MAY cache configurations and use version for cache invalidation.
-
----
 
 ##### `proofSystem` (REQUIRED)
 
@@ -401,8 +397,6 @@ The configuration file MUST be a valid JSON document. The following shows the sc
 - Can be obtained from cryptographic libraries (e.g., `snarkjs`, `circomlibjs`)
 
 **Client Usage**: Clients MUST validate that all public signals are less than `fieldSize`. The `protocol` determines which proof verification library to use.
-
----
 
 ##### `treeConfig` (REQUIRED)
 
@@ -435,8 +429,6 @@ The configuration file MUST be a valid JSON document. The following shows the sc
 ```
 
 **Client Usage**: Clients use this to build correct Merkle proofs. Tree capacity = 2^levels (or 2^subtreeLevels × 2^rootTreeLevels for dual-layer).
-
----
 
 ##### `circuits` (REQUIRED)
 
@@ -488,8 +480,6 @@ Each circuit entry contains:
 2. Use `publicSignalsSchema` to correctly encode/decode proof public inputs
 3. Pass `proofType` value to contract function calls
 
----
-
 ##### `noteEncryption` (REQUIRED)
 
 **Purpose**: Specifies the encryption algorithm and parameters for encrypted notes.
@@ -540,8 +530,6 @@ Each circuit entry contains:
 3. Use `aadTag` as AES-GCM additional authenticated data
 4. Use `noteFormat` to identify encrypted note serialization format
 
----
-
 ##### `hashFunction` (REQUIRED)
 
 **Purpose**: Specifies the hash function used for commitments, nullifiers, and Merkle tree.
@@ -566,8 +554,6 @@ Each circuit entry contains:
 
 **Client Usage**: Clients use this hash function for computing commitments, nullifiers, and Merkle tree nodes locally.
 
----
-
 ##### `keyDerivation` (OPTIONAL)
 
 **Purpose**: Describes how users derive privacy keys from their wallet.
@@ -588,8 +574,6 @@ Each circuit entry contains:
 
 **Client Usage**: Guides wallet integration for key derivation. This is informational and clients MAY use different methods.
 
----
-
 ##### `endpoints` (OPTIONAL)
 
 **Purpose**: Service discovery for auxiliary infrastructure.
@@ -609,8 +593,6 @@ Each circuit entry contains:
 ```
 
 **Client Usage**: Clients MAY use these endpoints for enhanced functionality (faster sync, gas-free transfers).
-
----
 
 #### URI Schemes
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -421,6 +421,14 @@ This standard defines a minimal interface for native privacy assets. It is an **
 As described in the Motivation section, this standard serves as a **foundational building block** for higher-level protocols to rapidly implement privacy capabilities:
 
 
+## Reference Implementation
+
+A reference implementation is available at:
+  - **Repository**: [erc-8086-reference](https://github.com/0xRowan/erc-8086-reference)
+  - **Testnet Deployment**: Base Sepolia (Chain ID: 84532)
+  - **Demo Application**: https://testnative.zkprotocol.xyz/
+
+
 ## Security Considerations
 
 ### Critical: Nullifier Uniqueness

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -55,8 +55,8 @@ Ecosystem Stack:
 ┌─────────────────────────────────────┐
 │  Applications (DeFi, DAO, Gaming)   │
 ├─────────────────────────────────────┤
-│  Dual-Mode Tokens ([ERC-20](./eip-20) + Privacy)│  ← Optional privacy
-│  Wrapper Protocols (ERC20→Privacy)  │  ← Add privacy to existing
+│  Dual-Mode Tokens                   │  ← Optional privacy
+│  Wrapper Protocols                  │  ← Add privacy to existing
 ├─────────────────────────────────────┤
 │  Native Privacy Token Interface     │  ← This standard (foundation)
 ├─────────────────────────────────────┤

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -427,7 +427,9 @@ This standard defines a minimal interface for native privacy assets. It is an **
 
 As described in the Motivation section, this standard serves as a **foundational building block** for higher-level protocols to rapidly implement privacy capabilities:
 
+## Reference Implementation
 
+[ERC-8086 Reference Implementation](../assets/erc-8086/README.md)
 
 ## Security Considerations
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -24,9 +24,7 @@ While building privacy solutions for Ethereum, we identified recurring patterns:
 
 **Wrapper Protocols** ([ERC-20](./eip-20) → Privacy → ERC-20):
 
-```
 DAI (transparent) → zDAI (private) → DAI (transparent)
-```
 
 - Each protocol implements custom privacy token logic
 - No interoperability between different privacy implementations
@@ -34,9 +32,7 @@ DAI (transparent) → zDAI (private) → DAI (transparent)
 
 **Dual-Mode Tokens** (Public ↔ Private in one token):
 
-```
 Single Token: Public mode (ERC-20) ↔ Private mode (ZK-based)
-```
 
 - Needs a privacy primitive as foundation
 - Current implementations reinvent the wheel
@@ -848,14 +844,12 @@ As described in the Motivation section, this standard serves as a **foundational
 
 **Example**:
 
-```
 1. Attacker has Note A (100 tokens)
 2. Creates valid proof spending Note A → generates Nullifier N
 3. If contract doesn't track nullifiers:
    - First spend: Valid, creates new notes
    - Second spend: Same proof, same nullifier N ← Should be rejected!
    - Result: 100 tokens spent twice = 200 tokens from 100
-```
 
 **Mitigation**: Implementations MUST permanently track spent nullifiers and reject duplicates:
 

--- a/ERCS/erc-8086.md
+++ b/ERCS/erc-8086.md
@@ -273,7 +273,7 @@ Since this standard defines a **minimal interface**, different implementations m
 - Tree structures (single vs. dual-layer)
 - Public signals schemas
 
-To enable **client interoperability** across different implementations, this standard defines an **OPTIONAL but RECOMMENDED** Privacy Configuration File mechanism, inspired by [ERC-8004](./eip-8004)'s Agent Registration File pattern.
+To enable **client interoperability** across different implementations, this standard defines an **OPTIONAL but RECOMMENDED** Privacy Configuration File mechanism, inspired by [ERC-8004](./eip-8004.md)'s Agent Registration File pattern.
 
 #### Configuration URI Functions
 

--- a/ERCS/erc-8099.md
+++ b/ERCS/erc-8099.md
@@ -3,7 +3,7 @@ eip: 8099
 title: Native Privacy Token Interface
 description: A minimal interface for native privacy-preserving fungible tokens on Ethereum
 author: Rowan (@0xRowan)
-discussions-to: https://ethereum-magicians.org/t/draft-native-privacy-token-interface-standard/26623
+discussions-to: https://ethereum-magicians.org/t/draft-native-privacy-token-interface/26623
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-8099.md
+++ b/ERCS/erc-8099.md
@@ -1,0 +1,482 @@
+---
+eip: 8099
+title: Native Privacy Token Interface Standard
+description: A minimal interface standard for native privacy-preserving fungible tokens on Ethereum
+author: Rowan (@0xRowan)
+discussions-to: https://ethereum-magicians.org/t/draft-native-privacy-token-interface-standard/26623
+status: Draft
+type: Standards Track
+category: ERC
+created: 2025-11-19
+---
+
+## Abstract
+
+This EIP defines a minimal interface standard for native privacy tokens on Ethereum.
+
+While developing privacy solutions for the Ethereum ecosystem—including wrapper protocols (converting [ERC-20](./eip-20) ↔ privacy tokens) and dual-mode tokens (combining public and private balances)—we identified a recurring need for standardized privacy primitives. Without a common interface, each implementation reinvents commitments, nullifiers, and note encryption, leading to ecosystem fragmentation.
+
+This standard provides that common foundation. It enables:
+- **Wrapper protocols**: Implement this interface for their privacy layer
+- **Dual-mode tokens protocols**: Combine standards via `contract DMT is ERC20, IZRC20`
+
+By unifying the native privacy token interface, we facilitate the development of wrapper and dual-mode protocols, accelerating Ethereum's privacy ecosystem growth.
+
+## Motivation
+
+### Privacy Infrastructure Needs Standardization
+
+While building privacy solutions for Ethereum, we identified recurring patterns:
+
+**Wrapper Protocols** ([ERC-20](./eip-20) → Privacy → ERC-20):
+```
+DAI (transparent) → zDAI (private) → DAI (transparent)
+```
+- Each protocol implements custom privacy token logic
+- No interoperability between different privacy implementations
+- Duplicated effort, increased security risks
+
+**Dual-Mode Tokens** (Public ↔ Private in one token):
+```
+Single Token: Public mode (ERC-20) ↔ Private mode (ZK-based)
+```
+- Needs a privacy primitive as foundation
+- Current implementations reinvent the wheel
+
+**The Solution**: Standardize the privacy primitive to enable:
+- Consistent wrapper protocol implementations
+- Reusable dual-mode token architectures
+- Faster ecosystem development
+
+### Design Philosophy
+
+This standard is **not** a replacement for Wrapper Protocols or Dual-Mode Protocol. It is the **privacy foundation** they can build upon:
+
+```
+Ecosystem Stack:
+┌─────────────────────────────────────┐
+│  Applications (DeFi, DAO, Gaming)   │
+├─────────────────────────────────────┤
+│  Dual-Mode Tokens ([ERC-20](./eip-20) + Privacy)│  ← Optional privacy
+│  Wrapper Protocols (ERC20→Privacy)  │  ← Add privacy to existing
+├─────────────────────────────────────┤
+│  Native Privacy Token Interface     │  ← This standard (foundation)
+├─────────────────────────────────────┤
+│  Ethereum L1 / L2s                  │
+└─────────────────────────────────────┘
+```
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### Definitions
+
+- **Native Privacy Asset**: A token with privacy as an inherent property from genesis, not achieved through post-hoc mixing
+- **Commitment**: A cryptographic binding of value and ownership that hides both the amount and recipient identity
+- **Nullifier**: A unique identifier proving a commitment has been spent, preventing double-spending
+- **Note**: Off-chain encrypted data `(amount, publicKey, randomness)` for recipient
+- **Merkle Tree**: Authenticated structure storing commitments for zero-knowledge membership proofs
+- **Proof Type**: Parameter routing different proof strategies
+- **View Tag**: Single-byte scanning optimization (OPTIONAL but RECOMMENDED)
+- **Stealth Address**: One-time recipient address from ephemeral keys (OPTIONAL)
+
+### Core Interface
+
+```solidity
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+/**
+ * @title IZRC20
+ * @notice Minimal interface for native privacy assets on Ethereum
+ * @dev This standard defines the foundation for privacy-preserving tokens
+ *      that can be used directly or as building blocks for wrapper protocols
+ *      and dual-mode protocols implementations.
+ */
+interface IZRC20 {
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Events
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Emitted when a commitment is added to the Merkle tree
+     * @param subtreeIndex Subtree index (0 for single-tree implementations)
+     * @param commitment The cryptographic commitment hash
+     * @param leafIndex Position within subtree (or global index)
+     * @param timestamp Block timestamp of insertion
+     * @dev For single-tree: subtreeIndex SHOULD be 0, leafIndex is global position
+     * @dev For dual-tree: subtreeIndex identifies which subtree, leafIndex is position within it     */
+    event CommitmentAppended(
+        uint32 indexed subtreeIndex,
+        bytes32 commitment,
+        uint32 indexed leafIndex,
+        uint256 timestamp
+    );
+
+    /**
+     * @notice Emitted when a nullifier is spent (note consumed)
+     * @param nullifier The unique nullifier hash
+     * @dev Once spent, nullifier can never be reused (prevents double-spending)
+     */
+    event NullifierSpent(bytes32 indexed nullifier);
+
+    /**
+     * @notice Emitted when tokens are minted directly into privacy mode
+     * @param minter Address that initiated the mint
+     * @param commitment The commitment created for minted value
+     * @param encryptedNote Encrypted note for recipient
+     * @param subtreeIndex Subtree where commitment was added
+     * @param leafIndex Position within subtree
+     * @param timestamp Block timestamp of mint
+     */
+    event Minted(
+        address indexed minter,
+        bytes32 commitment,
+        bytes encryptedNote,
+        uint32 subtreeIndex,
+        uint32 leafIndex,
+        uint256 timestamp
+    );
+
+    /**
+     * @notice Emitted on privacy transfers with public scanning data
+     * @param newCommitments Output commitments created (typically 1-2)
+     * @param encryptedNotes Encrypted notes for recipients
+     * @param ephemeralPublicKey Ephemeral public key for ECDH key exchange (if used)
+     * @param viewTag Scanning optimization byte (0 if not used)
+     * @dev Provides data for recipients to detect and decrypt their notes
+     */
+    event Transaction(
+        bytes32[2] newCommitments,
+        bytes[] encryptedNotes,
+        uint256[2] ephemeralPublicKey,
+        uint256 viewTag
+    );
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Metadata (ERC-20 compatible, OPTIONAL but RECOMMENDED)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Returns the token name
+     * @return Token name string
+     * @dev OPTIONAL but RECOMMENDED for UX and interoperability
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @notice Returns the token symbol
+     * @return Token symbol string
+     * @dev OPTIONAL but RECOMMENDED for UX and interoperability
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @notice Returns the number of decimals
+     * @return Number of decimals (typically 18)
+     * @dev OPTIONAL but RECOMMENDED for amount formatting
+     */
+    function decimals() external view returns (uint8);
+
+    /**
+     * @notice Returns the total supply across all privacy notes
+     * @return Total token supply
+     * @dev OPTIONAL - May be required for certain economic models (e.g., fixed cap)
+     *      Individual balances remain private; only aggregate supply is visible
+     */
+    function totalSupply() external view returns (uint256);
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Core Functions
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Mints new privacy tokens
+     * @param proofType Type of proof to support multiple proof strategies.
+     * @param proof Zero-knowledge proof of valid transfer
+     * @param encryptedNote Encrypted note for minter's wallet
+     * @dev Proof must demonstrate valid commitment creation and payment
+     *      Implementations define minting rules
+     */
+    function mint(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes calldata encryptedNote
+    ) external payable;
+
+    /**
+     * @notice Executes a privacy-preserving transfer
+     * @param proofType Implementation-specific proof type identifier
+     * @param proof Zero-knowledge proof of valid transfer
+     * @param encryptedNotes Encrypted output notes (for recipient and/or change)
+     * @dev Proof must demonstrate:
+     *      1. Input commitments exist in Merkle tree
+     *      2. Prover knows private keys
+     *      3. Nullifiers not spent
+     *      4. Value conservation: sum(inputs) = sum(outputs)
+     */
+    function transfer(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) external;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Query Functions (OPTIONAL but RECOMMENDED)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Check if a nullifier has been spent
+     * @param nullifier The nullifier to check
+     * @return spent True if nullifier spent, false otherwise
+     * @dev OPTIONAL but RECOMMENDED for client-side validation before proof generation
+     */
+    function isNullifierSpent(bytes32 nullifier) external view returns (bool spent);
+
+}
+```
+
+### Proof Types
+
+**Purpose**: Different proof types may be needed for:
+- Different data structures (e.g., active vs. archived state in dual-tree implementations)
+- Different optimization strategies (e.g., activeTree proofs vs. finalizedTree proofs)
+
+
+### Privacy Guarantees
+
+Implementations MUST ensure:
+
+1. **Amount Privacy**: Transaction amounts not revealed in events/storage
+2. **Sender Privacy**: Sender identities not linkable across transactions
+3. **Recipient Privacy**: Recipient addresses not publicly visible
+4. **Balance Privacy**: No `balanceOf(address)` queries (completely private)
+
+
+### State Management Options
+
+**Option 1: Single Merkle Tree**
+- One tree storing all commitments chronologically
+- Simpler implementation
+- Higher proof generation cost for large trees
+- `subtreeIndex = 0` in events
+
+**Option 2: Dual-Layer Tree** (RECOMMENDED for scalability)
+- Active subtree (e.g., height 16): Recent commitments, fast proofs
+- Root tree (e.g., height 20): Finalized subtree roots, archival
+- Better performance for common operations (2-3x faster proofs)
+- Decades of capacity (e.g., 68.7B notes with 16×20 config)
+
+Implementations MUST document their architecture choice.
+
+
+### Metadata Functions
+
+`name()`, `symbol()`, `decimals()` are OPTIONAL but RECOMMENDED for:
+- User interface display
+- Wallet integration
+- Ecosystem interoperability
+
+`totalSupply()` is OPTIONAL:
+- Required for fixed-cap verification
+- Privacy trade-off: reveals aggregate supply (but not individual balances)
+- Can be omitted for maximum privacy
+
+## Rationale
+
+### Why Do We Need This Standard?
+
+Let's consider the privacy scenarios needed on Ethereum:
+
+1. **Existing tokens need privacy**: Through wrapper protocols
+   ```
+   [ERC-20](./eip-20) (DAI, USDC) → Privacy Layer → ERC-20
+   ```
+
+2. **Future dual-mode tokens**: Built-in privacy from genesis
+   ```
+   Dual-Mode Token (ERC-20 + Privacy in one contract)
+   ```
+
+**With this standard as the unified privacy foundation**:
+- **Dual-Mode Protocols** focus on mode conversion logic (their core value)
+- **Wrapper Protocols** focus on wrapping/unwrapping logic (their core value)
+- **Privacy layer uses unified interface** (this standard)
+- Result: Faster ecosystem expansion in the privacy direction
+
+### Why Include Metadata Functions?
+
+`name()`, `symbol()`, `decimals()` are marked OPTIONAL but RECOMMENDED.
+
+**Ecosystem Benefits**:
+- **Wallet Integration**: Existing wallets can display privacy tokens without special handling
+- **Explorer Compatibility**: Block explorers show meaningful token information
+- **Developer Familiarity**: Matches [ERC-20](./eip-20) conventions, reducing learning curve
+- **Interoperability**: Higher-level protocols can query token metadata consistently
+
+
+### Why Optional `totalSupply()`?
+
+Different use cases have different transparency requirements.
+
+**Use Cases Requiring `totalSupply()`**:
+- Fixed-cap tokens (verify no hidden inflation)
+- DAO treasuries (aggregate holdings visible)
+- Regulatory compliance (prove total supply matches expectations)
+- Wrapper protocols (track total wrapped amount)
+
+**Design Decision**: Make it OPTIONAL—let each implementation choose based on:
+- Target use case requirements
+- Regulatory environment
+- Privacy vs. transparency trade-offs
+
+This flexibility enables the standard to serve both transparent-leaning (wrapper protocols) and privacy-maximalist (pure privacy tokens) use cases.
+
+### Why Proof Types?
+
+The `proofType` parameter is a key design decision for **interface stability** and **implementation flexibility**.
+
+**The Challenge**:
+
+Different implementations may need different proof strategies:
+- Simple single-tree implementations: One proof type for all operations
+- Optimized dual-layer implementations: Different proofs for active vs. archived state
+- Future optimizations: New proof types without breaking existing contracts
+
+**Design Decision**: Single parameter routes to appropriate verifiers
+
+```solidity
+function mint(uint8 proofType, bytes proof, ...) external;
+function transfer(uint8 proofType, bytes proof, ...) external;
+```
+
+### Why Standardize Encrypted Notes and View Tags?
+
+These fields appear in the `Transaction` event, which is emitted for all privacy transfers.
+
+**The Client Synchronization Challenge**:
+
+For privacy tokens to work, clients must:
+1. Monitor blockchain events to detect received payments
+2. Decrypt note data to learn amounts and spending keys
+3. Build local state to construct future transactions
+
+Without standardization, each implementation would use incompatible formats, fragmenting the ecosystem.
+
+**Encrypted Notes**:
+- **Required for privacy**: Notes contain amounts and secrets that must stay private
+- **Standardizing the concept**: Enables wallets to support multiple implementations
+- **Not mandating the algorithm**: Implementations can use different encryption schemes
+- **Event carries the ciphertext**: Clients know where to find their data
+
+**View Tags** (OPTIONAL but RECOMMENDED):
+- **Problem**: Scanning requires trial-decryption of every transaction (expensive)
+- **Solution**: Small tag allows fast pre-filtering 
+- **Trade-off**: Minimal metadata leakage vs. practical usability
+- **Standardizing usage**: Wallets can optimize scanning across implementations
+
+### How Higher-Level Protocols Build on This Standard
+
+This standard is designed as a **foundation layer**, enabling higher-level protocols without prescribing their exact form.
+
+**Wrapper Protocols**: Add privacy to existing [ERC-20](./eip-20) tokens
+
+Conceptual pattern:
+```
+1. User deposits DAI into wrapper contract
+2. Wrapper mints privacy token (using IZRC20.mint)
+3. User transfers privately (using IZRC20.transfer)
+4. User withdraws to get DAI back
+```
+
+Benefits of standardization:
+- All wrapper protocols use the same privacy interface
+- Wallets support all wrappers without custom integration
+- Security audits focus on the wrapper logic, not reinventing privacy primitives
+
+**Dual-Mode Tokens Protocols**: Single token with both modes
+
+Conceptual pattern:
+```solidity
+contract DualModeToken is ERC20, IZRC20 {
+    // Inherits both standards
+    // Adds mode conversion: toPrivacy() / toPublic()
+}
+```
+
+Benefits of standardization:
+- Public mode: Standard ERC-20 (works with all DeFi)
+- Private mode: Standard IZRC20 (works with all privacy wallets)
+- Higher-level protocols can focus more on specific business scenarios and solving concrete problems—this is the advantage of a unified privacy asset interface.
+
+
+## Backwards Compatibility
+
+This standard defines a minimal interface for native privacy assets. It is an **independent interface implementation** that does not depend on other protocols.
+
+As described in the Motivation section, this standard serves as a **foundational building block** for higher-level protocols to rapidly implement privacy capabilities:
+
+
+## Security Considerations
+
+### Critical: Nullifier Uniqueness
+
+**Attack Vector**: Reusing the same nullifier allows spending a commitment multiple times (double-spending).
+
+**Example**:
+```
+1. Attacker has Note A (100 tokens)
+2. Creates valid proof spending Note A → generates Nullifier N
+3. If contract doesn't track nullifiers:
+   - First spend: Valid, creates new notes
+   - Second spend: Same proof, same nullifier N ← Should be rejected!
+   - Result: 100 tokens spent twice = 200 tokens from 100
+```
+
+**Mitigation**: Implementations MUST permanently track spent nullifiers and reject duplicates:
+```solidity
+require(!nullifiers[nullifier], "Nullifier already spent");
+nullifiers[nullifier] = true;
+```
+
+Each nullifier can only be used once. Nullifiers MUST never expire or be removed.
+
+### Proof Verification
+
+**Attack**: Submitting invalid proofs to create unauthorized commitments or spend notes without proper authorization.
+
+**Mitigation**: Implementations MUST:
+- Verify all zero-knowledge proofs on-chain before any state changes
+- Use verifier contracts (generated by trusted ZK frameworks)
+- Validate all public signals match current contract state
+- Route to correct verifier based on `proofType`
+
+### Merkle Tree Integrity
+
+**Attack**: Modifying or deleting commitments from the Merkle tree breaks proof validity and allows erasing transaction history.
+
+**Mitigation**: Implementations MUST:
+- Use append-only commitment trees (no deletions or modifications)
+- Atomically update roots when adding commitments
+- Verify old roots in proofs match current state before acceptance
+- For dual-layer implementations: validate both active and finalized roots during state transitions
+
+Any modification to historical commitments would invalidate all proofs referencing them.
+
+### Circuit Soundness
+
+**Attack**: Malicious circuits that don't enforce proper constraints allow minting tokens or stealing funds.
+
+**Critical Requirements**: Zero-knowledge circuits MUST enforce:
+- **Value conservation**: `Σ input amounts = Σ output amounts`
+- **Merkle membership**: Input commitments exist in the tree
+- **Nullifier binding**: Nullifiers are derived from commitments and private keys (prevents theft)
+- **Public signal validation**: All public inputs match on-chain state
+
+Implementations MUST use audited circuits and trusted setup ceremonies (or transparent setup schemes).
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-8099.md
+++ b/ERCS/erc-8099.md
@@ -1,7 +1,7 @@
 ---
 eip: 8099
-title: Native Privacy Token Interface Standard
-description: A minimal interface standard for native privacy-preserving fungible tokens on Ethereum
+title: Native Privacy Token Interface
+description: A minimal interface for native privacy-preserving fungible tokens on Ethereum
 author: Rowan (@0xRowan)
 discussions-to: https://ethereum-magicians.org/t/draft-native-privacy-token-interface-standard/26623
 status: Draft

--- a/assets/erc-8085/README.md
+++ b/assets/erc-8085/README.md
@@ -1,0 +1,172 @@
+# ERC-8085: Dual-Mode Fungible Tokens - Reference Implementation
+
+## ⚠️ Implementation Status
+
+This directory contains the **smart contract implementation** of ERC-8085.
+
+**Note**: Complete end-to-end testing of this standard requires ZK-SNARK circuit artifacts (proving keys, witness generators) which are **not included** in this repository due to size constraints.
+
+### What's Included
+
+- ✅ Core Solidity contracts
+- ✅ Interface definitions (IDualModeToken, IZRC20)
+- ✅ Verifier contracts (Groth16)
+- ✅ Factory pattern for token deployment
+- ✅ Testnet deployment information
+
+### What's NOT Included
+
+- ❌ ZK circuit source code (.circom files)
+- ❌ Compiled circuit artifacts (.zkey, .wasm files)
+- ❌ Client-side proof generation SDK
+- ❌ Unit test suite (requires circuit artifacts)
+
+## Directory Structure
+
+```
+erc-8085/
+├── README.md                          # This file
+├── contracts/
+│   ├── interfaces/
+│   │   ├── IDualModeToken.sol        # Core interface (ERC-8085)
+│   │   └── IZRC20.sol                # Privacy interface (ERC-8086)
+│   └── reference/
+│       ├── DualModeToken.sol         # Reference implementation
+│       └── DualModeTokenFactory.sol  # Factory for token deployment
+└── deployments/
+    └── base-sepolia.json              # Deployment addresses & config
+```
+
+## How to Test This Implementation
+
+Due to the ZK-SNARK requirements, there are two ways to verify this implementation:
+
+### Option 1: Use the Live Testnet Deployment (Recommended)
+
+A fully functional deployment is available on **Base Sepolia** testnet:
+
+**🔗 Test Application**: [testdmt.zkprotocol.xyz](https://testdmt.zkprotocol.xyz/)
+
+**Deployed Contracts** (verified on Basescan):
+
+| Contract | Address | Link |
+|----------|---------|------|
+| DualModeTokenFactory | `0xf5c16f708777cCb57C3A8887065b4EC02eAf9130` | [View Code](https://sepolia.basescan.org/address/0xf5c16f708777cCb57C3A8887065b4EC02eAf9130#code) |
+| DualModeToken (Implementation) | `0x1EFab166064AaD33fcB6074Ec8bA6302013C965C` | [View Code](https://sepolia.basescan.org/address/0x1EFab166064AaD33fcB6074Ec8bA6302013C965C#code) |
+| MintVerifier | `0xC655b758f07bAaE8B956c95b055424a5c3B04e79` | [View Code](https://sepolia.basescan.org/address/0xC655b758f07bAaE8B956c95b055424a5c3B04e79#code) |
+| MintRolloverVerifier | `0x9a6898B2e6C963EA81D17dCB9B0D483B590e168f` | [View Code](https://sepolia.basescan.org/address/0x9a6898B2e6C963EA81D17dCB9B0D483B590e168f#code) |
+| ActiveTransferVerifier | `0x7159EcAc6d1BB1433922b597fc2887dCA33a3A62` | [View Code](https://sepolia.basescan.org/address/0x7159EcAc6d1BB1433922b597fc2887dCA33a3A62#code) |
+| FinalizedTransferVerifier | `0x0f9b6F788774671C8c47D8adE9D36E884c96580D` | [View Code](https://sepolia.basescan.org/address/0x0f9b6F788774671C8c47D8adE9D36E884c96580D#code) |
+| RolloverTransferVerifier | `0x0B22df9887351Ecfb403cfB27056f3A371F3bD92` | [View Code](https://sepolia.basescan.org/address/0x0B22df9887351Ecfb403cfB27056f3A371F3bD92#code) |
+
+**Network**: Base Sepolia (Chain ID: 84532)
+
+**Testing Instructions**:
+1. Visit [testdmt.zkprotocol.xyz](https://testdmt.zkprotocol.xyz/)
+2. Connect a wallet to Base Sepolia testnet
+3. Get test ETH from [Base Sepolia faucet](https://www.alchemy.com/faucets/base-sepolia)
+4. Mint public tokens (ERC-20)
+5. Convert to privacy mode: `toPrivacy()`
+6. Perform privacy transfers
+7. Convert back to public: `toPublic()`
+8. Verify transactions on [Base Sepolia explorer](https://sepolia.basescan.org/)
+
+### Option 2: Review Contract Code On-Chain
+
+All contracts are verified on Basescan. You can:
+- Read the full source code directly on Basescan
+- Verify the bytecode matches the source
+- Review all constructor parameters
+- Check deployment history
+- Inspect transaction history
+
+## Implementation Notes
+
+### Architecture
+
+ERC-8085 combines two standards in a single contract:
+- **Public Mode**: Standard ERC-20 (OpenZeppelin implementation)
+- **Privacy Mode**: ERC-8086 IZRC20 compatible
+- **Mode Conversion**: `toPrivacy()` and `toPublic()` functions
+
+### Key Design Decisions
+
+1. **Unified Supply**: `totalSupply() = ERC20.totalSupply() + privacyTotalSupply`
+2. **Direct Privacy Mint Disabled**: Tokens must enter via public mode first
+3. **BURN_ADDRESS Enforcement**: Ensures privacy-to-public conversion security
+4. **Supply Invariant**: Total supply remains constant during mode conversions
+
+### Dual-Layer Merkle Tree (Privacy Mode)
+
+- **Active subtree**: 16 levels (65,536 notes)
+- **Finalized tree**: 20 levels (1,048,576 subtrees)
+- **Total capacity**: 68.7 billion notes
+
+### Mode Conversion Flow
+
+**Public → Privacy** (`toPrivacy`):
+```solidity
+1. User holds 100 ERC-20 tokens
+2. Calls toPrivacy(100, proof, encryptedNote)
+3. Contract burns 100 ERC-20 tokens
+4. Contract creates privacy commitment (ZK proof verified)
+5. Result: -100 public, +100 privacy, totalSupply unchanged
+```
+
+**Privacy → Public** (`toPublic`):
+```solidity
+1. User holds 100 in privacy mode
+2. Calls toPublic(recipient, proof, encryptedNotes)
+3. Contract verifies first output → BURN_ADDRESS
+4. Contract mints 100 ERC-20 tokens to recipient
+5. Result: -100 privacy, +100 public, totalSupply unchanged
+```
+
+### Security Features
+
+- ✅ BURN_ADDRESS enforcement (prevents double-spending across modes)
+- ✅ Supply invariant maintenance
+- ✅ Nullifier uniqueness enforcement
+- ✅ Merkle tree integrity (append-only)
+- ✅ ZK-SNARK proof verification (Groth16)
+- ✅ Reentrancy protection
+- ✅ Mode isolation (public/privacy balances cryptographically separated)
+
+## Technical Details
+
+### Cryptographic Parameters
+
+From `deployments/base-sepolia.json`:
+- Subtree levels: 16
+- Root tree levels: 20
+- Subtree capacity: 65,536 notes
+- Empty subtree root: `0x2a7c7c9b6ce5880b9f6f228d72bf6a575a526f29c66ecceef8b753d38bba7323`
+- Empty finalized root: `0x224ccc25981822d4c5b6fc199fbc74828488741c7151a6159ecfaab7c2a8bac9`
+
+### Compiler Configuration
+
+- Solidity version: 0.8.20
+- Optimizer: Enabled (200 runs)
+- Via IR: true
+
+### BURN_ADDRESS Constants
+
+Used in `toPublic()` verification:
+```solidity
+BURN_ADDRESS_X = 3782696719816812986959462081646797447108674627635188387134949121808249992769
+BURN_ADDRESS_Y = 10281180275793753078781257082583594598751421619807573114845203265637415315067
+```
+
+This is an unspendable point, ensuring converted values cannot be double-spent.
+
+## Use Cases
+
+| Scenario | Public Mode | Privacy Mode |
+|----------|-------------|--------------|
+| **DAO Governance** | Treasury management, grant distributions | Anonymous voting, private delegation |
+| **DeFi Trading** | DEX liquidity, staking | Long-term holdings, OTC transfers |
+| **Business Tokens** | Investor reporting, compliance | Employee compensation, strategic reserves |
+
+## License
+
+CC0-1.0

--- a/assets/erc-8085/README.md
+++ b/assets/erc-8085/README.md
@@ -31,10 +31,11 @@ erc-8085/
 │   │   ├── IDualModeToken.sol        # Core interface (ERC-8085)
 │   │   └── IZRC20.sol                # Privacy interface (ERC-8086)
 │   └── reference/
-│       ├── DualModeToken.sol         # Reference implementation
+│       ├── PrivacyToken.sol          # ERC-8086 base layer (abstract)
+│       ├── DualModeToken.sol         # ERC-8085 implementation
 │       └── DualModeTokenFactory.sol  # Factory for token deployment
 └── deployments/
-    └── base-sepolia.json              # Deployment addresses & config
+    ├── base-sepolia.json             
 ```
 
 ## How to Test This Implementation
@@ -47,17 +48,17 @@ A fully functional deployment is available on **Base Sepolia** testnet:
 
 **🔗 Test Application**: [testdmt.zkprotocol.xyz](https://testdmt.zkprotocol.xyz/)
 
-**Deployed Contracts** (verified on Basescan):
+**Deployed Contracts** (Latest - December 2025):
 
 | Contract | Address | Link |
 |----------|---------|------|
-| DualModeTokenFactory | `0xf5c16f708777cCb57C3A8887065b4EC02eAf9130` | [View Code](https://sepolia.basescan.org/address/0xf5c16f708777cCb57C3A8887065b4EC02eAf9130#code) |
-| DualModeToken (Implementation) | `0x1EFab166064AaD33fcB6074Ec8bA6302013C965C` | [View Code](https://sepolia.basescan.org/address/0x1EFab166064AaD33fcB6074Ec8bA6302013C965C#code) |
-| MintVerifier | `0xC655b758f07bAaE8B956c95b055424a5c3B04e79` | [View Code](https://sepolia.basescan.org/address/0xC655b758f07bAaE8B956c95b055424a5c3B04e79#code) |
-| MintRolloverVerifier | `0x9a6898B2e6C963EA81D17dCB9B0D483B590e168f` | [View Code](https://sepolia.basescan.org/address/0x9a6898B2e6C963EA81D17dCB9B0D483B590e168f#code) |
-| ActiveTransferVerifier | `0x7159EcAc6d1BB1433922b597fc2887dCA33a3A62` | [View Code](https://sepolia.basescan.org/address/0x7159EcAc6d1BB1433922b597fc2887dCA33a3A62#code) |
-| FinalizedTransferVerifier | `0x0f9b6F788774671C8c47D8adE9D36E884c96580D` | [View Code](https://sepolia.basescan.org/address/0x0f9b6F788774671C8c47D8adE9D36E884c96580D#code) |
-| RolloverTransferVerifier | `0x0B22df9887351Ecfb403cfB27056f3A371F3bD92` | [View Code](https://sepolia.basescan.org/address/0x0B22df9887351Ecfb403cfB27056f3A371F3bD92#code) |
+| DualModeTokenFactory | `0x64EeF485F82918bBf61dd5349300F5a84f907140` | [View Code](https://sepolia.basescan.org/address/0x64EeF485F82918bBf61dd5349300F5a84f907140#code) |
+| DualModeToken (Implementation) | `0xd8714b3E2B490585c22d5a7a030f3946e46940c4` | [View Code](https://sepolia.basescan.org/address/0xd8714b3E2B490585c22d5a7a030f3946e46940c4#code) |
+| MintVerifier | `0x0C9F3208b44d26B7e5D0ab145d49b050F5C7fFa5` | [View Code](https://sepolia.basescan.org/address/0x0C9F3208b44d26B7e5D0ab145d49b050F5C7fFa5#code) |
+| MintRolloverVerifier | `0x8F1C5De7b7193B0Ce1E9886E5f1c58aE3A5491dF` | [View Code](https://sepolia.basescan.org/address/0x8F1C5De7b7193B0Ce1E9886E5f1c58aE3A5491dF#code) |
+| ActiveTransferVerifier | `0x791cd059fA2b4B2d4015408eF6624BBD2F80d50E` | [View Code](https://sepolia.basescan.org/address/0x791cd059fA2b4B2d4015408eF6624BBD2F80d50E#code) |
+| FinalizedTransferVerifier | `0x96Bb15bE0a79C1f17dFed17b9D57c3DE1C5eA205` | [View Code](https://sepolia.basescan.org/address/0x96Bb15bE0a79C1f17dFed17b9D57c3DE1C5eA205#code) |
+| RolloverTransferVerifier | `0xEB85CA2d80da109fe9348a9B17F2E683BEaa4a07` | [View Code](https://sepolia.basescan.org/address/0xEB85CA2d80da109fe9348a9B17F2E683BEaa4a07#code) |
 
 **Network**: Base Sepolia (Chain ID: 84532)
 
@@ -84,10 +85,17 @@ All contracts are verified on Basescan. You can:
 
 ### Architecture
 
-ERC-8085 combines two standards in a single contract:
-- **Public Mode**: Standard ERC-20 (OpenZeppelin implementation)
-- **Privacy Mode**: ERC-8086 IZRC20 compatible
-- **Mode Conversion**: `toPrivacy()` and `toPublic()` functions
+ERC-8085 uses a layered design (updated December 2025):
+```
+DualModeToken.sol (ERC-8085)
+  ├─ Public Mode: ERC-20 (OpenZeppelin)
+  ├─ Mode Conversion: toPrivacy() / toPublic()
+  └─ Extends: PrivacyToken.sol (ERC-8086 base layer)
+       └─ Privacy Mode: IZRC20 compatible
+```
+
+- **PrivacyToken.sol**: Abstract base contract implementing ERC-8086
+- **DualModeToken.sol**: Extends PrivacyToken with ERC-8085 mode conversion
 
 ### Key Design Decisions
 

--- a/assets/erc-8085/README.md
+++ b/assets/erc-8085/README.md
@@ -38,49 +38,6 @@ erc-8085/
     ├── base-sepolia.json             
 ```
 
-## How to Test This Implementation
-
-Due to the ZK-SNARK requirements, there are two ways to verify this implementation:
-
-### Option 1: Use the Live Testnet Deployment (Recommended)
-
-A fully functional deployment is available on **Base Sepolia** testnet:
-
-**🔗 Test Application**: [testdmt.zkprotocol.xyz](https://testdmt.zkprotocol.xyz/)
-
-**Deployed Contracts** (Latest - December 2025):
-
-| Contract | Address | Link |
-|----------|---------|------|
-| DualModeTokenFactory | `0x64EeF485F82918bBf61dd5349300F5a84f907140` | [View Code](https://sepolia.basescan.org/address/0x64EeF485F82918bBf61dd5349300F5a84f907140#code) |
-| DualModeToken (Implementation) | `0xd8714b3E2B490585c22d5a7a030f3946e46940c4` | [View Code](https://sepolia.basescan.org/address/0xd8714b3E2B490585c22d5a7a030f3946e46940c4#code) |
-| MintVerifier | `0x0C9F3208b44d26B7e5D0ab145d49b050F5C7fFa5` | [View Code](https://sepolia.basescan.org/address/0x0C9F3208b44d26B7e5D0ab145d49b050F5C7fFa5#code) |
-| MintRolloverVerifier | `0x8F1C5De7b7193B0Ce1E9886E5f1c58aE3A5491dF` | [View Code](https://sepolia.basescan.org/address/0x8F1C5De7b7193B0Ce1E9886E5f1c58aE3A5491dF#code) |
-| ActiveTransferVerifier | `0x791cd059fA2b4B2d4015408eF6624BBD2F80d50E` | [View Code](https://sepolia.basescan.org/address/0x791cd059fA2b4B2d4015408eF6624BBD2F80d50E#code) |
-| FinalizedTransferVerifier | `0x96Bb15bE0a79C1f17dFed17b9D57c3DE1C5eA205` | [View Code](https://sepolia.basescan.org/address/0x96Bb15bE0a79C1f17dFed17b9D57c3DE1C5eA205#code) |
-| RolloverTransferVerifier | `0xEB85CA2d80da109fe9348a9B17F2E683BEaa4a07` | [View Code](https://sepolia.basescan.org/address/0xEB85CA2d80da109fe9348a9B17F2E683BEaa4a07#code) |
-
-**Network**: Base Sepolia (Chain ID: 84532)
-
-**Testing Instructions**:
-1. Visit [testdmt.zkprotocol.xyz](https://testdmt.zkprotocol.xyz/)
-2. Connect a wallet to Base Sepolia testnet
-3. Get test ETH from [Base Sepolia faucet](https://www.alchemy.com/faucets/base-sepolia)
-4. Mint public tokens (ERC-20)
-5. Convert to privacy mode: `toPrivacy()`
-6. Perform privacy transfers
-7. Convert back to public: `toPublic()`
-8. Verify transactions on [Base Sepolia explorer](https://sepolia.basescan.org/)
-
-### Option 2: Review Contract Code On-Chain
-
-All contracts are verified on Basescan. You can:
-- Read the full source code directly on Basescan
-- Verify the bytecode matches the source
-- Review all constructor parameters
-- Check deployment history
-- Inspect transaction history
-
 ## Implementation Notes
 
 ### Architecture

--- a/assets/erc-8085/README.md
+++ b/assets/erc-8085/README.md
@@ -46,7 +46,7 @@ ERC-8085 uses a layered design (updated December 2025):
 ```
 DualModeToken.sol (ERC-8085)
   ├─ Public Mode: ERC-20 (OpenZeppelin)
-  ├─ Mode Conversion: toPrivacy() / toPublic()
+  ├─ Mode Conversion: toPrivate() / toPublic()
   └─ Extends: PrivacyToken.sol (ERC-8086 base layer)
        └─ Privacy Mode: IZRC20 compatible
 ```
@@ -69,10 +69,10 @@ DualModeToken.sol (ERC-8085)
 
 ### Mode Conversion Flow
 
-**Public → Privacy** (`toPrivacy`):
+**Public → Privacy** (`toPrivate`):
 ```solidity
 1. User holds 100 ERC-20 tokens
-2. Calls toPrivacy(100, proof, encryptedNote)
+2. Calls toPrivate(100, proof, encryptedNote)
 3. Contract burns 100 ERC-20 tokens
 4. Contract creates privacy commitment (ZK proof verified)
 5. Result: -100 public, +100 privacy, totalSupply unchanged

--- a/assets/erc-8085/contracts/interfaces/IDualModeToken.sol
+++ b/assets/erc-8085/contracts/interfaces/IDualModeToken.sol
@@ -14,37 +14,9 @@ import "./IZRC20.sol";
  * Architecture:
  *   - Public Mode: Standard ERC-20 (transparent balances and transfers)
  *   - Privacy Mode: ERC-8086 IZRC20 (ZK-SNARK protected balances and transfers)
- *   - Mode Conversion: toPrivacy (public → private) and toPublic (private → public)
+ *   - Mode Conversion: toPrivate (public → private) and toPublic (private → public)
  */
 interface IDualModeToken is IERC20, IZRC20 {
-
-    // ═══════════════════════════════════════════════════════════════════════
-    // Events (Mode Conversion Specific)
-    // ═══════════════════════════════════════════════════════════════════════
-
-    /// @notice Emitted when value is converted from transparent to privacy mode
-    /// @param account The address converting tokens
-    /// @param amount The amount converted
-    /// @param commitment The cryptographic commitment created
-    /// @param timestamp Block timestamp of conversion
-    event ConvertToPrivacy(
-        address indexed account,
-        uint256 amount,
-        bytes32 indexed commitment,
-        uint256 timestamp
-    );
-
-    /// @notice Emitted when value is converted from privacy to transparent mode
-    /// @param initiator The address initiating the conversion
-    /// @param recipient The address receiving transparent tokens
-    /// @param amount The amount converted
-    /// @param timestamp Block timestamp of conversion
-    event ConvertToPublic(
-        address indexed initiator,
-        address indexed recipient,
-        uint256 amount,
-        uint256 timestamp
-    );
 
     // ═══════════════════════════════════════════════════════════════════════
     // Mode Conversion Functions (Core of ERC-8085)
@@ -58,7 +30,7 @@ interface IDualModeToken is IERC20, IZRC20 {
      * @param proof ZK-SNARK proof of valid commitment creation
      * @param encryptedNote Encrypted note data for recipient wallet
      */
-    function toPrivacy(
+    function toPrivate(
         uint256 amount,
         uint8 proofType,
         bytes calldata proof,

--- a/assets/erc-8085/contracts/interfaces/IDualModeToken.sol
+++ b/assets/erc-8085/contracts/interfaces/IDualModeToken.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./IZRC20.sol";
+
+/**
+ * @title IDualModeToken
+ * @notice Interface for dual-mode tokens (ERC-8085) combining ERC-20 and ERC-8086 (IZRC20)
+ * @dev Implementations MUST inherit both IERC20 and IZRC20
+ *      Privacy events and core functions are inherited from IZRC20 (ERC-8086)
+ *      This interface only defines mode conversion logic - the core value of ERC-8085
+ *
+ * Architecture:
+ *   - Public Mode: Standard ERC-20 (transparent balances and transfers)
+ *   - Privacy Mode: ERC-8086 IZRC20 (ZK-SNARK protected balances and transfers)
+ *   - Mode Conversion: toPrivacy (public → private) and toPublic (private → public)
+ */
+interface IDualModeToken is IERC20, IZRC20 {
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Events (Mode Conversion Specific)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @notice Emitted when value is converted from transparent to privacy mode
+    /// @param account The address converting tokens
+    /// @param amount The amount converted
+    /// @param commitment The cryptographic commitment created
+    /// @param timestamp Block timestamp of conversion
+    event ConvertToPrivacy(
+        address indexed account,
+        uint256 amount,
+        bytes32 indexed commitment,
+        uint256 timestamp
+    );
+
+    /// @notice Emitted when value is converted from privacy to transparent mode
+    /// @param initiator The address initiating the conversion
+    /// @param recipient The address receiving transparent tokens
+    /// @param amount The amount converted
+    /// @param timestamp Block timestamp of conversion
+    event ConvertToPublic(
+        address indexed initiator,
+        address indexed recipient,
+        uint256 amount,
+        uint256 timestamp
+    );
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Mode Conversion Functions (Core of ERC-8085)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Convert transparent balance to privacy mode
+     * @dev Burns ERC-20 tokens and creates privacy commitment via IZRC20
+     * @param amount Amount to convert (must match proof)
+     * @param proofType Type of proof to support multiple proof strategies.
+     * @param proof ZK-SNARK proof of valid commitment creation
+     * @param encryptedNote Encrypted note data for recipient wallet
+     */
+    function toPrivacy(
+        uint256 amount,
+        uint8 proofType,
+        bytes calldata proof,
+        bytes calldata encryptedNote
+    ) external;
+
+    /**
+     * @notice Convert privacy balance to transparent mode
+     * @dev Spends privacy notes and mints ERC-20 tokens to recipient
+     * @param recipient Address to receive public tokens
+     * @param proofType Type of proof to support multiple proof strategies.
+     * @param proof ZK-SNARK proof of note ownership and spending
+     * @param encryptedNotes Encrypted notes for change outputs (if any)
+     */
+    function toPublic(
+        address recipient,
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) external;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Supply Tracking
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // Note: Privacy transfers use IZRC20.transfer(uint8, bytes, bytes[])
+    // which is inherited from IZRC20 (ERC-8086)
+
+    /**
+     * @notice Total supply across both modes (overrides IERC20 and IZRC20)
+     * @return Total supply = publicSupply + privacySupply
+     */
+    function totalSupply() external view override(IERC20, IZRC20) returns (uint256);
+
+    /**
+     * @notice Get total supply in privacy mode
+     * @dev Tracked by increments/decrements during mode conversions
+     * @return Total privacy supply
+     */
+    function totalPrivacySupply() external view returns (uint256);
+
+    /**
+     * @notice Check if a nullifier has been spent
+     * @dev Alias for IZRC20.nullifiers() with different naming convention
+     * @param nullifier The nullifier hash to check
+     * @return True if spent, false otherwise
+     */
+    function isNullifierSpent(bytes32 nullifier) external view returns (bool);
+}

--- a/assets/erc-8085/contracts/interfaces/IZRC20.sol
+++ b/assets/erc-8085/contracts/interfaces/IZRC20.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+/**
+ * @title IZRC20
+ * @notice Minimal interface for native privacy assets on Ethereum (ERC-8086)
+ * @dev This standard defines the foundation for privacy-preserving tokens
+ *      that can be used directly or as building blocks for wrapper protocols
+ *      and dual-mode protocols implementations.
+ */
+interface IZRC20 {
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Events
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Emitted when a commitment is added to the Merkle tree
+     * @param subtreeIndex Subtree index (0 for single-tree implementations)
+     * @param commitment The cryptographic commitment hash
+     * @param leafIndex Position within subtree (or global index)
+     * @param timestamp Block timestamp of insertion
+     * @dev For single-tree: subtreeIndex SHOULD be 0, leafIndex is global position
+     * @dev For dual-tree: subtreeIndex identifies which subtree, leafIndex is position within it
+     */
+    event CommitmentAppended(
+        uint32 indexed subtreeIndex,
+        bytes32 commitment,
+        uint32 indexed leafIndex,
+        uint256 timestamp
+    );
+
+    /**
+     * @notice Emitted when a nullifier is spent (note consumed)
+     * @param nullifier The unique nullifier hash
+     * @dev Once spent, nullifier can never be reused (prevents double-spending)
+     */
+    event NullifierSpent(bytes32 indexed nullifier);
+
+    /**
+     * @notice Emitted when tokens are minted directly into privacy mode
+     * @param minter Address that initiated the mint
+     * @param commitment The commitment created for minted value
+     * @param encryptedNote Encrypted note for recipient
+     * @param subtreeIndex Subtree where commitment was added
+     * @param leafIndex Position within subtree
+     * @param timestamp Block timestamp of mint
+     */
+    event Minted(
+        address indexed minter,
+        bytes32 commitment,
+        bytes encryptedNote,
+        uint32 subtreeIndex,
+        uint32 leafIndex,
+        uint256 timestamp
+    );
+
+    /**
+     * @notice Emitted on privacy transfers with public scanning data
+     * @param newCommitments Output commitments created (typically 1-2)
+     * @param encryptedNotes Encrypted notes for recipients
+     * @param ephemeralPublicKey Ephemeral public key for ECDH key exchange (if used)
+     * @param viewTag Scanning optimization byte (0 if not used)
+     * @dev Provides data for recipients to detect and decrypt their notes
+     */
+    event Transaction(
+        bytes32[2] newCommitments,
+        bytes[] encryptedNotes,
+        uint256[2] ephemeralPublicKey,
+        uint256 viewTag
+    );
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Metadata (ERC-20 compatible, OPTIONAL but RECOMMENDED)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Returns the token name
+     * @return Token name string
+     * @dev OPTIONAL but RECOMMENDED for UX and interoperability
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @notice Returns the token symbol
+     * @return Token symbol string
+     * @dev OPTIONAL but RECOMMENDED for UX and interoperability
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @notice Returns the number of decimals
+     * @return Number of decimals (typically 18)
+     * @dev OPTIONAL but RECOMMENDED for amount formatting
+     */
+    function decimals() external view returns (uint8);
+
+    /**
+     * @notice Returns the total supply across all privacy notes
+     * @return Total token supply
+     * @dev OPTIONAL - May be required for certain economic models (e.g., fixed cap)
+     *      Individual balances remain private; only aggregate supply is visible
+     */
+    function totalSupply() external view returns (uint256);
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Core Functions
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Mints new privacy tokens
+     * @param proofType Type of proof to support multiple proof strategies.
+     * @param proof Zero-knowledge proof of valid transfer
+     * @param encryptedNote Encrypted note for minter's wallet
+     * @dev Proof must demonstrate valid commitment creation and payment
+     *      Implementations define minting rules
+     */
+    function mint(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes calldata encryptedNote
+    ) external payable;
+
+    /**
+     * @notice Executes a privacy-preserving transfer
+     * @param proofType Implementation-specific proof type identifier
+     * @param proof Zero-knowledge proof of valid transfer
+     * @param encryptedNotes Encrypted output notes (for recipient and/or change)
+     * @dev Proof must demonstrate:
+     *      1. Input commitments exist in Merkle tree
+     *      2. Prover knows private keys
+     *      3. Nullifiers not spent
+     *      4. Value conservation: sum(inputs) = sum(outputs)
+     */
+    function transfer(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) external;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Query Functions
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Check if a nullifier has been spent
+     * @param nullifier The nullifier to check
+     * @return True if nullifier spent, false otherwise
+     * @dev Implementations using `mapping(bytes32 => bool) public nullifiers`
+     *      will auto-generate this function.
+     */
+    function nullifiers(bytes32 nullifier) external view returns (bool);
+
+    /**
+     * @notice Returns the current active subtree Merkle root
+     * @return The root hash of the active subtree
+     * @dev The active subtree stores recent commitments for faster proof computation.
+     *      For dual-tree implementations, this is the root of the current working subtree.
+     */
+    function activeSubtreeRoot() external view returns (bytes32);
+}

--- a/assets/erc-8085/contracts/reference/DualModeToken.sol
+++ b/assets/erc-8085/contracts/reference/DualModeToken.sol
@@ -14,12 +14,12 @@ import "../interfaces/IDualModeToken.sol";
 * Architecture:
  *   - Public Mode: Standard ERC-20 (OpenZeppelin)
  *   - Privacy Mode: ERC-8086 IZRC20 compatible
- *   - Mode Conversion: toPrivacy() / toPublic()
+ *   - Mode Conversion: toPrivate() / toPublic()
  *Layered Design:
  *   ┌─────────────────────────────────────────┐
  *   │    DualModeToken (ERC-8085 Layer)       │
  *   │  - Public mode (ERC-20)                 │
- *   │  - Mode conversion (toPrivacy/toPublic) │
+ *   │  - Mode conversion (toPrivate/toPublic) │
  *   │                                         │
  *   ├─────────────────────────────────────────┤
  *   │    PrivacyToken (ERC-8086 Layer)        │
@@ -31,7 +31,7 @@ import "../interfaces/IDualModeToken.sol";
  * Key Features:
  *   - Unified token with dual capabilities
  *   - totalSupply = publicSupply + privacySupply
- *   - Seamless mode conversion: toPrivacy() switch token into privacy mode
+ *   - Seamless mode conversion: toPrivate() switch token into privacy mode
  *   - Seamless mode conversion: toPublic() switch token into public mode
  *
  * Design Philosophy:
@@ -215,7 +215,7 @@ contract DualModeToken is PrivacyToken, ERC20, IDualModeToken {
 
     /**
      * @notice Direct privacy mint is NOT supported for dual-mode tokens
-     * @dev Use mintPublic() to get public tokens, then toPrivacy() to convert
+     * @dev Use mintPublic() to get public tokens, then toPrivate() to convert
      *      This design ensures all tokens enter through the public mode first,
      *      maintaining supply transparency and preventing hidden inflation.
      */
@@ -239,7 +239,7 @@ contract DualModeToken is PrivacyToken, ERC20, IDualModeToken {
      * @param proof ZK-SNARK proof of valid commitment creation
      * @param encryptedNote Encrypted note data for recipient wallet
      */
-    function toPrivacy(
+    function toPrivate(
         uint256 amount,
         uint8 proofType,
         bytes calldata proof,
@@ -251,9 +251,7 @@ contract DualModeToken is PrivacyToken, ERC20, IDualModeToken {
         _burn(msg.sender, amount);
 
         // 2. Create privacy commitment (PrivacyToken layer)
-        bytes32 commitment = _privacyMint(amount, proofType, proof, encryptedNote);
-
-        emit ConvertToPrivacy(msg.sender, amount, commitment, block.timestamp);
+        _privacyMint(amount, proofType, proof, encryptedNote);
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -281,8 +279,6 @@ contract DualModeToken is PrivacyToken, ERC20, IDualModeToken {
 
         // 2. Mint public tokens (ERC-20 layer)
         _mint(recipient, conversionAmount);
-
-        emit ConvertToPublic(msg.sender, recipient, conversionAmount, block.timestamp);
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/assets/erc-8085/contracts/reference/DualModeToken.sol
+++ b/assets/erc-8085/contracts/reference/DualModeToken.sol
@@ -1,0 +1,606 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "../interfaces/IZRC20.sol";
+import "../verifiers/IVerifier.sol";
+import "../interfaces/IDualModeToken.sol";
+
+/**
+ * @title DualModeToken
+ * @notice Dual-mode token (ERC-8085) combining ERC-20 and ERC-8086 privacy features
+ * @dev This contract implements both transparent (ERC-20) and privacy (IZRC20) modes
+ *      with seamless conversion between them.
+ *
+ * Architecture:
+ *   - Public Mode: Standard ERC-20 (OpenZeppelin)
+ *   - Privacy Mode: ERC-8086 IZRC20 compatible
+ *   - Mode Conversion: toPrivacy() / toPublic()
+ *
+ * Key Features:
+ *   - Unified token with dual capabilities
+ *   - totalSupply = publicSupply + privacySupply
+ *   - ZK-SNARK proof verification for all privacy operations
+ */
+contract DualModeToken is ERC20, ReentrancyGuard, IDualModeToken {
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Custom Errors
+    // ═══════════════════════════════════════════════════════════════════════
+    error AlreadyInitialized();
+    error MaxSupplyExceeded();
+    error IncorrectMintPrice(uint256 expected, uint256 sent);
+    error IncorrectMintAmount(uint256 expected, uint256 actual);
+    error InsufficientPublicBalance();
+    error DirectPrivacyMintNotSupported();
+    error ZeroAddress();
+    error NoFeesToDistribute();
+    error FeeTransferFailed();
+    error InvalidProofType(uint8 receivedType);
+    error InvalidProof();
+    error CommitmentAlreadyExists(bytes32 commitment);
+    error DoubleSpend(bytes32 nullifier);
+    error OldActiveRootMismatch(bytes32 expected, bytes32 received);
+    error OldFinalizedRootMismatch(bytes32 expected, bytes32 received);
+    error IncorrectSubtreeIndex(uint256 expected, uint256 received);
+    error InvalidStateForRegularMint();
+    error InvalidStateForRollover();
+    error SubtreeCapacityExceeded(uint256 needed, uint256 available);
+    error InvalidConversionAmount(uint256 expected, uint256 proven);
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Constants
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @dev Burn address for toPublic conversion (unspendable point on curve)
+    uint256 public constant BURN_ADDRESS_X = 3782696719816812986959462081646797447108674627635188387134949121808249992769;
+    uint256 public constant BURN_ADDRESS_Y = 10281180275793753078781257082583594598751421619807573114845203265637415315067;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // State Variables - Configuration
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @dev Token metadata (stored separately for clone pattern compatibility)
+    string private _tokenName;
+    string private _tokenSymbol;
+
+    uint256 public MAX_SUPPLY;
+    uint256 public PUBLIC_MINT_PRICE;
+    uint256 public PUBLIC_MINT_AMOUNT;
+    address public platformTreasury;
+    uint256 public platformFeeBps;
+    address public initiator;  // Token creator, receives fees
+    bool private _initialized;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // State Variables - Privacy (IZRC20 / ERC-8086)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @dev ZK Verifiers
+    IActiveTransferVerifier public activeTransferVerifier;
+    IFinalizedTransferVerifier public finalizedTransferVerifier;
+    ITransferRolloverVerifier public rolloverTransferVerifier;
+    IMintVerifier public mintVerifier;
+    IMintRolloverVerifier public mintRolloverVerifier;
+
+    /// @dev Privacy state
+    mapping(bytes32 => bool) public override nullifiers;
+    mapping(bytes32 => bool) public commitmentHashes;
+    uint256 public privacyTotalSupply;
+
+    /// @dev Merkle tree state (packed for gas efficiency)
+    struct ContractState {
+        uint32 currentSubtreeIndex;
+        uint32 nextLeafIndexInSubtree;
+        uint8 subTreeHeight;
+        uint8 rootTreeHeight;
+        bool initialized;
+    }
+    ContractState public state;
+
+    /// @dev Tree roots
+    bytes32 public EMPTY_SUBTREE_ROOT;
+    bytes32 public override activeSubtreeRoot;
+    bytes32 public finalizedRoot;
+    uint256 public SUBTREE_CAPACITY;
+
+    /// @dev Transaction data structure for internal processing
+    struct TransactionData {
+        bytes32[2] nullifiers;
+        bytes32[2] commitments;
+        uint256[2] ephemeralPublicKey;
+        uint256 viewTag;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Constructor & Initialization
+    // ═══════════════════════════════════════════════════════════════════════
+
+    constructor() ERC20("", "") {}
+
+    /**
+     * @notice Initialize the dual-mode token (called by factory via clone pattern)
+     */
+    function initialize(
+        string memory name_,
+        string memory symbol_,
+        uint256 maxSupply_,
+        uint256 publicMintPrice_,
+        uint256 publicMintAmount_,
+        address platformTreasury_,
+        uint256 platformFeeBps_,
+        address initiator_,
+        address[5] memory verifiers_,
+        uint8 subtreeHeight_,
+        uint8 rootTreeHeight_,
+        bytes32 initialSubtreeEmptyRoot_,
+        bytes32 initialFinalizedEmptyRoot_
+    ) external {
+        if (_initialized) revert AlreadyInitialized();
+        _initialized = true;
+
+        // ERC20 metadata (stored in our own storage variables)
+        _tokenName = name_;
+        _tokenSymbol = symbol_;
+
+        // Configuration
+        MAX_SUPPLY = maxSupply_;
+        PUBLIC_MINT_PRICE = publicMintPrice_;
+        PUBLIC_MINT_AMOUNT = publicMintAmount_;
+        platformTreasury = platformTreasury_;
+        platformFeeBps = platformFeeBps_;
+        initiator = initiator_;
+
+        // Verifiers
+        mintVerifier = IMintVerifier(verifiers_[0]);
+        mintRolloverVerifier = IMintRolloverVerifier(verifiers_[1]);
+        activeTransferVerifier = IActiveTransferVerifier(verifiers_[2]);
+        finalizedTransferVerifier = IFinalizedTransferVerifier(verifiers_[3]);
+        rolloverTransferVerifier = ITransferRolloverVerifier(verifiers_[4]);
+
+        // Privacy tree state
+        state.subTreeHeight = subtreeHeight_;
+        SUBTREE_CAPACITY = 1 << subtreeHeight_;
+        state.rootTreeHeight = rootTreeHeight_;
+        EMPTY_SUBTREE_ROOT = initialSubtreeEmptyRoot_;
+        activeSubtreeRoot = initialSubtreeEmptyRoot_;
+        finalizedRoot = initialFinalizedEmptyRoot_;
+        state.nextLeafIndexInSubtree = 0;
+        state.initialized = true;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ERC-20 Metadata Overrides
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function name() public view override(ERC20, IZRC20) returns (string memory) {
+        return _tokenName;
+    }
+
+    function symbol() public view override(ERC20, IZRC20) returns (string memory) {
+        return _tokenSymbol;
+    }
+
+    function decimals() public pure override(ERC20, IZRC20) returns (uint8) {
+        return 18;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Supply Tracking (ERC-8085 Requirement)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Total supply across both modes (ERC-20 + Privacy)
+     * @dev ERC-8085 requirement: totalSupply = publicSupply + privacySupply
+     */
+    function totalSupply() public view override(ERC20, IDualModeToken) returns (uint256) {
+        return ERC20.totalSupply() + privacyTotalSupply;
+    }
+
+    /**
+     * @notice Total supply in privacy mode only
+     */
+    function totalPrivacySupply() external view override returns (uint256) {
+        return privacyTotalSupply;
+    }
+
+    /**
+     * @notice Check if nullifier has been spent
+     */
+    function isNullifierSpent(bytes32 nullifier) external view override returns (bool) {
+        return nullifiers[nullifier];
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Public Minting (ERC-20)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Mint public tokens (standard ERC-20)
+     */
+    function mintPublic(address to, uint256 amount) external payable nonReentrant {
+        if (msg.value != PUBLIC_MINT_PRICE) revert IncorrectMintPrice(PUBLIC_MINT_PRICE, msg.value);
+        if (amount != PUBLIC_MINT_AMOUNT) revert IncorrectMintAmount(PUBLIC_MINT_AMOUNT, amount);
+        if (totalSupply() + amount > MAX_SUPPLY) revert MaxSupplyExceeded();
+
+        _mint(to, amount);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // IZRC20.mint - NOT SUPPORTED for Dual-Mode Tokens
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Direct privacy mint is NOT supported for dual-mode tokens
+     * @dev Use mintPublic() to get public tokens, then toPrivacy() to convert
+     *      This design ensures all tokens enter through the public mode first
+     */
+    function mint(
+        uint8,
+        bytes calldata,
+        bytes calldata
+    ) external payable override {
+        revert DirectPrivacyMintNotSupported();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Mode Conversion: Public → Privacy (ERC-8085 Core)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Convert public balance to privacy mode
+     * @dev Burns ERC-20 tokens and creates privacy commitment
+     */
+    function toPrivacy(
+        uint256 amount,
+        uint8 proofType,
+        bytes calldata proof,
+        bytes calldata encryptedNote
+    ) external override nonReentrant {
+        if (balanceOf(msg.sender) < amount) revert InsufficientPublicBalance();
+
+        // 1. Burn public tokens
+        _burn(msg.sender, amount);
+
+        // 2. Create privacy commitment
+        bytes32 commitment = _privacyMint(amount, proofType, proof, encryptedNote);
+
+        emit ConvertToPrivacy(msg.sender, amount, commitment, block.timestamp);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Mode Conversion: Privacy → Public (ERC-8085 Core)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Convert privacy balance to public mode
+     * @dev Spends privacy notes and mints ERC-20 tokens
+     */
+    function toPublic(
+        address recipient,
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) external override nonReentrant {
+        if (recipient == address(0)) revert ZeroAddress();
+
+        // 1. Spend privacy notes and get conversion amount
+        uint256 conversionAmount = _privacyBurn(proofType, proof, encryptedNotes);
+
+        // 2. Mint public tokens (no fee for mode conversion)
+        _mint(recipient, conversionAmount);
+
+        emit ConvertToPublic(msg.sender, recipient, conversionAmount, block.timestamp);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Privacy Transfer (IZRC20 / ERC-8086)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Privacy-preserving transfer (IZRC20.transfer)
+     */
+    function transfer(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) external override(IZRC20) {
+        _privacyTransfer(proofType, proof, encryptedNotes);
+    }
+    
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Internal: Privacy Mint
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function _privacyMint(
+        uint256 expectedAmount,
+        uint8 proofType,
+        bytes calldata proof,
+        bytes calldata encryptedNote
+    ) internal returns (bytes32 commitment) {
+        if (proofType == 0) {
+            commitment = _mintRegular(expectedAmount, proof, encryptedNote);
+        } else if (proofType == 1) {
+            commitment = _mintAndRollover(expectedAmount, proof, encryptedNote);
+        } else {
+            revert InvalidProofType(proofType);
+        }
+        privacyTotalSupply += expectedAmount;
+    }
+
+    function _mintRegular(
+        uint256 expectedAmount,
+        bytes calldata _proof,
+        bytes calldata _encryptedNote
+    ) private returns (bytes32) {
+        if (state.nextLeafIndexInSubtree >= SUBTREE_CAPACITY) revert InvalidStateForRegularMint();
+
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[4] memory pubSignals) =
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[4]));
+
+        bytes32 newActiveRoot = bytes32(pubSignals[0]);
+        bytes32 oldActiveRoot = bytes32(pubSignals[1]);
+        bytes32 newCommitment = bytes32(pubSignals[2]);
+        uint256 mintAmount = pubSignals[3];
+
+        if (expectedAmount != mintAmount) revert IncorrectMintAmount(expectedAmount, mintAmount);
+        if (commitmentHashes[newCommitment]) revert CommitmentAlreadyExists(newCommitment);
+        if (activeSubtreeRoot != oldActiveRoot) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot);
+        if (!mintVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        commitmentHashes[newCommitment] = true;
+        activeSubtreeRoot = newActiveRoot;
+
+        emit CommitmentAppended(state.currentSubtreeIndex, newCommitment, state.nextLeafIndexInSubtree, block.timestamp);
+        emit Minted(msg.sender, newCommitment, _encryptedNote, state.currentSubtreeIndex, state.nextLeafIndexInSubtree, block.timestamp);
+
+        state.nextLeafIndexInSubtree++;
+        return newCommitment;
+    }
+
+    function _mintAndRollover(
+        uint256 expectedAmount,
+        bytes calldata _proof,
+        bytes calldata _encryptedNote
+    ) private returns (bytes32) {
+        if (state.nextLeafIndexInSubtree != SUBTREE_CAPACITY) revert InvalidStateForRollover();
+
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[7] memory pubSignals) =
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[7]));
+
+        bytes32 newActiveRoot = bytes32(pubSignals[0]);
+        bytes32 newFinalizedRoot = bytes32(pubSignals[1]);
+        bytes32 oldActiveRoot = bytes32(pubSignals[2]);
+        bytes32 oldFinalizedRoot = bytes32(pubSignals[3]);
+        bytes32 newCommitment = bytes32(pubSignals[4]);
+        uint256 mintAmount = pubSignals[5];
+        uint256 subtreeIndex = pubSignals[6];
+
+        if (expectedAmount != mintAmount) revert IncorrectMintAmount(expectedAmount, mintAmount);
+        if (commitmentHashes[newCommitment]) revert CommitmentAlreadyExists(newCommitment);
+        if (activeSubtreeRoot != oldActiveRoot) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot);
+        if (finalizedRoot != oldFinalizedRoot) revert OldFinalizedRootMismatch(finalizedRoot, oldFinalizedRoot);
+        if (state.currentSubtreeIndex != subtreeIndex) revert IncorrectSubtreeIndex(state.currentSubtreeIndex, subtreeIndex);
+        if (!mintRolloverVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        commitmentHashes[newCommitment] = true;
+        activeSubtreeRoot = newActiveRoot;
+        finalizedRoot = newFinalizedRoot;
+        state.currentSubtreeIndex++;
+        state.nextLeafIndexInSubtree = 0;
+
+        emit CommitmentAppended(state.currentSubtreeIndex, newCommitment, state.nextLeafIndexInSubtree, block.timestamp);
+        emit Minted(msg.sender, newCommitment, _encryptedNote, state.currentSubtreeIndex, state.nextLeafIndexInSubtree, block.timestamp);
+
+        state.nextLeafIndexInSubtree++;
+        return newCommitment;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Internal: Privacy Transfer
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function _privacyTransfer(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) internal {
+        if (proofType == 0) {
+            _transferActive(proof, encryptedNotes, false);
+        } else if (proofType == 1) {
+            _transferFinalized(proof, encryptedNotes, false);
+        } else if (proofType == 2) {
+            _transferAndRollover(proof, encryptedNotes);
+        } else {
+            revert InvalidProofType(proofType);
+        }
+    }
+
+    function _privacyBurn(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) internal returns (uint256 burnAmount) {
+        if (proofType == 0) {
+            burnAmount = _transferActive(proof, encryptedNotes, true);
+        } else if (proofType == 1) {
+            burnAmount = _transferFinalized(proof, encryptedNotes, true);
+        } else {
+            revert InvalidProofType(proofType);
+        }
+        privacyTotalSupply -= burnAmount;
+    }
+
+    function _transferActive(
+        bytes calldata _proof,
+        bytes[] calldata _encryptedNotes,
+        bool isModeConversion
+    ) private returns (uint256 conversionAmount) {
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[13] memory pubSignals) =
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[13]));
+
+        bytes32 newActiveRoot = bytes32(pubSignals[2]);
+        uint256 numRealOutputs = pubSignals[3];
+        conversionAmount = pubSignals[4];
+        bytes32 oldActiveRoot = bytes32(pubSignals[5]);
+
+        // Mode conversion validation
+        if (isModeConversion) {
+            if (conversionAmount == 0) revert InvalidConversionAmount(1, 0);
+            uint256 recipientX = pubSignals[10];
+            uint256 recipientY = pubSignals[11];
+            if (recipientX != BURN_ADDRESS_X || recipientY != BURN_ADDRESS_Y) {
+                revert InvalidConversionAmount(0, 1);
+            }
+        } else {
+            if (conversionAmount != 0) revert InvalidConversionAmount(0, conversionAmount);
+        }
+
+        uint256 availableCapacity = SUBTREE_CAPACITY - state.nextLeafIndexInSubtree;
+        if (numRealOutputs > availableCapacity) revert SubtreeCapacityExceeded(numRealOutputs, availableCapacity);
+        if (activeSubtreeRoot != oldActiveRoot) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot);
+        if (!activeTransferVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        activeSubtreeRoot = newActiveRoot;
+
+        TransactionData memory data;
+        data.ephemeralPublicKey = [pubSignals[0], pubSignals[1]];
+        data.nullifiers = [bytes32(pubSignals[6]), bytes32(pubSignals[7])];
+        data.commitments = [bytes32(pubSignals[8]), bytes32(pubSignals[9])];
+        data.viewTag = pubSignals[12];
+
+        _processTransaction(data, _encryptedNotes);
+    }
+
+    function _transferFinalized(
+        bytes calldata _proof,
+        bytes[] calldata _encryptedNotes,
+        bool isModeConversion
+    ) private returns (uint256 conversionAmount) {
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[14] memory pubSignals) =
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[14]));
+
+        bytes32 newActiveRoot = bytes32(pubSignals[2]);
+        uint256 numRealOutputs = pubSignals[3];
+        conversionAmount = pubSignals[4];
+        bytes32 oldFinalizedRoot = bytes32(pubSignals[5]);
+        bytes32 oldActiveRoot = bytes32(pubSignals[6]);
+
+        if (isModeConversion) {
+            if (conversionAmount == 0) revert InvalidConversionAmount(1, 0);
+            uint256 recipientX = pubSignals[11];
+            uint256 recipientY = pubSignals[12];
+            if (recipientX != BURN_ADDRESS_X || recipientY != BURN_ADDRESS_Y) {
+                revert InvalidConversionAmount(0, 1);
+            }
+        } else {
+            if (conversionAmount != 0) revert InvalidConversionAmount(0, conversionAmount);
+        }
+
+        uint256 availableCapacity = SUBTREE_CAPACITY - state.nextLeafIndexInSubtree;
+        if (numRealOutputs > availableCapacity) revert SubtreeCapacityExceeded(numRealOutputs, availableCapacity);
+        if (activeSubtreeRoot != oldActiveRoot) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot);
+        if (finalizedRoot != oldFinalizedRoot) revert OldFinalizedRootMismatch(finalizedRoot, oldFinalizedRoot);
+        if (!finalizedTransferVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        activeSubtreeRoot = newActiveRoot;
+
+        TransactionData memory data;
+        data.ephemeralPublicKey = [pubSignals[0], pubSignals[1]];
+        data.nullifiers = [bytes32(pubSignals[7]), bytes32(pubSignals[8])];
+        data.commitments = [bytes32(pubSignals[9]), bytes32(pubSignals[10])];
+        data.viewTag = pubSignals[13];
+
+        _processTransaction(data, _encryptedNotes);
+    }
+
+    function _transferAndRollover(
+        bytes calldata _proof,
+        bytes[] calldata _encryptedNotes
+    ) private {
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[13] memory pubSignals) =
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[13]));
+
+        bytes32 newActive = bytes32(pubSignals[2]);
+        bytes32 newFinalized = bytes32(pubSignals[3]);
+        uint256 conversionAmount = pubSignals[4];
+        bytes32 oldActive = bytes32(pubSignals[5]);
+        bytes32 oldFinalized = bytes32(pubSignals[6]);
+        uint256 subtreeIndex = pubSignals[12];
+
+        // Rollover doesn't support mode conversion
+        if (conversionAmount != 0) revert InvalidConversionAmount(0, conversionAmount);
+        if (state.nextLeafIndexInSubtree != SUBTREE_CAPACITY) revert InvalidStateForRollover();
+        if (activeSubtreeRoot != oldActive) revert OldActiveRootMismatch(activeSubtreeRoot, oldActive);
+        if (finalizedRoot != oldFinalized) revert OldFinalizedRootMismatch(finalizedRoot, oldFinalized);
+        if (state.currentSubtreeIndex != subtreeIndex) revert IncorrectSubtreeIndex(state.currentSubtreeIndex, subtreeIndex);
+        if (!rolloverTransferVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        activeSubtreeRoot = newActive;
+        finalizedRoot = newFinalized;
+        state.currentSubtreeIndex++;
+        state.nextLeafIndexInSubtree = 0;
+
+        TransactionData memory data;
+        data.ephemeralPublicKey = [pubSignals[0], pubSignals[1]];
+        data.nullifiers = [bytes32(pubSignals[7]), bytes32(0)];
+        data.commitments = [bytes32(pubSignals[8]), bytes32(0)];
+        data.viewTag = pubSignals[11];
+
+        _processTransaction(data, _encryptedNotes);
+    }
+
+    function _processTransaction(
+        TransactionData memory _data,
+        bytes[] calldata _encryptedNotes
+    ) private {
+        // Spend nullifiers
+        for (uint32 i = 0; i < _data.nullifiers.length; i++) {
+            bytes32 n = _data.nullifiers[i];
+            if (n != bytes32(0)) {
+                if (nullifiers[n]) revert DoubleSpend(n);
+                nullifiers[n] = true;
+                emit NullifierSpent(n);
+            }
+        }
+
+        // Append commitments
+        for (uint i = 0; i < _data.commitments.length; i++) {
+            bytes32 c = _data.commitments[i];
+            if (c != bytes32(0)) {
+                emit CommitmentAppended(state.currentSubtreeIndex, c, state.nextLeafIndexInSubtree, block.timestamp);
+                state.nextLeafIndexInSubtree++;
+            }
+        }
+
+        emit Transaction(_data.commitments, _encryptedNotes, _data.ephemeralPublicKey, _data.viewTag);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Fee Distribution
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Distribute collected mint fees to platform and token creator
+     * @dev Fees are split: platformFeeBps to platform, remainder to initiator
+     */
+    function distributeFees() external nonReentrant {
+        uint256 balance = address(this).balance;
+        if (balance == 0) revert NoFeesToDistribute();
+
+        uint256 platformAmount = (balance * platformFeeBps) / 10000;
+        uint256 initiatorAmount = balance - platformAmount;
+
+        if (platformAmount > 0) {
+            (bool success1, ) = platformTreasury.call{value: platformAmount}("");
+            if (!success1) revert FeeTransferFailed();
+        }
+
+        if (initiatorAmount > 0) {
+            (bool success2, ) = initiator.call{value: initiatorAmount}("");
+            if (!success2) revert FeeTransferFailed();
+        }
+    }
+}

--- a/assets/erc-8085/contracts/reference/DualModeTokenFactory.sol
+++ b/assets/erc-8085/contracts/reference/DualModeTokenFactory.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import "@openzeppelin/contracts/proxy/Clones.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./DualModeToken.sol";
+import "../verifiers/IVerifier.sol";
+
+/**
+ * @title DualModeTokenFactory
+ * @dev Factory for creating dual-mode tokens with ERC20 + ZK-SNARK privacy
+ *
+ * Features:
+ *   - Clone-based deployment for gas efficiency
+ *   - Centralized verifier management
+ *   - Configurable tree parameters
+ *   - Creation fee collection
+ */
+contract DualModeTokenFactory is Ownable {
+
+    // ===================================
+    //        STATE VARIABLES
+    // ===================================
+
+    /// @notice Implementation contract for cloning
+    address public immutable dualModeTokenImplementation;
+
+    /// @notice Platform treasury address
+    address public platformTreasury;
+
+    /// @notice Platform fee in basis points (e.g., 250 = 2.5%)
+    uint256 public platformFeeBps;
+
+    /// @notice Fee to create a new token
+    uint256 public creationFee;
+
+    /// @notice Shared ZK verifier contracts
+    IVerifier public mintVerifier;
+    IVerifier public mintRolloverVerifier;
+    IVerifier public activeTransferVerifier;
+    IVerifier public finalizedTransferVerifier;
+    IVerifier public rolloverTransferVerifier;
+
+    /// @notice Tree geometry parameters
+    uint8 public subtree_height;
+    uint8 public roottree_height;
+    bytes32 public initialSubtreeEmptyRoot;
+    bytes32 public initialFinalizedEmptyRoot;
+
+    /// @notice Track deployed tokens
+    address[] public deployedTokens;
+    mapping(address => bool) public isDeployedToken;
+
+    // ===================================
+    //        EVENTS
+    // ===================================
+
+    event TokenCreated(
+        address indexed tokenAddress,
+        address indexed creator,
+        string name,
+        string symbol,
+        uint256 maxSupply,
+        uint256 publicMintPrice,
+        uint256 publicMintAmount,
+        uint256 subTreeHeight,
+        uint256 rootTreeHeight
+    );
+
+    event VerifiersUpdated(
+        address mintVerifier,
+        address mintRolloverVerifier,
+        address activeTransferVerifier,
+        address finalizedTransferVerifier,
+        address rolloverTransferVerifier
+    );
+
+    event TreasuryUpdated(address indexed newTreasury);
+    event PlatformFeeUpdated(uint256 newFeeBps);
+    event CreationFeeUpdated(uint256 newCreationFee);
+    event TreeParametersUpdated(uint8 subtreeHeight, uint8 rootTreeHeight);
+
+    // ===================================
+    //        CONSTRUCTOR
+    // ===================================
+
+    /**
+     * @param _implementation Address of DualModeToken implementation
+     * @param _treasury Platform treasury address
+     * @param _verifiers Array of verifier addresses [mint, mintRollover, active, finalized, rollover]
+     * @param _initialSubtreeEmptyRoot Empty subtree root hash
+     * @param _initialFinalizedEmptyRoot Empty finalized root hash
+     */
+    constructor(
+        address _implementation,
+        address _treasury,
+        address[5] memory _verifiers,
+        bytes32 _initialSubtreeEmptyRoot,
+        bytes32 _initialFinalizedEmptyRoot
+    ) Ownable(msg.sender) {
+        require(_implementation != address(0), "Invalid implementation");
+        require(_treasury != address(0), "Invalid treasury");
+        for (uint i = 0; i < _verifiers.length; i++) {
+            require(_verifiers[i] != address(0), "Invalid verifier");
+        }
+
+        dualModeTokenImplementation = _implementation;
+        platformTreasury = _treasury;
+        platformFeeBps = 250; // Default 2.5%
+        creationFee = 0 ether;
+        subtree_height = 16;
+        roottree_height = 20;
+
+        mintVerifier = IVerifier(_verifiers[0]);
+        mintRolloverVerifier = IVerifier(_verifiers[1]);
+        activeTransferVerifier = IVerifier(_verifiers[2]);
+        finalizedTransferVerifier = IVerifier(_verifiers[3]);
+        rolloverTransferVerifier = IVerifier(_verifiers[4]);
+
+        initialSubtreeEmptyRoot = _initialSubtreeEmptyRoot;
+        initialFinalizedEmptyRoot = _initialFinalizedEmptyRoot;
+    }
+
+    // ===================================
+    //        CORE FUNCTIONALITY
+    // ===================================
+
+    /**
+     * @notice Create a new dual-mode token
+     * @param name Token name
+     * @param symbol Token symbol
+     * @param maxSupply Maximum total supply (public + privacy)
+     * @param publicMintPrice Price to mint public tokens
+     * @param publicMintAmount Amount minted per public mint
+     * @return token Address of the newly created token
+     */
+    function createToken(
+        string calldata name,
+        string calldata symbol,
+        uint256 maxSupply,
+        uint256 publicMintPrice,
+        uint256 publicMintAmount
+    ) external payable returns (address token) {
+        require(msg.value == creationFee, "Incorrect creation fee");
+        require(bytes(name).length > 0, "Name required");
+        require(bytes(symbol).length > 0, "Symbol required");
+        require(maxSupply > 0, "Max supply must be positive");
+
+        // Clone the implementation
+        token = Clones.clone(dualModeTokenImplementation);
+
+        // Initialize the token
+        DualModeToken(token).initialize(
+            name,
+            symbol,
+            maxSupply,
+            publicMintPrice,
+            publicMintAmount,
+            platformTreasury,
+            platformFeeBps,
+            msg.sender,  // initiator = token creator
+            [
+                address(mintVerifier),
+                address(mintRolloverVerifier),
+                address(activeTransferVerifier),
+                address(finalizedTransferVerifier),
+                address(rolloverTransferVerifier)
+            ],
+            subtree_height,
+            roottree_height,
+            initialSubtreeEmptyRoot,
+            initialFinalizedEmptyRoot
+        );
+
+        // Track deployment
+        deployedTokens.push(token);
+        isDeployedToken[token] = true;
+
+        emit TokenCreated(
+            token,
+            msg.sender,
+            name,
+            symbol,
+            maxSupply,
+            publicMintPrice,
+            publicMintAmount,
+            subtree_height,
+            roottree_height
+        );
+    }
+
+    // ===================================
+    //        ADMIN FUNCTIONS
+    // ===================================
+
+    /**
+     * @notice Update verifier contracts
+     * @param _newVerifiers Array of new verifier addresses
+     */
+    function setVerifiers(address[5] memory _newVerifiers) external onlyOwner {
+        for (uint i = 0; i < _newVerifiers.length; i++) {
+            require(_newVerifiers[i] != address(0), "Invalid verifier");
+        }
+
+        mintVerifier = IVerifier(_newVerifiers[0]);
+        mintRolloverVerifier = IVerifier(_newVerifiers[1]);
+        activeTransferVerifier = IVerifier(_newVerifiers[2]);
+        finalizedTransferVerifier = IVerifier(_newVerifiers[3]);
+        rolloverTransferVerifier = IVerifier(_newVerifiers[4]);
+
+        emit VerifiersUpdated(
+            _newVerifiers[0],
+            _newVerifiers[1],
+            _newVerifiers[2],
+            _newVerifiers[3],
+            _newVerifiers[4]
+        );
+    }
+
+    /**
+     * @notice Update platform treasury
+     * @param _newTreasury New treasury address
+     */
+    function setTreasury(address _newTreasury) external onlyOwner {
+        require(_newTreasury != address(0), "Invalid treasury");
+        platformTreasury = _newTreasury;
+        emit TreasuryUpdated(_newTreasury);
+    }
+
+    /**
+     * @notice Update platform fee
+     * @param _newFeeBps New fee in basis points (max 10000 = 100%)
+     */
+    function setPlatformFeeBps(uint256 _newFeeBps) external onlyOwner {
+        require(_newFeeBps <= 10000, "Fee cannot exceed 100%");
+        platformFeeBps = _newFeeBps;
+        emit PlatformFeeUpdated(_newFeeBps);
+    }
+
+    /**
+     * @notice Update creation fee
+     * @param _newCreationFee New creation fee
+     */
+    function setCreationFee(uint256 _newCreationFee) external onlyOwner {
+        creationFee = _newCreationFee;
+        emit CreationFeeUpdated(_newCreationFee);
+    }
+
+    /**
+     * @notice Update tree height parameters
+     * @param _subtree_height New subtree height
+     * @param _roottree_height New root tree height
+     */
+    function setTreeHeight(uint8 _subtree_height, uint8 _roottree_height) external onlyOwner {
+        require(_subtree_height > 9, "Invalid subtree height");
+        require(_roottree_height > 15, "Invalid root tree height");
+        subtree_height = _subtree_height;
+        roottree_height = _roottree_height;
+        emit TreeParametersUpdated(_subtree_height, _roottree_height);
+    }
+
+    /**
+     * @notice Withdraw collected creation fees
+     */
+    function withdrawCreationFees() external onlyOwner {
+        uint256 balance = address(this).balance;
+        require(balance > 0, "No fees to withdraw");
+        (bool success, ) = platformTreasury.call{value: balance}("");
+        require(success, "Fee withdrawal failed");
+    }
+
+    // ===================================
+    //        VIEW FUNCTIONS
+    // ===================================
+
+    /**
+     * @notice Get total number of deployed tokens
+     */
+    function getDeployedTokenCount() external view returns (uint256) {
+        return deployedTokens.length;
+    }
+
+    /**
+     * @notice Get deployed token at index
+     */
+    function getDeployedToken(uint256 index) external view returns (address) {
+        require(index < deployedTokens.length, "Index out of bounds");
+        return deployedTokens[index];
+    }
+
+    /**
+     * @notice Get all deployed tokens
+     */
+    function getAllDeployedTokens() external view returns (address[] memory) {
+        return deployedTokens;
+    }
+}

--- a/assets/erc-8085/contracts/reference/DualModeTokenFactory.sol
+++ b/assets/erc-8085/contracts/reference/DualModeTokenFactory.sol
@@ -15,6 +15,36 @@ import "../verifiers/IVerifier.sol";
  *   - Centralized verifier management
  *   - Configurable tree parameters
  *   - Creation fee collection
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════
+ * IMPORTANT: Factory Pattern is NOT Required by ERC-8085
+ * ═══════════════════════════════════════════════════════════════════════════════
+ *
+ * ⚠️ THIS IS A REFERENCE IMPLEMENTATION CHOICE, NOT A STANDARD REQUIREMENT!
+ *
+ * This factory contract demonstrates ONE way to deploy ERC-8085 tokens efficiently.
+ *
+ * Other valid deployment approaches:
+ *   - Direct contract deployment (no factory, no clones)
+ *   - Different clone patterns (e.g., Beacon proxies, UUPS)
+ *   - No central verifier management (each token has its own)
+ *   - Different fee structures or no creation fees
+ *   - Permissioned deployment (vs. permissionless)
+ *
+ * The factory pattern here provides:
+ *   ✅ Gas optimization (clones ~10x cheaper than direct deployment)
+ *   ✅ Centralized verifier upgrades (if needed)
+ *   ✅ Revenue model (creation fees)
+ *   ✅ Token registry (tracking deployed tokens)
+ *
+ * But ERC-8085 does NOT mandate:
+ *   - Using factories
+ *   - Using clones
+ *   - Central verifier management
+ *   - Creation fees
+ *   - Token registries
+ *
+ * You can deploy ERC-8085 tokens however you want!
  */
 contract DualModeTokenFactory is Ownable {
 

--- a/assets/erc-8085/contracts/reference/PrivacyToken.sol
+++ b/assets/erc-8085/contracts/reference/PrivacyToken.sol
@@ -1,0 +1,515 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "../interfaces/IZRC20.sol";
+import "../verifiers/IVerifier.sol";
+
+/**
+ * @title PrivacyToken
+ * @notice Pure ERC-8086 privacy token implementation - the foundation layer
+ * @dev This contract implements the complete IZRC20 interface with ZK-SNARK privacy features.
+ *      It serves as the base layer for dual-mode tokens (ERC-8085) and can also be used
+ *      standalone for pure privacy applications.
+ *
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════
+ * IMPORTANT: ERC-8086 Standard vs. Reference Implementation
+ * ═══════════════════════════════════════════════════════════════════════════════
+ *
+ * The standard ONLY requires privacy guarantees and core interface compatibility.
+ * All business logic (fees, deployment) is implementation-specific.
+ */
+abstract contract PrivacyToken is IZRC20, ReentrancyGuard {
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Custom Errors
+    // ═══════════════════════════════════════════════════════════════════════
+
+    error AlreadyInitialized();
+    error InvalidProofType(uint8 receivedType);
+    error InvalidProof();
+    error CommitmentAlreadyExists(bytes32 commitment);
+    error DoubleSpend(bytes32 nullifier);
+    error OldActiveRootMismatch(bytes32 expected, bytes32 received);
+    error OldFinalizedRootMismatch(bytes32 expected, bytes32 received);
+    error IncorrectSubtreeIndex(uint256 expected, uint256 received);
+    error InvalidStateForRegularMint();
+    error InvalidStateForRollover();
+    error SubtreeCapacityExceeded(uint256 needed, uint256 available);
+    error InvalidConversionAmount(uint256 expected, uint256 proven);
+    error ModeConversionNotSupported();
+    error IncorrectMintAmount(uint256 expected, uint256 actual);
+    error NoFeesToDistribute();
+    error FeeTransferFailed();
+
+    /// @dev ZK Verifiers for different proof types
+    /// @custom:implementation-detail Not required by ERC-8086, specific to this ZK circuit design
+    IActiveTransferVerifier public activeTransferVerifier;
+    IFinalizedTransferVerifier public finalizedTransferVerifier;
+    ITransferRolloverVerifier public rolloverTransferVerifier;
+    IMintVerifier public mintVerifier;
+    IMintRolloverVerifier public mintRolloverVerifier;
+
+    /// @dev Privacy state mappings
+    /// @custom:standard-required ERC-8086 requires nullifier tracking for double-spend prevention
+    mapping(bytes32 => bool) public override nullifiers;        // ERC-8086 required
+    /// @custom:implementation-detail Commitment deduplication is a reference implementation choice
+    mapping(bytes32 => bool) public commitmentHashes;           // Prevent duplicate commitments
+
+    /// @dev Total supply in privacy mode (internal for inheritance flexibility)
+    /// @custom:standard-optional ERC-8086 totalSupply() is optional but recommended
+    uint256 internal _privacySupply;
+
+    /// @dev Merkle tree state (packed for gas efficiency)
+    /// @custom:implementation-detail Dual-layer tree structure is an optimization, not required by standard
+    struct ContractState {
+        uint32 currentSubtreeIndex;
+        uint32 nextLeafIndexInSubtree;
+        uint8 subTreeHeight;
+        uint8 rootTreeHeight;
+        bool initialized;
+    }
+    ContractState public state;
+
+    /// @dev Tree roots
+    /// @custom:implementation-detail Specific tree configuration, other implementations may differ
+    bytes32 public EMPTY_SUBTREE_ROOT;
+    /// @custom:standard-required ERC-8086 requires activeSubtreeRoot() for proof verification
+    bytes32 public override activeSubtreeRoot;    // ERC-8086 required
+    /// @custom:implementation-detail Finalized root is part of dual-layer optimization
+    bytes32 public finalizedRoot;
+    uint256 public SUBTREE_CAPACITY;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // State Variables - Business Logic (NOT part of ERC-8086 standard)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @dev Platform and fee configuration
+    /// @custom:business-logic These are reference implementation choices, NOT required by ERC-8086
+    /// @notice Other implementations may use different fee models or no fees at all
+    address public platformTreasury;
+    uint256 public platformFeeBps;
+    address public initiator;  // Token creator, receives fees
+
+    /// @dev Transaction data structure for internal processing
+    struct TransactionData {
+        bytes32[2] nullifiers;
+        bytes32[2] commitments;
+        uint256[2] ephemeralPublicKey;
+        uint256 viewTag;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Initialization
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Internal initializer for privacy state (called by derived contracts)
+     * @dev This is an internal function to support different initialization patterns
+     *      (e.g., standalone PrivacyToken vs. DualModeToken)
+     */
+    function __PrivacyToken_init(
+        address platformTreasury_,
+        uint256 platformFeeBps_,
+        address initiator_,
+        address[5] memory verifiers_,
+        uint8 subtreeHeight_,
+        uint8 rootTreeHeight_,
+        bytes32 initialSubtreeEmptyRoot_,
+        bytes32 initialFinalizedEmptyRoot_
+    ) internal {
+        if (state.initialized) revert AlreadyInitialized();
+
+        // Platform configuration
+        platformTreasury = platformTreasury_;
+        platformFeeBps = platformFeeBps_;
+        initiator = initiator_;
+
+        // Verifiers
+        mintVerifier = IMintVerifier(verifiers_[0]);
+        mintRolloverVerifier = IMintRolloverVerifier(verifiers_[1]);
+        activeTransferVerifier = IActiveTransferVerifier(verifiers_[2]);
+        finalizedTransferVerifier = IFinalizedTransferVerifier(verifiers_[3]);
+        rolloverTransferVerifier = ITransferRolloverVerifier(verifiers_[4]);
+
+        // Privacy tree state
+        state.subTreeHeight = subtreeHeight_;
+        SUBTREE_CAPACITY = 1 << subtreeHeight_;
+        state.rootTreeHeight = rootTreeHeight_;
+        EMPTY_SUBTREE_ROOT = initialSubtreeEmptyRoot_;
+        activeSubtreeRoot = initialSubtreeEmptyRoot_;
+        finalizedRoot = initialFinalizedEmptyRoot_;
+        state.nextLeafIndexInSubtree = 0;
+        state.initialized = true;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ERC-8086 Interface Implementation (IZRC20)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Returns the total supply in privacy mode
+     * @dev Virtual to allow DualModeToken to combine with public supply
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _privacySupply;
+    }
+
+    /**
+     * @notice Privacy-preserving transfer (IZRC20.transfer)
+     * @dev Routes to appropriate internal transfer function based on proof type
+     */
+    function transfer(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) external virtual override {
+        _privacyTransfer(proofType, proof, encryptedNotes);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Internal: Privacy Mint (ERC-8086 Core Logic)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Internal privacy mint dispatcher
+     * @dev Routes to regular or rollover mint based on proof type
+     *      Virtual to allow derived contracts to add pre/post hooks
+     */
+    function _privacyMint(
+        uint256 expectedAmount,
+        uint8 proofType,
+        bytes calldata proof,
+        bytes calldata encryptedNote
+    ) internal virtual returns (bytes32 commitment) {
+        if (proofType == 0) {
+            commitment = _mintRegular(expectedAmount, proof, encryptedNote);
+        } else if (proofType == 1) {
+            commitment = _mintAndRollover(expectedAmount, proof, encryptedNote);
+        } else {
+            revert InvalidProofType(proofType);
+        }
+        _privacySupply += expectedAmount;
+    }
+
+    /**
+     * @notice Regular mint (when subtree is not full)
+     * @dev Verifies proof and appends commitment to active subtree
+     */
+    function _mintRegular(
+        uint256 expectedAmount,
+        bytes calldata _proof,
+        bytes calldata _encryptedNote
+    ) internal virtual returns (bytes32) {
+        if (state.nextLeafIndexInSubtree >= SUBTREE_CAPACITY) revert InvalidStateForRegularMint();
+
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[4] memory pubSignals) =
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[4]));
+
+        bytes32 newActiveRoot = bytes32(pubSignals[0]);
+        bytes32 oldActiveRoot = bytes32(pubSignals[1]);
+        bytes32 newCommitment = bytes32(pubSignals[2]);
+        uint256 mintAmount = pubSignals[3];
+
+        if (expectedAmount != mintAmount) revert IncorrectMintAmount(expectedAmount, mintAmount);
+        if (commitmentHashes[newCommitment]) revert CommitmentAlreadyExists(newCommitment);
+        if (activeSubtreeRoot != oldActiveRoot) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot);
+        if (!mintVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        commitmentHashes[newCommitment] = true;
+        activeSubtreeRoot = newActiveRoot;
+
+        emit CommitmentAppended(state.currentSubtreeIndex, newCommitment, state.nextLeafIndexInSubtree, block.timestamp);
+        emit Minted(msg.sender, newCommitment, _encryptedNote, state.currentSubtreeIndex, state.nextLeafIndexInSubtree, block.timestamp);
+
+        state.nextLeafIndexInSubtree++;
+        return newCommitment;
+    }
+
+    /**
+     * @notice Rollover mint (when subtree is full, triggers finalization)
+     * @dev Atomically updates both active and finalized roots
+     */
+    function _mintAndRollover(
+        uint256 expectedAmount,
+        bytes calldata _proof,
+        bytes calldata _encryptedNote
+    ) internal virtual returns (bytes32) {
+        if (state.nextLeafIndexInSubtree != SUBTREE_CAPACITY) revert InvalidStateForRollover();
+
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[7] memory pubSignals) =
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[7]));
+
+        bytes32 newActiveRoot = bytes32(pubSignals[0]);
+        bytes32 newFinalizedRoot = bytes32(pubSignals[1]);
+        bytes32 oldActiveRoot = bytes32(pubSignals[2]);
+        bytes32 oldFinalizedRoot = bytes32(pubSignals[3]);
+        bytes32 newCommitment = bytes32(pubSignals[4]);
+        uint256 mintAmount = pubSignals[5];
+        uint256 subtreeIndex = pubSignals[6];
+
+        if (expectedAmount != mintAmount) revert IncorrectMintAmount(expectedAmount, mintAmount);
+        if (commitmentHashes[newCommitment]) revert CommitmentAlreadyExists(newCommitment);
+        if (activeSubtreeRoot != oldActiveRoot) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot);
+        if (finalizedRoot != oldFinalizedRoot) revert OldFinalizedRootMismatch(finalizedRoot, oldFinalizedRoot);
+        if (state.currentSubtreeIndex != subtreeIndex) revert IncorrectSubtreeIndex(state.currentSubtreeIndex, subtreeIndex);
+        if (!mintRolloverVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        commitmentHashes[newCommitment] = true;
+        activeSubtreeRoot = newActiveRoot;
+        finalizedRoot = newFinalizedRoot;
+        state.currentSubtreeIndex++;
+        state.nextLeafIndexInSubtree = 0;
+
+        emit CommitmentAppended(state.currentSubtreeIndex, newCommitment, state.nextLeafIndexInSubtree, block.timestamp);
+        emit Minted(msg.sender, newCommitment, _encryptedNote, state.currentSubtreeIndex, state.nextLeafIndexInSubtree, block.timestamp);
+
+        state.nextLeafIndexInSubtree++;
+        return newCommitment;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Internal: Privacy Transfer (ERC-8086 Core Logic)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Internal privacy transfer dispatcher
+     * @dev Routes to appropriate transfer function based on proof type
+     *      Virtual to allow derived contracts to intercept
+     */
+    function _privacyTransfer(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) internal virtual {
+        if (proofType == 0) {
+            _transferActive(proof, encryptedNotes, false);
+        } else if (proofType == 1) {
+            _transferFinalized(proof, encryptedNotes, false);
+        } else if (proofType == 2) {
+            _transferAndRollover(proof, encryptedNotes);
+        } else {
+            revert InvalidProofType(proofType);
+        }
+    }
+
+    /**
+     * @notice Active tree transfer (spending from recent commitments)
+     * @dev Supports mode conversion through isModeConversion flag (for ERC-8085)
+     *      Virtual to allow derived contracts to add mode conversion logic
+     */
+    function _transferActive(
+        bytes calldata _proof,
+        bytes[] calldata _encryptedNotes,
+        bool isModeConversion
+    ) internal virtual returns (uint256 conversionAmount) {
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[13] memory pubSignals) =
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[13]));
+
+        bytes32 newActiveRoot = bytes32(pubSignals[2]);
+        uint256 numRealOutputs = pubSignals[3];
+        conversionAmount = pubSignals[4];
+        bytes32 oldActiveRoot = bytes32(pubSignals[5]);
+
+        // Mode conversion validation (extensible via virtual function)
+        if (isModeConversion) {
+            _validateModeConversion(conversionAmount, pubSignals[10], pubSignals[11]);
+        } else {
+            if (conversionAmount != 0) revert InvalidConversionAmount(0, conversionAmount);
+        }
+
+        uint256 availableCapacity = SUBTREE_CAPACITY - state.nextLeafIndexInSubtree;
+        if (numRealOutputs > availableCapacity) revert SubtreeCapacityExceeded(numRealOutputs, availableCapacity);
+        if (activeSubtreeRoot != oldActiveRoot) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot);
+        if (!activeTransferVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        activeSubtreeRoot = newActiveRoot;
+
+        TransactionData memory data;
+        data.ephemeralPublicKey = [pubSignals[0], pubSignals[1]];
+        data.nullifiers = [bytes32(pubSignals[6]), bytes32(pubSignals[7])];
+        data.commitments = [bytes32(pubSignals[8]), bytes32(pubSignals[9])];
+        data.viewTag = pubSignals[12];
+
+        _processTransaction(data, _encryptedNotes);
+    }
+
+    /**
+     * @notice Finalized tree transfer (spending from archived commitments)
+     * @dev Supports mode conversion through isModeConversion flag (for ERC-8085)
+     *      Virtual to allow derived contracts to add mode conversion logic
+     */
+    function _transferFinalized(
+        bytes calldata _proof,
+        bytes[] calldata _encryptedNotes,
+        bool isModeConversion
+    ) internal virtual returns (uint256 conversionAmount) {
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[14] memory pubSignals) =
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[14]));
+
+        bytes32 newActiveRoot = bytes32(pubSignals[2]);
+        uint256 numRealOutputs = pubSignals[3];
+        conversionAmount = pubSignals[4];
+        bytes32 oldFinalizedRoot = bytes32(pubSignals[5]);
+        bytes32 oldActiveRoot = bytes32(pubSignals[6]);
+
+        // Mode conversion validation (extensible via virtual function)
+        if (isModeConversion) {
+            _validateModeConversion(conversionAmount, pubSignals[11], pubSignals[12]);
+        } else {
+            if (conversionAmount != 0) revert InvalidConversionAmount(0, conversionAmount);
+        }
+
+        uint256 availableCapacity = SUBTREE_CAPACITY - state.nextLeafIndexInSubtree;
+        if (numRealOutputs > availableCapacity) revert SubtreeCapacityExceeded(numRealOutputs, availableCapacity);
+        if (activeSubtreeRoot != oldActiveRoot) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot);
+        if (finalizedRoot != oldFinalizedRoot) revert OldFinalizedRootMismatch(finalizedRoot, oldFinalizedRoot);
+        if (!finalizedTransferVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        activeSubtreeRoot = newActiveRoot;
+
+        TransactionData memory data;
+        data.ephemeralPublicKey = [pubSignals[0], pubSignals[1]];
+        data.nullifiers = [bytes32(pubSignals[7]), bytes32(pubSignals[8])];
+        data.commitments = [bytes32(pubSignals[9]), bytes32(pubSignals[10])];
+        data.viewTag = pubSignals[13];
+
+        _processTransaction(data, _encryptedNotes);
+    }
+
+    /**
+     * @notice Rollover transfer (triggers subtree finalization)
+     * @dev Does not support mode conversion (incompatible with rollover mechanics)
+     *      Virtual to allow derived contracts to add hooks
+     */
+    function _transferAndRollover(
+        bytes calldata _proof,
+        bytes[] calldata _encryptedNotes
+    ) internal virtual {
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[13] memory pubSignals) =
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[13]));
+
+        bytes32 newActive = bytes32(pubSignals[2]);
+        bytes32 newFinalized = bytes32(pubSignals[3]);
+        uint256 conversionAmount = pubSignals[4];
+        bytes32 oldActive = bytes32(pubSignals[5]);
+        bytes32 oldFinalized = bytes32(pubSignals[6]);
+        uint256 subtreeIndex = pubSignals[12];
+
+        // Rollover doesn't support mode conversion
+        if (conversionAmount != 0) revert InvalidConversionAmount(0, conversionAmount);
+        if (state.nextLeafIndexInSubtree != SUBTREE_CAPACITY) revert InvalidStateForRollover();
+        if (activeSubtreeRoot != oldActive) revert OldActiveRootMismatch(activeSubtreeRoot, oldActive);
+        if (finalizedRoot != oldFinalized) revert OldFinalizedRootMismatch(finalizedRoot, oldFinalized);
+        if (state.currentSubtreeIndex != subtreeIndex) revert IncorrectSubtreeIndex(state.currentSubtreeIndex, subtreeIndex);
+        if (!rolloverTransferVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        activeSubtreeRoot = newActive;
+        finalizedRoot = newFinalized;
+        state.currentSubtreeIndex++;
+        state.nextLeafIndexInSubtree = 0;
+
+        TransactionData memory data;
+        data.ephemeralPublicKey = [pubSignals[0], pubSignals[1]];
+        data.nullifiers = [bytes32(pubSignals[7]), bytes32(0)];
+        data.commitments = [bytes32(pubSignals[8]), bytes32(0)];
+        data.viewTag = pubSignals[11];
+
+        _processTransaction(data, _encryptedNotes);
+    }
+
+    /**
+     * @notice Process transaction data (spend nullifiers, append commitments, emit events)
+     * @dev Virtual to allow derived contracts to add hooks
+     */
+    function _processTransaction(
+        TransactionData memory _data,
+        bytes[] calldata _encryptedNotes
+    ) internal virtual {
+        // Spend nullifiers (double-spend prevention)
+        for (uint32 i = 0; i < _data.nullifiers.length; i++) {
+            bytes32 n = _data.nullifiers[i];
+            if (n != bytes32(0)) {
+                if (nullifiers[n]) revert DoubleSpend(n);
+                nullifiers[n] = true;
+                emit NullifierSpent(n);
+            }
+        }
+
+        // Append commitments to active subtree
+        for (uint i = 0; i < _data.commitments.length; i++) {
+            bytes32 c = _data.commitments[i];
+            if (c != bytes32(0)) {
+                emit CommitmentAppended(state.currentSubtreeIndex, c, state.nextLeafIndexInSubtree, block.timestamp);
+                state.nextLeafIndexInSubtree++;
+            }
+        }
+
+        emit Transaction(_data.commitments, _encryptedNotes, _data.ephemeralPublicKey, _data.viewTag);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Mode Conversion Extension Point (for ERC-8085 and other protocols)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Validate mode conversion parameters (virtual hook for derived contracts)
+     * @dev Default implementation rejects mode conversion (pure ERC-8086 behavior)
+     *      DualModeToken overrides this to validate BURN_ADDRESS
+     * @param conversionAmount Amount being converted (must be > 0 for valid conversion)
+     * @param recipientX X coordinate of recipient public key
+     * @param recipientY Y coordinate of recipient public key
+     */
+    function _validateModeConversion(
+        uint256 conversionAmount,
+        uint256 recipientX,
+        uint256 recipientY
+    ) internal virtual {
+        // Default: mode conversion not supported in pure privacy tokens
+        revert ModeConversionNotSupported();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Fee Distribution (REFERENCE IMPLEMENTATION - NOT PART OF ERC-8086)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Distribute collected fees to platform and token creator
+     * @dev Fees are split: platformFeeBps to platform, remainder to initiator
+     *      Virtual to allow derived contracts to customize fee distribution
+     *
+     * ⚠️ IMPORTANT: This is NOT required by ERC-8086 standard!
+     *
+     * This is a REFERENCE IMPLEMENTATION business logic choice.
+     * Other ERC-8086 implementations MAY:
+     *   - Not charge any fees
+     *   - Use different fee distribution models
+     *   - Send fees to different addresses
+     *   - Use different revenue mechanisms
+     *
+     * ERC-8086 standard does NOT mandate:
+     *   - Platform fees
+     *   - Fee distribution logic
+     *   - Initiator/treasury addresses
+     *
+     * This function exists to demonstrate ONE possible revenue model.
+     */
+    function distributeFees() external virtual nonReentrant {
+        uint256 balance = address(this).balance;
+        if (balance == 0) revert NoFeesToDistribute();
+
+        uint256 platformAmount = (balance * platformFeeBps) / 10000;
+        uint256 initiatorAmount = balance - platformAmount;
+
+        if (platformAmount > 0) {
+            (bool success1, ) = platformTreasury.call{value: platformAmount}("");
+            if (!success1) revert FeeTransferFailed();
+        }
+
+        if (initiatorAmount > 0) {
+            (bool success2, ) = initiator.call{value: initiatorAmount}("");
+            if (!success2) revert FeeTransferFailed();
+        }
+    }
+}

--- a/assets/erc-8085/deployments/base-sepolia.json
+++ b/assets/erc-8085/deployments/base-sepolia.json
@@ -1,36 +1,36 @@
 {
   "network": "Base Sepolia",
   "chainId": 84532,
-  "deployedAt": "2025-11-29T04:04:00.649Z",
-  "blockNumber": 34310376,
+  "deployedAt": "2025-12-09T06:10:52.733Z",
+  "blockNumber": 34746182,
   "contracts": {
     "DualModeTokenFactory": {
-      "address": "0xf5c16f708777cCb57C3A8887065b4EC02eAf9130",
-      "basescan": "https://sepolia.basescan.org/address/0xf5c16f708777cCb57C3A8887065b4EC02eAf9130#code"
+      "address": "0x64EeF485F82918bBf61dd5349300F5a84f907140",
+      "basescan": "https://sepolia.basescan.org/address/0x64EeF485F82918bBf61dd5349300F5a84f907140#code"
     },
     "DualModeToken (Implementation)": {
-      "address": "0x1EFab166064AaD33fcB6074Ec8bA6302013C965C",
-      "basescan": "https://sepolia.basescan.org/address/0x1EFab166064AaD33fcB6074Ec8bA6302013C965C#code"
+      "address": "0xd8714b3E2B490585c22d5a7a030f3946e46940c4",
+      "basescan": "https://sepolia.basescan.org/address/0xd8714b3E2B490585c22d5a7a030f3946e46940c4#code"
     },
     "MintVerifier": {
-      "address": "0xC655b758f07bAaE8B956c95b055424a5c3B04e79",
-      "basescan": "https://sepolia.basescan.org/address/0xC655b758f07bAaE8B956c95b055424a5c3B04e79#code"
+      "address": "0x0C9F3208b44d26B7e5D0ab145d49b050F5C7fFa5",
+      "basescan": "https://sepolia.basescan.org/address/0x0C9F3208b44d26B7e5D0ab145d49b050F5C7fFa5#code"
     },
     "MintRolloverVerifier": {
-      "address": "0x9a6898B2e6C963EA81D17dCB9B0D483B590e168f",
-      "basescan": "https://sepolia.basescan.org/address/0x9a6898B2e6C963EA81D17dCB9B0D483B590e168f#code"
+      "address": "0x8F1C5De7b7193B0Ce1E9886E5f1c58aE3A5491dF",
+      "basescan": "https://sepolia.basescan.org/address/0x8F1C5De7b7193B0Ce1E9886E5f1c58aE3A5491dF#code"
     },
     "ActiveTransferVerifier": {
-      "address": "0x7159EcAc6d1BB1433922b597fc2887dCA33a3A62",
-      "basescan": "https://sepolia.basescan.org/address/0x7159EcAc6d1BB1433922b597fc2887dCA33a3A62#code"
+      "address": "0x791cd059fA2b4B2d4015408eF6624BBD2F80d50E",
+      "basescan": "https://sepolia.basescan.org/address/0x791cd059fA2b4B2d4015408eF6624BBD2F80d50E#code"
     },
     "FinalizedTransferVerifier": {
-      "address": "0x0f9b6F788774671C8c47D8adE9D36E884c96580D",
-      "basescan": "https://sepolia.basescan.org/address/0x0f9b6F788774671C8c47D8adE9D36E884c96580D#code"
+      "address": "0x96Bb15bE0a79C1f17dFed17b9D57c3DE1C5eA205",
+      "basescan": "https://sepolia.basescan.org/address/0x96Bb15bE0a79C1f17dFed17b9D57c3DE1C5eA205#code"
     },
     "RolloverTransferVerifier": {
-      "address": "0x0B22df9887351Ecfb403cfB27056f3A371F3bD92",
-      "basescan": "https://sepolia.basescan.org/address/0x0B22df9887351Ecfb403cfB27056f3A371F3bD92#code"
+      "address": "0xEB85CA2d80da109fe9348a9B17F2E683BEaa4a07",
+      "basescan": "https://sepolia.basescan.org/address/0xEB85CA2d80da109fe9348a9B17F2E683BEaa4a07#code"
     }
   },
   "cryptoParams": {

--- a/assets/erc-8085/deployments/base-sepolia.json
+++ b/assets/erc-8085/deployments/base-sepolia.json
@@ -1,0 +1,51 @@
+{
+  "network": "Base Sepolia",
+  "chainId": 84532,
+  "deployedAt": "2025-11-29T04:04:00.649Z",
+  "blockNumber": 34310376,
+  "contracts": {
+    "DualModeTokenFactory": {
+      "address": "0xf5c16f708777cCb57C3A8887065b4EC02eAf9130",
+      "basescan": "https://sepolia.basescan.org/address/0xf5c16f708777cCb57C3A8887065b4EC02eAf9130#code"
+    },
+    "DualModeToken (Implementation)": {
+      "address": "0x1EFab166064AaD33fcB6074Ec8bA6302013C965C",
+      "basescan": "https://sepolia.basescan.org/address/0x1EFab166064AaD33fcB6074Ec8bA6302013C965C#code"
+    },
+    "MintVerifier": {
+      "address": "0xC655b758f07bAaE8B956c95b055424a5c3B04e79",
+      "basescan": "https://sepolia.basescan.org/address/0xC655b758f07bAaE8B956c95b055424a5c3B04e79#code"
+    },
+    "MintRolloverVerifier": {
+      "address": "0x9a6898B2e6C963EA81D17dCB9B0D483B590e168f",
+      "basescan": "https://sepolia.basescan.org/address/0x9a6898B2e6C963EA81D17dCB9B0D483B590e168f#code"
+    },
+    "ActiveTransferVerifier": {
+      "address": "0x7159EcAc6d1BB1433922b597fc2887dCA33a3A62",
+      "basescan": "https://sepolia.basescan.org/address/0x7159EcAc6d1BB1433922b597fc2887dCA33a3A62#code"
+    },
+    "FinalizedTransferVerifier": {
+      "address": "0x0f9b6F788774671C8c47D8adE9D36E884c96580D",
+      "basescan": "https://sepolia.basescan.org/address/0x0f9b6F788774671C8c47D8adE9D36E884c96580D#code"
+    },
+    "RolloverTransferVerifier": {
+      "address": "0x0B22df9887351Ecfb403cfB27056f3A371F3bD92",
+      "basescan": "https://sepolia.basescan.org/address/0x0B22df9887351Ecfb403cfB27056f3A371F3bD92#code"
+    }
+  },
+  "cryptoParams": {
+    "subtreeLevels": 16,
+    "rootTreeLevels": 20,
+    "subtreeCapacity": 65536,
+    "initialSubtreeEmptyRoot": "0x2a7c7c9b6ce5880b9f6f228d72bf6a575a526f29c66ecceef8b753d38bba7323",
+    "initialFinalizedEmptyRoot": "0x224ccc25981822d4c5b6fc199fbc74828488741c7151a6159ecfaab7c2a8bac9"
+  },
+  "compiler": {
+    "version": "0.8.20",
+    "optimizer": {
+      "enabled": true,
+      "runs": 200
+    },
+    "viaIR": true
+  }
+}

--- a/assets/erc-8086/README.md
+++ b/assets/erc-8086/README.md
@@ -1,0 +1,128 @@
+# ERC-8086: Privacy Token - Reference Implementation
+
+## ⚠️ Implementation Status
+
+This directory contains the **smart contract implementation** of ERC-8086.
+
+**Note**: Complete end-to-end testing of this standard requires ZK-SNARK circuit artifacts (proving keys, witness generators) which are **not included** in this repository due to size constraints .
+
+### What's Included
+
+- ✅ Core Solidity contracts (production-ready)
+- ✅ Interface definitions (IZRC20)
+- ✅ Verifier contracts (Groth16)
+- ✅ Factory pattern for token deployment
+- ✅ Testnet deployment information
+
+### What's NOT Included
+
+- ❌ ZK circuit source code (.circom files)
+- ❌ Compiled circuit artifacts (.zkey, .wasm files)
+- ❌ Client-side proof generation SDK
+- ❌ Unit test suite (requires circuit artifacts)
+
+## Directory Structure
+
+```
+erc-8086/
+├── README.md                          # This file
+├── contracts/
+│   ├── interfaces/
+│   │   ├── IZRC20.sol                # Core interface (ERC-8086)
+│   │   └── IVerifier.sol             # Verifier interfaces
+│   └── reference/
+│       ├── PrivacyToken.sol          # Reference implementation
+│       └── PrivacyTokenFactory.sol   # Factory for token deployment
+└── deployments/
+    └── base-sepolia.json              # Deployment addresses & config
+```
+
+## How to Test This Implementation
+
+Due to the ZK-SNARK requirements, there are two ways to verify this implementation:
+
+### Option 1: Use the Live Testnet Deployment (Recommended)
+
+A fully functional deployment is available on **Base Sepolia** testnet:
+
+**🔗 Test Application**: [testnative.zkprotocol.xyz](https://testnative.zkprotocol.xyz/)
+
+**Deployed Contracts** (verified on Basescan):
+
+| Contract | Address | Link |
+|----------|---------|------|
+| PrivacyTokenFactory | `0x04df6DbAe3BAe8bC91ef3b285d0666d36dda24af` | [View Code](https://sepolia.basescan.org/address/0x04df6DbAe3BAe8bC91ef3b285d0666d36dda24af#code) |
+| PrivacyToken (Implementation) | `0xa025070b46a38d5793F491097A6aae1A6109000c` | [View Code](https://sepolia.basescan.org/address/0xa025070b46a38d5793F491097A6aae1A6109000c#code) |
+| MintVerifier | `0x1C9260008DA7a12dF2DE2E562dC72b877f4B9a4b` | [View Code](https://sepolia.basescan.org/address/0x1C9260008DA7a12dF2DE2E562dC72b877f4B9a4b#code) |
+| MintRolloverVerifier | `0x9423767D08eF34CEC1F1aD384e2884dd24c68f5B` | [View Code](https://sepolia.basescan.org/address/0x9423767D08eF34CEC1F1aD384e2884dd24c68f5B#code) |
+| ActiveTransferVerifier | `0x14834a1b1E67977e4ec9a33fc84e58851E21c4Aa` | [View Code](https://sepolia.basescan.org/address/0x14834a1b1E67977e4ec9a33fc84e58851E21c4Aa#code) |
+| FinalizedTransferVerifier | `0x1b7c464ed02af392a44CE7881081d1fb1D15b970` | [View Code](https://sepolia.basescan.org/address/0x1b7c464ed02af392a44CE7881081d1fb1D15b970#code) |
+| RolloverTransferVerifier | `0x4dd4D44f99Afb3AE4F4e8C03BAdA2Ff84E75f9Cb` | [View Code](https://sepolia.basescan.org/address/0x4dd4D44f99Afb3AE4F4e8C03BAdA2Ff84E75f9Cb#code) |
+
+**Network**: Base Sepolia (Chain ID: 84532)
+
+**Testing Instructions**:
+1. Visit [testnative.zkprotocol.xyz](https://testnative.zkprotocol.xyz/)
+2. Connect a wallet to Base Sepolia testnet
+3. Get test ETH from [Base Sepolia faucet](https://www.alchemy.com/faucets/base-sepolia)
+4. Mint privacy tokens
+5. Perform privacy transfers
+6. Verify transactions on [Base Sepolia explorer](https://sepolia.basescan.org/)
+
+### Option 2: Review Contract Code On-Chain
+
+All contracts are verified on Basescan. You can:
+- Read the full source code directly on Basescan
+- Verify the bytecode matches the source
+- Review all constructor parameters
+- Check deployment history
+- Inspect transaction history
+
+## Implementation Notes
+
+### Architecture
+
+- **Dual-layer Merkle tree**: 16-level active subtree + 20-level finalized tree
+- **Total capacity**: 68.7 billion notes (65,536 × 1,048,576)
+- **Proof types**:
+  - Type 0: Active transfer (both inputs from active subtree)
+  - Type 1: Finalized transfer (inputs from finalized tree)
+  - Type 2: Rollover transfer (triggers subtree finalization)
+- **Gas optimization**: Custom errors, packed storage, ReentrancyGuard
+
+### Key Features
+
+- **Privacy-preserving**: Amounts and recipients hidden via commitments
+- **Nullifier-based**: Prevents double-spending
+- **Scalable**: Dual-tree architecture supports decades of transactions
+- **Flexible**: Supports multiple proof strategies via `proofType` parameter
+
+### Security Features
+
+- ✅ Nullifier uniqueness enforcement
+- ✅ Merkle tree integrity (append-only)
+- ✅ ZK-SNARK proof verification (Groth16)
+- ✅ Reentrancy protection
+- ✅ Double-spending prevention
+- ✅ Commitment existence checks
+
+## Technical Details
+
+### Cryptographic Parameters
+
+From `deployments/base-sepolia.json`:
+- Subtree levels: 16
+- Root tree levels: 20
+- Subtree capacity: 65,536 notes
+- Empty subtree root: `0x2a7c7c9b6ce5880b9f6f228d72bf6a575a526f29c66ecceef8b753d38bba7323`
+- Empty finalized root: `0x224ccc25981822d4c5b6fc199fbc74828488741c7151a6159ecfaab7c2a8bac9`
+
+### Compiler Configuration
+
+- Solidity version: 0.8.20
+- Optimizer: Enabled (200 runs)
+- Via IR: true
+
+## License
+
+CC0-1.0

--- a/assets/erc-8086/README.md
+++ b/assets/erc-8086/README.md
@@ -37,47 +37,6 @@ erc-8086/
     └── base-sepolia.json              # Deployment addresses & config
 ```
 
-## How to Test This Implementation
-
-Due to the ZK-SNARK requirements, there are two ways to verify this implementation:
-
-### Option 1: Use the Live Testnet Deployment (Recommended)
-
-A fully functional deployment is available on **Base Sepolia** testnet:
-
-**🔗 Test Application**: [testnative.zkprotocol.xyz](https://testnative.zkprotocol.xyz/)
-
-**Deployed Contracts** (verified on Basescan):
-
-| Contract | Address | Link |
-|----------|---------|------|
-| PrivacyTokenFactory | `0x04df6DbAe3BAe8bC91ef3b285d0666d36dda24af` | [View Code](https://sepolia.basescan.org/address/0x04df6DbAe3BAe8bC91ef3b285d0666d36dda24af#code) |
-| PrivacyToken (Implementation) | `0xa025070b46a38d5793F491097A6aae1A6109000c` | [View Code](https://sepolia.basescan.org/address/0xa025070b46a38d5793F491097A6aae1A6109000c#code) |
-| MintVerifier | `0x1C9260008DA7a12dF2DE2E562dC72b877f4B9a4b` | [View Code](https://sepolia.basescan.org/address/0x1C9260008DA7a12dF2DE2E562dC72b877f4B9a4b#code) |
-| MintRolloverVerifier | `0x9423767D08eF34CEC1F1aD384e2884dd24c68f5B` | [View Code](https://sepolia.basescan.org/address/0x9423767D08eF34CEC1F1aD384e2884dd24c68f5B#code) |
-| ActiveTransferVerifier | `0x14834a1b1E67977e4ec9a33fc84e58851E21c4Aa` | [View Code](https://sepolia.basescan.org/address/0x14834a1b1E67977e4ec9a33fc84e58851E21c4Aa#code) |
-| FinalizedTransferVerifier | `0x1b7c464ed02af392a44CE7881081d1fb1D15b970` | [View Code](https://sepolia.basescan.org/address/0x1b7c464ed02af392a44CE7881081d1fb1D15b970#code) |
-| RolloverTransferVerifier | `0x4dd4D44f99Afb3AE4F4e8C03BAdA2Ff84E75f9Cb` | [View Code](https://sepolia.basescan.org/address/0x4dd4D44f99Afb3AE4F4e8C03BAdA2Ff84E75f9Cb#code) |
-
-**Network**: Base Sepolia (Chain ID: 84532)
-
-**Testing Instructions**:
-1. Visit [testnative.zkprotocol.xyz](https://testnative.zkprotocol.xyz/)
-2. Connect a wallet to Base Sepolia testnet
-3. Get test ETH from [Base Sepolia faucet](https://www.alchemy.com/faucets/base-sepolia)
-4. Mint privacy tokens
-5. Perform privacy transfers
-6. Verify transactions on [Base Sepolia explorer](https://sepolia.basescan.org/)
-
-### Option 2: Review Contract Code On-Chain
-
-All contracts are verified on Basescan. You can:
-- Read the full source code directly on Basescan
-- Verify the bytecode matches the source
-- Review all constructor parameters
-- Check deployment history
-- Inspect transaction history
-
 ## Implementation Notes
 
 ### Architecture

--- a/assets/erc-8086/contracts/interfaces/IVerifier.sol
+++ b/assets/erc-8086/contracts/interfaces/IVerifier.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title IVerifier
+ * @notice Generic interface for zk-SNARK proof verifiers
+ * @dev Different verifier implementations may require different public signal lengths
+ */
+interface IVerifier {
+    /**
+     * @dev Verifies a ZK-SNARK proof.
+     * @param _pA The A point of the proof.
+     * @param _pB The B point of the proof.
+     * @param _pC The C point of the proof.
+     * @param _pubSignals An array of public signals. The length and order
+     *                    must match what the specific verifier expects.
+     * @return bool True if the proof is valid.
+     */
+    function verifyProof(
+        uint[2] calldata _pA,
+        uint[2][2] calldata _pB,
+        uint[2] calldata _pC,
+        uint[] calldata _pubSignals
+    ) external view returns (bool);
+}
+
+/**
+ * @title IMintVerifier
+ * @notice Verifier for regular mint operations
+ * @dev Public signals: [newActiveRoot, oldActiveRoot, newCommitment, mintAmount]
+ */
+interface IMintVerifier {
+    function verifyProof(
+        uint[2] calldata _pA,
+        uint[2][2] calldata _pB,
+        uint[2] calldata _pC,
+        uint[4] calldata _pubSignals
+    ) external view returns (bool);
+}
+
+/**
+ * @title IMintRolloverVerifier
+ * @notice Verifier for mint operations that trigger subtree rollover
+ * @dev Public signals: [newActiveRoot, newFinalizedRoot, oldActiveRoot, oldFinalizedRoot, newCommitment, mintAmount, subtreeIndex]
+ */
+interface IMintRolloverVerifier {
+    function verifyProof(
+        uint[2] calldata _pA,
+        uint[2][2] calldata _pB,
+        uint[2] calldata _pC,
+        uint[7] calldata _pubSignals
+    ) external view returns (bool);
+}
+
+/**
+ * @title IActiveTransferVerifier
+ * @notice Verifier for transfers within the active subtree
+ * @dev Fastest proof generation - most common transfer type
+ */
+interface IActiveTransferVerifier {
+    function verifyProof(
+        uint[2] calldata _pA,
+        uint[2][2] calldata _pB,
+        uint[2] calldata _pC,
+        uint[12] calldata _pubSignals
+    ) external view returns (bool);
+}
+
+/**
+ * @title IFinalizedTransferVerifier
+ * @notice Verifier for transfers spending from finalized (historical) subtrees
+ */
+interface IFinalizedTransferVerifier {
+    function verifyProof(
+        uint[2] calldata _pA,
+        uint[2][2] calldata _pB,
+        uint[2] calldata _pC,
+        uint[13] calldata _pubSignals
+    ) external view returns (bool);
+}
+
+/**
+ * @title ITransferRolloverVerifier
+ * @notice Verifier for transfers that trigger subtree rollover
+ */
+interface ITransferRolloverVerifier {
+    function verifyProof(
+        uint[2] calldata _pA,
+        uint[2][2] calldata _pB,
+        uint[2] calldata _pC,
+        uint[12] calldata _pubSignals
+    ) external view returns (bool);
+}

--- a/assets/erc-8086/contracts/interfaces/IZRC20.sol
+++ b/assets/erc-8086/contracts/interfaces/IZRC20.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+/**
+ * @title IZRC20
+ * @notice Minimal interface for native privacy assets on Ethereum (ERC-8086)
+ * @dev This standard defines the foundation for privacy-preserving tokens
+ *      that can be used directly or as building blocks for wrapper protocols
+ *      and dual-mode protocols implementations.
+ */
+interface IZRC20 {
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Events
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Emitted when a commitment is added to the Merkle tree
+     * @param subtreeIndex Subtree index (0 for single-tree implementations)
+     * @param commitment The cryptographic commitment hash
+     * @param leafIndex Position within subtree (or global index)
+     * @param timestamp Block timestamp of insertion
+     * @dev For single-tree: subtreeIndex SHOULD be 0, leafIndex is global position
+     * @dev For dual-tree: subtreeIndex identifies which subtree, leafIndex is position within it
+     */
+    event CommitmentAppended(
+        uint32 indexed subtreeIndex,
+        bytes32 commitment,
+        uint32 indexed leafIndex,
+        uint256 timestamp
+    );
+
+    /**
+     * @notice Emitted when a nullifier is spent (note consumed)
+     * @param nullifier The unique nullifier hash
+     * @dev Once spent, nullifier can never be reused (prevents double-spending)
+     */
+    event NullifierSpent(bytes32 indexed nullifier);
+
+    /**
+     * @notice Emitted when tokens are minted directly into privacy mode
+     * @param minter Address that initiated the mint
+     * @param commitment The commitment created for minted value
+     * @param encryptedNote Encrypted note for recipient
+     * @param subtreeIndex Subtree where commitment was added
+     * @param leafIndex Position within subtree
+     * @param timestamp Block timestamp of mint
+     */
+    event Minted(
+        address indexed minter,
+        bytes32 commitment,
+        bytes encryptedNote,
+        uint32 subtreeIndex,
+        uint32 leafIndex,
+        uint256 timestamp
+    );
+
+    /**
+     * @notice Emitted on privacy transfers with public scanning data
+     * @param newCommitments Output commitments created (typically 1-2)
+     * @param encryptedNotes Encrypted notes for recipients
+     * @param ephemeralPublicKey Ephemeral public key for ECDH key exchange (if used)
+     * @param viewTag Scanning optimization byte (0 if not used)
+     * @dev Provides data for recipients to detect and decrypt their notes
+     */
+    event Transaction(
+        bytes32[2] newCommitments,
+        bytes[] encryptedNotes,
+        uint256[2] ephemeralPublicKey,
+        uint256 viewTag
+    );
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Metadata (ERC-20 compatible, OPTIONAL but RECOMMENDED)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Returns the token name
+     * @return Token name string
+     * @dev OPTIONAL but RECOMMENDED for UX and interoperability
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @notice Returns the token symbol
+     * @return Token symbol string
+     * @dev OPTIONAL but RECOMMENDED for UX and interoperability
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @notice Returns the number of decimals
+     * @return Number of decimals (typically 18)
+     * @dev OPTIONAL but RECOMMENDED for amount formatting
+     */
+    function decimals() external view returns (uint8);
+
+    /**
+     * @notice Returns the total supply across all privacy notes
+     * @return Total token supply
+     * @dev OPTIONAL - May be required for certain economic models (e.g., fixed cap)
+     *      Individual balances remain private; only aggregate supply is visible
+     */
+    function totalSupply() external view returns (uint256);
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Core Functions
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Mints new privacy tokens
+     * @param proofType Type of proof to support multiple proof strategies.
+     * @param proof Zero-knowledge proof of valid transfer
+     * @param encryptedNote Encrypted note for minter's wallet
+     * @dev Proof must demonstrate valid commitment creation and payment
+     *      Implementations define minting rules
+     */
+    function mint(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes calldata encryptedNote
+    ) external payable;
+
+    /**
+     * @notice Executes a privacy-preserving transfer
+     * @param proofType Implementation-specific proof type identifier
+     * @param proof Zero-knowledge proof of valid transfer
+     * @param encryptedNotes Encrypted output notes (for recipient and/or change)
+     * @dev Proof must demonstrate:
+     *      1. Input commitments exist in Merkle tree
+     *      2. Prover knows private keys
+     *      3. Nullifiers not spent
+     *      4. Value conservation: sum(inputs) = sum(outputs)
+     */
+    function transfer(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) external;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Query Functions
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Check if a nullifier has been spent
+     * @param nullifier The nullifier to check
+     * @return True if nullifier spent, false otherwise
+     * @dev Implementations using `mapping(bytes32 => bool) public nullifiers`
+     *      will auto-generate this function.
+     */
+    function nullifiers(bytes32 nullifier) external view returns (bool);
+
+    /**
+     * @notice Returns the current active subtree Merkle root
+     * @return The root hash of the active subtree
+     * @dev The active subtree stores recent commitments for faster proof computation.
+     *      For dual-tree implementations, this is the root of the current working subtree.
+     */
+    function activeSubtreeRoot() external view returns (bytes32);
+}

--- a/assets/erc-8086/contracts/reference/PrivacyToken.sol
+++ b/assets/erc-8086/contracts/reference/PrivacyToken.sol
@@ -440,7 +440,6 @@ contract PrivacyToken is IZRC20, ReentrancyGuard {
 
                 emit CommitmentAppended(state.currentSubtreeIndex, c, state.nextLeafIndexInSubtree, block.timestamp);
                 state.nextLeafIndexInSubtree++;
-                if (state.nextLeafIndexInSubtree >= SUBTREE_CAPACITY) revert InvalidStateForRegularMint();
             }
         }
         emit Transaction(_data.commitments, _encryptedNotes, _data.ephemeralPublicKey, _data.viewTag);

--- a/assets/erc-8086/contracts/reference/PrivacyToken.sol
+++ b/assets/erc-8086/contracts/reference/PrivacyToken.sol
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "../interfaces/IVerifier.sol";
+import "../interfaces/IZRC20.sol";
+
+
+/**
+ * @title PrivacyToken
+ * @dev Refactored implementation with a standard, robust, and readable Merkle tree.
+ */
+contract PrivacyToken is IZRC20, ReentrancyGuard {
+
+    // ===================================
+    //        CUSTOM ERRORS (GAS OPTIMIZATION)
+    // ===================================
+    // --- General Errors ---
+    error AlreadyInitialized();
+    error InvalidProofType(uint8 receivedType);
+    error InvalidProof();
+    error InvalidPublicSignalLength(uint256 expected, uint256 received);
+
+    // --- Minting Errors ---
+    error IncorrectMintPrice(uint256 expected, uint256 sent);
+    error MaxSupplyExceeded();
+    error IncorrectMintAmount(uint256 expected, uint256 proven);
+    error CommitmentAlreadyExists(bytes32 commitment);
+
+    // --- Transfer Errors ---
+    error DoubleSpend(bytes32 nullifier);
+    
+    // --- State & Root Mismatch Errors ---
+    error OldActiveRootMismatch(bytes32 expected, bytes32 received);
+    error OldFinalizedRootMismatch(bytes32 expected, bytes32 received);
+    error IncorrectSubtreeIndex(uint256 expected, uint256 received);
+
+    // --- Capacity & State Condition Errors ---
+    error InvalidStateForRegularMint();
+    error InvalidStateForRollover();
+    error SubtreeCapacityExceeded(uint256 needed, uint256 available);
+    
+    // --- Fee Distribution Errors ---
+    error NoFeesToDistribute();
+    error FeeTransferFailed();
+
+    struct ContractState {
+        uint32 currentSubtreeIndex;
+        uint32 nextLeafIndexInSubtree;
+        uint8 subTreeHeight;
+        uint8 rootTreeHeight;
+        bool initialized; 
+    }
+
+    // ===================================
+    //        STATE VARIABLES
+    // ===================================
+    // --- Configuration (Set once) ---
+    string private _name;
+    string private _symbol;
+    uint256 public MAX_SUPPLY;
+    uint256 public MINT_PRICE;
+    uint256 public MINT_AMOUNT;
+    address public initiator;
+    address public platformTreasury;
+    uint256 public platformFeeBps;
+
+     // --- Verifiers ---
+    IActiveTransferVerifier public activeTransferVerifier;
+    IFinalizedTransferVerifier public finalizedTransferVerifier;
+    ITransferRolloverVerifier public rolloverTransferVerifier;
+    IMintVerifier public mintVerifier; 
+    IMintRolloverVerifier public mintRolloverVerifier; 
+
+   // --- Dynamic State ---
+    mapping(bytes32 => bool) public nullifiers;
+    mapping(bytes32 => bool) public commitmentHashes;
+    uint256 public override totalSupply;
+    
+    // --- Packed State (For Gas Savings on SSTORE) ---
+    ContractState public state;
+
+    // --- Tree Roots ---
+    bytes32 public EMPTY_SUBTREE_ROOT;
+    bytes32 public override activeSubtreeRoot;
+    bytes32 public finalizedRoot;
+    uint256 public SUBTREE_CAPACITY;
+
+    /**
+     * @dev A struct to hold the relevant data extracted from the ZK proof's public signals.
+     * This decouples the business logic from the specific layout of the circuit's output.
+     */
+    struct TransactionData {
+        bytes32[2] nullifiers;
+        bytes32[2] commitments;
+        uint256[2] ephemeralPublicKey;
+        uint256 viewTag;
+    }
+
+    constructor(){}
+
+    /**
+     * @notice Initializes the state of the cloned contract.
+     * @dev This function replaces the original constructor and can only be called once.
+     *      It's called by the factory immediately after cloning.
+     */
+    function initialize(
+        string memory name_,
+        string memory symbol_,
+        uint256 max_supply_,
+        uint256 mintPrice_,
+        uint256 mint_amount_,
+        address initiator_,
+        address platformTreasury_,
+        uint256 platformFeeBps_,
+        address[5] memory verifiers_,
+        uint8 subtreeHeight_,
+        uint8 rootTreeHeight_,
+        bytes32 initialSubtreeEmptyRoot_,
+        bytes32 initialFinalizedEmptyRoot_
+    ) external {
+        if (state.initialized) revert AlreadyInitialized();
+        state.initialized = true;
+
+        initiator = initiator_;
+        _name = name_;
+        _symbol = symbol_;
+        MAX_SUPPLY = max_supply_;
+        MINT_PRICE = mintPrice_;
+        MINT_AMOUNT = mint_amount_;
+        platformTreasury = platformTreasury_;
+        platformFeeBps = platformFeeBps_;
+
+        mintVerifier = IMintVerifier(verifiers_[0]);
+        mintRolloverVerifier = IMintRolloverVerifier(verifiers_[1]);
+        activeTransferVerifier = IActiveTransferVerifier(verifiers_[2]);
+        finalizedTransferVerifier = IFinalizedTransferVerifier(verifiers_[3]);
+        rolloverTransferVerifier = ITransferRolloverVerifier(verifiers_[4]);
+
+        
+        state.subTreeHeight = subtreeHeight_;
+        SUBTREE_CAPACITY = 1 << subtreeHeight_;
+        state.rootTreeHeight = rootTreeHeight_;
+        EMPTY_SUBTREE_ROOT = initialSubtreeEmptyRoot_;
+
+        activeSubtreeRoot = initialSubtreeEmptyRoot_;
+        finalizedRoot = initialFinalizedEmptyRoot_;
+        state.nextLeafIndexInSubtree = 0;
+    }
+
+    // --- Metadata Views ---
+    function name() external view override returns (string memory) { return _name; }
+    function symbol() external view override returns (string memory) { return _symbol; }
+    function decimals() external pure override returns (uint8) { return 18; } // Standard
+
+
+    // =============================================================
+    // ===               PUBLIC MINTING INTERFACE                ===
+    // =============================================================
+    
+    /**
+     * @notice A single, unified, and permissionless entry point for minting new tokens.
+     * @dev Anyone can call this function by paying the MINT_PRICE. It routes the request
+     *      to the appropriate internal function based on the state of the active subtree.
+     *      This function is protected against re-entrancy attacks.
+     * @param proofType 0 for a regular mint, 1 for a mint that triggers a rollover.
+     * @param proof The abi-encoded ZK-SNARK proof, which includes pA, pB, pC, and all public signals.
+     * @param encryptedNote The encrypted note data for the new owner.
+     */
+    function mint(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes calldata encryptedNote
+    ) external override payable nonReentrant{
+        // --- 1. Initial Business Logic Checks ---
+        if (msg.value != MINT_PRICE) revert IncorrectMintPrice(MINT_PRICE, msg.value);
+        if (totalSupply + MINT_AMOUNT > MAX_SUPPLY) revert MaxSupplyExceeded();
+
+        // --- 2. Dispatch to the correct internal logic ---
+        if (proofType == 0) { // Regular Mint
+            _mintRegular(proof, encryptedNote);
+        } else if (proofType == 1) { // Rollover Mint
+            _mintAndRollover(proof, encryptedNote);
+        } else {
+            revert InvalidProofType(proofType);
+        }
+    }
+
+    // =============================================================
+    // ===        INTERNAL SPECIALIZED MINTING LOGIC             ===
+    // =============================================================
+
+    /**
+     * @dev Handles the logic for a regular mint that does NOT trigger a subtree rollover.
+     *      It verifies the proof against the ProveMint circuit and updates the activeSubtreeRoot.
+     */
+    function _mintRegular(bytes calldata _proof, bytes calldata _encryptedNote) internal {
+        // --- Pre-condition Check ---
+        // A stricter check could be 
+        if (state.nextLeafIndexInSubtree >= SUBTREE_CAPACITY) revert InvalidStateForRegularMint();
+
+        // --- Decode Proof ---
+        // The proof must be decoded according to the ProveMint circuit's public signals.
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[4] memory pubSignals) = 
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[4]));
+
+        // --- Extract and Verify Public Signals ---
+        bytes32 newActiveRoot = bytes32(pubSignals[0]);
+        bytes32 oldActiveRoot_from_proof = bytes32(pubSignals[1]);
+        bytes32 newCommitment = bytes32(pubSignals[2]);
+        uint256 mintAmount_from_proof = pubSignals[3];
+
+        if (commitmentHashes[newCommitment]) revert CommitmentAlreadyExists(newCommitment);
+        commitmentHashes[newCommitment] = true;
+
+        // --- On-Chain State Validation ---
+        if (activeSubtreeRoot != oldActiveRoot_from_proof) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot_from_proof);
+        if (MINT_AMOUNT != mintAmount_from_proof) revert IncorrectMintAmount(MINT_AMOUNT, mintAmount_from_proof);
+        if (!mintVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        // --- State Updates (Effects) ---
+        totalSupply += MINT_AMOUNT;
+        activeSubtreeRoot = newActiveRoot; // Atomically update the root to the proven new state.
+        
+        emit CommitmentAppended(state.currentSubtreeIndex, newCommitment, state.nextLeafIndexInSubtree, block.timestamp);
+
+        state.nextLeafIndexInSubtree++;
+        
+        // --- Event Emission for Scanners ---
+        emit Minted(msg.sender, newCommitment, _encryptedNote, state.currentSubtreeIndex, state.nextLeafIndexInSubtree-1, block.timestamp);
+    }
+
+    /**
+     * @dev Handles the logic for a mint that triggers a subtree rollover.
+     *      It verifies the proof against the ProveMintAndRollover circuit and updates BOTH roots.
+     */
+    function _mintAndRollover(bytes calldata _proof, bytes calldata _encryptedNote) internal {
+        // --- Pre-condition Check ---
+        if (state.nextLeafIndexInSubtree != SUBTREE_CAPACITY) revert InvalidStateForRollover();
+        
+        // --- Decode Proof ---
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[7] memory pubSignals) = 
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[7]));
+            
+        // --- Extract and Verify Public Signals ---
+        bytes32 newActiveRoot = bytes32(pubSignals[0]);
+        bytes32 newFinalizedRoot = bytes32(pubSignals[1]);
+        bytes32 oldActiveRoot_from_proof = bytes32(pubSignals[2]);
+        bytes32 oldFinalizedRoot_from_proof = bytes32(pubSignals[3]);
+        bytes32 newCommitment = bytes32(pubSignals[4]);
+        uint256 mintAmount_from_proof = pubSignals[5];
+        uint256 subtreeIndex_from_proof = pubSignals[6];
+
+        if (commitmentHashes[newCommitment]) revert CommitmentAlreadyExists(newCommitment);
+        commitmentHashes[newCommitment] = true;
+
+        // --- On-Chain State Validation ---
+        if (activeSubtreeRoot != oldActiveRoot_from_proof) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot_from_proof);
+        if (finalizedRoot != oldFinalizedRoot_from_proof) revert OldFinalizedRootMismatch(finalizedRoot, oldFinalizedRoot_from_proof);
+        if (MINT_AMOUNT != mintAmount_from_proof) revert IncorrectMintAmount(MINT_AMOUNT, mintAmount_from_proof);
+
+        if (state.currentSubtreeIndex != subtreeIndex_from_proof) revert IncorrectSubtreeIndex(state.currentSubtreeIndex, subtreeIndex_from_proof);
+
+        // --- ZK Proof Verification ---
+        if (!mintRolloverVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        activeSubtreeRoot = newActiveRoot;
+        finalizedRoot = newFinalizedRoot;
+        state.currentSubtreeIndex++;
+        state.nextLeafIndexInSubtree = 0;
+        
+        totalSupply += MINT_AMOUNT;
+        
+        // This commitment is the FIRST leaf of the NEW subtree.
+        emit CommitmentAppended(state.currentSubtreeIndex, newCommitment, state.nextLeafIndexInSubtree, block.timestamp);        
+        state.nextLeafIndexInSubtree++;
+
+        // --- Event Emission for Scanners ---
+        emit Minted(msg.sender, newCommitment, _encryptedNote, state.currentSubtreeIndex, state.nextLeafIndexInSubtree-1, block.timestamp);
+    }
+
+    // =============================================================
+    // ===           UNIFIED TRANSFER INTERFACE                  ===
+    // =============================================================
+    function transfer(
+        uint8 proofType,
+        bytes calldata proof,
+        bytes[] calldata encryptedNotes
+    ) external override {
+        if (proofType == 0) { // Active
+            _transferActive(proof, encryptedNotes);
+        } else if (proofType == 1) { // Finalized
+            _transferFinalized(proof, encryptedNotes);
+        } else if (proofType == 2) { // Rollover
+            _transferAndRollover(proof, encryptedNotes);
+        } else {
+            revert InvalidProofType(proofType);        
+        }
+    }
+
+    // =============================================================
+    // ===        INTERNAL SPECIALIZED TRANSFER LOGIC            ===
+    // =============================================================
+
+    function _transferActive(bytes calldata _proof, bytes[] calldata _encryptedNotes) internal {
+
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[12] memory pubSignals) = 
+        abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[12]));
+        
+        bytes32 newActiveSubTreeRoot = bytes32(pubSignals[2]);
+        uint256 numRealOutputs = pubSignals[3];
+        bytes32 oldActiveSubTreeRoot = bytes32(pubSignals[4]);
+
+        uint256 availableCapacity = uint256(SUBTREE_CAPACITY - state.nextLeafIndexInSubtree);
+        if (numRealOutputs > availableCapacity) revert SubtreeCapacityExceeded(numRealOutputs, availableCapacity);
+        if (activeSubtreeRoot != oldActiveSubTreeRoot) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveSubTreeRoot);
+        if (!activeTransferVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        activeSubtreeRoot = newActiveSubTreeRoot;
+
+        TransactionData memory data;
+        data.ephemeralPublicKey = [pubSignals[0], pubSignals[1]];
+        data.nullifiers         = [bytes32(pubSignals[5]), bytes32(pubSignals[6])]; 
+        data.commitments        = [bytes32(pubSignals[7]), bytes32(pubSignals[8])]; 
+        data.viewTag            = pubSignals[11]; 
+
+        _processTransaction(data, _encryptedNotes);
+    }
+
+
+    function _transferFinalized(bytes calldata _proof, bytes[] calldata _encryptedNotes) internal {
+        
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[13] memory pubSignals) = 
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[13]));
+
+        bytes32 newActiveRoot = bytes32(pubSignals[2]);
+        uint256 numRealOutputs = pubSignals[3];
+        bytes32 oldFinalizedRoot = bytes32(pubSignals[4]);
+        bytes32 oldActiveRoot = bytes32(pubSignals[5]);
+        
+        uint256 availableCapacity = uint32(SUBTREE_CAPACITY - state.nextLeafIndexInSubtree);
+        if (numRealOutputs > availableCapacity) revert SubtreeCapacityExceeded(numRealOutputs, availableCapacity);
+        if (activeSubtreeRoot != oldActiveRoot) revert OldActiveRootMismatch(activeSubtreeRoot, oldActiveRoot);
+        if (finalizedRoot != oldFinalizedRoot) revert OldFinalizedRootMismatch(finalizedRoot, oldFinalizedRoot);
+        if (!finalizedTransferVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        activeSubtreeRoot = newActiveRoot;
+
+        TransactionData memory data;
+        data.ephemeralPublicKey = [pubSignals[0], pubSignals[1]];
+        data.nullifiers         = [bytes32(pubSignals[6]), bytes32(pubSignals[7])]; 
+        data.commitments        = [bytes32(pubSignals[8]), bytes32(pubSignals[9])];
+        data.viewTag            = pubSignals[12]; 
+
+        _processTransaction(data, _encryptedNotes);
+    }
+
+    function _transferAndRollover(bytes calldata _proof, bytes[] calldata _encryptedNotes) internal {
+
+        (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[12] memory pubSignals) = 
+            abi.decode(_proof, (uint[2], uint[2][2], uint[2], uint[12]));
+        
+        bytes32 newActive = bytes32(pubSignals[2]);
+        bytes32 newFinalized = bytes32(pubSignals[3]);
+        bytes32 oldActive = bytes32(pubSignals[4]);
+        bytes32 oldFinalized = bytes32(pubSignals[5]);
+        uint256 subtreeIndex_from_proof = pubSignals[11];
+
+        // A rollover transfer must be happening when the subtree is nearly full.
+        if (state.nextLeafIndexInSubtree != SUBTREE_CAPACITY) revert InvalidStateForRollover();
+        if (activeSubtreeRoot != oldActive) revert OldActiveRootMismatch(activeSubtreeRoot, oldActive);
+        if (finalizedRoot != oldFinalized) revert OldFinalizedRootMismatch(finalizedRoot, oldFinalized);
+
+        if (state.currentSubtreeIndex != subtreeIndex_from_proof) revert IncorrectSubtreeIndex(state.currentSubtreeIndex, subtreeIndex_from_proof);
+        if (!rolloverTransferVerifier.verifyProof(a, b, c, pubSignals)) revert InvalidProof();
+
+        // Atomically update both roots and all indices
+        activeSubtreeRoot = newActive;
+        finalizedRoot = newFinalized;
+
+        state.currentSubtreeIndex++;
+        state.nextLeafIndexInSubtree = 0;
+
+        TransactionData memory data;
+        data.ephemeralPublicKey = [pubSignals[0], pubSignals[1]];
+        data.nullifiers         = [bytes32(pubSignals[6]), bytes32(0)]; 
+        data.commitments        = [bytes32(pubSignals[7]), bytes32(0)]; 
+        data.viewTag            = pubSignals[10]; 
+
+        _processTransaction(data, _encryptedNotes);
+    }
+
+    /**
+     * @dev Internal function to distribute fees to the platform and token creator.
+     */
+    function distributeFees() external nonReentrant {
+        uint256 balance = address(this).balance;
+        if (balance == 0) revert NoFeesToDistribute();
+        
+        uint256 platformAmount = (balance * platformFeeBps) / 10000;
+        uint256 initiatorAmount = balance - platformAmount;
+        
+        if (platformAmount > 0) {
+            (bool success1, ) = platformTreasury.call{value: platformAmount}("");
+            if (!success1) revert FeeTransferFailed();
+        }
+        
+        if (initiatorAmount > 0) {
+            (bool success2, ) = initiator.call{value: initiatorAmount}("");
+            if (!success2) revert FeeTransferFailed();
+        }        
+    }
+
+    /**
+     * @dev Processes a verified transaction by spending nullifiers and appending new commitments.
+     * This is the single, refactored function for all transfer types.
+     * @param _data The structured transaction data, extracted from public signals.
+     * @param _encryptedNotes The encrypted output notes.
+     */
+    function _processTransaction(
+        TransactionData memory _data,
+        bytes[] calldata _encryptedNotes
+    ) internal {
+        // Spend Nullifiers
+        for (uint32 i = 0; i < _data.nullifiers.length; i++) {
+            bytes32 n = _data.nullifiers[i];
+            if (n != bytes32(0)) {
+                if (nullifiers[n]) revert DoubleSpend(n);
+                nullifiers[n] = true;
+                emit NullifierSpent(n);
+            }
+        }
+        
+        // Append Commitments
+        for (uint i = 0; i < _data.commitments.length; i++) {
+            bytes32 c = _data.commitments[i];
+            if (c != bytes32(0)) {
+                // Note: The logic for subtree and leaf index updates might need to be
+                // passed in or handled just before this call if it differs.
+
+                emit CommitmentAppended(state.currentSubtreeIndex, c, state.nextLeafIndexInSubtree, block.timestamp);
+                state.nextLeafIndexInSubtree++;
+                if (state.nextLeafIndexInSubtree >= SUBTREE_CAPACITY) revert InvalidStateForRegularMint();
+            }
+        }
+        emit Transaction(_data.commitments, _encryptedNotes, _data.ephemeralPublicKey, _data.viewTag);
+    }
+
+}

--- a/assets/erc-8086/contracts/reference/PrivacyTokenFactory.sol
+++ b/assets/erc-8086/contracts/reference/PrivacyTokenFactory.sol
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import "@openzeppelin/contracts/proxy/Clones.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./PrivacyToken.sol";
+
+/**
+ * @title PrivacyTokenFactory
+ * @notice Factory for deploying new ERC-8086 compliant privacy tokens
+ * @dev Uses minimal proxy pattern (EIP-1167) for gas-efficient deployments.
+ *      Anyone can create a new privacy token by paying the creation fee.
+ */
+contract PrivacyTokenFactory is Ownable {
+
+    // ===================================
+    //        IMMUTABLE STATE
+    // ===================================
+
+    /// @notice The implementation contract address used for all clones
+    address public immutable privacyTokenImplementation;
+
+    // ===================================
+    //        PLATFORM CONFIGURATION
+    // ===================================
+
+    /// @notice Treasury address for platform fees
+    address public platformTreasury;
+
+    /// @notice Platform fee in basis points (e.g., 250 = 2.5%)
+    uint256 public platformFeeBps;
+
+    /// @notice Fee required to create a new token
+    uint256 public creationFee;
+
+    // ===================================
+    //        SHARED VERIFIERS
+    // ===================================
+
+    IVerifier public mintVerifier;
+    IVerifier public mintRolloverVerifier;
+    IVerifier public activeTransferVerifier;
+    IVerifier public finalizedTransferVerifier;
+    IVerifier public rolloverTransferVerifier;
+
+    // ===================================
+    //        TREE CONFIGURATION
+    // ===================================
+
+    /// @notice Height of active subtree (e.g., 16 = 65536 leaves)
+    uint8 public subtree_height;
+
+    /// @notice Height of root tree (e.g., 20 = 1048576 subtrees)
+    uint8 public roottree_height;
+
+    /// @notice Precomputed empty root for new subtrees
+    bytes32 public initialSubtreeEmptyRoot;
+
+    /// @notice Precomputed empty root for finalized tree
+    bytes32 public initialFinalizedEmptyRoot;
+
+    // ===================================
+    //        EVENTS
+    // ===================================
+
+    event TokenCreated(
+        address indexed tokenAddress,
+        address indexed creator,
+        string name,
+        string symbol,
+        uint256 maxSupply,
+        uint256 mintAmount,
+        uint256 mintPrice,
+        uint256 subTreeHeight,
+        uint256 rootTreeHeight
+    );
+
+    event VerifiersUpdated(
+        address newMintVerifier,
+        address newMintRolloverVerifier,
+        address newActiveTransferVerifier,
+        address newFinalizedTransferVerifier,
+        address newRolloverTransferVerifier
+    );
+
+    event PlatformFeeUpdated(uint256 newFeeBps);
+    event TreasuryUpdated(address indexed newTreasury);
+    event CreationFeeUpdated(uint256 newCreationFee);
+
+    // ===================================
+    //        CONSTRUCTOR
+    // ===================================
+
+    /**
+     * @notice Deploys the factory with initial configuration
+     * @param _implementation Address of PrivacyToken implementation
+     * @param _treasury Address to receive platform fees
+     * @param _verifiers Array of 5 verifier addresses: [mint, mintRollover, active, finalized, transferRollover]
+     * @param _initialSubtreeEmptyRoot Precomputed empty subtree root
+     * @param _initialFinalizedEmptyRoot Precomputed empty finalized tree root
+     */
+    constructor(
+        address _implementation,
+        address _treasury,
+        address[5] memory _verifiers,
+        bytes32 _initialSubtreeEmptyRoot,
+        bytes32 _initialFinalizedEmptyRoot
+    ) Ownable(msg.sender) {
+        require(_implementation != address(0), "Impl address cannot be zero");
+        require(_treasury != address(0), "Treasury address cannot be zero");
+        for (uint i = 0; i < _verifiers.length; i++) {
+            require(_verifiers[i] != address(0), "Verifier address cannot be zero");
+        }
+
+        privacyTokenImplementation = _implementation;
+        platformTreasury = _treasury;
+        platformFeeBps = 250; // Default 2.5%
+        creationFee = 0.005 ether;
+        subtree_height = 16;
+        roottree_height = 20;
+
+        mintVerifier = IVerifier(_verifiers[0]);
+        mintRolloverVerifier = IVerifier(_verifiers[1]);
+        activeTransferVerifier = IVerifier(_verifiers[2]);
+        finalizedTransferVerifier = IVerifier(_verifiers[3]);
+        rolloverTransferVerifier = IVerifier(_verifiers[4]);
+
+        initialSubtreeEmptyRoot = _initialSubtreeEmptyRoot;
+        initialFinalizedEmptyRoot = _initialFinalizedEmptyRoot;
+    }
+
+    // ===================================
+    //        TOKEN CREATION
+    // ===================================
+
+    /**
+     * @notice Creates a new privacy token
+     * @param name Token name
+     * @param symbol Token symbol
+     * @param maxSupply Maximum supply (in wei, 18 decimals)
+     * @param mintPrice Price per mint in native token (ETH)
+     * @param mintAmount Amount minted per mint operation
+     * @return tokenProxy Address of the newly created token
+     */
+    function createToken(
+        string calldata name,
+        string calldata symbol,
+        uint256 maxSupply,
+        uint256 mintPrice,
+        uint256 mintAmount
+    ) external payable returns (address tokenProxy) {
+        require(msg.value == creationFee, "Incorrect creation fee");
+        require(bytes(name).length > 0 && bytes(symbol).length > 0, "Name and symbol required");
+        require(maxSupply > 0, "Max supply must be positive");
+
+        tokenProxy = Clones.clone(privacyTokenImplementation);
+
+        PrivacyToken(tokenProxy).initialize(
+            name,
+            symbol,
+            maxSupply,
+            mintPrice,
+            mintAmount,
+            msg.sender,
+            platformTreasury,
+            platformFeeBps,
+            [
+                address(mintVerifier),
+                address(mintRolloverVerifier),
+                address(activeTransferVerifier),
+                address(finalizedTransferVerifier),
+                address(rolloverTransferVerifier)
+            ],
+            subtree_height,
+            roottree_height,
+            initialSubtreeEmptyRoot,
+            initialFinalizedEmptyRoot
+        );
+
+        emit TokenCreated(
+            tokenProxy,
+            msg.sender,
+            name,
+            symbol,
+            maxSupply,
+            mintAmount,
+            mintPrice,
+            subtree_height,
+            roottree_height
+        );
+    }
+
+    // ===================================
+    //        ADMIN FUNCTIONS
+    // ===================================
+
+    function setCreationFee(uint256 _newCreationFee) external onlyOwner {
+        creationFee = _newCreationFee;
+        emit CreationFeeUpdated(_newCreationFee);
+    }
+
+    function setTreeHeight(uint8 _subtree_height, uint8 _roottree_height) external onlyOwner {
+        require(_subtree_height > 9, "Invalid subtree height");
+        require(_roottree_height > 15, "Invalid roottree height");
+        subtree_height = _subtree_height;
+        roottree_height = _roottree_height;
+    }
+
+    function withdrawCreationFees() external onlyOwner {
+        uint256 balance = address(this).balance;
+        require(balance > 0, "Factory: No fees to withdraw");
+        (bool success, ) = platformTreasury.call{value: balance}("");
+        require(success, "Factory: Fee withdrawal failed");
+    }
+
+    function setPlatformFeeBps(uint256 _newFeeBps) external onlyOwner {
+        require(_newFeeBps <= 10000, "Factory: Fee cannot exceed 100%");
+        platformFeeBps = _newFeeBps;
+        emit PlatformFeeUpdated(_newFeeBps);
+    }
+
+    function setTreasury(address _newTreasury) external onlyOwner {
+        require(_newTreasury != address(0), "Factory: Invalid treasury address");
+        platformTreasury = _newTreasury;
+        emit TreasuryUpdated(_newTreasury);
+    }
+
+    function setVerifiers(address[5] memory _newVerifiers) external onlyOwner {
+        for (uint i = 0; i < _newVerifiers.length; i++) {
+            require(_newVerifiers[i] != address(0), "New verifier address cannot be zero");
+        }
+
+        mintVerifier = IVerifier(_newVerifiers[0]);
+        mintRolloverVerifier = IVerifier(_newVerifiers[1]);
+        activeTransferVerifier = IVerifier(_newVerifiers[2]);
+        finalizedTransferVerifier = IVerifier(_newVerifiers[3]);
+        rolloverTransferVerifier = IVerifier(_newVerifiers[4]);
+
+        emit VerifiersUpdated(
+            _newVerifiers[0],
+            _newVerifiers[1],
+            _newVerifiers[2],
+            _newVerifiers[3],
+            _newVerifiers[4]
+        );
+    }
+}

--- a/assets/erc-8086/deployments/base-sepolia.json
+++ b/assets/erc-8086/deployments/base-sepolia.json
@@ -1,0 +1,51 @@
+{
+  "network": "Base Sepolia",
+  "chainId": 84532,
+  "deployedAt": "2025-11-26T02:48:35.733Z",
+  "blockNumber": 34178513,
+  "contracts": {
+    "PrivacyTokenFactory": {
+      "address": "0x04df6DbAe3BAe8bC91ef3b285d0666d36dda24af",
+      "basescan": "https://sepolia.basescan.org/address/0x04df6DbAe3BAe8bC91ef3b285d0666d36dda24af#code"
+    },
+    "PrivacyToken (Implementation)": {
+      "address": "0xa025070b46a38d5793F491097A6aae1A6109000c",
+      "basescan": "https://sepolia.basescan.org/address/0xa025070b46a38d5793F491097A6aae1A6109000c#code"
+    },
+    "MintVerifier": {
+      "address": "0x1C9260008DA7a12dF2DE2E562dC72b877f4B9a4b",
+      "basescan": "https://sepolia.basescan.org/address/0x1C9260008DA7a12dF2DE2E562dC72b877f4B9a4b#code"
+    },
+    "MintRolloverVerifier": {
+      "address": "0x9423767D08eF34CEC1F1aD384e2884dd24c68f5B",
+      "basescan": "https://sepolia.basescan.org/address/0x9423767D08eF34CEC1F1aD384e2884dd24c68f5B#code"
+    },
+    "ActiveTransferVerifier": {
+      "address": "0x14834a1b1E67977e4ec9a33fc84e58851E21c4Aa",
+      "basescan": "https://sepolia.basescan.org/address/0x14834a1b1E67977e4ec9a33fc84e58851E21c4Aa#code"
+    },
+    "FinalizedTransferVerifier": {
+      "address": "0x1b7c464ed02af392a44CE7881081d1fb1D15b970",
+      "basescan": "https://sepolia.basescan.org/address/0x1b7c464ed02af392a44CE7881081d1fb1D15b970#code"
+    },
+    "RolloverTransferVerifier": {
+      "address": "0x4dd4D44f99Afb3AE4F4e8C03BAdA2Ff84E75f9Cb",
+      "basescan": "https://sepolia.basescan.org/address/0x4dd4D44f99Afb3AE4F4e8C03BAdA2Ff84E75f9Cb#code"
+    }
+  },
+  "cryptoParams": {
+    "subtreeLevels": 16,
+    "rootTreeLevels": 20,
+    "subtreeCapacity": 65536,
+    "initialSubtreeEmptyRoot": "0x2a7c7c9b6ce5880b9f6f228d72bf6a575a526f29c66ecceef8b753d38bba7323",
+    "initialFinalizedEmptyRoot": "0x224ccc25981822d4c5b6fc199fbc74828488741c7151a6159ecfaab7c2a8bac9"
+  },
+  "compiler": {
+    "version": "0.8.20",
+    "optimizer": {
+      "enabled": true,
+      "runs": 200
+    },
+    "viaIR": true
+  }
+}


### PR DESCRIPTION
This EIP defines a minimal interface standard for privacy tokens on Ethereum.

While developing privacy solutions for the Ethereum ecosystem—including wrapper protocols (converting [ERC-20](./eip-20) ↔ privacy tokens) and dual-mode tokens (combining public and private balances)—we identified a recurring need for standardized privacy primitives. Without a common interface, each implementation reinvents commitments, nullifiers, and note encryption, leading to ecosystem fragmentation.

This standard provides that common foundation. It enables:
- **Wrapper protocols**: Implement this interface for their privacy layer
- **Dual-mode tokens protocols**: Combine standards via `contract DMT is ERC20, IZRC20`

By unifying the privacy token interface, we facilitate the development of wrapper and dual-mode protocols, accelerating Ethereum's privacy ecosystem growth.

Discussion

Community discussion: 
https://ethereum-magicians.org/t/erc-8086-privacy-token/26623
https://ethereum-magicians.org/t/erc-8085-dual-mode-fungible-tokens/26592
