### PR TITLE
Add ERC: Wallet Call Gas Limit Override Capability

### DIFF
--- a/ERCS/erc-8132.md
+++ b/ERCS/erc-8132.md
@@ -13,7 +13,7 @@ requires: 5792
 
 ## Abstract
 
-With the introduction of [EIP-5792](./eip-5792.md), apps can now request calls to be batched by a Wallet, but there is no way for an app to set a gas limit for those calls. Gas estimation for 5792 batches is currently fully delegated to the wallet. This proposal introduces a capability that restores the ability for apps to specify a gas limit for calls in a 5792 batch, analogous to the `gas` parameter of an `eth_sendTransaction` request.
+With the introduction of [EIP-5792](./eip-5792.md), apps can now request calls to be batched by a Wallet, but there is no way for an app to set a gas limit for those calls. Gas estimation for EIP-5792 batches is currently fully delegated to the wallet. This proposal introduces a capability that restores the ability for apps to specify a gas limit for calls in an EIP-5792 batch, analogous to the `gas` parameter of an `eth_sendTransaction` request.
 
 ## Motivation
 
@@ -62,6 +62,8 @@ type GasLimitOverrideCapability = {
 When an app wants to override the gas limits used for calls in a batch, they SHOULD do this using the `gasLimitOverride` capability as part of an [EIP-5792](./eip-5792.md) `wallet_sendCalls` call.
 
 This is a call-level capability. Apps MAY specify gas limits for only some calls in a batch; the wallet MUST estimate gas for any calls that do not include a `gasLimitOverride` capability.
+
+Apps SHOULD only include the `gasLimitOverride` capability in their `wallet_sendCalls` requests if they are aware that the wallet supports it (e.g., by checking the `wallet_getCapabilities` response). Apps MAY include the `gasLimitOverride` capability with `optional: true` (as defined in [EIP-5792](./eip-5792.md)) to ensure compatibility with wallets that do not support this capability.
 
 ##### `wallet_sendCalls` Gas Limit Override Capability Specification
 
@@ -128,12 +130,12 @@ This simplifies the interface somewhat by allowing the app to pass a single gas 
 
 ## Backwards Compatibility
 
-* Applications SHOULD only include the `gasLimitOverride` capability in their `wallet_sendCalls` requests if they are aware that the wallet supports it (e.g., by checking the `wallet_getCapabilities` response).
-* Applications MAY include the `gasLimitOverride` capability with `optional: true` (as defined in [EIP-5792](./eip-5792.md)) to ensure compatibility with wallets that do not support this capability. When marked as optional, wallets that do not support the capability will ignore it rather than rejecting the request.
+Backwards compatibility with wallets that do not support this capability is handled by the [EIP-5792](./eip-5792.md) capability negotiation mechanism. Apps can check for support via `wallet_getCapabilities`, or include the capability with `optional: true` so that unsupported capabilities are ignored rather than rejected.
 
 ## Security Considerations
 
-* Wallets MUST validate that provided gas limits are non-zero and do not exceed the block gas limit of the target chain.
+* App-provided gas limits that are too low could cause calls to revert. Wallets should consider warning users if a provided gas limit appears insufficient.
+* Malicious or misconfigured apps could provide excessively high gas limits. Wallets validate that provided gas limits do not exceed the block gas limit of the target chain, as specified in the Specification section.
 
 ## Copyright
 


### PR DESCRIPTION
This ERC introduces a `gasLimitOverride` capability for EIP-5792, allowing apps to specify per-call gas limits when using `wallet_sendCalls`. Apps often have more context about expected gas usage than wallets, particularly for calls with nondeterministic behavior. Wallets are responsible for estimating any batching overhead and for calls where apps don't provide a limit.

Discussion link: https://ethereum-magicians.org/t/new-erc-gas-limit-override-capability/25159 