### PR TITLE
Add ERC: Human Readable Token Identifiers

### DIFF
--- a/ERCS/erc-8127.md
+++ b/ERCS/erc-8127.md
@@ -72,7 +72,7 @@ The canonical form of a Token Identifier is `[<alias>.]<token-id>@<registry>` wi
 
 The Token Identifier format combines several design elements to balance usability, uniqueness, and interoperability. Each component serves a specific purpose in creating a format that is partly human readable (alias and token ID) and partly opaque (registry), while remaining machine parseable and supporting the diverse needs of token registry systems including NFTs, RWAs, and agent registries.
 
-### Comparison with CAIP-19
+### Comparison with [CAIP-19](https://github.com/ChainAgnostic/CAIPs/blob/ff573534d413153f8cbab0be94eddeca566d0792/CAIPs/caip-19.md)
 
 This format intentionally separates the identifier into two parts: a fully human readable portion (`<alias>.<token-id>`) and an opaque location portion (`@<registry>`). In many registries (including typical NFT, RWA, and agent registries), token IDs are simple decimal numbers rather than hashes, so both the alias and token ID can remain fully human readable (e.g., `punk.2344`, `agent.235234`, `silver-bullion-bar.58348729`).
 


### PR DESCRIPTION
## What this adds
This PR introduces a new draft ERC that defines a simple, URI compatible way to identify a token across chains and registries while keeping the most important part for humans up front.

The format is:

- `[alias.]tokenId@registry`

Where:
- `alias` is optional and can come from registry metadata (or be client assigned) to provide a semantic hint (e.g. `support-agent.3453`)
- `tokenId` is the primary identifier within the registry
- `registry` is an [ERC-7930](./eip-7930.md) interoperable address encoding the chain and contract address

## Why it matters
Many identifiers put the “human meaning” behind opaque chain and contract data. This ERC splits the identifier into two parts:
- a human readable prefix (`alias.tokenId`)
- an opaque locator (`@registry`)

This makes identifiers easier to read, say, copy, and share between systems, while still being globally unique when combined with the registry.
