### PR TITLE
Update ERC-7496: Clarify behavior for unset trait values

### DIFF
--- a/ERCS/erc-7496.md
+++ b/ERCS/erc-7496.md
@@ -61,7 +61,9 @@ The `traitKey` SHOULD be a `keccak256` hash of a human readable trait name.
 
 ### Errors
 
-If a `traitKey` does not exist, the contract MUST revert with `TraitDoesNotExist(traitKey)`.
+If a `traitKey` is not defined in the contract (i.e., not present in the trait metadata schema), the contract MUST revert with `TraitDoesNotExist(traitKey)`. This allows applications to detect when they have queried an invalid or unsupported trait key.
+
+If a `traitKey` is defined in the contract but a specific token does not have a value set for that trait, the contract MUST return `bytes32(0)` as the default value instead of reverting. This enables batch querying of all defined trait keys across multiple tokens without failures due to unset values.
 
 If a `tokenId` does not exist, the contract MUST revert with `TokenDoesNotExist(tokenId)`. If the token contract already defines a custom error for non-existent tokens (e.g. from [ERC-721](./eip-721.md) or [ERC-1155](./eip-1155.md)), that error MAY be used instead.
 


### PR DESCRIPTION
## Summary

This PR clarifies the behavior of `getTraitValue` and `getTraitValues` when querying trait keys:

### Changes

**Undefined trait key** (not present in the contract's trait metadata schema):
- MUST revert with `TraitDoesNotExist(traitKey)`
- This allows applications to detect when they have queried an invalid or unsupported trait key

**Defined trait key but no value set for a specific token**:
- MUST return `bytes32(0)` as the default value instead of reverting
- This enables batch querying of all defined trait keys across multiple tokens without failures due to unset values

### Motivation

Backends that refresh dynamic traits need to:
1. Fetch trait metadata from a contract via `getTraitMetadataURI()`
2. Extract the list of defined trait keys
3. Query `getTraitValues(tokenId, traitKeys)` for all tokens

Without this clarification, querying a token that doesn't have a value set for a particular trait key would revert, breaking batch refresh workflows. By returning `bytes32(0)` for unset values, applications can query all known trait keys for any token without the call failing.