### PR TITLE
Update ERC-8110: fix formatting and clarify rationale

### DIFF
--- a/ERCS/erc-8110.md
+++ b/ERCS/erc-8110.md
@@ -13,7 +13,7 @@ requires: 2535, 8042, 8109
 
 ## Abstract
 
-This EIP introduces a **domain-based architectural pattern** for contracts implementing the Diamond execution model defined by [ERC-2535 (Diamond Standard)](./eip-2535.md) or
+This standard introduces a **domain-based architectural pattern** for contracts implementing the Diamond execution model defined by [ERC-2535 (Diamond Standard)](./eip-2535.md) or
 [ERC-8109 (Diamond, Simplified)](./eip-8109.md), together with the storage identifier mechanism defined by [ERC-8042 (Diamond Storage Identifier)](./eip-8042).
 
 It defines a consistent naming convention for storage identifiers and a directory organization model that **decouples storage management from facet logic**.  
@@ -351,7 +351,11 @@ There is a special case within the separation principle where a domain (or sub-d
 In this scenario, the facet implements all functions belonging to its domain.
 This reduces flexibility, but improves encapsulation and self-containment, making the facet behave like a reusable application module rather than a low-level primitive.  
 
-This approach is suitable for systems that prioritize modular composition and standardized functionality, allowing developers to safely integrate common features with predictable behavior. However, when implementing custom or project-specific logic, domains and facets SHOULD still be treated as separate entities.
+A concrete example of this approach can be found in the `Compose project`.  
+In Compose, a facet and its associated sub-domain are explicitly mapped into a single entity, enabling the creation of predefined, plug-and-play standard facets.
+
+This approach is suitable for systems that prioritize modular composition and standardized functionality, allowing developers to safely integrate common features with predictable behavior.  
+However, when implementing custom or project-specific logic, domains and facets SHOULD still be treated as separate entities.
 
 Maintaining this separation preserves clarity of ownership, supports future upgrades, and supports the long-term evolution of application-level Diamond architectures.
 


### PR DESCRIPTION
This PR improves clarity and readability in ERC-8110 by fixing formatting issues and refining the rationale around domain–facet separation at the application level.  
It clarifies a special case where a domain and its facet may intentionally overlap, explains when this pattern is appropriate, and reinforces that domain–facet separation should still be preserved for custom or project-specific logic.
