### PR TITLE
Add ERC: Cross-Chain Function Calls via Hooks

### DIFF
--- a/ERCS/erc-8121.md
+++ b/ERCS/erc-8121.md
@@ -1,32 +1,30 @@
 ---
 eip: 8121
-title: Delegated metadata resolution via hooks
-description: A method for delegating metadata resolution to a different contract via hooks.
+title: Cross-Chain Function Calls via Hooks
+description: A specification for cross-chain function calls using hooks with ERC-7930 interoperable addresses.
 author: Prem Makeig (@nxt3d)
 discussions-to: https://ethereum-magicians.org/t/erc-8121-delegated-metadata-resolution-via-hooks/27424
 status: Draft
 type: Standards Track
 category: ERC
 created: 2025-12-12
-requires: 3668
+requires: 3668, 7930
 ---
 
 ## Abstract
 
-This ERC introduces hooks, a method for redirecting metadata records to a different contract for resolution. When a metadata value contains a hook, clients "jump" to the destination contract to resolve the actual value by calling the specified function. This enables secure resolution from known contracts with known security properties. Hooks can call any function that returns a single `bytes` or `string` value, with the return type matching the hook's encoding format.
+This ERC introduces hooks, a specification for cross-chain function calls. A hook fully specifies what function to call, with what parameters, on which contract, on which chain. Hooks are particularly useful for redirecting metadata to known contracts with verifiable security properties, such as credential registries for Proof-of-Personhood (PoP) or Know-Your-Agent (KYA) for AI agent identity.
 
 ## Motivation
 
-The goal of this ERC is to propose a method for securely resolving onchain metadata from known contracts. Hooks allow metadata records to be redirected to trusted resolvers by specifying a function call and destination contract address. If the destination is a known contract, such as a credential resolver for Proof-of-Personhood (PoP) or Know-Your-Customer (KYC), clients can verify the contract's security properties before resolving.
-
-The hook both notifies resolving clients of a credential source, as well as provides the method for resolving the credential.
+Cross-chain reads require specifying exactly what function to call, on which contract, on which chain. Hooks provide a complete specification by combining a function selector, readable function call, return type, and [ERC-7930](./eip-7930.md) interoperable address. This enables secure resolution from known contracts with verifiable security properties, whether on the same chain or across chains.
 
 ### Use Cases
 
+- **Cross-Chain Metadata**: Resolve metadata from contracts on other chains
 - **Credential Resolution**: Redirect a Proof-of-Person (PoP) or Know-Your-Customer (KYC) record to a trusted credential registry
-- **Singleton Registries**: Point to canonical registries with known security properties
-- **Shared Metadata**: Multiple contracts can reference the same metadata source
-- **Generic Function Calls**: Call any function on any contract that returns a single `bytes` or `string` value
+- **Singleton Registries**: Point to canonical registries with known security properties on any chain
+- **Shared Metadata**: Multiple contracts can reference the same metadata source across chains
 
 ## Specification
 
@@ -34,31 +32,29 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Overview
 
-A hook is a value stored in a smart contract record (string or bytes) that redirects resolution to a different contract. 
-
-The target function's return type MUST match the hook's encoding format:
-- If the hook is encoded and stored as `bytes`, the target function MUST return `bytes`
-- If the hook is encoded and stored as a `string`, the target function MUST return `string`
-
-This ensures type consistency throughout the resolution chain.
+A hook is a fully specified function call containing a function selector, human-readable function call, return type, and an [ERC-7930](./eip-7930.md) interoperable address specifying both the target contract and chain. This makes hooks completely self-describing - any client can resolve them without external documentation.
 
 ### Hook Function Signature
 
 ```solidity
 function hook(
+    bytes4 functionSelector,
     string calldata functionCall,
-    address target
+    string calldata returnType,
+    bytes calldata target
 )
 ```
 
 ```solidity
-bytes4 constant HOOK_SELECTOR = 0x9645b9c8;
+bytes4 constant HOOK_SELECTOR = 0x396b32a0;
 ```
 
 #### Parameters
 
-- **`functionCall`**: A string representation of the function to call with its parameters
-- **`target`**: The address of the target contract to call
+- **`functionSelector`**: The 4-byte selector of the function to call, computed as `bytes4(keccak256("functionName(type1,type2)"))`
+- **`functionCall`**: A string representation of the function to call with its parameters (human-readable)
+- **`returnType`**: The return type in Solidity tuple notation for ABI decoding (e.g., `(string)`, `(uint256, bytes32)`, `((string, uint256[], bytes32))`)
+- **`target`**: An [ERC-7930](./eip-7930.md) interoperable address specifying both the target contract and chain
 
 ### Function Call Format
 
@@ -67,18 +63,15 @@ The `functionCall` parameter uses a Solidity-style syntax:
 - String parameters are enclosed in single quotes: `'value'`
 - Bytes/hex parameters use the `0x` prefix: `0x1234abcd`
 - Numbers are written as literals: `42` or `1000000`
+- Arrays use square brackets: `[1, 2, 3]` or `['a', 'b', 'c']`
+- Structs/tuples use parentheses: `('alice', 42, true)`
 
-The return type of the called function depends on the hook encoding format:
-- **Bytes hooks**: Function MUST return a single `bytes` value (can be ABI-encoded for arrays, structs, etc.)
-- **String hooks**: Function MUST return a single `string` value
+The target function's return type is specified by the `returnType` parameter. Functions return ABI-encoded data which clients decode using the specified return type.
 
-**Examples:**
+**Example:**
 
 ```
-getContractMetadata('kyc')
-getMetadata(42,'avatar')
-getBytes(0x42)
-getText('description')
+hook(0xc41a360a, "getOwner(42)", "(address)", 0x000100000101141234567890abcdef1234567890abcdef12345678)
 ```
 
 ### Hook Encoding
@@ -87,15 +80,23 @@ Hooks can be encoded in two formats depending on the storage type:
 
 #### Bytes Format
 
-For metadata systems that store `bytes` values, hooks MUST be ABI-encoded. The target function MUST return `bytes`. An example might be:
+For systems that store `bytes` values, hooks MUST be ABI-encoded:
 
 ```solidity
-bytes4 constant HOOK_SELECTOR = 0x9645b9c8;
+bytes4 constant HOOK_SELECTOR = 0x396b32a0;
+
+// Target function selector: bytes4(keccak256("getContractMetadata(string)"))
+bytes4 functionSelector = 0x1837de7f;
+
+// ERC-7930 address: Ethereum mainnet (chain 1) contract
+bytes memory target = hex"000100000101141234567890abcdef1234567890abcdef12345678";
 
 bytes memory hookData = abi.encodeWithSelector(
     HOOK_SELECTOR,
+    functionSelector,
     "getContractMetadata('kyc')",
-    targetContract
+    "(string)",  // return type
+    target
 );
 
 // Store the hook as the value
@@ -105,57 +106,68 @@ originatingContract.setContractMetadata("kyc", hookData);
 
 #### String Format
 
-For metadata systems that store `string` values, hooks MUST be formatted as shown below. The target function MUST return `string`.
+For systems that store `string` values, hooks MUST be formatted as shown below. The target is an [ERC-7930](./eip-7930.md) interoperable address.
 
 ```
-hook("functionCall()", 0xTargetAddress)
+hook(0xFunctionSelector, "functionCall()", "(returnType)", 0xERC7930Address)
 ```
 
 **Examples:**
 
 ```
-hook("getText('kyc')", 0x1234567890AbcdEF1234567890aBcdef12345678)
-hook("text(12453)", 0x1234567890AbcdEF1234567890aBcdef12345678)
+hook(0x5cc4350a, "getText('kyc')", "(string)", 0x000100000101141234567890abcdef1234567890abcdef12345678)
+hook(0x5c60da1b, "getRecord(42)", "(string, uint256, bytes32)", 0x00010000010a141234567890abcdef1234567890abcdef12345678)
+hook(0x1234abcd, "getData()", "((string, uint256[], address))", 0x000100000101141234567890abcdef1234567890abcdef12345678)
 
-// Target functions: function getText(string) external view returns (string memory)
-//                   function text(uint256) external view returns (string memory)
+// First example: returns string, Ethereum mainnet (chain 1)
+// Second example: returns tuple, Optimism (chain 10)
+// Third example: returns struct (nested tuple), Ethereum mainnet
 ```
 
 ### Detecting Hooks
 
 Clients SHOULD be aware in advance which metadata keys may contain hooks. It is intentional that hook-enabled keys are known by clients beforehand, similar to how clients know to look for keys like `"image"` or `"description"`.
 
-For bytes values, hooks can be detected by checking if the value starts with the hook selector `0x9645b9c8`. For string values, hooks can be detected by checking if the value starts with `hook(`.
+For bytes values, hooks can be detected by checking if the value starts with the hook selector `0x396b32a0`. For string values, hooks can be detected by checking if the value starts with `hook(`.
 
 ### Resolving Hooks
 
 When a client encounters a hook that it wants to use:
 
-1. **Parse the hook** to extract the `functionCall` and `target` address
-2. **Verify the target** (RECOMMENDED): Check that the target contract is known and trusted
-3. **Parse the function call**: Extract the function name and parameters from the string
-4. **Call the target**: Execute the function on the target contract
-5. **Support [ERC-3668](./eip-3668.md)**: Clients MUST support [ERC-3668](./eip-3668.md) offchain data retrieval when resolving from the target contract
+1. **Parse the hook** to extract the `functionSelector`, `functionCall`, `returnType`, and `target` ([ERC-7930](./eip-7930.md) address)
+2. **Verify the selector**: Compute the expected selector from the function signature in `functionCall` and verify it matches `functionSelector`. Reject the hook if they don't match.
+3. **Parse the target**: Decode the [ERC-7930](./eip-7930.md) address to extract the chain and contract address
+4. **Verify the target** (RECOMMENDED): Check that the target contract is known and trusted
+5. **Parse the function call**: Extract the function name and parameters from the string
+6. **Enable [ERC-3668](./eip-3668.md)**: Clients MUST enable [ERC-3668](./eip-3668.md) offchain data retrieval before calling the target
+7. **Call the target**: Execute the function on the target contract and chain using the `functionSelector`
+8. **Decode the result**: ABI-decode the returned data using the `returnType`
 
 Clients MAY choose NOT to resolve hooks if the target contract is not known to be secure and trustworthy. Some clients have [ERC-3668](./eip-3668.md) disabled by default, but clients MUST enable it before resolving the hook.
 
-### Example: KYC Credential Resolution
+### Example: Cross-Chain KYC Credential Resolution
 
-A contract can redirect its `"kyc"` metadata key to a trusted KYC provider contract:
+A contract on Optimism can redirect its `"kyc"` metadata key to a trusted KYC provider contract on Ethereum mainnet:
 
-**Step 1: Store the hook in the originating contract**
+**Step 1: Store the hook in the originating contract (on Optimism)**
 
 ```solidity
-bytes4 constant HOOK_SELECTOR = 0x9645b9c8;
+bytes4 constant HOOK_SELECTOR = 0x396b32a0;
 
-// KYCProvider is a trusted singleton registry at a known address
-address kycProvider = 0x1234567890AbcdEF1234567890aBcdef12345678;
+// Target function selector: bytes4(keccak256("getCredential(string)"))
+bytes4 functionSelector = 0x1837de7f;
+
+// KYCProvider on Ethereum mainnet (ERC-7930 format)
+// Chain: Ethereum mainnet (chain 1), Address: 0x1234...5678
+bytes memory target = hex"000100000101141234567890abcdef1234567890abcdef12345678";
 
 // Create hook that calls getCredential('kyc: 0x76F1Ff...') on the KYC provider
 bytes memory hookData = abi.encodeWithSelector(
     HOOK_SELECTOR,
+    functionSelector,
     "getCredential('kyc: 0x76F1Ff0186DDb9461890bdb3094AF74A5F24a162')",
-    kycProvider
+    "(string)",  // return type
+    target
 );
 
 // Store the hook
@@ -165,41 +177,67 @@ originatingContract.setContractMetadata("kyc", hookData);
 **Step 2: Client resolves the hook**
 
 ```javascript
-// Client reads metadata from originating contract
+// Client reads metadata from originating contract (on Optimism)
 const value = await originatingContract.getContractMetadata("kyc");
 
 // Client detects this is a hook (starts with HOOK_SELECTOR)
-if (value.startsWith("0x9645b9c8")) {
+if (value.startsWith("0x396b32a0")) {
     // Parse the hook (ABI decode after 4-byte selector)
-    const { functionCall, target } = decodeHook(value);
-    
+    const { functionSelector, functionCall, returnType, target } = decodeHook(value);
+
+    // Verify selector matches the function signature
+    const expectedSelector = keccak256("getCredential(string)").slice(0, 10);
+    if (functionSelector !== expectedSelector) {
+        throw new Error("Selector mismatch");
+    }
+
+    // Decode ERC-7930 address to get chain and contract
+    const { chainId, address } = decodeERC7930(target);
+    // chainId = 1 (Ethereum mainnet)
+    // address = 0x1234567890abcdef1234567890abcdef12345678
+
     // Verify target is trusted (implementation-specific)
-    if (!isTrustedResolver(target)) {
+    if (!isTrustedResolver(chainId, address)) {
         throw new Error("Untrusted resolver");
     }
-    
+
     // Parse the function call string to get function name and args
     const { functionName, args } = parseFunctionCall(functionCall);
     // functionName = "getCredential"
     // args = ["kyc: 0x76F1Ff0186DDb9461890bdb3094AF74A5F24a162"]
-    
-    // Enable [ERC-3668](./eip-3668.md) (CCIP-Read) support for this resolution
+
+    // Get provider for target chain and enable ERC-3668 (CCIP-Read)
+    const targetProvider = getProviderForChain(chainId);
     const targetContract = new ethers.Contract(
-        target,
+        address,
         [`function ${functionName}(string) view returns (bytes)`],
-        provider.ccipReadEnabled(true)  // Enable CCIP-Read
+        targetProvider.ccipReadEnabled(true)  // Enable CCIP-Read
     );
-    
-    // Resolve from target contract
-    const credential = await targetContract[functionName](...args);
-    
-    // credential is bytes containing: "Maria Garcia /0x76F1Ff0186DDb9461890bdb3094AF74A5F24a162/ ID: 146-DJH-6346-25294"
+
+    // Resolve from target contract on Ethereum mainnet
+    const resultBytes = await targetContract[functionName](...args);
+
+    // ABI-decode using returnType: "(string)"
+    const credential = ethers.utils.defaultAbiCoder.decode([returnType], resultBytes);
+    // credential = "Maria Garcia /0x76F1Ff.../ ID: 146-DJH-6346-25294"
 }
 ```
 
 ## Rationale
 
-Hooks introduce redirection for resolving metadata records, which allows for resolving records from "known" contracts. Known contracts may have security properties which are verifiable, for example a registry which resolves Proof-of-Personhood (PoP) IDs or Know-Your-Customer (KYC) credentials.
+Hooks provide a complete specification for cross-chain function calls by combining a function selector, human-readable function call, return type, and [ERC-7930](./eip-7930.md) interoperable address. This makes hooks entirely self-describing - any client can resolve them without external documentation or ABI files.
+
+### Why Include Both Function Selector and Function String?
+
+Hooks include both a 4-byte function selector and a human-readable function call string. The selector provides type disambiguation (e.g., `getData(bytes32)` and `getData(bytes)` have different selectors, but `0x1234...` in the string is ambiguous), while the string provides human readability. Clients can verify the selector matches the function signature, rejecting mismatches as errors or tampering.
+
+### Why Use ERC-7930 Interoperable Addresses?
+
+[ERC-7930](./eip-7930.md) addresses include chain information, making hooks a complete cross-chain function call specification. A hook specifies exactly what function to call, with what parameters, on which contract, on which chain. This eliminates ambiguity and enables secure cross-chain reads when combined with [ERC-3668](./eip-3668.md).
+
+### Why Include the Return Type?
+
+The `returnType` parameter allows clients to ABI-decode the result without external documentation. Target functions return `bytes`, which clients decode using the specified return type. This is not restrictive - any data (arrays, structs, multiple values) can be returned via ABI encoding. Applications can impose their own constraints (e.g., requiring `(string)` for metadata hooks), but hooks themselves support any return type.
 
 ### Why Mandate [ERC-3668](./eip-3668.md)?
 


### PR DESCRIPTION
ERC-8121 introduces **hooks**, a specification for cross-chain function calls. A hook fully specifies what function to call, with what parameters, on which contract, on which chain.

A hook combines a function selector, human-readable function call, return type, and an interoperable address:

```
hook(0xc41a360a, "getOwner(42)", "(address)", 0x000100000101141234567890abcdef1234567890abcdef12345678)
```

Hooks are useful for redirecting to trusted credential registries (PoP, KYC, KYA for AI agents), cross-chain metadata resolution, and singleton registries with known security properties.
