### PR TITLE
Update ERC-7828: duplication, optional checksum notation

### DIFF
--- a/ERCS/erc-7828.md
+++ b/ERCS/erc-7828.md
@@ -61,10 +61,11 @@ This section builds upon the Terminology defined in [ERC-7930].
 
 ### Interoperable Name Definition
 
-The format of an _Interoperable Name_ is `<address> @ <chain> # <checksum>` where the components match the following regular expressions:
+The format of an _Interoperable Name_ is `<address>@<chain>#<checksum>` where the components match the following regular expressions:
 
 #### Syntax
 ```bnf
+<interoperable-name>  ::= <address> "@" <chain> [ "#" <checksum> ]
 <address>             ::= [.-:_%a-zA-Z0-9]*
 <chain>               ::= [.-:_a-zA-Z0-9]*
 <checksum>            ::= [0-9A-F]{8}
@@ -98,7 +99,6 @@ The checksum provides an optional integrity verification mechanism for Interoper
 
 - The checksum is OPTIONAL but RECOMMENDED when the <address> component represents a target address, as it helps mitigate homoglyph and spoofing attacks for chain-specific addresses.
 - A checksum SHOULD NOT be included when the <address> component is an ENS name
-- Clients MAY include or omit the checksum when displaying or sharing an _Interoperable Name_.
 - Clients MAY include or omit the checksum when displaying or sharing an _Interoperable Name_.
 - Clients MAY accept _Interoperable Name_ inputs with or without a checksum.
 - When a checksum is provided for a target address, clients MAY validate it by deriving the underlying _Interoperable Address_ and recalculating the checksum.


### PR DESCRIPTION
- add notation that clarifies the optional nature of the checksum
- removes a duplicate checksum bulletpoint
