### PR TITLE
Add ERC: Domain Architecture for Diamonds

### DIFF
--- a/ERCS/erc-8110.md
+++ b/ERCS/erc-8110.md
@@ -189,10 +189,10 @@ contracts/
 From the beginning, the Diamond Standard (ERC-2535) was designed around the relationship between **function selectors** and **storage positions**, not around facets themselves.  
 Facets are replaceable units of logic — the `diamondCut` operation only replaces, removes or adds code — but the **storage layout persists** and defines the actual state continuity of the contract.  
 
-A clear example of this can be found in the reference Diamond implementation `diamond-1-hardhat`.
+A clear example of this can be found in `Reference Implementation` of ERC-8109.
 
-Both `DiamondCutFacet` and `DiamondLoupeFacet` interact with the same `LibDiamond` storage.  
-Although these facets serve different purposes — one mutating, one querying — they share the same domain (`diamond.storage`).  
+Both `DiamondUpgradeFacet` and `DiamondInspectFacet` interact with the same storage.  
+Although these facets serve different purposes — one mutating, one querying — they share the same domain (`erc8109.diamond`).  
 This demonstrates that **storage belongs to the domain**, not the facet, facets merely provide interfaces for logic to read or mutate that domain.
 
 Over time, many implementations have treated facets as the primary boundary of responsibility, grouping logic and storage together without recognizing that **storage domains** are the true architectural anchors.  
@@ -237,16 +237,6 @@ Existing state MAY be migrated explicitly if required, but such migration is not
 When introducing a new domain, a new storage identifier and storage layout are defined independently, without modifying or reusing existing storage.
 
 This approach ensures that logic upgrades can proceed independently of storage schema changes, while storage evolution remains explicit, deliberate, and auditable.
-
-### Domain Storage Scope
-
-In this specification, the requirement that each domain MUST have exactly one storage struct refers to the existence of a single, domain-owned storage entrypoint.
-
-Each storage struct maps to exactly one storage slot, derived from a single ERC-8042 identifier.
-All state owned by the domain MUST be accessed exclusively through this entrypoint.
-
-This requirement does not constrain Solidity’s type system.
-Mappings and enums MAY be used within the storage struct, including cases where mappings reference structured values.
 
 ### Special Case: Domain-Facet Overlap
 


### PR DESCRIPTION
This PR adds a new Informational ERC that documents a domain-based architectural pattern for Diamond contracts, building on ERC-2535 and ERC-8042.

The proposal describes an organizational approach for structuring Diamond storage and identifiers, intended to improve clarity and reduce human error in multi-facet systems.  
It does not introduce new protocol rules or normative requirements.

Discussion:
https://ethereum-magicians.org/t/proposing-a-domain-based-architecture-for-diamond-contracts/27250
