### PR TITLE
Update ERC-7496: clarify dynamic traits must emit events for indexer sync

### DIFF
--- a/ERCS/erc-7496.md
+++ b/ERCS/erc-7496.md
@@ -198,6 +198,8 @@ It is RECOMMENDED to use the `UniformValue` events when the trait value is unifo
 
 Updating the trait metadata MUST emit the event `TraitMetadataURIUpdated` so offchain indexers can be notified to query the contract for the latest changes via `getTraitMetadataURI()`.
 
+Note that dynamic trait values MUST NOT be based on time-dependent factors (e.g. block timestamp) or other implicit state changes. All trait changes MUST be the result of an explicit onchain action that emits a corresponding `TraitUpdated` event. This requirement ensures that offchain indexers can remain synchronized with the current trait values by processing emitted events, rather than needing to continuously poll or re-evaluate trait values.
+
 ### `setTrait`
 
 If a trait defines `tokenOwnerCanUpdateValue` as `true`, then the trait value MUST be updatable by the token owner by calling `setTrait`.


### PR DESCRIPTION
This clarifies that dynamic trait values must not be based on time-dependent factors (e.g. block timestamp) or other implicit state changes. All trait changes must be the result of an explicit onchain action that emits a corresponding `TraitUpdated` event.

This ensures that offchain indexers can remain synchronized with current trait values by processing emitted events, rather than needing to continuously poll or re-evaluate trait values.