### PR TITLE
Update ERC 8121: Cross- Chain Function Calls via Hooks

### DIFF
--- a/ERCS/erc-8121.md
+++ b/ERCS/erc-8121.md
@@ -72,7 +72,7 @@ bytes4 constant HOOK_SELECTOR_WITHOUT_SELECTOR = 0x6113bfa3; // When functionSel
 - **`returnType`**: The return type in Solidity tuple notation for ABI decoding (e.g., `(string)`, `(uint256, bytes32)`, `((string, uint256[], bytes32))`)
 - **`target`**: An [ERC-7930](./eip-7930.md) interoperable address specifying both the target contract and chain
 
-### Function Call and Return Type Format
+### Function Call Format
 
 The `functionCall` parameter uses a Solidity-style syntax:
 
@@ -91,8 +91,6 @@ hook(0xc41a360a, "getOwner(uint256)", "getOwner(42)", "(address)", 0x00010000010
 // Example with function selector omitted
 hook("getOwner(uint256)", "getOwner(42)", "(address)", 0x000100000101141234567890abcdef1234567890abcdef12345678)
 ```
-
-The `functionSignature` provides explicit types (`"getOwner(uint256)"`), while `functionCall` provides the human-readable values (`"getOwner(42)"`). The `functionSelector` (`0xc41a360a`) is optional but when provided acts as a checksum to verify integrity. When omitted, the hook structure starts with `functionSignature` as the first parameter. Clients can always compute the selector from `functionSignature` as `bytes4(keccak256(functionSignature))`.
 
 ### Hook Encoding
 


### PR DESCRIPTION

## Summary

This PR refactors ERC-8121 to make the function selector optional and adds explicit type specification via `functionSignature`. The hook selector values have been corrected and documentation has been improved throughout.

## Key Changes

- **Optional Function Selector**: `functionSelector` is now optional. When omitted, `functionSignature` becomes the first parameter
- **Function Signature Parameter**: Added `functionSignature` for explicit type specification, preventing ambiguity with structs and overloaded functions
- **Corrected Hook Selectors**: Updated to correct values (`0x037f43ed` and `0x6113bfa3`) calculated using `cast`
- **Documentation**: Improved Abstract, Motivation, and Rationale sections; added Write Operations section; updated examples to use concrete function signatures
- **Code Fixes**: Fixed indentation and updated examples with correct selectors

## Hook Function Signatures

**With optional function selector:**
```solidity
function hook(bytes4 functionSelector, string calldata functionSignature, string calldata functionCall, string calldata returnType, bytes calldata target)
```

**Without function selector:**
```solidity
function hook(string calldata functionSignature, string calldata functionCall, string calldata returnType, bytes calldata target)
```
