### PR TITLE
Update ERC-8004: add co-author (Onchain Metadata; see PR #1237)

### DIFF
--- a/ERCS/erc-8004.md
+++ b/ERCS/erc-8004.md
@@ -2,7 +2,7 @@
 eip: 8004
 title: Trustless Agents
 description: Discover agents and establish trust through reputation and validation
-author: Marco De Rossi (@MarcoMetaMask), Davide Crapis (@dcrapis) <davide@ethereum.org>, Jordan Ellis <jordanellis@google.com>, Erik Reppel <erik.reppel@coinbase.com>, Prem Makeig <premm@unruggable.com>
+author: Marco De Rossi (@MarcoMetaMask), Davide Crapis (@dcrapis) <davide@ethereum.org>, Jordan Ellis <jordanellis@google.com>, Erik Reppel <erik.reppel@coinbase.com>, Prem Makeig <prem@unruggable.com>
 discussions-to: https://ethereum-magicians.org/t/erc-8004-trustless-agents/25098
 status: Review
 type: Standards Track


### PR DESCRIPTION
## Summary
- Adds Prem Makeig to the `author` header of [ERC-8004](./eip-8004.md) as a co-author (author of the Onchain Metadata section).

## Provenance (original introduction)
- The Onchain Metadata work was originally introduced, in [ERCs PR #1237: Add ERC: Fixed-Supply Agent NFT Collections](https://github.com/ethereum/ERCs/pull/1237/changes/13f11f243293b6a1eb45b19765e3854ca172e6f2) (initially as part of ERC-8041).
- Initial commit date: **Sep 30, 2025**

## Follow-up (moved into ERC-8048)
- The Onchain Metadata spec was later split/moved into ERC-8048 in [ERCs PR #1259: Add ERC: Onchain Metadata for Token Registries](https://github.com/ethereum/ERCs/pull/1259).
