### PR TITLE
Add ERC: Associated Accounts

### DIFF
--- a/ERCS/erc-8092.md
+++ b/ERCS/erc-8092.md
@@ -61,7 +61,7 @@ Where the AssociatedAccountRecord contains:
 - `data` is the arbitrary context data payload (optional).
 
 ### Signed Association Record
-When `AssociatedAccountRecord`s will be consumed in a trustless context, integrators SHOULD require that both paries sign over the [EIP-712](./eip-712.md) hash of the `AssociatedAccountRecord` (see Support for EIP-712 below). The resulting signatures MUST be included in a `SignedAssociationRecord`. 
+When `AssociatedAccountRecord`s will be consumed in a trustless context, integrators SHOULD require that both parties sign over the [EIP-712](./eip-712.md) hash of the `AssociatedAccountRecord` (see Support for EIP-712 below). The resulting signatures MUST be included in a `SignedAssociationRecord`. 
 
 ```solidity
     /// @notice Complete payload containing a finalized association.
@@ -115,7 +115,7 @@ The resulting table enumerates the known keys and distinguishes between the two 
 In some contexts it might be ergonomic to delegate authorization to another account, access control mechanism, or external protocol. Implementers leveraging the `Delegated` key type MUST also publish how consumers can parse the application-specific delegation schema.
 
 ### Support for EIP-712
-All signatures contained in this specification MUST comply with EIP-712 wherein the signature pre-image can be generated from:
+All signatures contained in this specification MUST comply with EIP-712 wherein the signature preimage can be generated from:
 
 ```solidity
 keccak256(abi.encodePacked(
@@ -160,7 +160,7 @@ where:
 - `approver` is the keccak256 hash of the ERC-7930 address of the account that accepted and completed the association.
 - `sar` is the completed SignedAssociationRecord. 
 
-If a SignedAssociationRecord is stored onchain, it MUST also be revokable onchain (see Revocation) below. 
+If a SignedAssociationRecord is stored onchain, it MUST also be revokable onchain (see Revocation section below). 
 
 ### Offchain Storage
 In some contexts, it might be desirable for Signed Association Records to be stored in an offchain store. While the implementation will differ from application-to-application, the following considerations SHOULD be taken into account:


### PR DESCRIPTION
Associated Accounts defines a data structure and mechanism for establishing and verifying associations between blockchain accounts. This allows addresses to publicly declare, prove and revoke a relationship with other addresses by sharing a standardized payload. For onchain applications, this payload may be signed by both parties for third-party authentication. This enables use cases like sub-account identity inheritance, authorization delegation, and reputation collation.