### PR TITLE
Add ERC: Compressed Display Format for Addresses

### DIFF
--- a/ERCS/erc-8117.md
+++ b/ERCS/erc-8117.md
@@ -3,7 +3,7 @@ eip: 8117
 title: Compressed Display Format for Addresses
 description: A display format for abbreviating consecutive identical hex characters in EVM addresses using run-length encoding for UI and logging.
 author: Zainan Victor Zhou (@xinbenlv)
-discussions-to: https://ethereum-magicians.org/t/erc-compressed-display-format-for-evm-addresses/27360
+discussions-to: https://ethereum-magicians.org/t/erc-8117-compressed-display-format-for-evm-addresses/27360
 status: Draft
 type: Standards Track
 category: ERC


### PR DESCRIPTION
## Summary

This PR introduces a new ERC proposing a presentation layer standard for abbreviating consecutive identical hex characters in EVM addresses using run-length encoding.

## Motivation

As vanity addresses (CREATE2) and gas optimization proposals like EIP-7939 become more common, addresses with long sequences of identical characters (especially zeros) are increasingly prevalent. This creates:

- **Security risks**: Difficult to distinguish 10 zeros from 11 zeros visually
- **UX issues**: Current truncation (`0x1234...5678`) obscures the internal structure

## Specification

Two display modes:

1. **Unicode (UI)**: `0x0¹⁸44...` - Uses superscript characters
2. **ASCII (CLI/Logs)**: `0x0{18}44...` - Uses bracket notation

Compression triggers when a sequence has length ≥ 6.

## Key Features

- Preserves EIP-55 checksum compatibility
- Fail-safe: Invalid hex characters (`{}`, superscripts) cause rejection in legacy systems
- Reference implementation included (Python)

## Checklist

- [x] Discussions thread: https://ethereum-magicians.org/t/erc-compressed-display-format-for-evm-addresses/27360
- [x] Local linting passes (`eipw`, `markdownlint`, `codespell`)
- [ ] ERC number to be assigned