### PR TITLE
Update ERC-7984: make `name()` and `symbol()` functions mandatory

### DIFF
--- a/ERCS/erc-7984.md
+++ b/ERCS/erc-7984.md
@@ -40,8 +40,6 @@ Compliant tokens MUST implement the following methods, unless otherwise specifie
 
 Returns the name of the token - e.g. `"MyConfidentialToken"`.
 
-OPTIONAL - This method can be used to improve usability, but interfaces and other contracts MUST NOT expect these values to be present.
-
 ```solidity
 function name() external view returns (string memory)
 ```
@@ -49,8 +47,6 @@ function name() external view returns (string memory)
 #### `symbol()`
 
 Returns the symbol of the token - e.g. `"MCT"`.
-
-OPTIONAL - This method can be used to improve usability, but interfaces and other contracts MUST NOT expect these values to be present.
 
 ```solidity
 function symbol() external view returns (string memory)


### PR DESCRIPTION
The addition of ERC-165 to this ERC assumed that the `name()` and `symbol()` functions were part of the interface. The interfaceId mentioned with regards to ERC-165 introspection takes these functions into account.

To ensure there is no ambiguity and ERC-165 interface consistency, we will make the `name()` and `symbol()` functions mandatory.