### PR TITLE
Update ERC-5564: Fix typo in ERCS/erc-5564.md

### DIFF
--- a/ERCS/erc-5564.md
+++ b/ERCS/erc-5564.md
@@ -14,7 +14,6 @@ created: 2022-08-13
 
 This specification establishes a standardized method for interacting with stealth addresses, which allow senders of transactions or transfers to non-interactively generate private accounts exclusively accessible by their recipients. Moreover, this specification enables developers to create stealth address protocols based on the foundational implementation outlined in this ERC, utilizing a singleton contract deployed at `0x55649E01B5Df198D18D95b5cc5051630cfD45564` to emit the necessary information for recipients. In addition to the base implementation, this ERC also outlines the first implementation of a cryptographic scheme, specifically the SECP256k1 curve.
 
-
 ## Motivation
 
 The standardization of non-interactive stealth address generation presents the potential to significantly improve the privacy capabilities of the Ethereum network and other EVM-compatible chains by allowing recipients to remain private when receiving assets. This is accomplished through the sender generating a stealth address based on a shared secret known exclusively to the sender and recipient. The recipients alone can access the funds stored at their stealth addresses, as they are the sole possessors of the necessary private key. As a result, observers are unable to associate the recipient's stealth address with their identity, thereby preserving the recipient's privacy and leaving the sender as the only party privy to this information. By offering a foundational implementation in the form of a single contract that is compatible with multiple cryptographic schemes, recipients are granted a centralized location to monitor, ensuring they do not overlook any incoming transactions.
@@ -87,14 +86,13 @@ function computeStealthKey(
 
 The implementation of these methods is scheme-specific. The specification of a new stealth address scheme MUST specify the implementation for each of these methods. Additionally, although these function interfaces are specified in Solidity, they do not necessarily ever need to be implemented in Solidity, but any library or SDK conforming to this specification MUST implement these methods with compatible function interfaces.
 
-A 256 bit integer (`schemeId`) is used to identify stealth address schemes. A mapping from the schemeId to its specification MUST be declared in the ERC that proposes to standardize a new stealth address scheme. It is RECOMMENDED  that `schemeId`s are chosen to be monotonically incrementing integers for simplicity, but arbitrary or meaningful `schemeId`s  may be chosen. This ERC introduces schemeId `1` with the following extensions:
+A 256 bit integer (`schemeId`) is used to identify stealth address schemes. A mapping from the schemeId to its specification MUST be declared in the ERC that proposes to standardize a new stealth address scheme. It is RECOMMENDED that `schemeId`s are chosen to be monotonically incrementing integers for simplicity, but arbitrary or meaningful `schemeId`s may be chosen. This ERC introduces schemeId `1` with the following extensions:
 
-- `1` is the integer identifier for the scheme, 
-  
-- `viewTags` MUST be included in the announcement event and is used to reduce the parsing time for the recipients. 
+- `1` is the integer identifier for the scheme,
+- `viewTags` MUST be included in the announcement event and is used to reduce the parsing time for the recipients.
 
-- SECP256k1 is the algorithm for encoding a stealth meta-address (i.e. the spending public key and viewing public key) into a `bytes` array, and decoding it from `bytes` to the native key types of that scheme. 
-- 
+- SECP256k1 is the algorithm for encoding a stealth meta-address (i.e. the spending public key and viewing public key) into a `bytes` array, and decoding it from `bytes` to the native key types of that scheme.
+
 - SECP256k1 with view tags will be used in `generateStealthAddress`, `checkStealthAddress`, and `computeStealthKey` methods.
 
 This specification additionally defines a singleton `ERC5564Announcer` contract that emits events to announce when something is sent to a stealth address. This MUST be a singleton contract, with one instance per chain. The contract is specified as follows:
@@ -105,10 +103,10 @@ contract IERC5564Announcer {
   /// @dev Emitted when sending something to a stealth address.
   /// @dev See the `announce` method for documentation on the parameters.
   event Announcement (
-    uint256 indexed schemeId, 
-    address indexed stealthAddress, 
-    address indexed caller, 
-    bytes ephemeralPubKey, 
+    uint256 indexed schemeId,
+    address indexed stealthAddress,
+    address indexed caller,
+    bytes ephemeralPubKey,
     bytes metadata
   );
 
@@ -117,7 +115,7 @@ contract IERC5564Announcer {
   /// @param stealthAddress The computed stealth address for the recipient.
   /// @param ephemeralPubKey Ephemeral public key used by the sender.
   /// @param metadata An arbitrary field MUST include the view tag in the first byte.
-  /// Besides the view tag, the metadata can be used by the senders however they like, 
+  /// Besides the view tag, the metadata can be used by the senders however they like,
   /// but the below guidelines are recommended:
   /// The first byte of the metadata MUST be the view tag.
   /// - When sending/interacting with the native token of the blockchain (cf. ETH), the metadata SHOULD be structured as follows:
@@ -135,9 +133,9 @@ contract IERC5564Announcer {
   ///   - Bytes 26-57 are the amount of tokens being sent/interacted with for fungible tokens, or
   ///     the token ID for non-fungible tokens.
   function announce (
-    uint256 schemeId, 
-    address stealthAddress, 
-    bytes memory ephemeralPubKey, 
+    uint256 schemeId,
+    address stealthAddress,
+    bytes memory ephemeralPubKey,
     bytes memory metadata
   )
     external
@@ -147,19 +145,18 @@ contract IERC5564Announcer {
 }
 ```
 
-
 ### Stealth meta-address format
 
-The new address format for the stealth meta-address extends the chain specific address format by adding a `st:` (*stealth*) prefix.
+The new address format for the stealth meta-address extends the chain specific address format by adding a `st:` (_stealth_) prefix.
 Thus, a stealth meta-address on Ethereum has the following format:
 
 ```
 st:eth:0x<spendingPubKey><viewingPubKey>
-``` 
+```
 
 Stealth meta-addresses may be managed by the user and/or registered within a publicly available `Registry` contract, as delineated in [ERC-6538](./eip-6538.md). This provides users with a centralized location for identifying stealth meta-addresses associated with other individuals while simultaneously enabling recipients to express their openness to engage via stealth addresses.
 
-*Notably, the address format is used only to differentiate stealth addresses from standard addresses, as the prefix is removed before performing any computations on the stealth meta-address.*
+_Notably, the address format is used only to differentiate stealth addresses from standard addresses, as the prefix is removed before performing any computations on the stealth meta-address._
 
 ---
 
@@ -175,7 +172,7 @@ The following reference is divided into three sections:
 
 3. Stealth private key derivation
 
- Definitions:
+Definitions:
 
 - $G$ represents the generator point of the curve.
 
@@ -189,7 +186,7 @@ The following reference is divided into three sections:
 
 - The `generateStealthAddress` function performs the following computations:
   - Generate a random 32-byte entropy ephemeral private key $p_{ephemeral}$.
-  - Derive the ephemeral public key  $P_{ephemeral}$ from $p_{ephemeral}$.
+  - Derive the ephemeral public key $P_{ephemeral}$ from $p_{ephemeral}$.
   - Parse the spending and viewing public keys, $P_{spend}$ and $P_{view}$, from the stealth meta-address.
   - A shared secret $s$ is computed as $s = p_{ephemeral} \cdot P_{view}$.
   - The secret is hashed $s_{h} = \textrm{h}(s)$.
@@ -197,17 +194,16 @@ The following reference is divided into three sections:
   - Multiply the hashed shared secret with the generator point $S_h = s_h \cdot G$.
   - The recipient's stealth public key is computed as $P_{stealth} = P_{spend} + S_h$.
   - The recipient's stealth address $a_{stealth}$ is computed as $\textrm{pubkeyToAddress}(P_{stealth})$.
-  - The function returns the stealth address $a_{stealth}$, the ephemeral public key $P_{ephemeral}$ and the view tag $v$. 
-
+  - The function returns the stealth address $a_{stealth}$, the ephemeral public key $P_{ephemeral}$ and the view tag $v$.
 
 #### Parsing - Locate one's own stealth address(es):
 
 - User has access to the viewing private key $p_{view}$ and the spending public key $P_{spend}$.
 
-- User has access to a set of `Announcement` events and applies the `checkStealthAddress` function to each of them. 
+- User has access to a set of `Announcement` events and applies the `checkStealthAddress` function to each of them.
 
-- The  `checkStealthAddress` function performs the following computations:
-  - Shared secret $s$ is computed by multiplying the viewing private key with the ephemeral public key of the announcement $s = p_{view}$ * $P_{ephemeral}$.
+- The `checkStealthAddress` function performs the following computations:
+  - Shared secret $s$ is computed by multiplying the viewing private key with the ephemeral public key of the announcement $s = p_{view}$ \* $P_{ephemeral}$.
   - The secret is hashed $s_{h} = h(s)$.
   - The view tag $v$ is extracted by taking the most significant byte $s_{h}[0]$ and can be compared to the given view tag. If the view tags do not match, this `Announcement` is not for the user and the remaining steps can be skipped. If the view tags match, continue on.
   - Multiply the hashed shared secret with the generator point $S_h = s_h \cdot G$.
@@ -219,14 +215,12 @@ The following reference is divided into three sections:
 
 - User has access to the viewing private key $p_{view}$ and spending private key $p_{spend}$.
 
-- User has access to a set of `Announcement` events for which the `checkStealthAddress` function returns `true`. 
+- User has access to a set of `Announcement` events for which the `checkStealthAddress` function returns `true`.
 
-- The  `computeStealthKey` function performs the following computations:
-  - Shared secret $s$ is computed by multiplying the viewing private key with the ephemeral public key of the announcement $s = p_{view}$ * $P_{ephemeral}$.
+- The `computeStealthKey` function performs the following computations:
+  - Shared secret $s$ is computed by multiplying the viewing private key with the ephemeral public key of the announcement $s = p_{view}$ \* $P_{ephemeral}$.
   - The secret is hashed $s_{h} = h(s)$.
   - The stealth private key is computed as $p_{stealth} = p_{spend} + s_h$.
-
-
 
 ### Parsing considerations
 
@@ -268,11 +262,11 @@ You can find the implementation of the `ERC5564Announcer` contract [here](../ass
 
 ### DoS Countermeasures
 
-There are potential denial of service (DoS) attack vectors that are not mitigated by network transaction fees. Stealth transfer senders cause an externality for recipients, as parsing announcement events consumes computational resources that are not compensated with gas. Therefore, spamming announcement events *can* be a detriment to the user experience, as it *can* lead to longer parsing times. 
+There are potential denial of service (DoS) attack vectors that are not mitigated by network transaction fees. Stealth transfer senders cause an externality for recipients, as parsing announcement events consumes computational resources that are not compensated with gas. Therefore, spamming announcement events _can_ be a detriment to the user experience, as it _can_ lead to longer parsing times.
 We consider the incentives to carry out such an attack to be low because **no monetary benefit can be obtained**
 However, to tackle potential spam, parsing providers may adopt their own anti-DoS attack methods. These may include ignoring the spamming users when serving announcements to users or, less harsh, de-prioritizing them when ordering the announcements. The indexed `caller` keyword may help parsing providers to effectively filter known spammers.
 
-Furthermore, parsing providers have a few options to counter spam, such as introducing staking mechanisms or requiring senders to pay a `toll` before including their `Announcement`. Moreover, a Staking mechanism may allow users to stake an unslashable amount of ETH (similarly to [ERC-4337](./eip-4337)), to help mitigate potential spam through *sybil attacks* and enable parsing providers filtering spam more effectively.
+Furthermore, parsing providers have a few options to counter spam, such as introducing staking mechanisms or requiring senders to pay a `toll` before including their `Announcement`. Moreover, a Staking mechanism may allow users to stake an unslashable amount of ETH (similarly to [ERC-4337](./eip-4337)), to help mitigate potential spam through _sybil attacks_ and enable parsing providers filtering spam more effectively.
 Introducing a `toll`, paid by sending users, would simply put a cost on each stealth address transaction, making spamming economically unattractive.
 
 ### Recipients' transaction costs


### PR DESCRIPTION
## Description
Removed an erroneous bullet point in the ERC-5564 specification that appeared between the SECP256k1 description and its usage note.

## Changes
- Removed extra bullet point (line with just a dot) in the specification

This is a minor formatting correction that improves the document's readability.


<img width="1204" height="428" alt="1" src="https://github.com/user-attachments/assets/82ad1312-a02e-4708-b65a-ce8558f8a861" />