### PR TITLE
Update ERC-7888: Generalize ERC-7888 to support multiple state commitment schemes

### DIFF
--- a/ERCS/erc-7888.md
+++ b/ERCS/erc-7888.md
@@ -134,20 +134,19 @@ interface IStateProver {
 
     /// @notice Verify a state value given a target chain state commitment and a proof.
     /// @dev    This function MUST NOT assume it is being called on the home chain.
-    ///         MUST revert if the input is invalid or the input is not sufficient to determine a state location and its value.
-    ///         MUST return a state location and its value on the target chain.
+    ///         MUST revert if the input is invalid or the input is not sufficient to determine a storage slot and its value.
+    ///         MUST return a storage slot and its value on the target chain.
     ///         MUST be pure, with 1 exception: MAY read address(this).code.
-    ///         SHOULD use storage slots as the state location. For storage-based implementations, the location is a storage slot.
     ///         While messages MUST be stored in storage slots (for duplicate prevention), alternative reading mechanisms may be used in some cases.
     /// @param  targetStateCommitment The state commitment of the target chain.
-    /// @param  input Any necessary input to determine a single state location and its value.
+    /// @param  input Any necessary input to determine a single storage slot and its value.
     /// @return account The address of the account on the target chain.
-    /// @return location The state location of the account on the target chain (e.g., storage slot for storage-based commitments).
-    /// @return value The value at the state location.
+    /// @return slot The state slot of the account on the target chain (e.g., storage slot for storage-based commitments).
+    /// @return value The value at the state slot.
     function verifyStateValue(bytes32 targetStateCommitment, bytes calldata input)
         external
         view
-        returns (address account, uint256 location, bytes32 value);
+        returns (address account, uint256 slot, bytes32 value);
 
     /// @notice The version of the state commitment prover.
     /// @dev    MUST be pure, with 1 exception: MAY read address(this).code.
@@ -260,9 +259,9 @@ The calls in Figure 6 perform the following operations:
 /// @notice Reads messages from a broadcaster.
 interface IReceiver {
     /// @notice Arguments required to read state of an account on a remote chain.
-    /// @dev    The proof is always for a single state location. If the proof is for multiple locations the IReceiver MUST revert.
+    /// @dev    The proof is always for a single storage slot. If the proof is for multiple slots the IReceiver MUST revert.
     ///         The proof format depends on the state commitment scheme used by the StateProver (e.g., storage proofs).
-    ///         SHOULD use storage slots as the state location. While messages MUST be stored in storage slots (for duplicate prevention), alternative reading mechanisms may be used in some cases.
+    ///         While messages MUST be stored in storage slots, alternative reading mechanisms may be used in some cases.
     /// @param  route The home chain addresses of the StateProverPointers along the route to the remote chain.
     /// @param  scpInputs The inputs to the StateProver / StateProverCopies.
     /// @param  proof Proof passed to the last StateProver / StateProverCopy
@@ -277,7 +276,7 @@ interface IReceiver {
     /// @param  broadcasterReadArgs A RemoteReadArgs object:
     ///         - The route points to the broadcasting chain
     ///         - The account proof is for the broadcaster's account
-    ///         - The proof is for the message state location (SHOULD be a storage slot; while messages MUST be stored in storage slots for duplicate prevention, alternative reading mechanisms may be used in some cases)
+    ///         - The proof is for the message storage slot (MAY use additional transmission mechanisms (e.g., child-to-parent native bridges) to make messages visible)
     /// @param  message The message to read.
     /// @param  publisher The address of the publisher who broadcast the message.
     /// @return broadcasterId The broadcaster's unique identifier.
@@ -319,7 +318,7 @@ See [Reference Implementation](#reference-implementation) for an example of a un
 Message reading SHOULD use storage proofs to read messages from storage slots. However, an alternative method to this would be to pass messages (perhaps batched) via the canonical bridges of the chains. However storage proofs have some advantages over this method:
 
 - They only require gas tokens on the chains where the message is sent and received, none on the chains on the route in between.
-- Batching by default. Since storage slots share a common state root, caching the state root allows readers to open adjacent locations at lower cost. This provides a form of implicit batching, whereas canonical bridges would need to create a form of explicit batching.
+- Batching by default. Since storage slots share a common state root, caching the state root allows readers to open adjacent slots at lower cost. This provides a form of implicit batching, whereas canonical bridges would need to create a form of explicit batching.
 - If the common ancestor of the two chains is Ethereum, sending a message using the canonical bridges would require sending a transaction on Ethereum, which would likely incur a high cost.
 
 ### No duplicate messages per publisher
@@ -469,12 +468,12 @@ contract Minter {
 ## Security Considerations
 
 ### Chain Upgrades
-If a chain upgrades such that a StateProver's `verifyTargetState` or `getTargetState` functions might return data besides a finalized target state commitment, then invalid messages could be read by a `Receiver`. For instance, if a chain stores its state commitments on the parent chain in a specific mapping, and that storage location is later repurposed, then an old StateProver might be able to pass along an invalid state commitment. It is therefore important that either:
+If a chain upgrades such that a StateProver's `verifyTargetState` or `getTargetState` functions might return data besides a finalized target state commitment, then invalid messages could be read by a `Receiver`. For instance, if a chain stores its state commitments on the parent chain in a specific mapping, and that storage slot is later repurposed, then an old StateProver might be able to pass along an invalid state commitment. It is therefore important that either:
 * the StateProver is written in such a way to detect changes like this
-* the owner who is able to repurpose these storage locations is aware of the StateProver and ensures they don't break it
+* the owner who is able to repurpose these storage slots is aware of the StateProver and ensures they don't break it
 
 ### StateProverPointer Ownership / Updates
-A malicious StateProverPointer owner can DoS or forge messages. However, so can the chain owner responsible for setting the location of historical parent/child state commitments. Therefore it is expected that this chain owner be the same as the owner of the StateProverPointer so as not to introduce additional risks.
+A malicious StateProverPointer owner can DoS or forge messages. However, so can the chain owner responsible for setting the slot of historical parent/child state commitments. Therefore it is expected that this chain owner be the same as the owner of the StateProverPointer so as not to introduce additional risks.
 
 * If the target chain of the referenced StateProver is the parent chain, the home chain owner is expected to be the StateProverPointer's owner.
 * If the target chain of the referenced StateProver is the child chain, the target chain owner is expected to be the StateProverPointer's owner.


### PR DESCRIPTION
This PR refactors ERC-7888 to support different state commitment schemes (block hashes, state roots, batch hashes) instead of only block hashes. Key changes:

- Rename IBlockHashProver → IStateCommitmentProver
- Update terminology: "block hash" → "state commitment" where referring to the commitment scheme
- Clarify that storage slots are required for message storage (duplicate prevention), while alternative reading mechanisms may be used in edge cases

Block hashes remain the recommended state commitment, and storage proofs remain the recommended reading mechanism. This change makes the ERC compatible with rollups that commit different types of state commitments to their parent chains.