### PR TITLE
Update ERC-8004: align metadataValue to bytes

### DIFF
--- a/ERCS/erc-8004.md
+++ b/ERCS/erc-8004.md
@@ -126,7 +126,7 @@ The *supportedTrust* field is OPTIONAL. If absent or empty, this ERC is used onl
 
 #### Onchain metadata
 
-The registry extends ERC-721 by adding `getMetadata(uint256 agentId, string metadataKey)` and `setMetadata(uint256 agentId, string metadataKey, string metadataValue)` functions for optional extra on-chain agent metadata.
+The registry extends ERC-721 by adding `getMetadata(uint256 agentId, string metadataKey) returns (bytes metadataValue)` and `setMetadata(uint256 agentId, string metadataKey, bytes metadataValue)` functions for optional extra on-chain agent metadata.
 
 When metadata is set, the following event is emitted:
 


### PR DESCRIPTION
Updated the ERC-8004 Identity Registry documentation so that getMetadata(uint256 agentId, string metadataKey) explicitly returns bytes metadataValue and setMetadata(uint256 agentId, string metadataKey, bytes metadataValue) uses bytes for the value parameter. This aligns the function signatures with the existing MetadataEntry struct and MetadataSet event, and matches the reference implementations and implementation guides where metadata values are treated as arbitrary byte payloads rather than strings.