### PR TITLE
Add ERC: Privacy Address Format

### DIFF
--- a/ERCS/erc-8091.md
+++ b/ERCS/erc-8091.md
@@ -324,6 +324,17 @@ Implementations MUST validate pv1 addresses according to these rules:
    - Accountants: scanPrivateKey + encryptionPrivateKey (full visibility, no spending)
    - Owner: all three private keys
 
+4. **Potential Extended Use Cases**
+
+   The encryption public key, being stable and publicly accessible as part of the pv-address, could potentially support use cases beyond note encryption:
+
+   - **Private messaging**: Direct encrypted communication between users
+   - **Encrypted metadata**: Payment references, invoice numbers, or custom notes attached to transactions
+   - **Cross-protocol notifications**: Privacy-preserving alerts like "payment received" or "note available"
+   - **Wallet-to-wallet communication**: Encrypted payment requests, refund addresses, or coordination messages
+
+   This standard does not restrict how implementations utilize the encryption key. Developers are free to innovate and extend its usage beyond the core privacy token protocol, enabling richer privacy-preserving applications.
+
 ### Why Baby Jubjub Instead of secp256k1?
 
 | Consideration          | secp256k1                  | Baby Jubjub                    |
@@ -623,6 +634,18 @@ class Pv1AddressManager {
 - Network code is embedded in the address
 - Implementations MUST verify the network code matches the current chain
 - Client applications SHOULD warn users of network mismatches
+
+### Encryption Key Extended Usage
+
+While this standard defines the encryption public key primarily for encrypting note data in privacy token protocols, implementations MAY use it for additional purposes such as private messaging, encrypted metadata, or other privacy-preserving communications.
+
+**Privacy Considerations for Extended Usage**:
+
+- **Linkability**: Using the same encryption key for multiple purposes (e.g., both transactions and messaging) may create linkability between different types of activities associated with the same pv-address
+- **Key Compromise Impact**: If the encryption private key is compromised, it affects all encrypted data across all use cases, not just transaction notes
+- **Use Case Evaluation**: Implementations SHOULD evaluate privacy implications specific to their use case when extending encryption key usage beyond note encryption
+
+The decision to use the encryption key for extended purposes is left to individual implementations. This flexibility enables innovation while maintaining the core address format standard.
 
 
 ## Copyright


### PR DESCRIPTION

This EIP defines a standardized client-side privacy address format for privacy-preserving tokens on Ethereum. The format uses a versioned prefix (`pv` + version number) to support cryptographic evolution and future upgrades.

**Privacy Version 1 (pv1)** is the initial version defined by this standard, using the Baby Jubjub elliptic curve for zk-SNARK optimization. Future versions (pv2, pv3, etc.) MAY adopt different cryptographic schemes, such as post-quantum resistant algorithms.

The format is designed for privacy-preserving token protocols, including native privacy tokens, dual-mode tokens, and wrapper protocols that add privacy capabilities to existing [ERC-20](./eip-20) tokens.

**Key Characteristics**:

- **Client-side specification**: Address generation and parsing are performed entirely off-chain without smart contract interaction
- **Version support**: The "pv" prefix followed by version number (pv1, pv2, pv3) allows future upgrades for new cryptographic schemes or post-quantum resistance
- **Three-key architecture**: Separate spend, scan, and encryption public keys for fine-grained permission control
- **zk-SNARK optimization**: Baby Jubjub elliptic curve for efficient zero-knowledge proof generation
- **Multi-chain support**: Single-character network codes supporting 58+ EVM-compatible chains
- **Compact encoding**: Base58 compression with FNV-1a checksum for error detection
- **Wrapper protocol compatible**: Applicable to wrapper protocol that adds privacy capabilities to existing [ERC-20](./eip-20) tokens (e.g., DAI → zDAI)

By standardizing the privacy address format at the client level, this proposal enables interoperability between privacy-preserving dApps and seamless privacy asset transfers across the Ethereum ecosystem.