### PR TITLE
Update ERC-8110: Add Isolated Domain

### DIFF
--- a/ERCS/erc-8110.md
+++ b/ERCS/erc-8110.md
@@ -16,7 +16,7 @@ requires: 2535, 8042, 8109
 This standard introduces a **domain-based architectural pattern** for contracts implementing the Diamond execution model defined by [ERC-2535 (Diamond Standard)](./eip-2535.md) or
 [ERC-8109 (Diamond, Simplified)](./eip-8109.md), together with the storage identifier mechanism defined by [ERC-8042 (Diamond Storage Identifier)](./eip-8042).
 
-It defines a consistent naming convention for storage identifiers and a directory organization model that **decouples storage management from facet logic**.  
+It defines a domain-centric storage management architecture, providing consistent storage identifiers and a structured directory model that decouples storage ownership from facet logic.
 
 This pattern helps reduce storage collisions and human error while enabling better tooling for multi-facet systems.
 
@@ -322,10 +322,9 @@ If the layout-breaking change is **partial**, and the newly required state can b
 From the beginning, the Diamond Standard (ERC-2535) was designed around the relationship between **function selectors** and **storage positions**, not around facets themselves.  
 Facets are replaceable units of logic — the `diamondCut` operation only replaces, removes or adds code — but the **storage layout persists** and defines the actual state continuity of the contract.  
 
-A clear example of this can be found in `Reference Implementation` of ERC-8109.
+ERC-8109 itself only defines introspection mechanisms for querying the Diamond and deliberately leaves the upgrade mechanism to implementations or to other standards.  
+This flexibility is achieved because both introspection facets and upgrade facets interact with the same underlying domain (`8109.diamond`).  
 
-Both `DiamondUpgradeFacet` and `DiamondInspectFacet` interact with the same storage.  
-Although these facets serve different purposes — one mutating, one querying — they share the same domain (`erc8109.diamond`).  
 This demonstrates that **storage belongs to the domain**, not the facet, facets merely provide interfaces for logic to read or mutate that domain.
 
 Over time, many implementations have treated facets as the primary boundary of responsibility, grouping logic and storage together without recognizing that **storage domains** are the true architectural anchors.  


### PR DESCRIPTION
Adds an Isolated Domain section and refines the Rationale to better reflect ERC-8109’s separation between introspection, upgrade mechanisms, and domain-owned storage.