### PR TITLE
Add ERC: Authentication SBT using Credential

### DIFF
--- a/ERCS/erc-7574.md
+++ b/ERCS/erc-7574.md
@@ -2,7 +2,7 @@
 eip: 7574
 title: Authentication SBT using Credential
 description: verifying a User's DID/credential and issuing SBT
-author: Geunyoung Kim (@c1ick), JaeCheol Ryou <jcryou@home.cnu.ac.kr
+author: Geunyoung Kim (@c1ick), JaeCheol Ryou <jcryou@home.cnu.ac.kr>
 discussions-to: https://ethereum-magicians.org/t/erc-7574-authentication-sbt-using-credential/17264
 status: Draft
 type: Standards Track
@@ -11,26 +11,7 @@ created: 2023-11-02
 requires: 165, 721
 ---
 
-<!--
-  READ EIP-1 (https://eips.ethereum.org/EIPS/eip-1) BEFORE USING THIS TEMPLATE!
-
-  This is the suggested template for new EIPs. After you have filled in the requisite fields, please delete these comments.
-
-  Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`.
-
-  The title should be 44 characters or less. It should not repeat the EIP number in title, irrespective of the category.
-
-  TODO: Remove this comment before submitting
--->
-
 ## Abstract
-
-<!--
-  The Abstract is a multi-sentence (short paragraph) technical summary. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
-
-  TODO: Remove this comment before submitting
--->
-
 
 This document outlines the step-by-step process for verifying a user's Decentralized Identity(DID) credential and issuing a Soul Bound Token (SBT) upon successful verification.
 
@@ -41,29 +22,10 @@ When validating the Credential within the smart contract, there is a risk of exp
 
 ## Motivation
 
-<!--
-  This section is optional.
-
-  The motivation section should include a description of any nontrivial problems the EIP solves. It should not describe how the EIP solves those problems, unless it is not immediately obvious. It should not describe why the EIP should be made into a standard, unless it is not immediately obvious.
-
-  With a few exceptions, external links are not allowed. If you feel that a particular resource would demonstrate a compelling case for your EIP, then save it as a printer-friendly PDF, put it in the assets folder, and link to that copy.
-
-  TODO: Remove this comment before submitting
--->
-
 The anonymous nature of wallets has led to numerous issues in DeFi, Metaverse Avatars, and similar platforms. Therefore, a new interface is needed where only individuals authenticated through Credentials can receive SBTs. Moreover, only those with issued SBTs should be permitted to access specific services.
 
 
 ## Specification
-
-<!--
-  The Specification section should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (besu, erigon, ethereumjs, go-ethereum, nethermind, or others).
-
-  It is recommended to follow RFC 2119 and RFC 8170. Do not remove the key word definitions if RFC 2119 and RFC 8170 are followed.
-
-  TODO: Remove this comment before submitting
--->
-
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
@@ -71,7 +33,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ### MetaData Interface
 
 
-NFT metadata structured by the official ERC721 metadata standard or the Enjin Metadata suggestions are as follows referring to OpenSea docs.
+NFT metadata structured by the official ERC-721 metadata standard or the Enjin Metadata suggestions are as follows referring to OpenSea docs.
 
 ```jsx
 {
@@ -84,7 +46,7 @@ NFT metadata structured by the official ERC721 metadata standard or the Enjin Me
 }
 ```
 
-In addition to the existing NFT metadata standards, a new standard for identity verification supplements the metadata with the "Issuer" and "credentialNumber" sections. When issuing SBTs, the Issuer and the credential number from the Credential are specified. This approach ensures that the user's personal information remains private. In case of any issues, the identity verification process can be traced back by requesting the credential number used for verification from the Issuer without revealing the user's information. This standard represents an extension of ERC721 metadata.
+In addition to the existing NFT metadata standards, a new standard for identity verification supplements the metadata with the "Issuer" and "credentialNumber" sections. When issuing SBTs, the Issuer and the credential number from the Credential are specified. This approach ensures that the user's personal information remains private. In case of any issues, the identity verification process can be traced back by requesting the credential number used for verification from the Issuer without revealing the user's information. This standard represents an extension of ERC-721 metadata.
 
 ```jsx
 {
@@ -147,42 +109,14 @@ Through this process, obtaining SBT is the only means of authentication, and the
 
 ## Rationale
 
-<!--
-  The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
-
-  The current placeholder is acceptable for a draft.
-
-  TODO: Remove this comment before submitting
--->
-
 This is a system that verifies the basic DID signature by integrating the Ethereum extension program Zokrates. Following the verification of the DID signature, it proceeds with issuing SBT, allowing the validation of a user's identity information.
 
 
 ## Backwards Compatibility
 
-<!--
-
-  This section is optional.
-
-  All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
-
-  The current placeholder is acceptable for a draft.
-
-  TODO: Remove this comment before submitting
--->
-
 No backward compatibility issues found.
 
-
 ## Security Considerations
-
-<!--
-  All EIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. For example, include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. EIP submissions missing the "Security Considerations" section will be rejected. An EIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.
-
-  The current placeholder is acceptable for a draft.
-
-  TODO: Remove this comment before submitting
--->
 
 There are no security considerations related directly to the implementation of this standard.
 

--- a/ERCS/erc-7574.md
+++ b/ERCS/erc-7574.md
@@ -1,0 +1,191 @@
+---
+eip: 7574
+title: Authentication SBT using Credential
+description: verifying a User's DID/credential and issuing SBT
+author: Geunyoung Kim (@c1ick), JaeCheol Ryou <jcryou@home.cnu.ac.kr
+discussions-to: TBD
+status: Draft
+type: Standards Track
+category: ERC
+created: 2023-11-02
+requires: 165, 721
+---
+
+<!--
+  READ EIP-1 (https://eips.ethereum.org/EIPS/eip-1) BEFORE USING THIS TEMPLATE!
+
+  This is the suggested template for new EIPs. After you have filled in the requisite fields, please delete these comments.
+
+  Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`.
+
+  The title should be 44 characters or less. It should not repeat the EIP number in title, irrespective of the category.
+
+  TODO: Remove this comment before submitting
+-->
+
+## Abstract
+
+<!--
+  The Abstract is a multi-sentence (short paragraph) technical summary. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
+
+  TODO: Remove this comment before submitting
+-->
+
+
+This document outlines the step-by-step process for verifying a user's Decentralized Identity(DID) credential and issuing a Soul Bound Token (SBT) upon successful verification.
+
+We have considered granting user identity based on DID Credentials. Instead of providing the DID Credential itself within the wallet, we will use Soul Bound token(SBT) to indicate that the person has been authenticated through the Credential.
+
+When validating the Credential within the smart contract, there is a risk of exposing personal information. To address this concern, we propose a process that protects user privacy using Zero-Knowledge Proofs (Zokrates) while authenticating the user.
+
+
+## Motivation
+
+<!--
+  This section is optional.
+
+  The motivation section should include a description of any nontrivial problems the EIP solves. It should not describe how the EIP solves those problems, unless it is not immediately obvious. It should not describe why the EIP should be made into a standard, unless it is not immediately obvious.
+
+  With a few exceptions, external links are not allowed. If you feel that a particular resource would demonstrate a compelling case for your EIP, then save it as a printer-friendly PDF, put it in the assets folder, and link to that copy.
+
+  TODO: Remove this comment before submitting
+-->
+
+The anonymous nature of wallets has led to numerous issues in DeFi, Metaverse Avatars, and similar platforms. Therefore, a new interface is needed where only individuals authenticated through Credentials can receive SBTs. Moreover, only those with issued SBTs should be permitted to access specific services.
+
+
+## Specification
+
+<!--
+  The Specification section should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (besu, erigon, ethereumjs, go-ethereum, nethermind, or others).
+
+  It is recommended to follow RFC 2119 and RFC 8170. Do not remove the key word definitions if RFC 2119 and RFC 8170 are followed.
+
+  TODO: Remove this comment before submitting
+-->
+
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+
+### MetaData Interface
+
+
+NFT metadata structured by the official ERC721 metadata standard or the Enjin Metadata suggestions are as follows referring to OpenSea docs.
+
+```jsx
+{
+   "description":"University bachelor KYC",
+   "external_url":"https://api.kor.credential/metadata/1/1",
+   "home_url":"https://app.kor.credential/token/1",
+   "image_url":"https://www.poap.xyz/events/badges/ethdenver-19.png",
+   "name":" KOREA KYC",
+   "attributes" : { ... },
+}
+```
+
+In addition to the existing NFT metadata standards, a new standard for identity verification supplements the metadata with the "Issuer" and "credentialNumber" sections. When issuing SBTs, the Issuer and the credential number from the Credential are specified. This approach ensures that the user's personal information remains private. In case of any issues, the identity verification process can be traced back by requesting the credential number used for verification from the Issuer without revealing the user's information. This standard represents an extension of ERC721 metadata.
+
+```jsx
+{
+   "description":"University bachelor KYC",
+   "external_url":"https://api.kor.credential/metadata/1/1",
+   "home_url":"https://app.kor.credential/token/1",
+   "image_url":"https://www.poap.xyz/events/badges/ethdenver-19.png",
+   "name":" KOREA KYC",
+   "attributes" : { ... },
+   "Iusser" : { ...},
+   "credentialNumber" : { ... },
+ }
+```
+
+We have defined a structure to represent VerifiedPresentation. It includes the user's wallet address, issuer, user name, and Credential Number
+
+```jsx
+struct VerifiedPresentation {
+address userAddr;
+string issuer;
+string user;
+uint CredentialNumber;
+}
+```
+
+Following that, here is the contract that verifies a user's Credential proof and issues SBTs:
+
+
+### Contract Interface
+
+
+In this scenario, a **`verify`** function is created using Zokrates. Upon successful verification, the generated **`verify`** function calls the SBT issuance contract, enabling the entire process.
+
+```
+/ SPDX-License-Identifier: CC0-1.0
+pragma solidity^0.8.0;interface IERC5192 {
+
+/// @ Function to verify the user's proof.
+/// @ Generated through Zokrates, required parameters upon completion of generation are proof, input, and numofCred.
+/// @ Other information such as issuer/holder is optional.
+function verify(Proof memory proof, uint[2] memory input, uint numOfCred) returns ();
+
+/// @ Only those who have completed verifyProof can obtain the opportunity to issue SBT.
+/// @ Only the service provider can call the createSBT function.
+/// @ Issues SBT to authenticated users, with the verified credential Number and Issuer being input for tokenURI.
+function createSBT(address user, String memory tokenURI) public onlyOwner returns(uint256) public onlyWoner returns(uint256))
+
+/// @ Only the service provider can call the createSBT function.
+/// @ Issuing an SBT allows cancellation effects by severing the user's tokenURI, such as when the credential is revoked.
+function updateTokenURI(address user, string memory tokenURI) public onlyOwner
+
+/// @ Added cannotTransfer functionality to prevent the transfer of SBT to others.
+function safeTransferFrom(adress _from, address _to, uint256 _tokenId) public virtual oveerid
+
+}
+```
+
+Through this process, obtaining SBT is the only means of authentication, and the possession of SBT subsequently serves as a method for identity verification.
+
+
+## Rationale
+
+<!--
+  The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
+
+  The current placeholder is acceptable for a draft.
+
+  TODO: Remove this comment before submitting
+-->
+
+This is a system that verifies the basic DID signature by integrating the Ethereum extension program Zokrates. Following the verification of the DID signature, it proceeds with issuing SBT, allowing the validation of a user's identity information.
+
+
+## Backwards Compatibility
+
+<!--
+
+  This section is optional.
+
+  All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+  The current placeholder is acceptable for a draft.
+
+  TODO: Remove this comment before submitting
+-->
+
+No backward compatibility issues found.
+
+
+## Security Considerations
+
+<!--
+  All EIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. For example, include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. EIP submissions missing the "Security Considerations" section will be rejected. An EIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.
+
+  The current placeholder is acceptable for a draft.
+
+  TODO: Remove this comment before submitting
+-->
+
+There are no security considerations related directly to the implementation of this standard.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-7574.md
+++ b/ERCS/erc-7574.md
@@ -86,8 +86,8 @@ Upon successful verification, the implementation issues a SBT to the user's addr
 
 Implementations of this ERC MUST ensure that issued SBTs are non-transferable and MUST implement [ERC-5192](./eip-5192.md) (Locked SBT).
 
-```
-/ SPDX-License-Identifier: CC0-1.0
+```solidity
+// SPDX-License-Identifier: CC0-1.0
 pragma solidity^0.8.0;
 interface IERC7574 {
 

--- a/ERCS/erc-7574.md
+++ b/ERCS/erc-7574.md
@@ -35,15 +35,14 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### MetaData Interface
 
-
-NFT metadata structured by the official [ERC-721](./eip-721.md) metadata standard or the Enjin Metadata suggestions are as follows referring to OpenSea docs.
+NFT metadata structured according to the  [ERC-721](./eip-721.md) metadata standard is as follows.
 
 ```jsx
 {
    "description":"University bachelor KYC",
    "external_url":"https://api.kor.credential/metadata/1/1",
    "home_url":"https://app.kor.credential/token/1",
-   "image_url":"https://www.poap.xyz/events/badges/ethdenver-19.png",
+   "image_url":"https://www.poap.xyz/events/badges/example.png",
    "name":" KOREA KYC",
    "attributes" : { ... },
 }
@@ -66,7 +65,7 @@ In addition to the existing NFT metadata standards, a new standard for identity 
 
 We have defined a structure to represent VerifiedPresentation. It includes the user's wallet address, issuer, user name, and Credential Number
 
-```jsx
+```solidity
 struct VerifiedPresentation {
 address userAddr;
 string issuer;

--- a/ERCS/erc-7574.md
+++ b/ERCS/erc-7574.md
@@ -33,7 +33,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ### MetaData Interface
 
 
-NFT metadata structured by the official ERC-721 metadata standard or the Enjin Metadata suggestions are as follows referring to OpenSea docs.
+NFT metadata structured by the official [ERC-721](./eip-721.md) metadata standard or the Enjin Metadata suggestions are as follows referring to OpenSea docs.
 
 ```jsx
 {
@@ -46,7 +46,7 @@ NFT metadata structured by the official ERC-721 metadata standard or the Enjin M
 }
 ```
 
-In addition to the existing NFT metadata standards, a new standard for identity verification supplements the metadata with the "Issuer" and "credentialNumber" sections. When issuing SBTs, the Issuer and the credential number from the Credential are specified. This approach ensures that the user's personal information remains private. In case of any issues, the identity verification process can be traced back by requesting the credential number used for verification from the Issuer without revealing the user's information. This standard represents an extension of ERC-721 metadata.
+In addition to the existing NFT metadata standards, a new standard for identity verification supplements the metadata with the "Issuer" and "credentialNumber" sections. When issuing SBTs, the Issuer and the credential number from the Credential are specified. This approach ensures that the user's personal information remains private. In case of any issues, the identity verification process can be traced back by requesting the credential number used for verification from the Issuer without revealing the user's information. This standard represents an extension of [ERC-721](./eip-721.md) metadata.
 
 ```jsx
 {

--- a/ERCS/erc-7574.md
+++ b/ERCS/erc-7574.md
@@ -3,7 +3,7 @@ eip: 7574
 title: Authentication SBT using Credential
 description: verifying a User's DID/credential and issuing SBT
 author: Geunyoung Kim (@c1ick), JaeCheol Ryou <jcryou@home.cnu.ac.kr
-discussions-to: TBD
+discussions-to: https://ethereum-magicians.org/t/erc-7574-authentication-sbt-using-credential/17264
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-7574.md
+++ b/ERCS/erc-7574.md
@@ -8,26 +8,29 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2023-11-02
-requires: 165, 721
+requires: 165, 721, 5192
 ---
 
 ## Abstract
 
-This document outlines the step-by-step process for verifying a user's Decentralized Identity(DID) credential and issuing a Soul Bound Token (SBT) upon successful verification.
+This specification defines a mechanism for issuing a non-transferable Soul Bound Token (SBT) as proof of successful authentication based on a [Decentralized Identity (DID)](https://www.w3.org/TR/2022/REC-did-core-20220719/).
 
-We have considered granting user identity based on DID Credentials. Instead of providing the DID Credential itself within the wallet, we will use Soul Bound token(SBT) to indicate that the person has been authenticated through the Credential.
-
-When validating the Credential within the smart contract, there is a risk of exposing personal information. To address this concern, we propose a process that protects user privacy using Zero-Knowledge Proofs (Zokrates) while authenticating the user.
-
+The proposed approach enables on-chain verification of credential possession using zero-knowledge proofs, allowing a smart contract to validate authentication without revealing personal information. Upon successful verification, an SBT is issued to the user’s address and can be used by relying services as an authentication and access control primitive.
 
 ## Motivation
 
-The anonymous nature of wallets has led to numerous issues in DeFi, Metaverse Avatars, and similar platforms. Therefore, a new interface is needed where only individuals authenticated through Credentials can receive SBTs. Moreover, only those with issued SBTs should be permitted to access specific services.
+Many blockchain-based applications rely on wallet addresses as the sole representation of user identity. While this model provides strong pseudonymity, it also introduces significant limitations for applications that require accountability, trust, or credential-based access control. As a result, decentralized finance platforms, metaverse environments, and on-chain governance systems often struggle with issues such as Sybil attacks, duplicate participation, and the inability to distinguish verified users from anonymous actors.
 
+Decentralized Identity (DID) credentials provide a standardized way to represent verifiable claims about a user, such as affiliation, qualification, or eligibility. However, directly presenting or storing credentials on-chain raises privacy, usability, and interoperability concerns, making them difficult for application developers to adopt consistently.
+
+This specification addresses these challenges by introducing a standardized mechanism for issuing non-transferable Soul Bound Tokens (SBTs) as a representation of successful credential verification. By binding the verification result to an SBT, applications can rely on a simple, privacy-preserving on-chain signal without accessing the underlying credential data.
+
+This approach enables developers to build applications that require authenticated or credentialed users—such as gated DeFi participation, verified metaverse avatars, reputation systems, and access-controlled services—using familiar token-based interfaces.
+Service providers and application developers can integrate this standard without implementing custom credential verification logic, while users benefit from improved privacy, portability, and reusability of their authenticated status across platforms.
 
 ## Specification
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174. 
 
 
 ### MetaData Interface
@@ -56,7 +59,7 @@ In addition to the existing NFT metadata standards, a new standard for identity 
    "image_url":"https://www.poap.xyz/events/badges/ethdenver-19.png",
    "name":" KOREA KYC",
    "attributes" : { ... },
-   "Iusser" : { ...},
+   "Issuer" : { ...},
    "credentialNumber" : { ... },
  }
 ```
@@ -77,29 +80,28 @@ Following that, here is the contract that verifies a user's Credential proof and
 
 ### Contract Interface
 
+In this scenario, a verification function validates a proof of credential possession.
+The mechanism used to generate and verify the proof is implementation-specific.
+Upon successful verification, the implementation issues a SBT to the user's address, completing the authentication process.
 
-In this scenario, a **`verify`** function is created using Zokrates. Upon successful verification, the generated **`verify`** function calls the SBT issuance contract, enabling the entire process.
+Implementations of this ERC MUST ensure that issued SBTs are non-transferable and MUST implement [ERC-5192](./eip-5192.md) (Locked SBT).
 
 ```
 / SPDX-License-Identifier: CC0-1.0
-pragma solidity^0.8.0;interface IERC5192 {
+pragma solidity^0.8.0;
+interface IERC7574 {
 
-/// @ Function to verify the user's proof.
-/// @ Generated through Zokrates, required parameters upon completion of generation are proof, input, and numofCred.
-/// @ Other information such as issuer/holder is optional.
-function verify(Proof memory proof, uint[2] memory input, uint numOfCred) returns ();
+/// @notice Verifies credential possession.
+/// @dev Verification mechanism is implementation-specific.
+function verify(bytes calldata verificationData) external returns (bool);
 
-/// @ Only those who have completed verifyProof can obtain the opportunity to issue SBT.
-/// @ Only the service provider can call the createSBT function.
-/// @ Issues SBT to authenticated users, with the verified credential Number and Issuer being input for tokenURI.
-function createSBT(address user, String memory tokenURI) public onlyOwner returns(uint256) public onlyWoner returns(uint256))
+/// @notice Issues a non-transferable SBT after successful verification.
+function issueSBT(address to, string calldata tokenURI)
+   external
+   returns (uint256 tokenId);
 
-/// @ Only the service provider can call the createSBT function.
-/// @ Issuing an SBT allows cancellation effects by severing the user's tokenURI, such as when the credential is revoked.
-function updateTokenURI(address user, string memory tokenURI) public onlyOwner
-
-/// @ Added cannotTransfer functionality to prevent the transfer of SBT to others.
-function safeTransferFrom(adress _from, address _to, uint256 _tokenId) public virtual oveerid
+/// @notice Updates metadata to reflect revocation or status change.
+function updateTokenURI(uint256 tokenId, string calldata tokenURI) external;
 
 }
 ```
@@ -109,8 +111,15 @@ Through this process, obtaining SBT is the only means of authentication, and the
 
 ## Rationale
 
-This is a system that verifies the basic DID signature by integrating the Ethereum extension program Zokrates. Following the verification of the DID signature, it proceeds with issuing SBT, allowing the validation of a user's identity information.
+This specification represents successful credential verification using a non-transferable SBT rather than exposing or storing the credential on-chain. A token-based signal allows relying contracts to integrate authentication using familiar ERC interfaces, while avoiding the privacy and linkability risks of publishing credential contents.
 
+The standard intentionally does not mandate a specific credential-proof mechanism (e.g., a particular zero-knowledge proving system). Different ecosystems may prefer different proof systems or verification approaches, and requiring a single tool would prevent independent interoperable implementations. Instead, the ERC standardizes the outcome: successful verification results in issuance of a non-transferable token to the user.
+
+Metadata is used to reference verification context (e.g., issuer and a credential reference identifier) while minimizing exposure of personally identifiable information. This enables auditability and revocation workflows (e.g., a relying party can request confirmation from the issuer using the reference identifier) without encoding user data in the token itself.
+
+Revocation and status changes are represented by updating token metadata (e.g., tokenURI) rather than burning the token. Preserving token existence while changing its status allows applications to distinguish between "never verified" and "verified but later revoked" states, which is useful for access control and compliance scenarios.
+
+Finally, transferability is disabled to ensure the authentication signal cannot be sold or lent. This preserves the intended meaning of the token as proof of verification bound to a specific address.
 
 ## Backwards Compatibility
 
@@ -118,7 +127,10 @@ No backward compatibility issues found.
 
 ## Security Considerations
 
-There are no security considerations related directly to the implementation of this standard.
+This specification does not mandate a specific credential verification mechanism.
+Implementers are responsible for ensuring the correctness and soundness of their verification logic, including protection against forged proofs or replay attacks.
+
+Additionally, while the standard minimizes on-chain exposure of personal data, metadata fields such as issuer references should be designed to avoid unintended linkability across applications.
 
 ## Copyright
 

--- a/ERCS/erc-7574.md
+++ b/ERCS/erc-7574.md
@@ -1,7 +1,7 @@
 ---
 eip: 7574
 title: Authentication SBT using Credential
-description: verifying a User's DID/credential and issuing SBT
+description: Verifying a user's decentralized identifier (DID)/credential and issuing soul-bound token (SBT)
 author: Geunyoung Kim (@c1ick), JaeCheol Ryou <jcryou@home.cnu.ac.kr>
 discussions-to: https://ethereum-magicians.org/t/erc-7574-authentication-sbt-using-credential/17264
 status: Draft
@@ -63,7 +63,7 @@ In addition to the existing NFT metadata standards, a new standard for identity 
  }
 ```
 
-We have defined a structure to represent VerifiedPresentation. It includes the user's wallet address, issuer, user name, and Credential Number
+We have defined a structure to represent `VerifiedPresentation`. It includes the user's wallet address, issuer, user name, and Credential Number
 
 ```solidity
 struct VerifiedPresentation {


### PR DESCRIPTION
This PR proposes a new ERC titled "Authentication SBT using Credential".

This proposal was previously submitted as an EIP:
ethereum/EIPs#8026

Per editor guidance, the proposal has been migrated to the ethereum/ERCs repository.

The proposal defines SBTs for authentication purposes,
focusing on credential binding, verification, and revocation.

The ERC number has already been assigned through prior discussion with the editors.
Based on the assigned number, the proposal will be added to the ERC list,
and further updates and refinements will be submitted in follow-up pull requests.

This revision incorporates feedback received during the initial review,
including clarifications to the specification structure, removal of
implementation-specific assumptions, correction of typos, and updates
to examples to align with EIP editorial guidelines.