### PR TITLE
Update ERC-8121: Cross-Chain Function Calls via Hooks

### DIFF
--- a/ERCS/erc-8121.md
+++ b/ERCS/erc-8121.md
@@ -72,7 +72,7 @@ bytes4 constant HOOK_SELECTOR_WITHOUT_SELECTOR = 0x6113bfa3; // When functionSel
 - **`returnType`**: The return type in Solidity tuple notation for ABI decoding (e.g., `(string)`, `(uint256, bytes32)`, `((string, uint256[], bytes32))`)
 - **`target`**: An [ERC-7930](./eip-7930.md) interoperable address specifying both the target contract and chain
 
-### Function Call and Return Type Format
+### Function Call Format
 
 The `functionCall` parameter uses a Solidity-style syntax:
 
@@ -91,8 +91,6 @@ hook(0xc41a360a, "getOwner(uint256)", "getOwner(42)", "(address)", 0x00010000010
 // Example with function selector omitted
 hook("getOwner(uint256)", "getOwner(42)", "(address)", 0x000100000101141234567890abcdef1234567890abcdef12345678)
 ```
-
-The `functionSignature` provides explicit types (`"getOwner(uint256)"`), while `functionCall` provides the human-readable values (`"getOwner(42)"`). The `functionSelector` (`0xc41a360a`) is optional but when provided acts as a checksum to verify integrity. When omitted, the hook structure starts with `functionSignature` as the first parameter. Clients can always compute the selector from `functionSignature` as `bytes4(keccak256(functionSignature))`.
 
 ### Hook Encoding
 


### PR DESCRIPTION
Updates to ERC-8121 from the `hooks` branch:

- Refactored hooks specification to support optional function selector as checksum
- Simplified function call format section
- Updated ERC-3668 references and removed circular dependencies
- Added discussions-to link
- Renamed from erc-hooks to erc-8121