### PR TITLE
Add ERC: Series Accounting for Incentivized Vaults

### DIFF
--- a/ERCS/erc-8113.md
+++ b/ERCS/erc-8113.md
@@ -68,7 +68,7 @@ For ERC-4626 type vaults, when the `oracle` provides the price-per-share for reb
 
 #### Redeem Flow
 
-[ERC-8113](./eip-8113.d) vaults MUST allow users to redeem (or request a redeem) by providing `assets` instead of `shares` as input.
+[ERC-8113](./eip-8113.md) vaults MUST allow users to redeem (or request a redeem) by providing `assets` instead of `shares` as input.
 
 The vault is RECOMMENDED to store the proportion of total `assets` for that user in the redeem request.
 


### PR DESCRIPTION
This PR adds a new Draft Standards Track ERC, "Series Accounting for Incentivized Vaults" which aims to standardize the traditional hedge fund accounting method for DeFi vaults.

The proposal explains why existing fee structures for incentivized vaults (vaults that collect performance fees) are not accurate for all async RWA vaults and outlines the specifications on how to implement "Series Accounting" to mitigate these issues along with a reference implementation.

Discussions on this proposal can be found here: https://ethereum-magicians.org/t/erc-8113-series-accounting-for-incentivized-vaults/27306
