### PR TITLE
Update ERC-7496: Add custom errors and complete validateOnSale comparison options

### DIFF
--- a/ERCS/erc-7496.md
+++ b/ERCS/erc-7496.md
@@ -30,7 +30,9 @@ Contracts implementing this EIP MUST include the events, getters, and setters as
 ```solidity
 interface IERC7496 {
     /* Errors */
-    error TraitKeyUnknown(bytes32 traitKey);
+    /// @notice Thrown when trying to set a trait that does not exist.
+    error TraitDoesNotExist(bytes32 traitKey);
+    /// @notice Thrown when the token does not exist.
     error TokenDoesNotExist(uint256 tokenId);
 
     /* Events */
@@ -59,7 +61,7 @@ The `traitKey` SHOULD be a `keccak256` hash of a human readable trait name.
 
 ### Errors
 
-If a `traitKey` is not defined or unknown, the contract MUST revert with `TraitKeyUnknown(traitKey)`.
+If a `traitKey` does not exist, the contract MUST revert with `TraitDoesNotExist(traitKey)`.
 
 If a `tokenId` does not exist, the contract MUST revert with `TokenDoesNotExist(tokenId)`. If the token contract already defines a custom error for non-existent tokens (e.g. from [ERC-721](./eip-721.md) or [ERC-1155](./eip-1155.md)), that error MAY be used instead.
 
@@ -79,8 +81,11 @@ The `validateOnSale` value provides a signal to marketplaces on how to validate 
 
 - `none`: No validation is necessary.
 - `requireEq`: The `bytes32` `traitValue` MUST be equal to the value at the time the offer to purchase was made.
-- `requireUintGte`: The `bytes32` `traitValue` MUST be greater than or equal to the value at the time the offer to purchase was made. This comparison is made using the `uint256` representation of the `bytes32` value.
+- `requireNeq`: The `bytes32` `traitValue` MUST NOT be equal to the value at the time the offer to purchase was made.
+- `requireUintLt`: The `bytes32` `traitValue` MUST be less than the value at the time the offer to purchase was made. This comparison is made using the `uint256` representation of the `bytes32` value.
 - `requireUintLte`: The `bytes32` `traitValue` MUST be less than or equal to the value at the time the offer to purchase was made. This comparison is made using the `uint256` representation of the `bytes32` value.
+- `requireUintGt`: The `bytes32` `traitValue` MUST be greater than the value at the time the offer to purchase was made. This comparison is made using the `uint256` representation of the `bytes32` value.
+- `requireUintGte`: The `bytes32` `traitValue` MUST be greater than or equal to the value at the time the offer to purchase was made. This comparison is made using the `uint256` representation of the `bytes32` value.
 
 Note that even though this specification requires marketplaces to validate the required trait values, buyers and sellers cannot fully rely on marketplaces to do this and must also take their own precautions to research the current trait values prior to initiating the transaction.
 


### PR DESCRIPTION
This PR updates ERC-7496 with:

1. **Custom errors** added to the interface (with NatSpec comments):
   - `TraitDoesNotExist(bytes32 traitKey)` - thrown when trying to set a trait that does not exist
   - `TokenDoesNotExist(uint256 tokenId)` - thrown when the token does not exist

2. **Missing validateOnSale comparison options**:
   - `requireNeq` (not equal to)
   - `requireUintLt` (less than)
   - `requireUintGt` (greater than)

This completes the full set of comparison operators (eq, neq, lt, lte, gt, gte).