### PR TITLE
Update ERC-7930: Remove Interoperable Name definition

### DIFF
--- a/ERCS/erc-7930.md
+++ b/ERCS/erc-7930.md
@@ -11,7 +11,7 @@ created: 2025-02-02
 ---
 
 ## Abstract
-This proposal introduces a **binary format** to describe a chain specific address.
+This proposal introduces a **binary format** to describe a _chain-specific address_.
 
 This is achieved through a versioned, length-prefixed binary envelope that supports arbitrary-length data. The interpretation and serialization rules for the data within this envelope are defined by companion standards ([CAIP-350]), which provide profiles for each chain type.
 
@@ -32,7 +32,7 @@ These features can not be added to existing standards as they are not easily ext
 
 [CAIP-10] proposes a standard text format to represent an address on a specific chain (referenced by its [CAIP-2] identifier).
 
-The standard **does not** concern itself with the serialization/deserialization of the target address. It assumes knowledge of the native address format for each chain and does not enforce any serialization or canonicalization rules.
+The standard **does not** concern itself with the serialization/deserialization of the _target address_. It assumes knowledge of the native address format for each chain and does not enforce any serialization or canonicalization rules.
 
 While it is trivial to add support for chains to [CAIP-10], the format is not optimized for usage within smart contracts as strings are an inefficient way to store data on-chain.
 
@@ -45,15 +45,15 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 **Target Address**
 : The address itself, independent of chain context. Serialized per the [CAIP-350] rules for the applicable namespace. In the examples below, the target address is `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`.
 
-**Chain Specific Address**
-: An address representation that includes both the _target address_ **and** the chain being targeted. The following are examples of chain specific addresses:
+**Chain-specific Address**
+: An address representation that includes both the _target address_ **and** the chain being targeted. The following are examples of chain-specific addresses:
 
 - The _Interoperable Address_ definition outlined in this specification
 - The addressing format outlined in [ERC-3770], e.g. `arb:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`
 - The _Interoperable Name_ definition outlined in [ERC-7828]
 
 **Interoperable Address**
-: A binary payload which unambiguously identifies a target address on a target chain. e.g. `0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045`
+: A binary payload which unambiguously identifies a _target address_ on a target chain. e.g. `0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045`
 
 
 ### _Interoperable Address_ Definition
@@ -221,6 +221,7 @@ The interoperability roadmap benefits significantly from first having a standard
 
 The rationale for some of the low level specification decisions are outlined below:
 
+- We maintain a strict Separation of Concerns (SoC) between the underlying binary format for _chain-specific addresses_ and human-readable abstractions defined in standards like [ERC-7828].
 - We chose to allow the `Address` and `ChainReference` components to be zero-length to make this standard flexible and to allow developers to use a single, uniform standard for many different jobs. For example if a user wants to represent an address on any compatible chain, or if the user simply wants to represent the chain itself.
 - We chose *not* to use alternate encoding formats (e.g., `base58` or `base64`) in order to make it easier for wallets and dApps to work with, and convert between, addresses that both use and do not use this addressing standard.
 


### PR DESCRIPTION
This PR removes the Interoperable Name definition, and adds clarification as to why in the 'Rationale' section - a separation of concerns between ERC-7930 and ERC-7828.

Based on extensive discussion within the Interop community.

Also, grammar fixes and small clarifications.
