### PR TITLE
Update ERC-7246: fix docs and emit `Release` on `_spendEncumbrance`

### DIFF
--- a/ERCS/erc-7246.md
+++ b/ERCS/erc-7246.md
@@ -63,7 +63,7 @@ interface IERC7246{
      * Grants to `taker` a guaranteed right to transfer `amount` from the caller's balance by using `transferFrom`.
      *
      * MUST revert if caller does not have `amount` tokens available
-     * (e.g. if `balanceOf(caller) - encumbrances(caller) < amount`).
+     * (e.g. if `balanceOf(caller) - encumberedBalanceOf(caller) < amount`).
      *
      * Emits an {Encumber} event.
      */
@@ -76,7 +76,7 @@ interface IERC7246{
      * The function SHOULD revert unless the owner account has deliberately authorized the sender of the message via some mechanism.
      *
      * MUST revert if `owner` does not have `amount` tokens available
-     * (e.g. if `balanceOf(owner) - encumbrances(owner) < amount`).
+     * (e.g. if `balanceOf(owner) - encumberedBalanceOf(owner) < amount`).
      *
      * Emits an {Encumber} event.
      */
@@ -190,7 +190,7 @@ contract EncumberableERC20 is ERC20, IERC7246 {
         if (exceedsEncumbrance)  {
             uint excessAmount = amount - encumberedToTaker;
 
-            // check that enough enencumbered tokens exist to spend from allowance
+            // check that enough unencumbered tokens exist to spend from allowance
            require(availableBalanceOf(src) >= excessAmount, "insufficient balance");
 
            // Exceeds Encumbrance , so spend all of it
@@ -211,6 +211,8 @@ contract EncumberableERC20 is ERC20, IERC7246 {
         uint newEncumbrance = currentEncumbrance - amount;
         encumbrances[owner][taker] = newEncumbrance;
         encumberedBalanceOf[owner] -= amount;
+
+        emit Release(owner, taker, amount);
     }
 }
 ```


### PR DESCRIPTION
According to the ERC, the `Release` event is emitted when:
> the encumbrance of a `taker` to an `owner` is reduced by `amount`.

There is currently a bug in the example implementation where the event is not emitted when encumbrances are spent (which reduces the encumbrance).

There are also small issues with the docs that were fixed.