### PR TITLE
Update ERC-7930: Rename "Interoperable Name" to "Interoperable Address String"

### DIFF
--- a/ERCS/erc-7930.md
+++ b/ERCS/erc-7930.md
@@ -11,18 +11,18 @@ created: 2025-02-02
 ---
 
 ## Abstract
-This proposal introduces a **binary format** to describe a chain specific address. Additionally, it defines a human-readable version of that identifier, which improves the user experience in user-facing interactions.
+This proposal introduces a **binary format** to describe a chain specific address. Additionally, it defines a standardized text encoding of that identifier, suitable for display, copy-paste, and manual verification.
 
 This is achieved through a versioned, length-prefixed binary envelope that supports arbitrary-length data. The interpretation and serialization rules for the data within this envelope are defined by companion standards ([CAIP-350]), which provide profiles for each chain type.
 
 ## Motivation
 The address format utilized on Ethereum mainnet ([ERC-55]) is shared by a large number of other blockchains. The format does not include details of the chain on which an interaction should occur. This introduces risk if, for example, a transaction is mistakenly executed on a chain where the address is inaccesible. This risk is particularly pronounced for addresses that represent smart contracts or smart accounts.
 
-This proposal builds on insights from [CAIP-10] and [CAIP-50]. It offers both a binary canonical _Interoperable Address_ format and a human readable _Interoperable Name_ format which:
+This proposal builds on insights from [CAIP-10] and [CAIP-50]. It introduces a canonical binary Interoperable Address format, and defines a standardized text encoding of that address — the Interoperable Address String — for use in user-facing contexts. This format:
 
 - Binds together chain identification and the raw address.
 - Is compact for usage with cross-chain message passing and intent declaration.
-- Includes short, easily verififiable checksums to protect users.
+- Includes short, visually comparable checksums to support manual verification.
 - Extends beyond EVM blockchains.
 
 These features can not be added to existing standards as they are not easily extensible - this one is.
@@ -39,27 +39,29 @@ While it is trivial to add support for chains to [CAIP-10], the format is not op
 
 [CAIP-10] depends on [CAIP-2], which limits the chain reference to 32 characters. This constraint means that [CAIP-2] can not losslessy represent a chain. e.g. Solana chains utilize the leading 32 characters of the base58btc-encoded genesis blockhash, which is not a uniquely deterministic way of representing a chain. 
 
-An _Interoperable Name_ contains all of the components of the [CAIP-10] identifier. It is therefore easy to convert between the two in cases where the [CAIP-10] standard is still in use.
+An _Interoperable Address String_ contains all of the components of the [CAIP-10] identifier. It is therefore easy to convert between the two in cases where the [CAIP-10] standard is still in use.
 
 ## Specification
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 ### Terminology
 **Target Address**
-: The address itself, independent of chain context. Serialized per the [CAIP-350] rules for the applicable namespace. In the context of the _Interoperable Name_ and _Interoperable Address_ examples below, the target address is `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`.
+: The address itself, independent of chain context. Serialized per the [CAIP-350] rules for the applicable namespace. In the context of the _Interoperable Address String_ and _Interoperable Address_ examples below, the target address is `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`.
 
 **Chain Specific Address**
 : An address representation that includes both the _target address_ **and** the chain being targeted. The following are examples of chain specific addresses:
 
 - The _Interoperable Address_ definition outlined in this specification
-- The _Interoperable Name_ definition outlined in this specification
+- The _Interoperable Address String_ definition outlined in this specification
 - The addressing format outlined in [ERC-3770], e.g. `arb:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`
 
 **Interoperable Address**
 : A binary payload which unambiguously identifies a target address on a target chain. e.g. `0x00010000010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045`
 
-**Interoperable Name**
-: A string representation of an _Interoperable Address_, meant to be used by humans. e.g. `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C`
+**Interoperable Address String**
+: A structured text encoding of an _Interoperable Address_. It is lossless and fully reversible, and is intended for display, copy-paste, and manual inspection by technically minded users. While largely opaque, its components are visually distinguishable and map 1:1 onto the fields of the underlying binary Interoperable Address. e.g. `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C`
+
+Note: The Interoperable Address String is not a naming system and does not introduce new semantics. All validation and comparison semantics are defined exclusively in terms of the binary Interoperable Address.
 
 
 ### _Interoperable Address_ Definition
@@ -92,9 +94,9 @@ The components outlined above have the following meanings:
 **Address**
 : Variable length field containing the binary encoding of the characters of the serialized address. The serialization for a specific _ChainType_ MUST follow the rules of its corresponding [CAIP-350] profile.
 
-### Interoperable Name Definition
+### Interoperable Address String Definition
 
-Recall that an _Interoperable Name_ is a human readable representation of an underlying _Interoperable Address_.
+Recall that an _Interoperable Address String_ is a structured text encoding of an underlying _Interoperable Address_, derived from the binary form.
 
 Its format is `<address> @ <chain> # <checksum>` where the components match the following regular expressions:
 
@@ -117,18 +119,20 @@ The 4-byte `<checksum>` is the first 4 bytes of the hexadecimal ([RFC 4648]) str
 
 #### Checksums
 
-A 4-byte checksum MUST be computed and included when sharing an _Interoperable Name_. 
+A 4-byte checksum MUST be computed and included when sharing an _Interoperable Address String_. 
 
-If a user-provided _Interoperable Name_ includes a checksum, clients MUST derive the underlying _Interoperable Address_, recalculate the checksum, and compare it to the provided value. In case of a mismatch, clients MUST warn the user and require explicit user input to continue with the operation.
+If a user-provided _Interoperable Address String_ includes a checksum, clients MUST derive the underlying _Interoperable Address_, recalculate the checksum, and compare it to the provided value. In case of a mismatch, clients MUST warn the user and require explicit user input to continue with the operation.
 
-Clients MAY include the checksum when displaying an _Interoperable Name_ within their interface.
-Clients MAY accept _Interoperable Name_ inputs without a checksum.
+Clients MAY include the checksum when displaying an _Interoperable Address String_ within their interface.
+Clients MAY accept _Interoperable Address String_ inputs without a checksum.
+
+The checksum provides short, visually comparable values to support manual verification.
 
 When displayed the checksum MUST be displayed using the 'Base 16 Alphabet', `[0-9A-Z]` as defined in [RFC 4648].
 
 #### Parsing and Serialization:
 
-When parsing an _Interoperable Name_ to generate its binary _Interoperable Address_, clients MUST follow the normalization and serialization rules defined in the relevant [CAIP-350] profile for the given `<chain>` and `<address>`. This ensures that different valid text representations (e.g., case variations in an address) resolve to a single, canonical binary form, which is essential for consistent checksum calculation and data integrity.
+When parsing an _Interoperable Address String_ to generate its binary _Interoperable Address_, clients MUST follow the normalization and serialization rules defined in the relevant [CAIP-350] profile for the given `<chain>` and `<address>`. The string form is derived from the binary form, and parsing reconstructs the canonical binary _Interoperable Address_. This ensures that different valid text representations (e.g., case variations in an address) resolve to a single, canonical binary form, which is essential for consistent checksum calculation and data integrity. All validation, equality, and canonicalization semantics are defined only on the binary form.
 
 ### Examples
 
@@ -159,15 +163,15 @@ These components produce the following _Interoperable Address_:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Address             
 ```
 
-**Interoperable Name**
+**Interoperable Address String**
 
-The _Interoperable Name_ representation is:
+The _Interoperable Address String_ representation is:
 
 | Key | Value |
 | :--- | :--- |
 | **Checksum Input** | `0x0000010114d8da6bf26964af9d7eed9e03e53415d37aa96045` |
 | **Checksum** | `4CA88C9C` |
-| **Interoperable Name** | `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C` |
+| **Interoperable Address String** | `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C` |
 
 ---  
 
@@ -199,15 +203,15 @@ These components produce the following _Interoperable Address_:
                                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--- Address
 ```
 
-**Interoperable Name**
+**Interoperable Address String**
 
-The _Interoperable Name_ representation is:
+The _Interoperable Address String_ representation is:
 
 | Key | Value |
 | :--- | :--- |
 | **Checksum Input** | `0x00022045296998a6f8e2a784db5d9f95e18fc23f70441a1039446801089879b08c7ef02005333498d5aea4ae009585c43f7b8c30df8e70187d4a713d134f977fc8dfe0b5` |
 | **Checksum** | `88835C11` |
-| **Interoperable Name** | `MJKqp326RZCHnAAbew9MDdui3iCKWco7fsK9sVuZTX2@solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d#88835C11` |
+| **Interoperable Address String** | `MJKqp326RZCHnAAbew9MDdui3iCKWco7fsK9sVuZTX2@solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d#88835C11` |
 
 ---  
 
@@ -237,15 +241,15 @@ These components produce the following _Interoperable Address_:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Address
 ```
 
-**Interoperable Name**
+**Interoperable Address String**
 
-The _Interoperable Name_ representation is:
+The _Interoperable Address String_ representation is:
 
 | Key | Value |
 | :--- | :--- |
 | **Checksum Input** | `0x00000014d8da6bf26964af9d7eed9e03e53415d37aa96045` |
 | **Checksum** | `B26DB7CB` |
-| **Interoperable Name** | `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155#B26DB7CB` |
+| **Interoperable Address String** | `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155#B26DB7CB` |
 
 ---  
 
@@ -275,15 +279,15 @@ These components produce the following _Interoperable Address_:
                                                                             ^^ AddressLength
 ```
 
-**Interoperable Name**
+**Interoperable Address String**
 
-The _Interoperable Name_ representation is:
+The _Interoperable Address String_ representation is:
 
 | Key | Value |
 | :--- | :--- |
 | **Checksum Input** | `0x00022045296998a6f8e2a784db5d9f95e18fc23f70441a1039446801089879b08c7ef000` |
 | **Checksum** | `2EB18670` |
-| **Interoperable Name** | `@solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d#2EB18670` |
+| **Interoperable Address String** | `@solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d#2EB18670` |
 
 ### Versioning
 
@@ -297,8 +301,8 @@ Future versions:
 - MAY add fields but MUST NOT alter or omit any data required to reconstruct the Version 1 _Interoperable Address_ exactly, bit for bit
 - MUST use the checksum algorithm outlined in this standard
 - MAY only be able to represent a subset of the CAIP namespaces
-- MAY introduce stricter syntactic rules for the _Interoperable Name_ (thereby narrowing the set of valid strings), but MUST NOT introduce new syntactic forms that enlarge the grammar.
-- MUST allow for the appropriate binary data to be derived from the _Interoperable Name_ to allow for the construction of an _Interoperable Address_ encoded as defined in this specification
+- MAY introduce stricter syntactic rules for the _Interoperable Address String_ (thereby narrowing the set of valid strings), but MUST NOT introduce new syntactic forms that enlarge the grammar.
+- MUST allow for the appropriate binary data to be derived from the _Interoperable Address String_ to allow for the construction of an _Interoperable Address_ encoded as defined in this specification
 
 ## Rationale
 
@@ -310,8 +314,8 @@ The rationale for some of the low level specification decisions are outlined bel
 - No length restriction is placed on addresses, allowing for chains with longer address formats to be represented.
 - The address field includes `%` as a valid character to allow for URL-encoding of any other characters that are not explicitly allowed. This allows backward compatibility with [CAIP-10].
 - We chose to support zero-length addresses and chain IDs to make this standard flexible and to allow developers to use a single, uniform standard for many different jobs. For example if a user wants to represent an address on any compatible chain, or if the user simply wants to represent the chain itself.
-- We chose *not* to use alternate encoding formats (e.g., `base58` or `base64`) in order to make it easier for wallets and dApps to work with, and convert between, addresses that both use and do not use this addressing standard. Whilst utilizing alternate formats could have reduced the size of the _Interoperable Name_ we decided that user and developer experience should be prioritized.
-- Checksums are short enough to be visually comparable by the human eye, allowing for easy differentiation.
+- We chose *not* to use alternate encoding formats (e.g., `base58` or `base64`) in order to make it easier for wallets and dApps to work with, and convert between, addresses that both use and do not use this addressing standard. Whilst utilizing alternate formats could have reduced the size of the _Interoperable Address String_ we decided that user and developer experience should be prioritized.
+- Checksums are short enough to be visually comparable, allowing for manual verification.
 
 ## Security Considerations
 While this standard aims to be a foundation to be able to canonically refer to addresses on different chains, that guarantee is going to be a leaky abstraction in the real world, given that e.g. a particular chain namespace might define a serialization scheme that can't guarantee canonicity of addresses, or a given network might have two valid [CAIP-2] ids referring to it.


### PR DESCRIPTION
## Summary

Renames "Interoperable Name" → "Interoperable Address String" and clarifies that the binary Interoperable Address is the canonical identifier, with the string being a derivative encoding. **No functional changes.**

## Changes

- Global rename: "Interoperable Name" → "Interoperable Address String"
- Updated Abstract: "human-readable version" → "standardized text encoding"
- Reframed Motivation: binary is canonical, string is derivative encoding
- Added Terminology note: string is not a naming system, all semantics defined on binary form
- Updated language: replaced "human-readable" with "structured text encoding"
- Clarified Parsing section: string → binary derivation, binary form is canonical

## Impact

No breaking changes. All technical specs, validation rules, and examples remain identical. Improves clarity that binary form is canonical.