### PR TITLE
ERC-7496: Register trait keys when setting metadata URI

### DIFF
--- a/assets/erc-7496/DynamicTraits.sol
+++ b/assets/erc-7496/DynamicTraits.sol
@@ -119,13 +119,21 @@ contract DynamicTraits is IERC7496 {
 
     /**
      * @notice Set the trait value (without emitting an event).
+     *         Automatically registers the trait key if not already registered.
      * @param tokenId The token ID to set the trait value for
      * @param traitKey The trait key to set the value of
      * @param newValue The new trait value to set
      */
     function _setTrait(uint256 tokenId, bytes32 traitKey, bytes32 newValue) internal virtual {
+        DynamicTraitsStorage.Layout storage layout = DynamicTraitsStorage.layout();
+
+        // Automatically register the trait key if not already registered.
+        if (!layout._validTraitKeys[traitKey]) {
+            layout._validTraitKeys[traitKey] = true;
+        }
+
         // Set the new trait value.
-        DynamicTraitsStorage.layout()._traits[tokenId][traitKey] = newValue;
+        layout._traits[tokenId][traitKey] = newValue;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds an overloaded `_setTraitMetadataURI(uri, traitKeys)` function that registers all trait keys when setting the metadata URI.

## Changes

```solidity
function _setTraitMetadataURI(string memory uri, bytes32[] memory traitKeys) internal virtual {
    DynamicTraitsStorage.Layout storage layout = DynamicTraitsStorage.layout();

    // Set the new trait metadata URI.
    layout._traitMetadataURI = uri;

    // Register all trait keys.
    for (uint256 i = 0; i < traitKeys.length;) {
        layout._validTraitKeys[traitKeys[i]] = true;
        unchecked {
            ++i;
        }
    }

    // Emit the event noting the update.
    emit TraitMetadataURIUpdated();
}
```

## Motivation

This is more gas efficient than checking/registering trait keys on every `_setTrait` call. The trait keys are known at the time the metadata URI is set, so they can all be registered upfront in a single transaction.