### PR TITLE
Update ERC-8049: Address reviewer feedback and fixes

### DIFF
--- a/ERCS/erc-8049.md
+++ b/ERCS/erc-8049.md
@@ -1,7 +1,7 @@
 ---
 eip: 8049
 title: Contract-Level Onchain Metadata
-description: Onchain Contract-level metadata with optional Diamond Storage pattern for predictable storage locations.
+description: Onchain metadata for arbitrary contracts with optional Diamond Storage for predictable data storage locations.
 author: Prem Makeig (@nxt3d)
 discussions-to: https://ethereum-magicians.org/t/erc-8049-contract-level-metadata-with-diamond-storage/25819
 status: Draft
@@ -16,7 +16,7 @@ This ERC defines a standard for storing contract-level metadata onchain. It exte
 
 ## Motivation
 
-[ERC-7572](./eip-7572.md) standardizes contract-level metadata via `contractURI()`, but it typically relies on offchain storage, which introduces trust and availability risks. This ERC enables fully onchain, verifiable contract metadata for trustless discovery in wallets and explorers, while preserving a familiar interface. Diamond Storage is optionally supported to provide predictable storage locations, making it easier to create inclusion proofs of individual metadata values for cross-chain verification and supporting upgradable contract deployments.
+Contract metadata today typically relies on offchain storage such as URLs or IPFS, creating trust and availability risks—servers go down, domains expire, and malicious actors can modify data without onchain record. Storing metadata onchain makes contract identity censorship-resistant and enables wallets and block explorers to display verifiable information without trusting external services. 
 
 ## Specification
 
@@ -27,7 +27,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 Contracts implementing this ERC MUST implement the following interface:
 
 ```solidity
-interface IERCXXXX {
+interface IERC8049 {
     /// @notice Get contract metadata value for a key.
     function getContractMetadata(string calldata key) external view returns (bytes memory);
     
@@ -35,8 +35,6 @@ interface IERCXXXX {
     event ContractMetadataUpdated(string indexed indexedKey, string key, bytes value);
 }
 ```
-
-- `getContractMetadata(key)`: Returns the contract metadata value for the given key as bytes
 
 Contracts implementing this ERC MAY also expose a `setContractMetadata(string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract.
 
@@ -83,7 +81,7 @@ This allows clients to discover the contract's ENS name and resolve it to get ad
 
 ### Optional Metadata Hooks
 
-Contracts implementing this ERC MAY use hooks to redirect metadata resolution to a different contract, enabling secure resolution from known contracts with verifiable security properties. This is particularly useful for credentials such as KYC, Proof-of-Personhood (PoP), and other verifiable credentials stored in singleton registries. For the full specification, see [ERC-8121](./eip-8121.md).
+Contracts implementing this ERC MAY use hooks to redirect metadata resolution to a different contract. For the full specification, see [ERC-8121](./eip-8121.md). When using hooks with contract metadata, the target function MUST be `getContractMetadata(string)` returning `bytes`. The hook selector is `0x9e574b14`.
 
 ## Rationale
 
@@ -103,9 +101,9 @@ The interface is defined in the Required Metadata Function and Event section abo
 ```solidity
 pragma solidity ^0.8.25;
 
-import "./IERCXXXX.sol";
+import "./IERC8049.sol";
 
-contract BasicContractMetadata is IERCXXXX {
+contract BasicContractMetadata is IERC8049 {
     // Simple mapping for contract-level metadata
     mapping(string key => bytes value) private _metadata;
 
@@ -125,9 +123,9 @@ contract BasicContractMetadata is IERCXXXX {
 ```solidity
 pragma solidity ^0.8.25;
 
-import "./IERCXXXX.sol";
+import "./IERC8049.sol";
 
-contract DiamondContractMetadata is IERCXXXX {
+contract DiamondContractMetadata is IERC8049 {
     struct ContractMetadataStorage {
         mapping(string key => bytes value) metadata;
     }


### PR DESCRIPTION
- Revise description to define contract-level metadata rather than restating term
- Rewrite Motivation section to explain ecosystem need and use cases
- Fix interface name from IERCXXXX to IERC8049
- Update hook selector to correct value (0x9e574b14)
- Simplify hooks section with technical details
- Remove redundant function description

