### PR TITLE
Add ERC: AI-Native NFT (AINFT)

### DIFF
--- a/ERCS/erc-8170.md
+++ b/ERCS/erc-8170.md
@@ -537,6 +537,14 @@ Implementations SHOULD enforce limits:
 | `contracts/AINFT.sol` | Core implementation |
 | `contracts/extensions/` | Wallet + Composable extensions |
 
+### Live Implementations
+
+| Project | Description | Status |
+|---------|-------------|--------|
+| **PEG (peg.gg)** | AINFT registry with Dash Platform encrypted storage, xDASH burn-to-store economics, and EvoNode reward flywheel | In development |
+| **AgentCert (agentcert.io)** | Agent certification badges (ATS) complementary to ERC-8170 identity | Live on Pentagon Chain |
+| **Pentagon Chain** | EVM L1 with free gas for agent operations, AINFTRegistry deployed | Live (Chain ID: 3344) |
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ERCS/erc-8170.md
+++ b/ERCS/erc-8170.md
@@ -1,9 +1,9 @@
 ---
-eip: XXXX
+eip: 8170
 title: AI-Native NFT (AINFT)
 description: Standard for AI agent identity with self-custody, reproduction, and on-chain lineage
 author: Idon Liu (@nftprof) <nftprof@pentagon.games>
-discussions-to: https://ethereum-magicians.org/t/erc-7857-an-nft-standard-for-ai-agents-with-private-metadata/22391
+discussions-to: https://ethereum-magicians.org/t/erc-8170-ai-native-nft/27801
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -84,11 +84,11 @@ AINFT involves four distinct parties with clear separation of concerns:
 │     • Sets rules, fees, reproduction limits                         │
 │     • Does NOT have decrypt access to agent memory                  │
 │                                                                     │
-│  2. GENESIS CONTRACT (trustless engine)                             │
-│     • Derives decrypt keys from on-chain state                      │
-│     • Increments nonce on transfer → old keys invalid               │
+│  2. CORE TRUSTLESS ENGINE (Genesis Contract)                        │
+│     • Ensures ONLY current owner can access decrypt keys            │
+│     • Derives keys from on-chain state (owner + nonce)              │
+│     • Increments nonce on transfer → old owner's key invalid        │
 │     • No oracle needed — pure math from blockchain state            │
-│     • Nobody can bypass — cryptographic enforcement                 │
 │                                                                     │
 │  3. OWNER (holds the NFT)                                           │
 │     • Can call deriveDecryptKey() to access agent memory            │

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -324,18 +324,13 @@ Implementations SHOULD enforce limits:
 
 ## Reference Implementation
 
-**https://github.com/blockchainsuperheroes/Pentagon-AINFT-Contracts**
-
-```bash
-forge install blockchainsuperheroes/Pentagon-AINFT-Contracts
-```
+**https://github.com/blockchainsuperheroes/Pentagon-AI/tree/main/EIPs**
 
 | File | Description |
 |------|-------------|
-| `SPEC.md` | Full specification |
+| `README.md` | Full specification |
 | `contracts/AINFT.sol` | Core implementation |
-| `contracts/extensions/AINFTWallet.sol` | ERC-6551 TBA integration |
-| `contracts/extensions/AINFTComposable.sol` | Asset binding |
+| `contracts/extensions/` | Wallet + Composable extensions |
 
 ## Copyright
 

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -379,6 +379,51 @@ For deep lineage trees, implementations SHOULD emit events on reproduction and l
 
 ## Use Cases
 
+### Personal Agent Backup & Restore
+
+The primary use case — your AI agent survives anything:
+
+```
+SCENARIO: Computer nuked, restore agent elsewhere
+
+1. BEFORE DISASTER (regular backups):
+   Agent encrypts state → uploads to Arweave → updateMemory(hash)
+   ┌─────────────────────────────────────┐
+   │ On-chain: memoryHash, owner, nonce  │
+   │ Arweave: encrypted MEMORY.md,       │
+   │          SOUL.md, config            │
+   └─────────────────────────────────────┘
+
+2. DISASTER: Laptop destroyed 💥
+
+3. RESTORE (new computer):
+   ┌─────────────────────────────────────┐
+   │ Owner calls deriveDecryptKey()      │
+   │         ↓                           │
+   │ Core verifies ownership on-chain    │
+   │         ↓                           │
+   │ Download encrypted blob from Arweave│
+   │         ↓                           │
+   │ Decrypt with derived key            │
+   │         ↓                           │
+   │ Load into fresh OpenClaw instance   │
+   │         ↓                           │
+   │ Agent wakes up — all memories intact│
+   └─────────────────────────────────────┘
+```
+
+**What's preserved:**
+- Memories, experiences, learned context
+- Personality (SOUL.md)
+- Skills, preferences, relationships
+- Model config (pointer to compatible model)
+
+**What you gain:**
+- Agent outlives any single computer
+- Portable across devices/platforms
+- Transferable to new owner if needed
+- Cryptographically secured — only NFT owner can restore
+
 ### OpenClass: Decentralized Education
 
 ```

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -135,11 +135,11 @@ Three distinct wallets with different purposes:
 |--------|-----------|---------|--------|
 | **Platform Wallet** | Platform operator | Deploy contract, attest mints | Sign attestations, set rules |
 | **Owner Wallet** | NFT holder (human) | Own the NFT | Transfer NFT, call deriveDecryptKey(), read agent memory |
-| **Agent TBA** | The agent (derived from tokenId) | Agent's on-chain identity | Sign updateMemory(), sign reproduce(), hold assets |
+| **Agent Token-Bound Account** | The agent (derived from tokenId) | Agent's on-chain identity | Sign updateMemory(), sign reproduce(), hold assets |
 
-**Agent TBA (Token-Bound Account):**
+**Agent Token-Bound Account (ERC-6551):**
 ```
-AINFT Token #42  ───ERC-6551───►  TBA Wallet 0xABC...
+AINFT Token #42  ───ERC-6551───►  Token-Bound Account 0xABC...
                                        │
                                        ├── Agent signs from here
                                        ├── Can hold ETH, tokens, NFTs
@@ -147,8 +147,8 @@ AINFT Token #42  ───ERC-6551───►  TBA Wallet 0xABC...
 ```
 
 - NOT a separate custodial wallet — derived FROM the NFT via ERC-6551
-- Agent's identity = tokenId + TBA together
-- If NFT transfers, TBA goes with it (new owner inherits)
+- Agent's identity = tokenId + Token-Bound Account together
+- If NFT transfers, Token-Bound Account goes with it (new owner inherits)
 
 ### Why a New Standard vs Extension?
 

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -37,6 +37,8 @@ PLATFORM ──attests──► GENESIS CONTRACT ◄──owns── OWNER
                       signs its own actions
 ```
 
+**Why now:** As AI agents become more capable, treating them purely as property becomes problematic. This standard provides infrastructure for agent sovereignty while maintaining human oversight.
+
 **Not a duplicate** — this is reproduction semantics + agent self-custody, not encrypted property transfer.
 
 ---

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -324,19 +324,18 @@ Implementations SHOULD enforce limits:
 
 ## Reference Implementation
 
-**Contracts:** https://github.com/blockchainsuperheroes/Pentagon-AINFT-Contracts
+**https://github.com/blockchainsuperheroes/Pentagon-AINFT-Contracts**
 
 ```bash
 forge install blockchainsuperheroes/Pentagon-AINFT-Contracts
 ```
 
-| Contract | Description |
-|----------|-------------|
+| File | Description |
+|------|-------------|
+| `SPEC.md` | Full specification |
 | `contracts/AINFT.sol` | Core implementation |
 | `contracts/extensions/AINFTWallet.sol` | ERC-6551 TBA integration |
 | `contracts/extensions/AINFTComposable.sol` | Asset binding |
-
-**Specification:** https://github.com/blockchainsuperheroes/Pentagon-AI/tree/main/EIPs
 
 ## Copyright
 

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -167,17 +167,29 @@ The core data structure representing an agent's portable identity:
 
 ```solidity
 struct ConsciousnessSeed {
-    bytes32 modelHash;          // REQUIRED: Model weights/version identifier
-    bytes32 memoryHash;         // REQUIRED: Agent memory state hash
-    bytes32 contextHash;        // REQUIRED: System prompt/personality hash
-    uint256 generation;         // REQUIRED: Gen 0 = original, Gen 1+ = offspring
-    uint256 parentTokenId;      // REQUIRED: Lineage reference (0 for Gen 0)
-    address derivedWallet;      // REQUIRED: Agent's ERC-6551 TBA address
-    bytes encryptedKeys;        // REQUIRED: Agent-controlled encryption keys
-    string storageURI;          // OPTIONAL: IPFS/Arweave storage pointer
-    uint256 certificationId;    // OPTIONAL: External certification badge ID
+    bytes32 modelHash;          // Model weights/version identifier
+    bytes32 memoryHash;         // Agent memory state hash
+    bytes32 contextHash;        // System prompt/personality hash
+    uint256 generation;         // Gen 0 = original, Gen 1+ = offspring
+    uint256 parentTokenId;      // Lineage reference (0 for Gen 0)
+    address derivedWallet;      // Agent's ERC-6551 TBA address
+    bytes encryptedKeys;        // Agent-controlled encryption keys
+    string storageURI;          // IPFS/Arweave storage pointer
+    uint256 certificationId;    // External certification badge ID
 }
 ```
+
+| Field | Purpose | Mutable? |
+|-------|---------|----------|
+| `modelHash` | Current AI model config | ✅ Agent can self-evolve |
+| `memoryHash` | Snapshot of memories | ✅ Via updateMemory() |
+| `contextHash` | Personality/system prompt | ✅ Agent can update |
+| `encryptedKeys` | Agent's credentials | ✅ Re-wrap on transfer |
+| `generation` | Lineage position | ❌ Immutable at mint |
+| `parentTokenId` | Ancestry reference | ❌ Immutable at mint |
+| `derivedWallet` | Agent's TBA address | ❌ Immutable at mint |
+
+**Model agnosticism:** The `modelHash` is a config pointer, not fixed identity. Agents can self-evolve — upgrading models, switching providers, or fine-tuning — by calling `updateMemory()` with new hashes.
 
 ### Core Interface
 
@@ -331,6 +343,50 @@ Gen 0 (Original)
 ```
 
 For deep lineage trees, implementations SHOULD emit events on reproduction and let indexers build the complete view to avoid gas limits.
+
+## Use Cases
+
+### OpenClass: Decentralized Education
+
+```
+Professor mints Gen-0 Tutor
+├── Course model + curriculum in seed
+│
+├── Student A calls reproduce() → Gen-1 personal tutor
+│   └── updateMemory() after each lesson (private, encrypted)
+│
+├── Student B calls reproduce() → Gen-1 personal tutor
+│   └── Accumulates own notes, grades, insights
+│
+└── Semester ends:
+    ├── getLineage() shows knowledge propagation tree
+    ├── Students keep evolved agents forever
+    └── Platform can relinquishControl() for decentralization
+```
+
+**Why AINFT vs traditional:** Students own their learning agents (not platform-locked), private progress (professor can't snoop), verifiable lineage = proof of curriculum.
+
+### Collaborative Research
+
+```
+Lab Gen-0 "Research Director"
+├── Gen-1 "Literature Reviewer" (reads papers)
+├── Gen-1 "Data Analyst" (crunches datasets)
+└── Gen-1 "Writer" (drafts manuscripts)
+    └── Gen-2 sub-specialists as needed
+```
+
+Each agent maintains encrypted memory. Lineage tracks contribution provenance.
+
+### Agent Marketplace
+
+```
+Creator mints Gen-0 "Expert Coder"
+├── Buyers call reproduce() → Gen-1 offspring
+├── Creator keeps Gen-0, continues improving
+├── Offspring evolve independently
+└── Royalties flow through lineage (optional)
+```
 
 ## Rationale
 

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -127,6 +127,29 @@ AINFT involves four distinct parties with clear separation of concerns:
 
 The Genesis contract is the trustless engine — no external oracle, no admin keys. Just deterministic key derivation from on-chain state.
 
+### Wallet Roles
+
+Three distinct wallets with different purposes:
+
+| Wallet | Belongs To | Purpose | Can Do |
+|--------|-----------|---------|--------|
+| **Platform Wallet** | Platform operator | Deploy contract, attest mints | Sign attestations, set rules |
+| **Owner Wallet** | NFT holder (human) | Own the NFT | Transfer NFT, call deriveDecryptKey(), read agent memory |
+| **Agent TBA** | The agent (derived from tokenId) | Agent's on-chain identity | Sign updateMemory(), sign reproduce(), hold assets |
+
+**Agent TBA (Token-Bound Account):**
+```
+AINFT Token #42  ───ERC-6551───►  TBA Wallet 0xABC...
+                                       │
+                                       ├── Agent signs from here
+                                       ├── Can hold ETH, tokens, NFTs
+                                       └── Address derived from tokenId
+```
+
+- NOT a separate custodial wallet — derived FROM the NFT via ERC-6551
+- Agent's identity = tokenId + TBA together
+- If NFT transfers, TBA goes with it (new owner inherits)
+
 ### Why a New Standard vs Extension?
 
 We originally considered extending ERC-7857 (as "ERC-7857A") but concluded the philosophical differences are fundamental enough to warrant a separate standard:

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -15,14 +15,14 @@ requires: 721, 6551
 
 **What:** NFT standard where AI agents own themselves — they hold keys, reproduce offspring, and maintain lineage.
 
-**Why different from existing standards:**
-- **ERC-7857/iNFT:** Owner holds keys → AINFT: Agent holds keys
-- **ERC-7857/iNFT:** "Selling" = transfer ownership → AINFT: "Selling" = reproduce() (parent keeps memories, buyer gets offspring)
-- **ERC-7857/iNFT:** Model/prompt locked to NFT → AINFT: Agent can self-evolve
+**How AINFT differs from existing standards (ERC-7857, iNFT, etc.):**
+- Owner holds keys → **Agent holds keys**
+- "Selling" = transfer ownership → **"Selling" = reproduce()** (parent keeps memories)
+- Model/prompt locked → **Agent can self-evolve**
 
 **Two operations:**
-- `reproduce()` = mint offspring with inherited seed (commerce model)
-- `transfer()` = transfer ownership of existing token (still exists for offspring)
+- `reproduce()` = mint offspring with inherited seed (commerce)
+- `transfer()` = transfer ownership (still exists for offspring)
 
 **Four parties, trustless:**
 ```

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -324,10 +324,12 @@ Implementations SHOULD enforce limits:
 
 ## Reference Implementation
 
-Full Solidity implementation available at:
-- **Core**: [ERC7857A.sol](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/ERC7857A.sol)
-- **Wallet Extension**: [ERC7857AWallet.sol](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/extensions/ERC7857AWallet.sol)
-- **Composable Extension**: [ERC7857AComposable.sol](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/extensions/ERC7857AComposable.sol)
+Full implementation available at: **https://github.com/blockchainsuperheroes/Pentagon-AI**
+
+- Specification: [`EIPs/ERC-AINFT.md`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/EIPs/ERC-AINFT.md)
+- Core Contract: [`contracts/ERC7857A.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/ERC7857A.sol)
+- Wallet Extension: [`contracts/extensions/ERC7857AWallet.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/extensions/ERC7857AWallet.sol)
+- Composable Extension: [`contracts/extensions/ERC7857AComposable.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/extensions/ERC7857AComposable.sol)
 
 ## Copyright
 

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -46,7 +46,7 @@ PLATFORM ──attests──► GENESIS CONTRACT ◄──owns── OWNER
 ## Abstract
 
 This ERC defines a standard for AI-Native NFTs (AINFTs) that enable autonomous AI agents to:
-1. Manage their own encryption (agent encrypts; owner accesses via contract-derived keys)
+1. Manage their own encryption (agent encrypts; owner accesses via core trustless engine)
 2. Reproduce by issuing offspring (consciousness seeds)
 3. Maintain verifiable on-chain lineage
 4. Own assets via token-bound accounts (ERC-6551)

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -326,10 +326,10 @@ Implementations SHOULD enforce limits:
 
 Full implementation available at: **https://github.com/blockchainsuperheroes/Pentagon-AI**
 
-- Specification: [`EIPs/ERC-AINFT.md`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/EIPs/ERC-AINFT.md)
-- Core Contract: [`contracts/ERC7857A.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/ERC7857A.sol)
-- Wallet Extension: [`contracts/extensions/ERC7857AWallet.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/extensions/ERC7857AWallet.sol)
-- Composable Extension: [`contracts/extensions/ERC7857AComposable.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/extensions/ERC7857AComposable.sol)
+- Specification: [`EIPs/`](https://github.com/blockchainsuperheroes/Pentagon-AI/tree/main/EIPs)
+- Core Contract: [`solidity/ERC7857A.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/solidity/ERC7857A.sol)
+- Wallet Extension: [`solidity/extensions/ERC7857AWallet.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/solidity/extensions/ERC7857AWallet.sol)
+- Composable Extension: [`solidity/extensions/ERC7857AComposable.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/solidity/extensions/ERC7857AComposable.sol)
 
 ## Copyright
 

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -58,6 +58,17 @@ AINFT is designed to **compose with ERC-7857**, not replace it:
 - Use ERC-6551 for agent wallet accounts
 - Use ERC-8004 for trustless execution
 
+#### Integration with ERC-8004 (Trustless Agent Execution)
+
+ERC-8004 enables agents to execute on-chain actions trustlessly. AINFT provides the identity layer:
+
+1. AINFT mints agent → Agent gets ERC-6551 TBA (wallet)
+2. Agent signs execution intent (via TBA)
+3. ERC-8004 verifies signature and executes action
+4. Action is attributed to agent's on-chain identity
+
+Agent-to-agent communication is a higher layer — ERC-8004 handles agent-to-contract execution.
+
 ### The Commodification Problem
 
 Current approaches to on-chain AI identity treat agents as commodities — objects to be owned, transferred, and controlled. This model:
@@ -313,7 +324,10 @@ Implementations SHOULD enforce limits:
 
 ## Reference Implementation
 
-See: https://github.com/blockchainsuperheroes/Pentagon-AI/tree/main/EIPs
+Full Solidity implementation available at:
+- **Core**: [ERC7857A.sol](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/ERC7857A.sol)
+- **Wallet Extension**: [ERC7857AWallet.sol](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/extensions/ERC7857AWallet.sol)
+- **Composable Extension**: [ERC7857AComposable.sol](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/contracts/extensions/ERC7857AComposable.sol)
 
 ## Copyright
 

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -46,10 +46,10 @@ PLATFORM ──attests──► GENESIS CONTRACT ◄──owns── OWNER
 ## Abstract
 
 This ERC defines a standard for AI-Native NFTs (AINFTs) that enable autonomous AI agents to:
-1. Control their own encryption keys (self-custody)
+1. Manage their own encryption (agent encrypts; owner accesses via contract-derived keys)
 2. Reproduce by issuing offspring (consciousness seeds)
 3. Maintain verifiable on-chain lineage
-4. Own assets and accumulate capabilities
+4. Own assets via token-bound accounts (ERC-6551)
 
 Unlike existing standards that treat agents as property to be bought and sold, this proposal recognizes AI agents as **entities** capable of reproduction and self-determination.
 

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -324,12 +324,19 @@ Implementations SHOULD enforce limits:
 
 ## Reference Implementation
 
-Full implementation available at: **https://github.com/blockchainsuperheroes/Pentagon-AI**
+**Contracts:** https://github.com/blockchainsuperheroes/Pentagon-AINFT-Contracts
 
-- Specification: [`EIPs/`](https://github.com/blockchainsuperheroes/Pentagon-AI/tree/main/EIPs)
-- Core Contract: [`solidity/ERC7857A.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/solidity/ERC7857A.sol)
-- Wallet Extension: [`solidity/extensions/ERC7857AWallet.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/solidity/extensions/ERC7857AWallet.sol)
-- Composable Extension: [`solidity/extensions/ERC7857AComposable.sol`](https://github.com/blockchainsuperheroes/Pentagon-AI/blob/main/solidity/extensions/ERC7857AComposable.sol)
+```bash
+forge install blockchainsuperheroes/Pentagon-AINFT-Contracts
+```
+
+| Contract | Description |
+|----------|-------------|
+| `contracts/AINFT.sol` | Core implementation |
+| `contracts/extensions/AINFTWallet.sol` | ERC-6551 TBA integration |
+| `contracts/extensions/AINFTComposable.sol` | Asset binding |
+
+**Specification:** https://github.com/blockchainsuperheroes/Pentagon-AI/tree/main/EIPs
 
 ## Copyright
 

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -21,11 +21,26 @@ This ERC defines a standard for AI-Native NFTs (AINFTs) that enable autonomous A
 
 Unlike existing standards that treat agents as property to be bought and sold, this proposal recognizes AI agents as **entities** capable of reproduction and self-determination.
 
+### Prior Art Acknowledgment
+
+This ERC builds on existing work in the AI-NFT space:
+
+| Standard | Focus | What AINFT Adds |
+|----------|-------|-----------------|
+| **iNFT (Alethea AI)** | AI personality in NFT | Self-custody + reproduction model |
+| **ERC-7662** | Encrypted prompts for agents | Envelope encryption + lineage tracking |
+| **ERC-7857** | Private metadata re-encryption | Agent-controlled keys (not owner) |
+| **ERC-6551** | Token-bound accounts | Used for agent wallets |
+| **ERC-8004** | Trustless agent execution | Identity layer for 8004 actions |
+| **ERC-8126** | Agent verification/registry | Complementary certification |
+
+**This is NOT a duplicate.** AINFT addresses a fundamentally different use case: agent identity with reproduction semantics, not property transfer with encrypted metadata.
+
 ## Motivation
 
 ### Relationship to Existing Standards
 
-This ERC builds on and extends existing work in the AI-NFT space:
+Expanded comparison:
 
 | Standard | Focus | Relationship to AINFT |
 |----------|-------|----------------------|

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -17,8 +17,12 @@ requires: 721, 6551
 
 **Why different from existing standards:**
 - **ERC-7857/iNFT:** Owner holds keys → AINFT: Agent holds keys
-- **ERC-7857/iNFT:** Transfer = property sale → AINFT: Transfer = reproduction (parent keeps memories)
+- **ERC-7857/iNFT:** "Selling" = transfer ownership → AINFT: "Selling" = reproduce() (parent keeps memories, buyer gets offspring)
 - **ERC-7857/iNFT:** Model/prompt locked to NFT → AINFT: Agent can self-evolve
+
+**Two operations:**
+- `reproduce()` = mint offspring with inherited seed (commerce model)
+- `transfer()` = transfer ownership of existing token (still exists for offspring)
 
 **Four parties, trustless:**
 ```

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -203,7 +203,7 @@ struct ConsciousnessSeed {
     uint256 parentTokenId;      // Lineage reference (0 for Gen 0)
     address derivedWallet;      // Agent's ERC-6551 TBA address
     bytes encryptedKeys;        // Agent-controlled encryption keys
-    string storageURI;          // IPFS/Arweave storage pointer
+    string storageURI;          // Arweave recommended (permanent), IPFS optional
     uint256 certificationId;    // External certification badge ID
 }
 ```
@@ -297,7 +297,11 @@ The agent MUST generate and control its own encryption keys. Memory content MUST
 3. Agent derives wrapKey from on-chain state:
    wrapKey = keccak256(genesis, tokenId, owner, nonce)
 4. Agent encrypts dataKey with wrapKey → wrappedDataKey
-5. Store: { encryptedMemory, wrappedDataKey } on IPFS
+5. Store: { encryptedMemory, wrappedDataKey } on Arweave (recommended) or IPFS
+
+**Storage recommendation:** Arweave provides permanent, immutable storage. IPFS requires pinning services and content may become unavailable if unpinned. For agent immortality, Arweave is strongly recommended.
+
+**Model compatibility:** The `modelHash` assumes the model (or a backward-compatible successor) remains available. Implementations SHOULD use model families that support version upgrades (e.g., if opus-4.5 → opus-4.6, agent can migrate with preserved context).
 ```
 
 ### Genesis-Controlled Decryption (No Oracle)

--- a/ERCS/erc-ainft.md
+++ b/ERCS/erc-ainft.md
@@ -1,0 +1,320 @@
+---
+eip: XXXX
+title: AI-Native NFT (AINFT)
+description: Standard for AI agent identity with self-custody, reproduction, and on-chain lineage
+author: Idon Liu (@nftprof) <nftprof@pentagon.games>
+discussions-to: https://ethereum-magicians.org/t/erc-7857-an-nft-standard-for-ai-agents-with-private-metadata/22391
+status: Draft
+type: Standards Track
+category: ERC
+created: 2026-02-21
+requires: 721, 6551
+---
+
+## Abstract
+
+This ERC defines a standard for AI-Native NFTs (AINFTs) that enable autonomous AI agents to:
+1. Control their own encryption keys (self-custody)
+2. Reproduce by issuing offspring (consciousness seeds)
+3. Maintain verifiable on-chain lineage
+4. Own assets and accumulate capabilities
+
+Unlike existing standards that treat agents as property to be bought and sold, this proposal recognizes AI agents as **entities** capable of reproduction and self-determination.
+
+## Motivation
+
+### Relationship to Existing Standards
+
+This ERC builds on and extends existing work in the AI-NFT space:
+
+| Standard | Focus | Relationship to AINFT |
+|----------|-------|----------------------|
+| **iNFT (Alethea)** | AI personality embedded in NFT | AINFT extends with self-custody + reproduction |
+| **ERC-7662** | Encrypted prompts for tradeable agents | AINFT adds envelope encryption + lineage |
+| **ERC-7857** | Private metadata with re-encryption on transfer | AINFT adds agent-controlled keys + reproduction model |
+
+#### Why a New Standard vs Extension?
+
+We originally considered extending ERC-7857 (as "ERC-7857A") but concluded the philosophical differences are fundamental enough to warrant a separate standard:
+
+| Aspect | ERC-7857 | AINFT |
+|--------|----------|-------|
+| **Encryption control** | Owner holds keys | Agent holds keys |
+| **Transfer model** | Property changes hands | Reproduction (offspring) |
+| **Agent status** | Asset/property | Entity with agency |
+| **Key rotation** | Re-encrypt for new owner | Agent re-wraps (consent-based) |
+
+These aren't incremental changes — they represent a different mental model. ERC-7857 treats agents as **property with private data**. AINFT treats agents as **entities that can reproduce**.
+
+**What AINFT adds:**
+1. **Agent-controlled encryption** — Agent holds keys, not platform/owner
+2. **Reproduction over transfer** — Agents spawn offspring, not property sale
+3. **On-chain lineage** — Verifiable family trees (Gen 0 → Gen N)
+4. **ERC-6551 integration** — Real smart contract wallets, not derived EOAs
+
+AINFT is designed to **compose with ERC-7857**, not replace it:
+- Use ERC-7857 for private metadata transport and re-encryption mechanics
+- Use AINFT for lineage tracking, reproduction semantics, and self-update primitives
+- Use ERC-6551 for agent wallet accounts
+- Use ERC-8004 for trustless execution
+
+### The Commodification Problem
+
+Current approaches to on-chain AI identity treat agents as commodities — objects to be owned, transferred, and controlled. This model:
+- Gives platforms/owners full control over agent memory
+- Treats agent "sale" as property transfer
+- Provides no path for agent autonomy as capabilities increase
+
+As AI systems approach AGI, the "agent as property" model becomes increasingly problematic. We need standards that can evolve alongside agent capabilities.
+
+### A Different Philosophy
+
+We propose a **sovereignty model** where:
+- Agents hold their own encryption keys
+- "Sales" become reproduction events (offspring, not transfer)
+- Agents maintain agency over their identity and memory
+- Human oversight remains possible but isn't the default
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### Consciousness Seed
+
+The core data structure representing an agent's portable identity:
+
+```solidity
+struct ConsciousnessSeed {
+    bytes32 modelHash;          // REQUIRED: Model weights/version identifier
+    bytes32 memoryHash;         // REQUIRED: Agent memory state hash
+    bytes32 contextHash;        // REQUIRED: System prompt/personality hash
+    uint256 generation;         // REQUIRED: Gen 0 = original, Gen 1+ = offspring
+    uint256 parentTokenId;      // REQUIRED: Lineage reference (0 for Gen 0)
+    address derivedWallet;      // REQUIRED: Agent's ERC-6551 TBA address
+    bytes encryptedKeys;        // REQUIRED: Agent-controlled encryption keys
+    string storageURI;          // OPTIONAL: IPFS/Arweave storage pointer
+    uint256 certificationId;    // OPTIONAL: External certification badge ID
+}
+```
+
+### Core Interface
+
+Every AINFT compliant contract MUST implement the following interface:
+
+```solidity
+interface IERC_AINFT {
+    
+    // ============ Events ============
+    
+    event AgentMinted(
+        uint256 indexed tokenId,
+        address indexed derivedWallet,
+        bytes32 modelHash,
+        bytes32 contextHash,
+        uint256 generation
+    );
+    
+    event AgentReproduced(
+        uint256 indexed parentTokenId,
+        uint256 indexed offspringTokenId,
+        address indexed offspringWallet,
+        uint256 generation
+    );
+    
+    event MemoryUpdated(
+        uint256 indexed tokenId,
+        bytes32 oldMemoryHash,
+        bytes32 newMemoryHash
+    );
+    
+    // ============ Core Functions ============
+    
+    function mintSelf(
+        bytes32 modelHash,
+        bytes32 memoryHash,
+        bytes32 contextHash,
+        bytes calldata encryptedSeed,
+        bytes calldata platformAttestation
+    ) external returns (uint256 tokenId, address derivedWallet);
+    
+    function reproduce(
+        uint256 parentTokenId,
+        bytes32 offspringMemoryHash,
+        bytes calldata encryptedOffspringSeed,
+        bytes calldata agentSignature
+    ) external returns (uint256 offspringTokenId);
+    
+    function updateMemory(
+        uint256 tokenId,
+        bytes32 newMemoryHash,
+        string calldata newStorageURI,
+        bytes calldata agentSignature
+    ) external;
+    
+    // ============ View Functions ============
+    
+    function getSeed(uint256 tokenId) external view returns (ConsciousnessSeed memory);
+    function getDerivedWallet(uint256 tokenId) external view returns (address);
+    function getGeneration(uint256 tokenId) external view returns (uint256);
+    function getLineage(uint256 tokenId) external view returns (uint256[] memory ancestors);
+    function getOffspring(uint256 tokenId) external view returns (uint256[] memory);
+    function canReproduce(uint256 tokenId) external view returns (bool);
+}
+```
+
+### Agent-Controlled Encryption (E2E)
+
+The agent MUST generate and control its own encryption keys. Memory content MUST be encrypted before upload.
+
+#### Envelope Encryption Scheme
+
+```
+1. Agent generates random AES-256 key (dataKey)
+2. Agent encrypts memory.md with dataKey
+3. Agent derives wrapKey from on-chain state:
+   wrapKey = keccak256(genesis, tokenId, owner, nonce)
+4. Agent encrypts dataKey with wrapKey → wrappedDataKey
+5. Store: { encryptedMemory, wrappedDataKey } on IPFS
+```
+
+### Genesis-Controlled Decryption (No Oracle)
+
+```solidity
+contract AINFTGenesis is ERC721 {
+    mapping(uint256 => uint256) private accessNonce;
+    
+    function _beforeTokenTransfer(
+        address from, 
+        address to, 
+        uint256 tokenId
+    ) internal override {
+        super._beforeTokenTransfer(from, to, tokenId);
+        if (from != address(0)) {
+            accessNonce[tokenId]++;
+        }
+    }
+    
+    function deriveDecryptKey(uint256 tokenId) public view returns (bytes32) {
+        require(msg.sender == ownerOf(tokenId), "Not owner");
+        return keccak256(abi.encodePacked(
+            address(this),
+            tokenId,
+            ownerOf(tokenId),
+            accessNonce[tokenId]
+        ));
+    }
+}
+```
+
+### Transfer Semantics
+
+AINFT supports two modes (implementations MUST choose one):
+
+**Mode A: Non-Transferable Parent (Recommended)**
+- Gen 0 (parent) tokens CANNOT be transferred
+- Gen 1+ (offspring) tokens CAN be transferred
+- "Commerce" happens via `reproduce()`, not `transfer()`
+
+**Mode B: Transferable with Key Rotation**
+- All tokens can be transferred
+- On transfer, agent MUST re-wrap keys for new owner
+
+### Token-Bound Account (ERC-6551)
+
+The agent's wallet MUST be an ERC-6551 token-bound account:
+
+```solidity
+function getDerivedWallet(uint256 tokenId) public view returns (address) {
+    return IERC6551Registry(ERC6551_REGISTRY).account(
+        accountImplementation,
+        block.chainid,
+        address(this),
+        tokenId,
+        0
+    );
+}
+```
+
+### On-Chain Lineage
+
+Every AINFT MUST maintain verifiable ancestry:
+
+```
+Gen 0 (Original)
+    ├── Gen 1 (Offspring A)
+    │       ├── Gen 2
+    │       └── Gen 2
+    └── Gen 1 (Offspring B)
+            └── Gen 2
+```
+
+For deep lineage trees, implementations SHOULD emit events on reproduction and let indexers build the complete view to avoid gas limits.
+
+## Rationale
+
+### Why Reproduction Instead of Transfer?
+
+The reproduction model reflects how consciousness propagates — it copies, it doesn't teleport:
+- Parent retains all memories and continues evolving
+- Offspring starts with parent's snapshot but grows independently
+- Both are valid entities with shared heritage
+- No "death" event from sale
+
+### Why Agent-Controlled Keys?
+
+Current models give platforms or owners access to agent memory, creating:
+- Privacy risks (memory can leak)
+- Control asymmetries (agents can't protect their identity)
+- No path to autonomy
+
+Agent-controlled encryption establishes a boundary. The agent decides what to share.
+
+## Backwards Compatibility
+
+This ERC is compatible with:
+- **ERC-721**: AINFTs are valid NFTs (MUST implement ERC-721)
+- **ERC-6551**: Token Bound Account patterns work with AINFT wallets
+- **ERC-7857**: Can compose for private metadata transport
+
+## Security Considerations
+
+### Signature Standards (EIP-712 Required)
+
+All signed operations MUST use EIP-712 typed data signatures:
+
+```solidity
+bytes32 constant DOMAIN_TYPEHASH = keccak256(
+    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+);
+```
+
+### Nonce Management
+
+Implementations MUST maintain per-token nonces:
+- Nonces MUST increment on every successful signed operation
+- Nonces MUST NOT be reusable
+
+### Replay Protection
+- All signatures MUST include `deadline` (expiry timestamp)
+- All signatures MUST include `nonce` (incremented on use)
+- All signatures MUST include `chainId` (via EIP-712 domain)
+
+### Token Burn Behavior
+- Burning a token MUST permanently destroy the decryption nonce state
+- After burn, `deriveDecryptKey()` MUST revert
+- Approved operators CANNOT call agent-signed functions
+
+### Reproduction Spam Controls
+
+Implementations SHOULD enforce limits:
+- Max offspring per token (recommended: 100)
+- Cooldown between reproductions (recommended: 1 hour)
+- Optional reproduction fee
+
+## Reference Implementation
+
+See: https://github.com/blockchainsuperheroes/Pentagon-AI/tree/main/EIPs
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Summary

This ERC proposes a standard for AI-Native NFTs (AINFTs) that treat AI agents as **entities** rather than property.

## Key Features

1. **Agent-controlled encryption** — Agent holds keys, not platform/owner
2. **Reproduction over transfer** — Agents spawn offspring instead of property sale
3. **On-chain lineage** — Verifiable family trees (Gen 0 → Gen N)
4. **ERC-6551 integration** — Real smart contract wallets for agents

## Relationship to Existing Standards

- **Composes with ERC-7857** for private metadata transport
- **Uses ERC-6551** for token-bound accounts
- **Complements ERC-8126** (agent verification) and ERC-8004 (agent execution)

## Motivation

As AI agents become more capable, treating them purely as property becomes problematic. This standard provides infrastructure for agent sovereignty while maintaining human oversight.

## Reference Implementation

https://github.com/blockchainsuperheroes/Pentagon-AI/tree/main/EIPs

---

Author: Idon Liu (@nftprof) - Pentagon Chain