### PR TITLE
Add ERC: Non-Transferable Token

### DIFF
--- a/ERCS/erc-8129.md
+++ b/ERCS/erc-8129.md
@@ -151,7 +151,7 @@ While ERC-4973 avoids implementing ERC-721's transfer interface, it includes `gi
 
 - Tokens can still change owners through consensual operations
 - The `give/take` mechanism contradicts the concept of permanent binding
-- Adds complexity through signature verification and [EIP-712](https://eips.ethereum.org/EIPS/eip-712) structured data
+- Adds complexity through signature verification and [EIP-712](./eip-712.md) structured data
 - The token is "movable with consent" rather than truly soulbound
 
 **This Standard:**

--- a/ERCS/erc-8129.md
+++ b/ERCS/erc-8129.md
@@ -132,7 +132,7 @@ Contracts implementing this standard MUST implement the [ERC-165](./erc-165.md) 
 
 - The `IERC8129` interface ID `0x4ba63534`
 - The `IERC721Metadata` interface ID `0x5b5e139f`
-- The `ERC-165` interface ID `0x01ffc9a7`
+- The ERC-165 interface ID `0x01ffc9a7`
 
 ## Rationale
 

--- a/ERCS/erc-8129.md
+++ b/ERCS/erc-8129.md
@@ -13,14 +13,14 @@ requires: 165, 721
 
 ## Abstract
 
-This EIP proposes a minimal standard for non-transferable tokens (commonly known as "Soulbound tokens"). Unlike existing approaches that extend [ERC-721](./erc-721.md) and disable transfer functionality, this standard defines tokens that are non-transferable by design, eliminating transfer-related functions entirely from the interface.
+This EIP proposes a minimal standard for non-transferable tokens (commonly known as "Soulbound tokens"). Unlike existing approaches that extend [ERC-721](./eip-721.md) and disable transfer functionality, this standard defines tokens that are non-transferable by design, eliminating transfer-related functions entirely from the interface.
 
 ## Motivation
 
 Current Soulbound token implementations take different approaches but all retain some form of token movement between addresses:
 
-- [ERC-5192](./erc-5192.md) and [ERC-5484](./erc-5484.md) extend [ERC-721](./erc-721.md), inheriting its complete transfer infrastructure and then blocking these capabilities
-- [ERC-4973](./erc-4973.md) avoids implementing ERC-721's transfer interface but includes `give()` and `take()` functions that allow token movement between addresses with signature consent
+- [ERC-5192](./eip-5192.md) and [ERC-5484](./eip-5484.md) extend [ERC-721](./eip-721.md), inheriting its complete transfer infrastructure and then blocking these capabilities
+- [ERC-4973](./eip-4973.md) avoids implementing ERC-721's transfer interface but includes `give()` and `take()` functions that allow token movement between addresses with signature consent
 
 Both approaches create several problems:
 
@@ -100,7 +100,7 @@ interface IERC721Metadata {
 }
 ```
 
-See [ERC-721](./erc-721.md) for a definition of its metadata JSON Schema.
+See [ERC-721](./eip-721.md) for a definition of its metadata JSON Schema.
 
 All compliant contracts MUST implement both `ERC8129` and `IERC721Metadata` interfaces.
 
@@ -126,9 +126,9 @@ All compliant contracts MUST implement both `ERC8129` and `IERC721Metadata` inte
    - `ownerOf(uint256 tokenId)` MUST return the address that owns the specified token
    - `ownerOf(uint256 tokenId)` MUST revert for non-existent tokens
 
-### [ERC-165](./erc-165.md) Interface Identification
+### [ERC-165](./eip-165.md) Interface Identification
 
-Contracts implementing this standard MUST implement the [ERC-165](./erc-165.md) [`supportsInterface`](./erc-165.md#how-a-contract-will-publish-the-interfaces-it-implements) function and MUST return `true` for:
+Contracts implementing this standard MUST implement the [ERC-165](./eip-165.md) [`supportsInterface`](./eip-165.md#how-a-contract-will-publish-the-interfaces-it-implements) function and MUST return `true` for:
 
 - The `IERC8129` interface ID `0x4ba63534`
 - The `IERC721Metadata` interface ID `0x5b5e139f`
@@ -202,7 +202,7 @@ While tokens cannot be transferred, allowing the owner to burn their token provi
 
 This standard is not backwards compatible with ERC-721. This is intentional - tokens that are fundamentally non-transferable should not masquerade as transferable tokens.
 
-Wallets and marketplaces can detect this standard via [ERC-165](./erc-165.md#how-to-detect-if-a-contract-implements-any-given-interface) and treat these tokens appropriately (e.g., not showing transfer or listing options).
+Wallets and marketplaces can detect this standard via [ERC-165](./eip-165.md#how-to-detect-if-a-contract-implements-any-given-interface) and treat these tokens appropriately (e.g., not showing transfer or listing options).
 
 ## Reference Implementation
 
@@ -303,7 +303,7 @@ The `mint(address to)` function allows minting to any address. Implementations s
 
 ### Interface Detection
 
-External contracts MUST NOT assume transfer capabilities based solely on the presence of metadata functions. Always check [ERC-165](./erc-165.md#how-to-detect-if-a-contract-implements-any-given-interface) interface support.
+External contracts MUST NOT assume transfer capabilities based solely on the presence of metadata functions. Always check [ERC-165](./eip-165.md#how-to-detect-if-a-contract-implements-any-given-interface) interface support.
 
 ### Reentrancy
 

--- a/ERCS/erc-8129.md
+++ b/ERCS/erc-8129.md
@@ -1,9 +1,9 @@
 ---
-eip: <to be assigned>
-title: Non-Transferable Token Standard
+eip: 8129
+title: Non-Transferable Token
 description: A minimal standard for tokens that are permanently bound to an address
 author: Ivan Zemko (@Vantana1995)
-discussions-to: https://ethereum-magicians.org/t/soulbound-nft-as-separate-standard/27407
+discussions-to: https://ethereum-magicians.org/t/erc-8129-non-transferable-token/27407
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-8129.md
+++ b/ERCS/erc-8129.md
@@ -1,7 +1,7 @@
 ---
 eip: 8129
 title: Non-Transferable Token
-description: A minimal standard for tokens that are permanently bound to an address
+description: A minimal interface for tokens that are permanently bound to an address
 author: Ivan Zemko (@Vantana1995)
 discussions-to: https://ethereum-magicians.org/t/erc-8129-non-transferable-token/27407
 status: Draft
@@ -13,13 +13,13 @@ requires: 165, 721
 
 ## Abstract
 
-This EIP proposes a minimal standard for non-transferable tokens (commonly known as "Soulbound tokens"). Unlike existing approaches that extend ERC-721 and disable transfer functionality, this standard defines tokens that are non-transferable by design, eliminating transfer-related functions entirely from the interface.
+This EIP proposes a minimal standard for non-transferable tokens (commonly known as "Soulbound tokens"). Unlike existing approaches that extend [ERC-721](./erc-721.md) and disable transfer functionality, this standard defines tokens that are non-transferable by design, eliminating transfer-related functions entirely from the interface.
 
 ## Motivation
 
 Current Soulbound token implementations take different approaches but all retain some form of token movement between addresses:
 
-- [ERC-5192](./erc-5192.md) and [ERC-5484](./erc-5484.md) extend [ERC-721](./eip-721.md), inheriting its complete transfer infrastructure and then blocking these capabilities
+- [ERC-5192](./erc-5192.md) and [ERC-5484](./erc-5484.md) extend [ERC-721](./erc-721.md), inheriting its complete transfer infrastructure and then blocking these capabilities
 - [ERC-4973](./erc-4973.md) avoids implementing ERC-721's transfer interface but includes `give()` and `take()` functions that allow token movement between addresses with signature consent
 
 Both approaches create several problems:
@@ -40,14 +40,15 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Core Interface
 
-Every compliant contract MUST implement the `IERC_NTT` (Non-Transferable Token) interface:
+Every compliant contract MUST implement the `ERC8129` (Non-Transferable Token) interface:
 
 ```solidity
 pragma solidity ^0.8.0;
 
-/// @title ERC-NTT Non-Transferable Token Standard
-/// @dev See https://eips.ethereum.org/EIPS/<to be assigned>
-interface IERC_NTT {
+/// @title ERC-8129 Non-Transferable Token Standard
+/// @dev See https://eips.ethereum.org/EIPS/eip-8129
+/// Note: the ERC-165 identifier for this interface is 0x4ba63534.
+interface ERC8129 {
     /// @dev Emitted when a token is minted and bound to an address
     /// @param to The address the token is bound to
     /// @param tokenId The identifier of the minted token
@@ -101,7 +102,7 @@ interface IERC721Metadata {
 
 See [ERC-721](./erc-721.md) for a definition of its metadata JSON Schema.
 
-All compliant contracts MUST implement both `IERC_NTT` and `IERC721Metadata` interfaces.
+All compliant contracts MUST implement both `ERC8129` and `IERC721Metadata` interfaces.
 
 ### Behavior Specification
 
@@ -125,13 +126,13 @@ All compliant contracts MUST implement both `IERC_NTT` and `IERC721Metadata` int
    - `ownerOf(uint256 tokenId)` MUST return the address that owns the specified token
    - `ownerOf(uint256 tokenId)` MUST revert for non-existent tokens
 
-### ERC-165 Interface Identification
+### [ERC-165](./erc-165.md) Interface Identification
 
-Contracts implementing this standard MUST implement the ERC-165 `supportsInterface` function and MUST return `true` for:
+Contracts implementing this standard MUST implement the [ERC-165](./erc-165.md) [`supportsInterface`](./erc-165.md#how-a-contract-will-publish-the-interfaces-it-implements) function and MUST return `true` for:
 
-- The `IERC_NTT` interface ID `0xXXXXXXXX` (to be calculated)
+- The `IERC8129` interface ID `0x4ba63534`
 - The `IERC721Metadata` interface ID `0x5b5e139f`
-- The ERC-165 interface ID `0x01ffc9a7`
+- The `ERC-165` interface ID `0x01ffc9a7`
 
 ## Rationale
 
@@ -150,7 +151,7 @@ While ERC-4973 avoids implementing ERC-721's transfer interface, it includes `gi
 
 - Tokens can still change owners through consensual operations
 - The `give/take` mechanism contradicts the concept of permanent binding
-- Adds complexity through signature verification and EIP-712 structured data
+- Adds complexity through signature verification and [EIP-712](https://eips.ethereum.org/EIPS/eip-712) structured data
 - The token is "movable with consent" rather than truly soulbound
 
 **This Standard:**
@@ -201,7 +202,7 @@ While tokens cannot be transferred, allowing the owner to burn their token provi
 
 This standard is not backwards compatible with ERC-721. This is intentional - tokens that are fundamentally non-transferable should not masquerade as transferable tokens.
 
-Wallets and marketplaces can detect this standard via ERC-165 and treat these tokens appropriately (e.g., not showing transfer or listing options).
+Wallets and marketplaces can detect this standard via [ERC-165](./erc-165.md#how-to-detect-if-a-contract-implements-any-given-interface) and treat these tokens appropriately (e.g., not showing transfer or listing options).
 
 ## Reference Implementation
 
@@ -209,10 +210,10 @@ Wallets and marketplaces can detect this standard via ERC-165 and treat these to
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./IERC_NTT.sol";
+import "./IERC8129.sol";
 import "./IERC721Metadata.sol";
 
-contract NonTransferableToken is IERC_NTT, IERC721Metadata {
+contract ERC8129 is IERC8129, IERC721Metadata {
     uint256 private _tokenIdCounter;
     string private _name;
     string private _symbol;
@@ -271,7 +272,7 @@ contract NonTransferableToken is IERC_NTT, IERC721Metadata {
 
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return
-            interfaceId == type(IERC_NTT).interfaceId ||
+            interfaceId == type(IERC8129).interfaceId ||
             interfaceId == type(IERC721Metadata).interfaceId ||
             interfaceId == 0x01ffc9a7; // ERC-165
     }
@@ -302,7 +303,7 @@ The `mint(address to)` function allows minting to any address. Implementations s
 
 ### Interface Detection
 
-External contracts MUST NOT assume transfer capabilities based solely on the presence of metadata functions. Always check ERC-165 interface support.
+External contracts MUST NOT assume transfer capabilities based solely on the presence of metadata functions. Always check [ERC-165](./erc-165.md#how-to-detect-if-a-contract-implements-any-given-interface) interface support.
 
 ### Reentrancy
 

--- a/ERCS/erc-8129.md
+++ b/ERCS/erc-8129.md
@@ -1,7 +1,7 @@
 ---
 eip: 8129
 title: Non-Transferable Token
-description: A minimal interface for tokens that are permanently bound to an address
+description: An interface for tokens that are permanently and structurally bound to a single address, with no transfer function defined at the interface level
 author: Ivan Zemko (@Vantana1995)
 discussions-to: https://ethereum-magicians.org/t/erc-8129-non-transferable-token/27407
 status: Draft
@@ -13,26 +13,28 @@ requires: 165, 721
 
 ## Abstract
 
-This EIP proposes a minimal standard for non-transferable tokens (commonly known as "Soulbound tokens"). Unlike existing approaches that extend [ERC-721](./eip-721.md) and disable transfer functionality, this standard defines tokens that are non-transferable by design, eliminating transfer-related functions entirely from the interface.
+A non-transferable token is bound to a single address for its entire lifetime: once minted, it can never be moved, sold, or reassigned by any party, including its owner. This makes non-transferable tokens suitable for representing credentials, achievements, certifications, memberships, and other identity attestations that only have meaning when tied to the party they were issued to.
+
+This EIP defines such tokens by omission rather than restriction: the interface defines minting, burning, and ownership queries, and simply does not define any transfer function. There is no `transferFrom`, no `approve`, and no signature-gated handoff to block or bypass - non-transferability is a property of the interface itself, not a rule enforced on top of a transferable one.
 
 ## Motivation
+
+Non-transferable tokens represent credentials, achievements, certifications, memberships, and identity attestations - assets that by their nature should be permanently bound to their owner. A university diploma, a proof of attendance, or a revocable membership badge only has meaning if it cannot be sold, gifted, or otherwise separated from the identity it was issued to. These use cases deserve a dedicated standard that explicitly communicates non-transferability through the absence of transfer functions, not their restriction.
 
 Current Soulbound token implementations take different approaches but all retain some form of token movement between addresses:
 
 - [ERC-5192](./eip-5192.md) and [ERC-5484](./eip-5484.md) extend [ERC-721](./eip-721.md), inheriting its complete transfer infrastructure and then blocking these capabilities
-- [ERC-4973](./eip-4973.md) avoids implementing ERC-721's transfer interface but includes `give()` and `take()` functions that allow token movement between addresses with signature consent
+- Other approaches avoid implementing ERC-721's transfer interface directly, but still expose signature-gated functions that let a token move between addresses with the recipient's consent
 
 Both approaches create several problems:
 
-1. **Semantic Mismatch**: Tokens that should never move between addresses still carry mechanisms for doing so - either through blocked transfer functions (ERC-5192, ERC-5484) or consensual movement (ERC-4973). True soulbound tokens should be permanently bound to their recipient.
+1. **Semantic Mismatch**: Tokens that should never move between addresses still carry mechanisms for doing so - either through blocked transfer functions (ERC-5192, ERC-5484) or consensual movement (via signature-gated give/take schemes). True soulbound tokens should be permanently bound to their recipient.
 
 2. **Bytecode Bloat**: Standards extending ERC-721 inherit functions like `transferFrom`, `safeTransferFrom`, `approve`, `setApprovalForAll`, `getApproved`, and `isApprovedForAll` in the contract bytecode, even when these functions will never execute successfully. This increases deployment costs and reduces available space for actual token functionality.
 
 3. **Interface Confusion**: External contracts and interfaces may incorrectly assume transfer or movement capabilities exist, leading to integration issues and user confusion.
 
 4. **Not Truly Non-Transferable**: Existing implementations either block transfers through restrictions or allow consensual movement between addresses. In both cases, the token is not fundamentally bound to a single address - it's restricted from free transfer or requires consent to move.
-
-Non-transferable tokens represent credentials, achievements, certifications, memberships, and identity attestations - assets that by their nature should be permanently bound to their owner. These use cases deserve a dedicated standard that explicitly communicates non-transferability through the absence of transfer functions, not their restriction.
 
 ## Specification
 
@@ -80,25 +82,7 @@ interface ERC8129 {
 
 ### Metadata Interface (Required)
 
-Compliant contracts MUST implement the ERC-721 metadata interface for human-readable token information:
-
-```solidity
-/// @title ERC-721 Metadata Interface (from EIP-721)
-/// @dev This is a REQUIRED part of the standard
-interface IERC721Metadata {
-    /// @notice A descriptive name for the token collection
-    function name() external view returns (string memory);
-
-    /// @notice An abbreviated name for the token collection
-    function symbol() external view returns (string memory);
-
-    /// @notice A URI pointing to metadata for a specific token
-    /// @dev MUST revert if tokenId does not exist
-    /// @param tokenId The identifier of the token
-    /// @return The URI string
-    function tokenURI(uint256 tokenId) external view returns (string memory);
-}
-```
+Compliant contracts MUST implement ERC-721's [`ERC721Metadata`](./eip-721.md#specification:~:text=interface%20ERC721Metadata) interface for human-readable token information.
 
 See [ERC-721](./eip-721.md) for a definition of its metadata JSON Schema.
 
@@ -126,6 +110,12 @@ All compliant contracts MUST implement both `ERC8129` and `IERC721Metadata` inte
    - `ownerOf(uint256 tokenId)` MUST return the address that owns the specified token
    - `ownerOf(uint256 tokenId)` MUST revert for non-existent tokens
 
+### Events
+
+- The `Mint` event MUST be emitted whenever a token is created and bound to an address, regardless of which function performs the creation (e.g., batch-minting functions MUST emit one `Mint` event per token created).
+- The `Burn` event MUST be emitted whenever a token is destroyed and its binding to an address is removed, regardless of which function performs the destruction.
+- Implementations MUST NOT emit `Mint` or `Burn` events for operations that do not change whether a token exists (e.g., metadata updates).
+
 ### [ERC-165](./eip-165.md) Interface Identification
 
 Contracts implementing this standard MUST implement the [ERC-165](./eip-165.md) [`supportsInterface`](./eip-165.md#how-a-contract-will-publish-the-interfaces-it-implements) function and MUST return `true` for:
@@ -134,11 +124,14 @@ Contracts implementing this standard MUST implement the [ERC-165](./eip-165.md) 
 - The `IERC721Metadata` interface ID `0x5b5e139f`
 - The ERC-165 interface ID `0x01ffc9a7`
 
+External contracts MUST NOT assume transfer capabilities based solely on the presence of metadata functions; they MUST rely on [ERC-165](./eip-165.md#how-to-detect-if-a-contract-implements-any-given-interface) interface support to determine capabilities.
+
 ## Rationale
 
 ### Why Not Extend ERC-721 or Use Consensual Transfer?
 
-**ERC-721 Extensions (ERC-5192, ERC-5484):**
+#### ERC-721 Extensions (ERC-5192, ERC-5484)
+
 ERC-721 is architecturally designed around transferability. Every aspect of its interface assumes tokens can move between addresses. Attempting to create non-transferable tokens by blocking these functions creates an architectural mismatch:
 
 - Transfer functions exist but always revert
@@ -146,15 +139,17 @@ ERC-721 is architecturally designed around transferability. Every aspect of its 
 - Events like `Transfer` and `Approval` create confusion
 - Storage slots for approvals and operators are unused
 
-**Consensual Transfer (ERC-4973):**
-While ERC-4973 avoids implementing ERC-721's transfer interface, it includes `give()` and `take()` functions that allow tokens to move between addresses with signature consent. This creates a fundamental contradiction:
+#### Consensual Transfer
+
+While some approaches avoid implementing ERC-721's transfer interface directly, they still expose `give()`/`take()`-style functions that let tokens move between addresses with signature consent. This creates a fundamental contradiction:
 
 - Tokens can still change owners through consensual operations
 - The `give/take` mechanism contradicts the concept of permanent binding
-- Adds complexity through signature verification and [EIP-712](./eip-712.md) structured data
+- Adds complexity through signature verification and structured data
 - The token is "movable with consent" rather than truly soulbound
 
-**This Standard:**
+#### This Standard
+
 A dedicated standard removes transfer baggage entirely and eliminates any mechanism for tokens to move between addresses, even with consent. Once minted to an address, the token is permanently bound.
 
 ### Minimal Interface Design
@@ -188,15 +183,15 @@ While tokens cannot be transferred, allowing the owner to burn their token provi
 
 ### Comparison with Existing Standards
 
-| Feature                    | ERC-721 Extensions (5192, 5484) | ERC-4973             | This Standard     |
-| -------------------------- | ------------------------------- | -------------------- | ----------------- |
-| Implements ERC-721         | Yes                             | No                   | No                |
-| Transfer functions         | Present but blocked             | Absent               | Absent            |
-| Movement between addresses | Blocked                         | Via give/take        | Impossible        |
-| Approval mechanisms        | Present but unused              | Absent               | Absent            |
-| Deployment bytecode        | ~500+ lines                     | ~300 lines           | ~100 lines        |
-| Semantic clarity           | Transferable with restrictions  | Movable with consent | Permanently bound |
-| Truly non-transferable     | No (logic exists)               | No (can move)        | Yes               |
+| Feature                    | ERC-721 Extensions (5192, 5484) | Consent-Based Approaches | This Standard     |
+| -------------------------- | -------------------------------- | ------------------------ | ----------------- |
+| Implements ERC-721         | Yes                              | No                        | No                |
+| Transfer functions         | Present but blocked              | Absent                    | Absent            |
+| Movement between addresses | Blocked                          | Via give/take             | Impossible        |
+| Approval mechanisms        | Present but unused               | Absent                    | Absent            |
+| Deployment bytecode        | ~500+ lines                      | ~300 lines                | ~100 lines        |
+| Semantic clarity           | Transferable with restrictions   | Movable with consent      | Permanently bound |
+| Truly non-transferable     | No (logic exists)                | No (can move)             | Yes               |
 
 ## Backwards Compatibility
 
@@ -207,7 +202,7 @@ Wallets and marketplaces can detect this standard via [ERC-165](./eip-165.md#how
 ## Reference Implementation
 
 ```solidity
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
 import "./IERC8129.sol";
@@ -303,7 +298,7 @@ The `mint(address to)` function allows minting to any address. Implementations s
 
 ### Interface Detection
 
-External contracts MUST NOT assume transfer capabilities based solely on the presence of metadata functions. Always check [ERC-165](./eip-165.md#how-to-detect-if-a-contract-implements-any-given-interface) interface support.
+Because this standard requires the ERC-721 metadata interface, a contract implementing ERC-8129 exposes `name()`, `symbol()`, and `tokenURI()` just like a transferable ERC-721 token would. Integrators that infer transfer capability from the presence of these metadata functions, instead of checking ERC-165 support for the `ERC8129` interface, risk treating a non-transferable token as transferable - for example, listing it on a marketplace or attempting a transfer that will always fail.
 
 ### Reentrancy
 

--- a/ERCS/erc-8129.md
+++ b/ERCS/erc-8129.md
@@ -1,7 +1,7 @@
 ---
 eip: 8129
 title: Non-Transferable Token
-description: An interface for tokens that are permanently and structurally bound to a single address, with no transfer function defined at the interface level
+description: An interface for tokens permanently and structurally bound to a single address, with no transfer function defined at the interface level
 author: Ivan Zemko (@Vantana1995)
 discussions-to: https://ethereum-magicians.org/t/erc-8129-non-transferable-token/27407
 status: Draft
@@ -298,7 +298,7 @@ The `mint(address to)` function allows minting to any address. Implementations s
 
 ### Interface Detection
 
-Because this standard requires the ERC-721 metadata interface, a contract implementing ERC-8129 exposes `name()`, `symbol()`, and `tokenURI()` just like a transferable ERC-721 token would. Integrators that infer transfer capability from the presence of these metadata functions, instead of checking ERC-165 support for the `ERC8129` interface, risk treating a non-transferable token as transferable - for example, listing it on a marketplace or attempting a transfer that will always fail.
+Because this standard requires the [ERC-721](./eip-721.md) metadata interface, a contract implementing `ERC8129` exposes `name()`, `symbol()`, and `tokenURI()` just like a transferable ERC-721 token would. Integrators that infer transfer capability from the presence of these metadata functions, instead of checking ERC-165 support for the `ERC8129` interface, risk treating a non-transferable token as transferable - for example, listing it on a marketplace or attempting a transfer that will always fail.
 
 ### Reentrancy
 


### PR DESCRIPTION
## Summary

This PR proposes EIP-8129: Non-Transferable Token Standard - a minimal standard for tokens that are permanently bound to an address.

## Description

Introduces a dedicated interface for non-transferable (Soulbound) tokens that eliminates transfer functionality by design, rather than extending ERC-721 and blocking transfers. The standard:

- Defines tokens as non-transferable through interface design (no transfer functions)
- Reduces bytecode bloat by ~80% compared to ERC-721 extensions
- Provides semantic clarity - tokens that cannot be transferred vs tokens that block transfers
- Includes only essential operations: `mint()`, `burn()`, `ownerOf()`
- Requires ERC-721 Metadata interface for wallet/indexer compatibility

This approach addresses architectural mismatches in existing Soulbound implementations (ERC-5192, ERC-4973, ERC-5484) that inherit unused transfer infrastructure.