### PR TITLE
Update ERC-7893: Move to Last Call

### DIFF
--- a/ERCS/erc-7893.md
+++ b/ERCS/erc-7893.md
@@ -5,7 +5,7 @@ description: Verifiable solvency proofs and financial health monitoring for DeFi
 author: Sean Luis Guada Rodríguez (@SeanLuis) <seanluis47@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/erc-7893-defi-protocol-solvency-proof-mechanism/24566
 status: Last Call
-last-call-deadline: 2026-02-17
+last-call-deadline: 2026-02-24
 type: Standards Track
 category: ERC
 created: 2025-01-30


### PR DESCRIPTION
Moves ERC-7893 (DeFi Protocol Solvency Proof Mechanism) from **Review** to **Last Call** per the ERC process.

- Status change: `Review` → `Last Call`
- Discussion: https://ethereum-magicians.org/t/erc-7893-defi-protocol-solvency-proof-mechanism/24566