### PR TITLE
Update ERC-7984: Forward transfer operator to callback recipient

### DIFF
--- a/ERCS/erc-7984.md
+++ b/ERCS/erc-7984.md
@@ -257,7 +257,7 @@ Compliant tokens MUST implement the following methods, unless otherwise specifie
 Transfer functions suffixed with `andCall` execute a callback to the `to` address AFTER all transfer logic is completed. The callback calls the `onConfidentialTransferReceived` function with the transfer initiator (operator), from address, actual amount sent, and given `callData` bytes (the last parameter for `andCall` functions). The callback flow is as follows:
 
 - If `address(to).code.length == 0` the callback is a no-op and returns successfully.
-- Call [`onConfidentialTransferReceived(address, address, bytes32, bytes)`](#onConfidentialTransferReceived) on `to`.
+- Call [`onConfidentialTransferReceived(address, address, bytes32, bytes)`](#onconfidentialtransferreceived) on `to`.
 - If the function call reverts, revert.
 - If the function call returns the false boolean, attempt to transfer back the tokens to the original holder and return.
 


### PR DESCRIPTION
This PR adds the `operator` parameter to the callback function--this is crucial for some use-cases where the initiator of the transfer affects the downstream flows. We also took advantage of this selector change to switch to a more natural function name--`onConfidentialTransferReceived`.