### PR TITLE
Update ERC-8056: Simplify spec with optional extensions

### DIFF
--- a/ERCS/erc-8056.md
+++ b/ERCS/erc-8056.md
@@ -73,7 +73,7 @@ interface IScaledUIAmountBalances {
 }
 ```
 
-### ERC-165 Interface Detection
+### Interface Detection
 
 Compliant contracts MUST implement [ERC-165](./eip-165.md) and return `true` when queried for the `IScaledUIAmount` interface ID.
 


### PR DESCRIPTION
## Summary

- Remove `setAtTimestamp` from `UIMultiplierUpdated` event
- Remove `setUIMultiplier` from core interface (how the multiplier is updated is an implementation detail)
- Add optional extension interfaces following ERC-721/ERC-1155 pattern:
  - `IScaledUIAmountConversion` for `toUIAmount`/`fromUIAmount`
  - `IScaledUIAmountBalances` for `balanceOfUI`/`totalSupplyUI`
- Make ERC-165 a required dependency for interface detection
- Update JavaScript examples to show off-chain conversion
- Add new authors: Gilbert Shih, Tino Martinez Molina

These changes address feedback from the [Ethereum Magicians discussion thread](https://ethereum-magicians.org/t/erc-8056-scaled-ui-amount-extension-for-erc-20-tokens/25899).
