### PR TITLE
Update ERC-7730: Add interoperableAddress format to support erc-7930 interoperable addresses

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2024-02-07
-requires: 155, 712
+requires: 155, 712, 7930
 ---
 
 ## Abstract
@@ -1313,6 +1313,15 @@ Formats usable for bytes
 | `amountPath` or `amount`    | Optional. Specifies the native currency amount associated with the calldata, if applicable. If provided, the ERC-7730 descriptor for this embedded calldata MAY reference this value using the `@.value` container path. |
 | `spenderPath` or `spender`  | Optional. Specifies the spender address associated with the calldata, if applicable. If provided, the ERC-7730 descriptor for this embedded calldata MAY reference this value using the `@.from` container path. |
 | *Examples*                  | --- |
+
+| **`interoperableAddress`** |                        |
+|----------------------------|------------------------|
+| *Description*              | Display byte array as an [ERC-7930](./eip-7930.md) Interoperable Name. The wallet MUST validate the checksum and format the display as `<address>@<chain>#<checksum>`. |
+| *Parameters*               | --- |
+| `resolveAddress`           | Boolean. If set to `true`, the wallet SHOULD attempt to resolve the inner address segment using the same logic as `addressName` (e.g., resolving ENS names). Defaults to `false`. |
+| *Examples*                 | --- |
+| `0xd8...45@eip155:1#4C...` | Field Value = `0x000100000101...` (ERC-7930 Binary) |
+| `vitalik.eth@eip155:1#...` | Field Value = `0x000100000101...` <br> `resolveAddress` = `true` |
 
 #### Address
 


### PR DESCRIPTION
# Abstract

This pull request extends ERC-7730 by introducing support for [EIP-7930 Interoperable Addresses](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-7930.md). The goal is to enable wallets to safely parse and display chain-specific addresses, improving security for cross-chain interactions.

# Specification

A new format specifier, `` interoperableAddress ``, has been added to the "Bytes formats" section. This instructs wallets to interpret a bytes value as an EIP-7930 binary payload and display it in its human-readable "Interoperable Name" format.
