### PR TITLE
Update ERC-7964: Use standard EIP-712 array encoding

### DIFF
--- a/ERCS/erc-7964.md
+++ b/ERCS/erc-7964.md
@@ -40,7 +40,7 @@ A cross-chain [EIP-712] signature MUST omit the `chainId` field from the `EIP712
 
 Cross-chain operations MUST be encoded as an array of chain-specific message structs. Each struct in the array SHOULD include a nested domain struct identifying both the target chain and verifying contract. This follows [EIP-712]'s recursive encoding pattern and ensures proper binding to chain-specific contracts.
 
-The nested domain struct SHOULD be named to avoid collision with `EIP712Domain` (e.g., `EIP712ChainDomain`) and SHOULD include at minimum the `chainId` field. In case the root EIP712Domain does not include the `verifyingContract` field, the nested domain struct MUST include it.
+The nested domain struct SHOULD be named to avoid collision with `EIP712Domain` (e.g., `EIP712ChainDomain`) and SHOULD include at minimum the `chainId` field. In case the root `EIP712Domain` does not include the `verifyingContract` field, the nested domain struct MUST include it.
 
 Per [EIP-712], arrays are encoded as `keccak256(encodeData(element[0]) ‖ encodeData(element[1]) ‖ ... ‖ encodeData(element[n]))`, where each element is a struct that is recursively encoded as `hashStruct(element[i])`, and nested structs are also recursively hashed.
 


### PR DESCRIPTION
This PR simplifies ERC-7964 by removing dependencies on draft standards and using only standard EIP-712 encoding, making it immediately adoptable by existing wallets.

## Key Changes

1. **Removed ERC-7803 dependency** - No longer requires draft standard support
2. **Omit `chainId` instead of using `0`** - Cleaner semantics, fully EIP-712 compliant
3. **Array-based encoding** - Cross-chain operations as standard EIP-712 arrays instead of Merkle trees
   - Provides full transparency in wallet UIs
   - For 2-5 chains (typical case), Merkle trees save only 32-64 bytes
   - No custom wallet logic required
4. **Introduced `EIP712ChainDomain` pattern** - Nested domain struct for proper chain/contract binding
   - Flexible: supports both same-address and different-address deployments
   - Follows EIP-712's recursive encoding

## Benefits

- Works with any EIP-712 wallet immediately
- Full operation transparency for users
- Minimal overhead (32-64 bytes vs Merkle trees)
- Handles real-world deployment scenarios

All examples updated to demonstrate both deterministic (same address) and non-deterministic (different addresses) contract deployments.