### PR TITLE
Update ERC-7496: Minimal Soulbound NFT

### DIFF
--- a/ERCS/erc-7496.md
+++ b/ERCS/erc-7496.md
@@ -79,8 +79,11 @@ The `validateOnSale` value provides a signal to marketplaces on how to validate 
 
 - `none`: No validation is necessary.
 - `requireEq`: The `bytes32` `traitValue` MUST be equal to the value at the time the offer to purchase was made.
-- `requireUintGte`: The `bytes32` `traitValue` MUST be greater than or equal to the value at the time the offer to purchase was made. This comparison is made using the `uint256` representation of the `bytes32` value.
+- `requireNeq`: The `bytes32` `traitValue` MUST NOT be equal to the value at the time the offer to purchase was made.
+- `requireUintLt`: The `bytes32` `traitValue` MUST be less than the value at the time the offer to purchase was made. This comparison is made using the `uint256` representation of the `bytes32` value.
 - `requireUintLte`: The `bytes32` `traitValue` MUST be less than or equal to the value at the time the offer to purchase was made. This comparison is made using the `uint256` representation of the `bytes32` value.
+- `requireUintGt`: The `bytes32` `traitValue` MUST be greater than the value at the time the offer to purchase was made. This comparison is made using the `uint256` representation of the `bytes32` value.
+- `requireUintGte`: The `bytes32` `traitValue` MUST be greater than or equal to the value at the time the offer to purchase was made. This comparison is made using the `uint256` representation of the `bytes32` value.
 
 Note that even though this specification requires marketplaces to validate the required trait values, buyers and sellers cannot fully rely on marketplaces to do this and must also take their own precautions to research the current trait values prior to initiating the transaction.
 


### PR DESCRIPTION
This PR updates ERC-7496 with:

1. **Custom errors** added to the interface:
   - `TraitKeyUnknown(bytes32 traitKey)` - reverts when a trait key doesn't exist or is unknown
   - `TokenDoesNotExist(uint256 tokenId)` - reverts when the token is not found

2. **Missing validateOnSale comparison options**:
   - `requireNeq` (not equal to)
   - `requireUintLt` (less than)
   - `requireUintGt` (greater than)

This completes the full set of comparison operators (eq, neq, lt, lte, gt, gte).