### PR TITLE
Website: replace comparison table with bullet format

### DIFF
--- a/ERCS/erc-7621.md
+++ b/ERCS/erc-7621.md
@@ -3,7 +3,7 @@ eip: 7621
 title: Basket Token
 description: A multi-asset token standard with weighted constituents and owner-managed rebalancing.
 author: Callum Mitchell-Clark (@AlvaraProtocol) <cal@alvara.xyz>, Dominic Ryder <dom@alvara.xyz>, Michael Ryder <mike@alvara.xyz>
-discussions-to: 
+discussions-to: https://ethereum-magicians.org/t/erc-7621-basket-token-revised/28050
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-7621.md
+++ b/ERCS/erc-7621.md
@@ -2,7 +2,7 @@
 eip: 7621
 title: Basket Token
 description: A multi-asset basket token with weighted constituents and owner-managed rebalancing.
-author: Callum Mitchell-Clark (@AlvaraProtocol) <cal@alvara.xyz>, Dominic Ryder <dom@alvara.xyz>, Michael Ryder <mike@alvara.xyz>
+author: Dominic Ryder <dom@alvara.xyz>, Michael Ryder <mike@alvara.xyz>, Callum Mitchell-Clark (@AlvaraProtocol) <cal@alvara.xyz>
 discussions-to: https://ethereum-magicians.org/t/erc-7621-basket-token-revised/28050
 status: Draft
 type: Standards Track

--- a/ERCS/erc-7621.md
+++ b/ERCS/erc-7621.md
@@ -1,120 +1,435 @@
 ---
 eip: 7621
 title: Basket Token
-description: Collateralized, tokenized funds with adjustable weights and reserves and minting/burning of LP tokens.
-author: Dominic Ryder <dom@alvaraprotocol.io>, Callum Mitchell-Clark (@AlvaraProtocol) <callum@alvaraprotocol.io>, Joey van Etten <joe@alvaraprotocol.io>, Michael Ryder <mike@alvaraprotocol.io>
-discussions-to: https://ethereum-magicians.org/t/proposal-for-a-new-eip-erc-the-erc-bts-basket-token-standard/18598
+description: A multi-asset token standard with weighted constituents and owner-managed rebalancing.
+author: Callum Mitchell-Clark (@AlvaraProtocol) <cal@alvara.xyz>, Dominic Ryder <dom@alvara.xyz>, Michael Ryder <mike@alvara.xyz>
+discussions-to: 
 status: Draft
 type: Standards Track
 category: ERC
 created: 2024-02-11
-requires: 20, 721
+requires: 20, 165, 173
 ---
 
 ## Abstract
 
-The Basket Token Standard (BTS) allows for the implementation of multi-asset tokenized funds. This standard provides basic functionality for anyone to deploy unique, non-fungible BTS tokens that can contain an unlimited number of underlying [ERC-20](./eip-20.md) tokens.
-
-The deployer receives a BTS token representative of their ownership of the fund, as well as liquidity provider (LP) tokens representative of their percentage share of the fund (100% at time of deployment but changing as other wallets contribute/withdraw). Whenever a contribution is made to a BTS, BTS LP tokens are minted and distributed to the contributor’s wallet (representative of their share of the fund); when a withdrawal is made from a BTS, the BTS LP tokens are burned and funds returned to the withdrawer’s wallet.
-
-The BTS has a rebalance function which allows for a BTS owner to change the percentage share of the fund that each underlying token makes up. Tokens can be removed entirely or added through this function after a BTS has already been minted.
-
-By leveraging the [ERC-721](./eip-721.md) standard as a representative token of ownership when minting the BTS, the tokenized fund can also be fully manageable and transferable on-chain.
+This standard defines a multi-asset basket token that extends [ERC-20](./eip-20.md). A basket holds a set of [ERC-20](./eip-20.md) constituent tokens at configurable target weights. The basket contract itself is the share token: holders of the basket's [ERC-20](./eip-20.md) supply have a proportional claim on its underlying reserves. A designated owner, identified via [ERC-173](./eip-173.md), has authority to rebalance the basket's composition.
 
 ## Motivation
 
-The motivation is to provide infrastructure that will enable the on-chain creation and management of asset-backed tokenized investment funds as no such standardized infrastructure curently exists. Providing the necessary infrastructure will help facilitate the onboarding of traditional fund management onto blockchain. No existing standard is capable of achieving this as they lack the required features for third party contribution, namely the minting of LP tokens when contribution is made. The [ERC-7621](./eip-7621.md) is the only token standard that facilitates this with a rebalance function required for effective fund management, and LP token distribution and burning, required for third party participation. 
+[ERC-4626](./eip-4626.md) standardized single-asset vaults for yield-bearing tokens. [ERC-7575](./eip-7575.md) extended that model to multi-asset vault entry points while preserving ERC-4626 semantics. However, neither standard addresses manager-rebalanced, weighted basket share tokens, where a designated owner actively adjusts the constituent set and target allocations over time.
+
+There is no standard specifically for this use case. Every protocol that implements a weighted basket (tokenized index funds, portfolio products, treasury diversification vehicles) uses a custom interface, which creates additional integration work for wallets, aggregators, and DeFi protocols that support such baskets.
+
+This standard provides a common interface for weighted, manager-rebalanced baskets: contributing assets, withdrawing proportionally, querying composition and target weights, and rebalancing. Unlike vault standards that primarily standardize asset entry and exit, this standard treats portfolio composition itself (constituent membership and target weights) as standardized, queryable state. Because the basket contract is itself an [ERC-20](./eip-20.md) token, basket shares are compatible with existing ERC-20 infrastructure.
 
 ## Specification
 
-### BTS
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-BTS is a smart contract enabling the creation of on-chain tokenized funds backed by assets, allowing users to manage assets and liquidity through functions like initialization, contribution, withdrawal, rebalancing, and token distribution.
+### Definitions
 
-#### Purpose
+- **Basket:** A collection of [ERC-20](./eip-20.md) tokens held at specified target weights, managed as a single unit.
+- **Constituent:** An [ERC-20](./eip-20.md) token held within a basket.
+- **Weight:** A constituent's target allocation in basis points (10000 = 100%). Weights are targets; actual reserves MAY diverge from weights at any time.
+- **Reserve:** The quantity of a constituent recognized by the basket for accounting purposes. This is the value returned by `getReserve()` and MAY differ from the raw `balanceOf(address(this))` if the implementation uses internal accounting.
+- **Owner:** The address returned by [ERC-173](./eip-173.md)'s `owner()`, with management authority over the basket.
 
-The purpose of the BTS is to allow anyone to build an on-chain tokenized fund that is fully asset backed using on-chain liquidity.
+### Interface
 
-#### Key Functions
+A conforming contract MUST implement [ERC-20](./eip-20.md) and the [ERC-20](./eip-20.md) metadata extensions (`name()`, `symbol()`, and `decimals()`), [ERC-165](./eip-165.md), [ERC-173](./eip-173.md), and the following interface. The contract's [ERC-20](./eip-20.md) supply represents shares, a proportional claim on the basket's reserves. Each contract manages exactly one basket. Implementations MAY additionally implement [EIP-2612](./eip-2612.md) for gasless approvals.
 
-`initialize`: Initializes a new BTS with name, symbol, creator, tokens, weights, token URI, and optional auto-rebalance setting.
+```solidity
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
 
-`contribute()`: Allows users to add ETH to the basket, purchasing proportional amounts of included tokens based on predefined weights.
+/// @title ERC-7621 Basket Token Standard
+/// @dev See https://eips.ethereum.org/EIPS/eip-7621
+///      Conforming contracts MUST also implement IERC20, IERC165, and IERC173.
+interface IERC7621 {
 
-`withdraw(uint256 _liquidity)`: Allows BTS LP holders to withdraw from the basket, receiving corresponding tokens.
+    // --- Errors ---
 
-`withdrawETH(uint256 _liquidity)`: Allows BTS LP holders to withdraw ETH from the basket, equivalent to the value of their BTS LP tokens.
+    /// @dev Array lengths do not match.
+    error LengthMismatch(uint256 expected, uint256 actual);
 
-`rebalance(address[] memory _newTokens, uint256[] memory _newWeights)`: The owner can manually adjust the types and weights of tokens in the basket.
+    /// @dev Weights do not sum to 10000.
+    error InvalidWeights(uint256 weightSum);
 
-`getTokenDetails`: Returns details of a token at a given index (address and weight).
+    /// @dev Amount is zero where a non-zero value is required.
+    error ZeroAmount();
 
-`totalTokens`: Returns the total number of tokens in the basket.
+    /// @dev Token is not a constituent of the basket.
+    error NotConstituent(address token);
 
-#### Distribution of BTS tokens
+    /// @dev Slippage tolerance exceeded on share minting.
+    error InsufficientShares(uint256 minimum, uint256 actual);
 
-The distribution of BTS tokens occurs during the mint function. The creator sends ETH to the contract, and the contract then swaps the ETH for user designated [ERC-20](./eip-20.md) tokens based on predefined weights. After the swaps, it mints a BTS token (NFT) for the sender using the initialize function of the BTS contract as well as BTS LP tokens. This BTS token is a representation of ownership and allows management of the BTS.
+    /// @dev Slippage tolerance exceeded on constituent withdrawal.
+    error InsufficientAmount(uint256 index, uint256 minimum, uint256 actual);
 
-#### Distribution of BTS LP tokens
+    /// @dev Duplicate constituent token address.
+    error DuplicateConstituent(address token);
 
-The distribution of BTS LP tokens occurs during the mint and contribute functions. After swapping ETH for the relevant [ERC-20](./eip-20.md) tokens, the contract mints BTS LP tokens (representing the user's share of the total BTS), and then mints BTS LP tokens using the mint function of the `BTSPair` contract. The BTS LP tokens represent the liquidity provided by the user to the specified BTS pair (`btsPair`). The distribution is logged through the `ContributedToBTS` event.
+    /// @dev Constituent address is the zero address.
+    error ZeroAddress();
 
-#### Burning the BTS LP tokens
+    // --- Events ---
 
-The burning of BTS LP tokens occurs during the `withdraw` function. Users can call this function, specifying the amount of BTS LP tokens they want to withdraw. The contract then transfers the specified amount of BTS LP tokens from the user to the BTS pair contract (`btsPair`). The burn function of the `IBTSPair` contract is called, which decreases the user's BTS LP token balance and returns an array of amounts representing the underlying tokens withdrawn. This array of amounts is logged through the `WithdrawnFromBTS` event.
+    /// @notice MUST be emitted when assets are contributed to the basket.
+    /// @param caller The address that called `contribute`.
+    /// @param receiver The address that received the minted shares.
+    /// @param lpAmount The number of shares minted.
+    /// @param amounts The constituent token amounts deposited.
+    event Contributed(
+        address indexed caller,
+        address indexed receiver,
+        uint256 lpAmount,
+        uint256[] amounts
+    );
 
-#### Events
+    /// @notice MUST be emitted when shares are burned and assets withdrawn.
+    /// @param caller The address that called `withdraw`.
+    /// @param receiver The address that received the constituent tokens.
+    /// @param lpAmount The number of shares burned.
+    /// @param amounts The constituent token amounts returned.
+    event Withdrawn(
+        address indexed caller,
+        address indexed receiver,
+        uint256 lpAmount,
+        uint256[] amounts
+    );
 
-`ContributedToBTS(address indexed bts, uint256 amount)`: Event when someone adds ETH to the basket.
+    /// @notice MUST be emitted when the constituent set or weights change.
+    /// @param newTokens The new constituent token addresses.
+    /// @param newWeights The new target weights in basis points.
+    event Rebalanced(address[] newTokens, uint256[] newWeights);
 
-`WithdrawnFromBTS(address indexed bts, uint256[] amounts)`: Event when BTS LP holder withdraws tokens from the basket.
+    // --- View Functions ---
 
-`WithdrawnETHFromBTS(address indexed bts, uint256 amount)`: Event when BTS LP holder withdraws ETH from the basket.
+    /// @notice Returns the constituent tokens and their target weights.
+    /// @dev The ordering of the returned arrays is stable between calls to
+    ///      `rebalance`. The `amounts` arrays in `contribute`, `withdraw`,
+    ///      and their preview counterparts MUST follow this same ordering.
+    /// @return tokens Constituent addresses.
+    /// @return weights Target weights in basis points, summing to 10000.
+    function getConstituents()
+        external view returns (address[] memory tokens, uint256[] memory weights);
 
-`RebalanceBTS(address indexed bts, uint256[] oldWeights, uint256[] newWeights)`: Event when the owner manually rebalances the basket.
+    /// @notice Returns the number of constituents.
+    /// @return count The number of constituent tokens.
+    function totalConstituents() external view returns (uint256 count);
 
-### `BTSPair`
+    /// @notice Returns the accounted reserve balance of a constituent.
+    /// @dev Returns the reserve recognized by the basket for share accounting,
+    ///      which MAY differ from `IERC20(token).balanceOf(address(this))`.
+    /// @param token The constituent token address.
+    /// @return balance The accounted reserve of `token`.
+    function getReserve(address token) external view returns (uint256 balance);
 
-#### Purpose
+    /// @notice Returns the target weight of a specific constituent.
+    /// @dev MUST revert with `NotConstituent` if `token` is not a constituent.
+    /// @param token The constituent token address.
+    /// @return weight The target weight in basis points.
+    function getWeight(address token) external view returns (uint256 weight);
 
-[ERC-20](./eip-20.md) token representing liquidity in a BTS.
+    /// @notice Returns whether an address is a current constituent.
+    /// @param token The token address to check.
+    /// @return True if `token` is a constituent.
+    function isConstituent(address token) external view returns (bool);
 
-#### Key Functions
+    /// @notice Returns the total basket value in the implementation's accounting unit.
+    /// @dev The accounting unit and valuation method are implementation-defined
+    ///      but MUST be deterministic and consistent with `previewContribute`.
+    ///      The returned value is only meaningful within this implementation's
+    ///      accounting model and MUST NOT be assumed comparable across
+    ///      different basket implementations.
+    /// @return value The total basket value in the implementation's unit.
+    function totalBasketValue() external view returns (uint256 value);
 
-`initialize`: Initializes a new `BTSPair` with a name and tokens.
+    // --- Actions ---
 
-`rebalance()`: Allows the owner to manually adjust the types and weights of tokens in the pair.
+    /// @notice Deposits constituent tokens and mints shares to `receiver`.
+    /// @dev The caller MUST have approved this contract to spend the required
+    ///      amounts of each constituent prior to calling.
+    ///      `amounts` MUST be ordered to match `getConstituents`.
+    ///      MUST emit `Contributed`.
+    ///      MUST revert with `LengthMismatch` if `amounts.length` does not
+    ///      equal `totalConstituents()`.
+    ///      MUST revert with `ZeroAmount` if all amounts are zero.
+    ///      MUST revert with `InsufficientShares` if shares minted is less
+    ///      than `minShares`.
+    ///      Shares minted MUST be monotonically non-decreasing with respect
+    ///      to amounts contributed — contributing more MUST NOT yield fewer shares.
+    ///      When rounding, MUST round shares minted down (favoring the basket).
+    /// @param amounts Ordered array of constituent token amounts to deposit.
+    /// @param receiver The address that will receive minted shares.
+    /// @param minShares Minimum acceptable shares to mint. Reverts if not met.
+    /// @return lpAmount Shares minted.
+    function contribute(uint256[] calldata amounts, address receiver, uint256 minShares)
+        external returns (uint256 lpAmount);
 
-`updateTokens(...)`: Allows the owner to change the types of tokens in the pair.
+    /// @notice Burns shares and transfers proportional reserves to `receiver`.
+    /// @dev MUST emit `Withdrawn`.
+    ///      MUST revert with `ZeroAmount` if `lpAmount` is zero.
+    ///      MUST revert if the caller holds fewer than `lpAmount` shares.
+    ///      MUST revert with `LengthMismatch` if `minAmounts.length` does not
+    ///      equal `totalConstituents()`.
+    ///      MUST revert with `InsufficientAmount` if any returned amount is
+    ///      less than the corresponding entry in `minAmounts`.
+    ///      For each constituent: `amount_i = reserve_i * lpAmount / totalSupply`,
+    ///      rounding down (favoring the basket).
+    ///      Shares MUST be burned before constituent tokens are transferred out.
+    /// @param lpAmount The number of shares to burn.
+    /// @param receiver The address that will receive constituent tokens.
+    /// @param minAmounts Minimum acceptable amounts per constituent. Reverts if not met.
+    /// @return amounts Constituent amounts returned, ordered by `getConstituents`.
+    function withdraw(uint256 lpAmount, address receiver, uint256[] calldata minAmounts)
+        external returns (uint256[] memory amounts);
 
-`mint(...)`: Creates new BTS LP tokens and adjusts token reserves.
+    /// @notice Updates the constituent set and target weights.
+    /// @dev MUST revert if caller is not `owner()` per ERC-173.
+    ///      MUST revert with `LengthMismatch` if array lengths differ.
+    ///      MUST revert with `InvalidWeights` if weights do not sum to 10000.
+    ///      MUST revert with `DuplicateConstituent` if `newTokens` contains duplicates.
+    ///      MUST revert with `ZeroAddress` if any entry in `newTokens` is `address(0)`.
+    ///      MUST emit `Rebalanced`.
+    ///      The standardized effect of this function is updating the constituent
+    ///      set and target weights. Any reserve realignment (swaps) is an
+    ///      implementation concern and MUST NOT be inferred by integrators
+    ///      from this call alone.
+    /// @param newTokens The new ordered set of constituent token addresses.
+    /// @param newWeights The new ordered set of target weights in basis points.
+    function rebalance(address[] calldata newTokens, uint256[] calldata newWeights)
+        external;
 
-`burn(...)`: Destroys BTS LP tokens and adjusts token reserves.
+    // --- Preview Functions ---
+
+    /// @notice Estimates shares that would be minted for given amounts.
+    /// @dev MUST return the same value as `contribute` would return if called
+    ///      in the same transaction. MUST NOT revert except for invalid inputs.
+    ///      MUST NOT vary by caller. MUST round down.
+    ///      MUST use the same valuation function as `contribute`.
+    /// @param amounts Ordered array of constituent token amounts.
+    /// @return lpAmount Estimated shares that would be minted.
+    function previewContribute(uint256[] calldata amounts)
+        external view returns (uint256 lpAmount);
+
+    /// @notice Estimates constituent amounts returned for burning shares.
+    /// @dev MUST return the same value as `withdraw` would return if called
+    ///      in the same transaction. MUST NOT revert except for invalid inputs.
+    ///      MUST round down.
+    /// @param lpAmount The number of shares to simulate burning.
+    /// @return amounts Estimated constituent amounts, ordered by `getConstituents`.
+    function previewWithdraw(uint256 lpAmount)
+        external view returns (uint256[] memory amounts);
+}
+```
+
+The `IERC7621` interface identifier is `0xc9c80f73`. Implementations MUST return `true` for this identifier via [ERC-165](./eip-165.md). Implementations MUST also return `true` for the [ERC-173](./eip-173.md) interface identifier (`0x7f5828d0`).
+
+### Ownership
+
+Basket ownership MUST conform to [ERC-173](./eip-173.md). The address returned by `owner()` is the only address authorized to call `rebalance`. Transferring ownership via `transferOwnership(address)` MUST emit the [ERC-173](./eip-173.md) `OwnershipTransferred` event. Implementations SHOULD also emit `OwnershipTransferred(address(0), initialOwner)` at contract creation, per ERC-173 convention.
+
+The standard does not prescribe how ownership is implemented internally. An [ERC-721](./eip-721.md) token backing the `owner()` return value, a multisig, a governance contract, or a simple storage variable are all valid. Implementations MAY use [ERC-721](./eip-721.md) to represent ownership when transferability of management rights on NFT marketplaces is desired.
+
+Share holders' claims MUST NOT be affected by ownership changes.
+
+If ownership is renounced via `transferOwnership(address(0))`, `rebalance` becomes permanently unavailable since no caller can satisfy the `owner()` check. Implementations that wish to prevent permanent lockout SHOULD restrict or override renunciation behavior.
+
+### Weight Encoding
+
+Weights MUST be expressed in basis points (10000 = 100%). The sum of all constituent weights MUST equal 10000. Implementations MUST NOT allow constituents with zero weight; remove them instead.
+
+Weights are informational targets and MUST NOT be assumed to reflect current reserve ratios. Actual reserves MAY diverge from targets between rebalances, during contributions, and during withdrawals. `getConstituents()` returns target weights; `getReserve()` returns accounted reserves recognized by the implementation.
+
+### Constituent Constraints
+
+Constituent token addresses MUST be unique within a basket; duplicates are not permitted. Constituent addresses MUST NOT be `address(0)`. These constraints MUST be enforced during `rebalance` and during initialization.
+
+### Constituent Ordering
+
+The order of constituent tokens returned by `getConstituents()` MUST be stable between calls to `rebalance`. The `amounts` arrays passed to `contribute` and returned by `withdraw` (and their preview counterparts) MUST follow this same ordering. After a `rebalance`, the ordering is determined by the `newTokens` array provided.
+
+### Valuation
+
+Implementations MUST define a deterministic function mapping current reserves to a total basket value, reported by `totalBasketValue()`. Shares minted during contribution MUST be proportional to the value contributed relative to this total. The standard does not prescribe the valuation function (summing reserve balances, querying oracles, and using time-weighted prices are all valid approaches), but the function MUST be deterministic and MUST be the same function used by `previewContribute`.
+
+### Contribution Mechanics
+
+Shares minted MUST be monotonically non-decreasing with respect to amounts contributed; contributing more of any constituent MUST NOT result in fewer shares.
+
+When rounding, implementations MUST round shares minted down (favoring the basket over the contributor). This matches [ERC-4626](./eip-4626.md)'s rounding convention.
+
+### Withdrawal Mechanics
+
+Constituent amounts returned during withdrawal MUST be proportional to the shares burned relative to total supply. For each constituent:
+
+```
+amount_i = reserve_i * lpAmount / totalSupply
+```
+
+When rounding, implementations MUST round amounts down (favoring the basket over the withdrawer).
+
+If `totalSupply()` is zero, `withdraw` MUST revert.
+
+### Initialization
+
+When `totalSupply()` is zero (empty basket), the implementation MUST mint shares according to a deterministic initialization rule. That rule MUST be the same rule used by `previewContribute` in the same state, and MUST NOT vary by caller. Implementations SHOULD document their initialization rule and SHOULD mitigate first-depositor inflation attacks using dead shares, virtual shares, or an equivalent mechanism.
+
+### Edge Cases
+
+- `contribute` with all-zero amounts MUST revert with `ZeroAmount`.
+- `withdraw` with zero `lpAmount` MUST revert with `ZeroAmount`.
+- `previewContribute` and `previewWithdraw` with zero inputs MUST return zero, not revert.
+- `getReserve` for a non-constituent token MUST return zero.
+- `getWeight` for a non-constituent token MUST revert with `NotConstituent`.
+
+### Scope and Non-Goals
+
+This standard covers:
+
+- An [ERC-20](./eip-20.md) share token representing proportional claims on a managed basket of [ERC-20](./eip-20.md) constituents.
+- First-class target weights as standardized, queryable state.
+- Owner-managed constituent set and weight changes via `rebalance`.
+- Multi-asset contribution, proportional withdrawal, and slippage protection.
+- Preview functions for user interfaces and integrators.
+
+This standard does not cover:
+
+- Swap execution or routing during rebalancing.
+- Oracle design or pricing methodology.
+- Fee models (management fees, performance fees, entry/exit fees).
+- Cross-implementation value comparability (`totalBasketValue()` is meaningful only within a single implementation's accounting model).
+- Multi-vault or multi-basket lookup registries.
+- Externalized share-token architectures (the basket contract IS the share token).
 
 ## Rationale
 
-<!-- TODO -->
+### Relationship to ERC-4626 and ERC-7575
+
+[ERC-4626](./eip-4626.md) standardizes single-asset vaults with `deposit(assets, receiver)` and `withdraw(assets, receiver, owner)`. [ERC-7575](./eip-7575.md) extends that model to multi-asset vault entry points while preserving ERC-4626 share semantics. We considered extending either, but manager-rebalanced weighted baskets diverge from both:
+
+- Contributions involve multiple tokens at specified ratios, not a single underlying asset or a set of independent entry points.
+- Withdrawals return multiple tokens proportionally, not a single asset.
+- Rebalancing (changing the constituent set and weights over time) has no analogue in ERC-4626 or ERC-7575.
+- Weights as explicit interface elements (target allocations that an owner actively manages) are not part of either standard.
+- The `convertToShares` / `convertToAssets` model assumes a single exchange rate. Baskets have N exchange rates, one per constituent.
+
+A separate standard with a dedicated multi-asset, manager-rebalanced model is more appropriate than overloading existing vault semantics.
+
+That said, we follow ERC-4626's conventions where they apply: the contract is itself the share token ([ERC-20](./eip-20.md)), preview functions provide read-only estimates, rounding favors the contract over the user, and `totalBasketValue()` serves a role analogous to `totalAssets()`.
+
+ERC-7621 is not an alternative implementation of [ERC-4626](./eip-4626.md) or [ERC-7575](./eip-7575.md). Those standards center vault accounting and asset entry points. ERC-7621 centers managed basket composition as a standardized state surface: constituent membership, target weights, and owner-driven rebalancing are explicit interface elements with no equivalent in either vault standard.
+
+| Dimension | ERC-4626 | ERC-7575 | ERC-7621 |
+|---|---|---|---|
+| Asset model | Single underlying | Multiple entry points, single share | Multiple constituents with target weights |
+| Composition state | N/A | N/A | `getConstituents()`, `getWeight()`, `isConstituent()` |
+| Composition mutation | N/A | N/A | `rebalance()` — owner changes constituents and weights |
+| Deposit | Single asset `deposit(assets, receiver)` | Per-asset entry points | Multi-asset `contribute(amounts[], receiver, minShares)` |
+| Withdrawal | Single asset `withdraw(assets, receiver, owner)` | Per-asset exit points | Proportional multi-asset `withdraw(lpAmount, receiver, minAmounts[])` |
+| Slippage protection | None (added by ERC-5143) | None | Built-in `minShares` / `minAmounts` |
+| Management role | Not standardized | Not standardized | `owner()` via ERC-173 |
+
+### Ownership via ERC-173
+
+Rather than defining a custom ownership accessor, this standard reuses [ERC-173](./eip-173.md) which already standardizes `owner()`, `transferOwnership(address)`, and `OwnershipTransferred`. Registries, wallets, and UIs that recognize ERC-173 will work with basket tokens without custom integration.
+
+The standard does not mandate the internal ownership mechanism. An implementation backed by an [ERC-721](./eip-721.md) token can implement `owner()` as `IERC721(nftContract).ownerOf(tokenId)` and `transferOwnership` as an NFT transfer. A simple `Ownable` contract works equally well. This flexibility is important because basket governance varies in practice: single EOAs, multisigs, DAOs, and NFT-based ownership are all in production use.
+
+### Slippage Protection
+
+The `minShares` parameter on `contribute` and `minAmounts` parameter on `withdraw` provide on-chain slippage protection. [ERC-4626](./eip-4626.md) omitted these, and [ERC-5143](./eip-5143.md) was later created specifically to add them. As with ERC-5143's extension of ERC-4626, ERC-7621 includes slippage protection in the base interface because baskets are sensitive to execution drift across multiple assets. Including it avoids the need for a follow-on ERC and makes the interface safer for direct EOA interaction.
+
+### Preview Functions
+
+Following [ERC-4626](./eip-4626.md)'s convention, `previewContribute` and `previewWithdraw` provide estimates for display and integration logic. They MUST return values matching what the corresponding action function would return if called in the same transaction, but MAY differ from actual results if state changes between the preview call and the action call.
+
+### Weights as Targets
+
+Weights represent the basket's intended allocation, not a guarantee about current reserves. After a contribution or withdrawal, actual reserve ratios will differ from target weights. After a `rebalance`, reserves may or may not be realigned depending on the implementation. This is intentional. Mandating immediate reserve alignment would require the standard to specify swap execution, which varies too widely across implementations (AMM routing, off-chain signatures, aggregator calls) to standardize.
+
+### Rebalance Semantics
+
+The standardized effect of `rebalance` is updating the constituent set and target weights. Any reserve realignment (executing swaps to match new weights) is an implementation concern. Integrators MUST NOT assume that a `rebalance` call results in reserves matching the new weights; it may only update targets, with reserve alignment deferred to future contributions and withdrawals, or through a separate implementation-specific mechanism. Accordingly, `rebalance` standardizes changes to intended composition, not execution strategy.
 
 ## Backwards Compatibility
 
-No backward compatibility issues found.
+This standard introduces a new interface and is not backwards compatible with any existing ERC. It extends [ERC-20](./eip-20.md) without modifying it and reuses [ERC-173](./eip-173.md) for ownership. Basket tokens are standard [ERC-20](./eip-20.md) tokens and work with all existing [ERC-20](./eip-20.md) infrastructure.
 
 ## Reference Implementation
 
-`BTS`: Implemented using a combination of OpenZeppelin's [ERC-721](./eip-721.md) `URIStorage` and `Ownable` contracts, along with custom logic for token management and rebalancing.
+A minimal reference implementation is provided in `../assets/erc-7621/`. It includes:
 
-`Factory`: Implemented using `ClonesUpgradeable` to deploy new `BTS` and `BTSPair` contracts.
+- `BasketToken.sol` — a single-basket implementation using direct [ERC-20](./eip-20.md) token deposits
+- `BasketFactory.sol` — a factory for deploying baskets
 
-`BTSPair`: Implemented using [ERC-20](./eip-20.md) `Upgradeable` and `Ownable` contracts, along with custom logic for liquidity tracking and rebalancing.
+The reference implementation is intentionally minimal. It does not include swap routing, fee collection, oracle integration, or advanced inflation-attack mitigations. These are production concerns, not interface concerns.
 
-`IUniswap`: Not implemented, as it only defines interfaces for external contracts.
+## Test Cases
 
-<!-- TODO: Remove this section or actually add the code (here or in your assets directory.) -->
+Test cases are provided in `../assets/erc-7621/test/`. Key scenarios covered:
+
+- Contribution mints shares proportionally and emits `Contributed` with caller, receiver, amounts
+- Contribution reverts with `InsufficientShares` when shares minted is below `minShares`
+- Withdrawal burns shares, returns proportional constituents, and emits `Withdrawn` with caller, receiver
+- Withdrawal reverts with `InsufficientAmount` when any returned amount is below `minAmounts`
+- Withdrawal reverts with `LengthMismatch` when `minAmounts` length mismatches constituents
+- Rebalance with duplicate constituent addresses reverts with `DuplicateConstituent`
+- Rebalance with zero-address constituent reverts with `ZeroAddress`
+- Withdrawal with rounding returns amounts that round down
+- Rebalance by `owner()` updates constituents and emits `Rebalanced`
+- Rebalance by non-owner reverts
+- Rebalance with invalid weight sum reverts with `InvalidWeights`
+- Contribution with mismatched array length reverts with `LengthMismatch`
+- Zero-amount contribution reverts with `ZeroAmount`
+- Zero-amount withdrawal reverts with `ZeroAmount`
+- Preview functions return values consistent with action functions
+- `getReserve` returns zero for non-constituent tokens
+- `getWeight` reverts with `NotConstituent` for non-constituent tokens
+- `getConstituents` ordering is stable across calls
+- `totalBasketValue` is consistent with `previewContribute`
+- `owner()` and `transferOwnership()` conform to ERC-173
+- First contribution to empty basket mints shares deterministically
+- Ownership renunciation makes `rebalance` permanently unavailable
+- Contract creation emits `OwnershipTransferred(address(0), initialOwner)` per ERC-173 convention
 
 ## Security Considerations
 
-<!-- TODO -->
+### Reentrancy
+
+`contribute`, `withdraw`, and `rebalance` make external calls to [ERC-20](./eip-20.md) token contracts. Implementations MUST use reentrancy guards or follow checks-effects-interactions. The `withdraw` function is especially sensitive; shares MUST be burned before constituent tokens are transferred out.
+
+### First-Contributor Manipulation
+
+The first contributor to an empty basket controls the initial share-to-reserve exchange rate and can manipulate it to extract value from subsequent contributors. This is the same inflation attack described in [ERC-4626](./eip-4626.md). Implementations SHOULD mint a minimum amount of shares to a dead address on first contribution, or use virtual shares.
+
+### Rebalancing Front-Running
+
+Rebalancing transactions are visible in the mempool and reveal the intended weight changes. If the implementation executes swaps during `rebalance`, those trades will be sandwiched. Implementations that execute swaps during `rebalance` SHOULD use private mempools, commit-reveal schemes, or off-chain routing with signature verification. Enforcing slippage limits on rebalancing swaps is also recommended.
+
+### Owner Trust
+
+Share holders trust the basket owner to rebalance responsibly. The owner can change constituents to illiquid or worthless tokens, or trigger rebalancing at unfavorable prices. This trust assumption is inherent to the model. Implementations MAY add timelocks, governance voting, or maximum-slippage constraints to reduce this trust assumption, but these are not required by the standard.
+
+### Donation Attacks
+
+Tokens sent directly to the basket contract (outside of `contribute`) can skew the relationship between tracked reserves and actual balances. Implementations SHOULD track reserves via internal accounting rather than relying on `balanceOf(address(this))`, and SHOULD ignore tokens received outside the standard contribution flow.
+
+### Fee-on-Transfer and Rebasing Tokens
+
+Baskets that track reserves via internal accounting will desync if a constituent charges transfer fees or rebases. Implementations that allow arbitrary constituents SHOULD check actual received balances after each transfer rather than trusting the transfer amount.
+
+### Poisoned Constituents
+
+A constituent token with blacklist, pause, or other transfer-restriction functionality can freeze basket withdrawals entirely. If any single constituent cannot be transferred out, `withdraw` reverts for all holders. Implementations SHOULD consider maintaining an allowlist of acceptable constituent tokens, or implement a partial-withdrawal mechanism that skips non-transferable constituents.
+
+### Preview Function Safety
+
+`previewContribute` and `previewWithdraw` are manipulable by altering on-chain state (e.g., donating tokens to the basket). They SHOULD NOT be used as price oracles. Integrators that need manipulation-resistant pricing SHOULD use external oracles or time-weighted calculations.
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](../LICENSE.md).
+Copyright and related rights waived via [CC0](/LICENSE).

--- a/ERCS/erc-7621.md
+++ b/ERCS/erc-7621.md
@@ -1,7 +1,7 @@
 ---
 eip: 7621
 title: Basket Token
-description: A multi-asset token standard with weighted constituents and owner-managed rebalancing.
+description: A multi-asset basket token with weighted constituents and owner-managed rebalancing.
 author: Callum Mitchell-Clark (@AlvaraProtocol) <cal@alvara.xyz>, Dominic Ryder <dom@alvara.xyz>, Michael Ryder <mike@alvara.xyz>
 discussions-to: https://ethereum-magicians.org/t/erc-7621-basket-token-revised/28050
 status: Draft
@@ -307,13 +307,13 @@ This standard does not cover:
 
 ## Rationale
 
-### Relationship to ERC-4626 and ERC-7575
+### Relationship to [ERC-4626](./eip-4626.md) and [ERC-7575](./eip-7575.md)
 
 [ERC-4626](./eip-4626.md) standardizes single-asset vaults with `deposit(assets, receiver)` and `withdraw(assets, receiver, owner)`. [ERC-7575](./eip-7575.md) extends that model to multi-asset vault entry points while preserving ERC-4626 share semantics. We considered extending either, but manager-rebalanced weighted baskets diverge from both:
 
 - Contributions involve multiple tokens at specified ratios, not a single underlying asset or a set of independent entry points.
 - Withdrawals return multiple tokens proportionally, not a single asset.
-- Rebalancing (changing the constituent set and weights over time) has no analogue in ERC-4626 or ERC-7575.
+- Rebalancing (changing the constituent set and weights over time) has no analogue in [ERC-4626](./eip-4626.md) or [ERC-7575](./eip-7575.md).
 - Weights as explicit interface elements (target allocations that an owner actively manages) are not part of either standard.
 - The `convertToShares` / `convertToAssets` model assumes a single exchange rate. Baskets have N exchange rates, one per constituent.
 
@@ -321,19 +321,19 @@ A separate standard with a dedicated multi-asset, manager-rebalanced model is mo
 
 That said, we follow ERC-4626's conventions where they apply: the contract is itself the share token ([ERC-20](./eip-20.md)), preview functions provide read-only estimates, rounding favors the contract over the user, and `totalBasketValue()` serves a role analogous to `totalAssets()`.
 
-ERC-7621 is not an alternative implementation of [ERC-4626](./eip-4626.md) or [ERC-7575](./eip-7575.md). Those standards center vault accounting and asset entry points. ERC-7621 centers managed basket composition as a standardized state surface: constituent membership, target weights, and owner-driven rebalancing are explicit interface elements with no equivalent in either vault standard.
+[ERC-7621](./eip-7621.md) is not an alternative implementation of [ERC-4626](./eip-4626.md) or [ERC-7575](./eip-7575.md). Those standards center vault accounting and asset entry points. [ERC-7621](./eip-7621.md) centers managed basket composition as a standardized state surface: constituent membership, target weights, and owner-driven rebalancing are explicit interface elements with no equivalent in either vault standard.
 
-| Dimension | ERC-4626 | ERC-7575 | ERC-7621 |
+| Dimension | [ERC-4626](./eip-4626.md) | [ERC-7575](./eip-7575.md) | [ERC-7621](./eip-7621.md) |
 |---|---|---|---|
 | Asset model | Single underlying | Multiple entry points, single share | Multiple constituents with target weights |
 | Composition state | N/A | N/A | `getConstituents()`, `getWeight()`, `isConstituent()` |
 | Composition mutation | N/A | N/A | `rebalance()` — owner changes constituents and weights |
 | Deposit | Single asset `deposit(assets, receiver)` | Per-asset entry points | Multi-asset `contribute(amounts[], receiver, minShares)` |
 | Withdrawal | Single asset `withdraw(assets, receiver, owner)` | Per-asset exit points | Proportional multi-asset `withdraw(lpAmount, receiver, minAmounts[])` |
-| Slippage protection | None (added by ERC-5143) | None | Built-in `minShares` / `minAmounts` |
-| Management role | Not standardized | Not standardized | `owner()` via ERC-173 |
+| Slippage protection | None (added by [ERC-5143](./eip-5143.md)) | None | Built-in `minShares` / `minAmounts` |
+| Management role | Not standardized | Not standardized | `owner()` via [ERC-173](./eip-173.md) |
 
-### Ownership via ERC-173
+### Ownership via [ERC-173](./eip-173.md)
 
 Rather than defining a custom ownership accessor, this standard reuses [ERC-173](./eip-173.md) which already standardizes `owner()`, `transferOwnership(address)`, and `OwnershipTransferred`. Registries, wallets, and UIs that recognize ERC-173 will work with basket tokens without custom integration.
 
@@ -341,7 +341,7 @@ The standard does not mandate the internal ownership mechanism. An implementatio
 
 ### Slippage Protection
 
-The `minShares` parameter on `contribute` and `minAmounts` parameter on `withdraw` provide on-chain slippage protection. [ERC-4626](./eip-4626.md) omitted these, and [ERC-5143](./eip-5143.md) was later created specifically to add them. As with ERC-5143's extension of ERC-4626, ERC-7621 includes slippage protection in the base interface because baskets are sensitive to execution drift across multiple assets. Including it avoids the need for a follow-on ERC and makes the interface safer for direct EOA interaction.
+The `minShares` parameter on `contribute` and `minAmounts` parameter on `withdraw` provide on-chain slippage protection. [ERC-4626](./eip-4626.md) omitted these, and [ERC-5143](./eip-5143.md) was later created specifically to add them. As with [ERC-5143](./eip-5143.md)'s extension of [ERC-4626](./eip-4626.md), [ERC-7621](./eip-7621.md) includes slippage protection in the base interface because baskets are sensitive to execution drift across multiple assets. Including it avoids the need for a follow-on ERC and makes the interface safer for direct EOA interaction.
 
 ### Preview Functions
 
@@ -359,18 +359,9 @@ The standardized effect of `rebalance` is updating the constituent set and targe
 
 This standard introduces a new interface and is not backwards compatible with any existing ERC. It extends [ERC-20](./eip-20.md) without modifying it and reuses [ERC-173](./eip-173.md) for ownership. Basket tokens are standard [ERC-20](./eip-20.md) tokens and work with all existing [ERC-20](./eip-20.md) infrastructure.
 
-## Reference Implementation
-
-A minimal reference implementation is provided in `../assets/erc-7621/`. It includes:
-
-- `BasketToken.sol` — a single-basket implementation using direct [ERC-20](./eip-20.md) token deposits
-- `BasketFactory.sol` — a factory for deploying baskets
-
-The reference implementation is intentionally minimal. It does not include swap routing, fee collection, oracle integration, or advanced inflation-attack mitigations. These are production concerns, not interface concerns.
-
 ## Test Cases
 
-Test cases are provided in `../assets/erc-7621/test/`. Key scenarios covered:
+Test cases are provided in the assets directory. Key scenarios covered:
 
 - Contribution mints shares proportionally and emits `Contributed` with caller, receiver, amounts
 - Contribution reverts with `InsufficientShares` when shares minted is below `minShares`
@@ -391,10 +382,19 @@ Test cases are provided in `../assets/erc-7621/test/`. Key scenarios covered:
 - `getWeight` reverts with `NotConstituent` for non-constituent tokens
 - `getConstituents` ordering is stable across calls
 - `totalBasketValue` is consistent with `previewContribute`
-- `owner()` and `transferOwnership()` conform to ERC-173
+- `owner()` and `transferOwnership()` conform to [ERC-173](./eip-173.md)
 - First contribution to empty basket mints shares deterministically
 - Ownership renunciation makes `rebalance` permanently unavailable
-- Contract creation emits `OwnershipTransferred(address(0), initialOwner)` per ERC-173 convention
+- Contract creation emits `OwnershipTransferred(address(0), initialOwner)` per [ERC-173](./eip-173.md) convention
+
+## Reference Implementation
+
+A minimal reference implementation is provided in the assets directory. It includes:
+
+- `BasketToken.sol` — a single-basket implementation using direct [ERC-20](./eip-20.md) token deposits
+- `BasketFactory.sol` — a factory for deploying baskets
+
+The reference implementation is intentionally minimal. It does not include swap routing, fee collection, oracle integration, or advanced inflation-attack mitigations. These are production concerns, not interface concerns.
 
 ## Security Considerations
 
@@ -432,4 +432,4 @@ A constituent token with blacklist, pause, or other transfer-restriction functio
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](/LICENSE).
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-7621.md
+++ b/ERCS/erc-7621.md
@@ -323,15 +323,11 @@ That said, we follow ERC-4626's conventions where they apply: the contract is it
 
 [ERC-7621](./eip-7621.md) is not an alternative implementation of [ERC-4626](./eip-4626.md) or [ERC-7575](./eip-7575.md). Those standards center vault accounting and asset entry points. [ERC-7621](./eip-7621.md) centers managed basket composition as a standardized state surface: constituent membership, target weights, and owner-driven rebalancing are explicit interface elements with no equivalent in either vault standard.
 
-| Dimension | [ERC-4626](./eip-4626.md) | [ERC-7575](./eip-7575.md) | [ERC-7621](./eip-7621.md) |
-|---|---|---|---|
-| Asset model | Single underlying | Multiple entry points, single share | Multiple constituents with target weights |
-| Composition state | N/A | N/A | `getConstituents()`, `getWeight()`, `isConstituent()` |
-| Composition mutation | N/A | N/A | `rebalance()` — owner changes constituents and weights |
-| Deposit | Single asset `deposit(assets, receiver)` | Per-asset entry points | Multi-asset `contribute(amounts[], receiver, minShares)` |
-| Withdrawal | Single asset `withdraw(assets, receiver, owner)` | Per-asset exit points | Proportional multi-asset `withdraw(lpAmount, receiver, minAmounts[])` |
-| Slippage protection | None (added by [ERC-5143](./eip-5143.md)) | None | Built-in `minShares` / `minAmounts` |
-| Management role | Not standardized | Not standardized | `owner()` via [ERC-173](./eip-173.md) |
+**[ERC-4626](./eip-4626.md):** Single underlying asset. Deposit and withdrawal operate on one asset via `deposit(assets, receiver)` and `withdraw(assets, receiver, owner)`. No composition state, no composition mutation, no management role. Slippage protection was omitted and later addressed by [ERC-5143](./eip-5143.md).
+
+**[ERC-7575](./eip-7575.md):** Multiple entry points sharing a single share token. Per-asset deposit and withdrawal. No composition state, no composition mutation, no management role. No slippage protection.
+
+**[ERC-7621](./eip-7621.md):** Multiple constituents with target weights. Composition is queryable via `getConstituents()`, `getWeight()`, and `isConstituent()`. Composition is mutable via `rebalance()`, restricted to `owner()` per [ERC-173](./eip-173.md). Multi-asset deposit via `contribute(amounts[], receiver, minShares)` and proportional multi-asset withdrawal via `withdraw(lpAmount, receiver, minAmounts[])`. Slippage protection is built in.
 
 ### Ownership via [ERC-173](./eip-173.md)
 

--- a/assets/erc-7621/contracts/BasketFactory.sol
+++ b/assets/erc-7621/contracts/BasketFactory.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import {BasketToken} from "./BasketToken.sol";
+
+/**
+ * @title BasketFactory
+ * @notice Factory for deploying ERC-7621 BasketToken instances.
+ */
+contract BasketFactory {
+
+    event BasketCreated(
+        address indexed basket,
+        address indexed creator,
+        address[] tokens,
+        uint256[] weights
+    );
+
+    address[] private _baskets;
+
+    function createBasket(
+        string calldata name,
+        string calldata symbol,
+        address[] calldata tokens,
+        uint256[] calldata weights
+    ) external returns (address basket) {
+        BasketToken b = new BasketToken(name, symbol, msg.sender, tokens, weights);
+        basket = address(b);
+        _baskets.push(basket);
+        emit BasketCreated(basket, msg.sender, tokens, weights);
+    }
+
+    function totalBaskets() external view returns (uint256) {
+        return _baskets.length;
+    }
+
+    function getBasket(uint256 index) external view returns (address) {
+        return _baskets[index];
+    }
+}

--- a/assets/erc-7621/contracts/BasketToken.sol
+++ b/assets/erc-7621/contracts/BasketToken.sol
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {IERC7621} from "./interfaces/IERC7621.sol";
+
+/**
+ * @title BasketToken
+ * @notice Minimal reference implementation of ERC-7621.
+ * @dev The basket contract IS the ERC-20 share token. Ownership follows ERC-173.
+ *      Valuation uses sum-of-reserves (no oracle). First deposit mints dead shares
+ *      to mitigate inflation attacks.
+ */
+contract BasketToken is ERC20, IERC7621, IERC165, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // --- Constants ---
+
+    uint256 public constant BASIS_POINTS = 10000;
+    uint256 public constant DEAD_SHARES = 1000;
+    address public constant DEAD_ADDRESS = address(0xdead);
+
+    // --- Storage ---
+
+    address private _owner;
+    address[] private _tokens;
+    mapping(address => uint256) private _weights;
+    mapping(address => uint256) private _reserves;
+    mapping(address => bool) private _isConstituent;
+
+    // --- ERC-173 Events ---
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    // --- ERC-173 Errors ---
+
+    error Unauthorized();
+
+    // --- Constructor ---
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        address initialOwner,
+        address[] memory tokens,
+        uint256[] memory weights
+    ) ERC20(name_, symbol_) {
+        if (tokens.length != weights.length) {
+            revert LengthMismatch(tokens.length, weights.length);
+        }
+
+        _validateConstituents(tokens, weights);
+        _setConstituents(tokens, weights);
+
+        _owner = initialOwner;
+        emit OwnershipTransferred(address(0), initialOwner);
+    }
+
+    // --- ERC-173 ---
+
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    function transferOwnership(address newOwner) external {
+        if (msg.sender != _owner) revert Unauthorized();
+        address previous = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(previous, newOwner);
+    }
+
+    // --- ERC-165 ---
+
+    function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
+        return
+            interfaceId == 0xc9c80f73 || // IERC7621
+            interfaceId == 0x7f5828d0 || // IERC173
+            interfaceId == 0x01ffc9a7;   // IERC165
+    }
+
+    // --- View Functions ---
+
+    function getConstituents()
+        external view override returns (address[] memory tokens, uint256[] memory weights)
+    {
+        uint256 len = _tokens.length;
+        tokens = new address[](len);
+        weights = new uint256[](len);
+        for (uint256 i = 0; i < len; i++) {
+            tokens[i] = _tokens[i];
+            weights[i] = _weights[_tokens[i]];
+        }
+    }
+
+    function totalConstituents() external view override returns (uint256) {
+        return _tokens.length;
+    }
+
+    function getReserve(address token) external view override returns (uint256) {
+        return _reserves[token];
+    }
+
+    function getWeight(address token) external view override returns (uint256) {
+        if (!_isConstituent[token]) revert NotConstituent(token);
+        return _weights[token];
+    }
+
+    function isConstituent(address token) external view override returns (bool) {
+        return _isConstituent[token];
+    }
+
+    function totalBasketValue() public view override returns (uint256 value) {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            value += _reserves[_tokens[i]];
+        }
+    }
+
+    // --- Actions ---
+
+    function contribute(
+        uint256[] calldata amounts,
+        address receiver,
+        uint256 minShares
+    ) external override nonReentrant returns (uint256 lpAmount) {
+        uint256 len = _tokens.length;
+        if (amounts.length != len) revert LengthMismatch(len, amounts.length);
+
+        lpAmount = _calculateContribution(amounts);
+        if (lpAmount == 0) revert ZeroAmount();
+        if (lpAmount < minShares) revert InsufficientShares(minShares, lpAmount);
+
+        bool isFirst = totalSupply() == 0;
+
+        // Transfer tokens in and update reserves
+        for (uint256 i = 0; i < len; i++) {
+            if (amounts[i] > 0) {
+                IERC20(_tokens[i]).safeTransferFrom(msg.sender, address(this), amounts[i]);
+                _reserves[_tokens[i]] += amounts[i];
+            }
+        }
+
+        // Mint dead shares on first deposit to mitigate inflation attacks
+        if (isFirst) {
+            _mint(DEAD_ADDRESS, DEAD_SHARES);
+        }
+
+        _mint(receiver, lpAmount);
+
+        emit Contributed(msg.sender, receiver, lpAmount, amounts);
+    }
+
+    function withdraw(
+        uint256 lpAmount,
+        address receiver,
+        uint256[] calldata minAmounts
+    ) external override nonReentrant returns (uint256[] memory amounts) {
+        if (lpAmount == 0) revert ZeroAmount();
+        uint256 len = _tokens.length;
+        if (minAmounts.length != len) revert LengthMismatch(len, minAmounts.length);
+
+        uint256 supply = totalSupply();
+        amounts = new uint256[](len);
+
+        for (uint256 i = 0; i < len; i++) {
+            amounts[i] = (_reserves[_tokens[i]] * lpAmount) / supply;
+            if (amounts[i] < minAmounts[i]) {
+                revert InsufficientAmount(i, minAmounts[i], amounts[i]);
+            }
+        }
+
+        // Burn before transfer (checks-effects-interactions)
+        _burn(msg.sender, lpAmount);
+
+        for (uint256 i = 0; i < len; i++) {
+            if (amounts[i] > 0) {
+                _reserves[_tokens[i]] -= amounts[i];
+                IERC20(_tokens[i]).safeTransfer(receiver, amounts[i]);
+            }
+        }
+
+        emit Withdrawn(msg.sender, receiver, lpAmount, amounts);
+    }
+
+    function rebalance(
+        address[] calldata newTokens,
+        uint256[] calldata newWeights
+    ) external override {
+        if (msg.sender != _owner) revert Unauthorized();
+        if (newTokens.length != newWeights.length) {
+            revert LengthMismatch(newTokens.length, newWeights.length);
+        }
+
+        _validateConstituents(newTokens, newWeights);
+
+        // Clear old constituent state
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            address token = _tokens[i];
+            delete _weights[token];
+            delete _isConstituent[token];
+        }
+        delete _tokens;
+
+        _setConstituents(newTokens, newWeights);
+
+        emit Rebalanced(newTokens, newWeights);
+    }
+
+    // --- Preview Functions ---
+
+    function previewContribute(uint256[] calldata amounts)
+        external view override returns (uint256 lpAmount)
+    {
+        if (amounts.length != _tokens.length) {
+            revert LengthMismatch(_tokens.length, amounts.length);
+        }
+
+        // Zero inputs return zero
+        bool allZero = true;
+        for (uint256 i = 0; i < amounts.length; i++) {
+            if (amounts[i] > 0) { allZero = false; break; }
+        }
+        if (allZero) return 0;
+
+        return _calculateContribution(amounts);
+    }
+
+    function previewWithdraw(uint256 lpAmount)
+        external view override returns (uint256[] memory amounts)
+    {
+        uint256 len = _tokens.length;
+        amounts = new uint256[](len);
+
+        uint256 supply = totalSupply();
+        if (supply == 0 || lpAmount == 0) return amounts;
+
+        for (uint256 i = 0; i < len; i++) {
+            amounts[i] = (_reserves[_tokens[i]] * lpAmount) / supply;
+        }
+    }
+
+    // --- Internal ---
+
+    function _calculateContribution(uint256[] calldata amounts)
+        internal view returns (uint256 lpAmount)
+    {
+        uint256 supply = totalSupply();
+
+        if (supply == 0) {
+            // First deposit: shares = sum of amounts, minus dead shares
+            uint256 total;
+            for (uint256 i = 0; i < amounts.length; i++) {
+                total += amounts[i];
+            }
+            if (total <= DEAD_SHARES) return 0;
+            return total - DEAD_SHARES;
+        }
+
+        // Subsequent deposits: proportional to minimum ratio across constituents
+        uint256 minRatio = type(uint256).max;
+        bool hasRatio = false;
+
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            uint256 reserve = _reserves[_tokens[i]];
+            if (reserve > 0 && amounts[i] > 0) {
+                uint256 ratio = (amounts[i] * 1e18) / reserve;
+                if (ratio < minRatio) {
+                    minRatio = ratio;
+                }
+                hasRatio = true;
+            }
+        }
+
+        if (!hasRatio) return 0;
+
+        lpAmount = (supply * minRatio) / 1e18;
+    }
+
+    function _validateConstituents(
+        address[] memory tokens,
+        uint256[] memory weights
+    ) internal pure {
+        uint256 totalWeight;
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (tokens[i] == address(0)) revert ZeroAddress();
+            for (uint256 j = 0; j < i; j++) {
+                if (tokens[i] == tokens[j]) revert DuplicateConstituent(tokens[i]);
+            }
+            totalWeight += weights[i];
+        }
+        if (totalWeight != BASIS_POINTS) revert InvalidWeights(totalWeight);
+    }
+
+    function _setConstituents(
+        address[] memory tokens,
+        uint256[] memory weights
+    ) internal {
+        for (uint256 i = 0; i < tokens.length; i++) {
+            _tokens.push(tokens[i]);
+            _weights[tokens[i]] = weights[i];
+            _isConstituent[tokens[i]] = true;
+        }
+    }
+}

--- a/assets/erc-7621/contracts/interfaces/IERC7621.sol
+++ b/assets/erc-7621/contracts/interfaces/IERC7621.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+/// @title ERC-7621 Basket Token Standard
+/// @dev See https://eips.ethereum.org/EIPS/eip-7621
+///      Conforming contracts MUST also implement IERC20, IERC165, and IERC173.
+interface IERC7621 {
+
+    // --- Errors ---
+
+    /// @dev Array lengths do not match.
+    error LengthMismatch(uint256 expected, uint256 actual);
+
+    /// @dev Weights do not sum to 10000.
+    error InvalidWeights(uint256 weightSum);
+
+    /// @dev Amount is zero where a non-zero value is required.
+    error ZeroAmount();
+
+    /// @dev Token is not a constituent of the basket.
+    error NotConstituent(address token);
+
+    /// @dev Slippage tolerance exceeded on share minting.
+    error InsufficientShares(uint256 minimum, uint256 actual);
+
+    /// @dev Slippage tolerance exceeded on constituent withdrawal.
+    error InsufficientAmount(uint256 index, uint256 minimum, uint256 actual);
+
+    /// @dev Duplicate constituent token address.
+    error DuplicateConstituent(address token);
+
+    /// @dev Constituent address is the zero address.
+    error ZeroAddress();
+
+    // --- Events ---
+
+    /// @notice MUST be emitted when assets are contributed to the basket.
+    /// @param caller The address that called `contribute`.
+    /// @param receiver The address that received the minted shares.
+    /// @param lpAmount The number of shares minted.
+    /// @param amounts The constituent token amounts deposited.
+    event Contributed(
+        address indexed caller,
+        address indexed receiver,
+        uint256 lpAmount,
+        uint256[] amounts
+    );
+
+    /// @notice MUST be emitted when shares are burned and assets withdrawn.
+    /// @param caller The address that called `withdraw`.
+    /// @param receiver The address that received the constituent tokens.
+    /// @param lpAmount The number of shares burned.
+    /// @param amounts The constituent token amounts returned.
+    event Withdrawn(
+        address indexed caller,
+        address indexed receiver,
+        uint256 lpAmount,
+        uint256[] amounts
+    );
+
+    /// @notice MUST be emitted when the constituent set or weights change.
+    /// @param newTokens The new constituent token addresses.
+    /// @param newWeights The new target weights in basis points.
+    event Rebalanced(address[] newTokens, uint256[] newWeights);
+
+    // --- View Functions ---
+
+    /// @notice Returns the constituent tokens and their target weights.
+    /// @dev The ordering of the returned arrays is stable between calls to
+    ///      `rebalance`. The `amounts` arrays in `contribute`, `withdraw`,
+    ///      and their preview counterparts MUST follow this same ordering.
+    /// @return tokens Constituent addresses.
+    /// @return weights Target weights in basis points, summing to 10000.
+    function getConstituents()
+        external view returns (address[] memory tokens, uint256[] memory weights);
+
+    /// @notice Returns the number of constituents.
+    /// @return count The number of constituent tokens.
+    function totalConstituents() external view returns (uint256 count);
+
+    /// @notice Returns the accounted reserve balance of a constituent.
+    /// @dev Returns the reserve recognized by the basket for share accounting,
+    ///      which MAY differ from `IERC20(token).balanceOf(address(this))`.
+    /// @param token The constituent token address.
+    /// @return balance The accounted reserve of `token`.
+    function getReserve(address token) external view returns (uint256 balance);
+
+    /// @notice Returns the target weight of a specific constituent.
+    /// @dev MUST revert with `NotConstituent` if `token` is not a constituent.
+    /// @param token The constituent token address.
+    /// @return weight The target weight in basis points.
+    function getWeight(address token) external view returns (uint256 weight);
+
+    /// @notice Returns whether an address is a current constituent.
+    /// @param token The token address to check.
+    /// @return True if `token` is a constituent.
+    function isConstituent(address token) external view returns (bool);
+
+    /// @notice Returns the total basket value in the implementation's accounting unit.
+    /// @dev The accounting unit and valuation method are implementation-defined
+    ///      but MUST be deterministic and consistent with `previewContribute`.
+    ///      The returned value is only meaningful within this implementation's
+    ///      accounting model and MUST NOT be assumed comparable across
+    ///      different basket implementations.
+    /// @return value The total basket value in the implementation's unit.
+    function totalBasketValue() external view returns (uint256 value);
+
+    // --- Actions ---
+
+    /// @notice Deposits constituent tokens and mints shares to `receiver`.
+    /// @dev The caller MUST have approved this contract to spend the required
+    ///      amounts of each constituent prior to calling.
+    ///      `amounts` MUST be ordered to match `getConstituents`.
+    ///      MUST emit `Contributed`.
+    ///      MUST revert with `LengthMismatch` if `amounts.length` does not
+    ///      equal `totalConstituents()`.
+    ///      MUST revert with `ZeroAmount` if all amounts are zero.
+    ///      MUST revert with `InsufficientShares` if shares minted is less
+    ///      than `minShares`.
+    ///      Shares minted MUST be monotonically non-decreasing with respect
+    ///      to amounts contributed — contributing more MUST NOT yield fewer shares.
+    ///      When rounding, MUST round shares minted down (favoring the basket).
+    /// @param amounts Ordered array of constituent token amounts to deposit.
+    /// @param receiver The address that will receive minted shares.
+    /// @param minShares Minimum acceptable shares to mint. Reverts if not met.
+    /// @return lpAmount Shares minted.
+    function contribute(uint256[] calldata amounts, address receiver, uint256 minShares)
+        external returns (uint256 lpAmount);
+
+    /// @notice Burns shares and transfers proportional reserves to `receiver`.
+    /// @dev MUST emit `Withdrawn`.
+    ///      MUST revert with `ZeroAmount` if `lpAmount` is zero.
+    ///      MUST revert if the caller holds fewer than `lpAmount` shares.
+    ///      MUST revert with `LengthMismatch` if `minAmounts.length` does not
+    ///      equal `totalConstituents()`.
+    ///      MUST revert with `InsufficientAmount` if any returned amount is
+    ///      less than the corresponding entry in `minAmounts`.
+    ///      For each constituent: `amount_i = reserve_i * lpAmount / totalSupply`,
+    ///      rounding down (favoring the basket).
+    ///      Shares MUST be burned before constituent tokens are transferred out.
+    /// @param lpAmount The number of shares to burn.
+    /// @param receiver The address that will receive constituent tokens.
+    /// @param minAmounts Minimum acceptable amounts per constituent. Reverts if not met.
+    /// @return amounts Constituent amounts returned, ordered by `getConstituents`.
+    function withdraw(uint256 lpAmount, address receiver, uint256[] calldata minAmounts)
+        external returns (uint256[] memory amounts);
+
+    /// @notice Updates the constituent set and target weights.
+    /// @dev MUST revert if caller is not `owner()` per ERC-173.
+    ///      MUST revert with `LengthMismatch` if array lengths differ.
+    ///      MUST revert with `InvalidWeights` if weights do not sum to 10000.
+    ///      MUST revert with `DuplicateConstituent` if `newTokens` contains duplicates.
+    ///      MUST revert with `ZeroAddress` if any entry in `newTokens` is `address(0)`.
+    ///      MUST emit `Rebalanced`.
+    ///      The standardized effect of this function is updating the constituent
+    ///      set and target weights. Any reserve realignment (swaps) is an
+    ///      implementation concern and MUST NOT be inferred by integrators
+    ///      from this call alone.
+    /// @param newTokens The new ordered set of constituent token addresses.
+    /// @param newWeights The new ordered set of target weights in basis points.
+    function rebalance(address[] calldata newTokens, uint256[] calldata newWeights)
+        external;
+
+    // --- Preview Functions ---
+
+    /// @notice Estimates shares that would be minted for given amounts.
+    /// @dev MUST return the same value as `contribute` would return if called
+    ///      in the same transaction. MUST NOT revert except for invalid inputs.
+    ///      MUST NOT vary by caller. MUST round down.
+    ///      MUST use the same valuation function as `contribute`.
+    /// @param amounts Ordered array of constituent token amounts.
+    /// @return lpAmount Estimated shares that would be minted.
+    function previewContribute(uint256[] calldata amounts)
+        external view returns (uint256 lpAmount);
+
+    /// @notice Estimates constituent amounts returned for burning shares.
+    /// @dev MUST return the same value as `withdraw` would return if called
+    ///      in the same transaction. MUST NOT revert except for invalid inputs.
+    ///      MUST round down.
+    /// @param lpAmount The number of shares to simulate burning.
+    /// @return amounts Estimated constituent amounts, ordered by `getConstituents`.
+    function previewWithdraw(uint256 lpAmount)
+        external view returns (uint256[] memory amounts);
+}

--- a/assets/erc-7621/contracts/mocks/MockERC20.sol
+++ b/assets/erc-7621/contracts/mocks/MockERC20.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title MockERC20
+ * @notice Simple mock ERC20 token for testing purposes.
+ */
+contract MockERC20 is ERC20 {
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint256 initialSupply
+    ) ERC20(name_, symbol_) {
+        _mint(msg.sender, initialSupply);
+    }
+
+    /**
+     * @notice Mints tokens to an address (for testing).
+     */
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/assets/erc-7621/test/BasketToken.test.js
+++ b/assets/erc-7621/test/BasketToken.test.js
@@ -1,0 +1,394 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ERC-7621 Basket Token", function () {
+  let basket;
+  let tokenA, tokenB, tokenC;
+  let owner, alice, bob;
+
+  const SUPPLY = ethers.parseEther("1000000");
+  const DEAD_SHARES = 1000n;
+
+  async function deployBasket(tokens, weights, signer) {
+    const s = signer || owner;
+    const BasketToken = await ethers.getContractFactory("BasketToken", s);
+    return BasketToken.deploy("Test Basket", "TBSK", s.address, tokens, weights);
+  }
+
+  async function deployAndSeed() {
+    const tokens = [await tokenA.getAddress(), await tokenB.getAddress()];
+    const weights = [6000n, 4000n];
+    basket = await deployBasket(tokens, weights);
+
+    const amounts = [ethers.parseEther("100"), ethers.parseEther("50")];
+    await tokenA.approve(await basket.getAddress(), amounts[0]);
+    await tokenB.approve(await basket.getAddress(), amounts[1]);
+    const minShares = 0n;
+    await basket.contribute(amounts, owner.address, minShares);
+    return { tokens, weights, amounts };
+  }
+
+  beforeEach(async function () {
+    [owner, alice, bob] = await ethers.getSigners();
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    tokenA = await MockERC20.deploy("Token A", "TKA", SUPPLY);
+    tokenB = await MockERC20.deploy("Token B", "TKB", SUPPLY);
+    tokenC = await MockERC20.deploy("Token C", "TKC", SUPPLY);
+  });
+
+  // ---- Contribution ----
+
+  describe("Contribution", function () {
+    it("mints shares proportionally and emits Contributed with caller, receiver, amounts", async function () {
+      await deployAndSeed();
+
+      const amounts = [ethers.parseEther("10"), ethers.parseEther("5")];
+      await tokenA.transfer(alice.address, amounts[0]);
+      await tokenB.transfer(alice.address, amounts[1]);
+      await tokenA.connect(alice).approve(await basket.getAddress(), amounts[0]);
+      await tokenB.connect(alice).approve(await basket.getAddress(), amounts[1]);
+
+      const tx = basket.connect(alice).contribute(amounts, alice.address, 0n);
+      await expect(tx)
+        .to.emit(basket, "Contributed")
+        .withArgs(alice.address, alice.address, () => true, amounts);
+
+      const bal = await basket.balanceOf(alice.address);
+      expect(bal).to.be.gt(0n);
+    });
+
+    it("reverts with InsufficientShares when shares minted is below minShares", async function () {
+      await deployAndSeed();
+
+      const amounts = [ethers.parseEther("10"), ethers.parseEther("5")];
+      await tokenA.transfer(alice.address, amounts[0]);
+      await tokenB.transfer(alice.address, amounts[1]);
+      await tokenA.connect(alice).approve(await basket.getAddress(), amounts[0]);
+      await tokenB.connect(alice).approve(await basket.getAddress(), amounts[1]);
+
+      const hugeMin = ethers.parseEther("999999");
+      await expect(
+        basket.connect(alice).contribute(amounts, alice.address, hugeMin)
+      ).to.be.revertedWithCustomError(basket, "InsufficientShares");
+    });
+
+    it("reverts with LengthMismatch when amounts length mismatches constituents", async function () {
+      await deployAndSeed();
+      await expect(
+        basket.contribute([ethers.parseEther("1")], owner.address, 0n)
+      ).to.be.revertedWithCustomError(basket, "LengthMismatch");
+    });
+
+    it("reverts with ZeroAmount when all amounts are zero", async function () {
+      await deployAndSeed();
+      await expect(
+        basket.contribute([0n, 0n], owner.address, 0n)
+      ).to.be.revertedWithCustomError(basket, "ZeroAmount");
+    });
+  });
+
+  // ---- Withdrawal ----
+
+  describe("Withdrawal", function () {
+    it("burns shares, returns proportional constituents, and emits Withdrawn", async function () {
+      await deployAndSeed();
+
+      const lpBal = await basket.balanceOf(owner.address);
+      const half = lpBal / 2n;
+      const minAmounts = [0n, 0n];
+
+      const balABefore = await tokenA.balanceOf(owner.address);
+      const balBBefore = await tokenB.balanceOf(owner.address);
+
+      const tx = basket.withdraw(half, owner.address, minAmounts);
+      await expect(tx).to.emit(basket, "Withdrawn");
+
+      const balAAfter = await tokenA.balanceOf(owner.address);
+      const balBAfter = await tokenB.balanceOf(owner.address);
+      expect(balAAfter).to.be.gt(balABefore);
+      expect(balBAfter).to.be.gt(balBBefore);
+      expect(await basket.balanceOf(owner.address)).to.equal(lpBal - half);
+    });
+
+    it("reverts with InsufficientAmount when any returned amount is below minAmounts", async function () {
+      await deployAndSeed();
+
+      const lpBal = await basket.balanceOf(owner.address);
+      const hugeMin = [ethers.parseEther("999999"), 0n];
+
+      await expect(
+        basket.withdraw(lpBal / 2n, owner.address, hugeMin)
+      ).to.be.revertedWithCustomError(basket, "InsufficientAmount");
+    });
+
+    it("reverts with LengthMismatch when minAmounts length mismatches constituents", async function () {
+      await deployAndSeed();
+      await expect(
+        basket.withdraw(1n, owner.address, [0n])
+      ).to.be.revertedWithCustomError(basket, "LengthMismatch");
+    });
+
+    it("reverts with ZeroAmount when lpAmount is zero", async function () {
+      await deployAndSeed();
+      await expect(
+        basket.withdraw(0n, owner.address, [0n, 0n])
+      ).to.be.revertedWithCustomError(basket, "ZeroAmount");
+    });
+
+    it("rounds amounts down (favoring the basket)", async function () {
+      await deployAndSeed();
+
+      // Withdraw an amount that creates rounding: 3 shares out of total supply
+      const supply = await basket.totalSupply();
+      const withdrawShares = 3n;
+      const resA = await basket.getReserve(await tokenA.getAddress());
+      const resB = await basket.getReserve(await tokenB.getAddress());
+
+      const previewAmounts = await basket.previewWithdraw(withdrawShares);
+
+      // Verify integer division rounds down
+      expect(previewAmounts[0]).to.equal((resA * withdrawShares) / supply);
+      expect(previewAmounts[1]).to.equal((resB * withdrawShares) / supply);
+      // And that rounding means amount * supply <= reserve * shares
+      expect(previewAmounts[0] * supply).to.be.lte(resA * withdrawShares);
+      expect(previewAmounts[1] * supply).to.be.lte(resB * withdrawShares);
+    });
+  });
+
+  // ---- Rebalance ----
+
+  describe("Rebalance", function () {
+    it("owner can update constituents and emits Rebalanced", async function () {
+      await deployAndSeed();
+
+      const newTokens = [await tokenA.getAddress(), await tokenB.getAddress()];
+      const newWeights = [7000n, 3000n];
+
+      const tx = basket.rebalance(newTokens, newWeights);
+      await expect(tx).to.emit(basket, "Rebalanced").withArgs(newTokens, newWeights);
+
+      expect(await basket.getWeight(newTokens[0])).to.equal(7000n);
+      expect(await basket.getWeight(newTokens[1])).to.equal(3000n);
+    });
+
+    it("reverts when called by non-owner", async function () {
+      await deployAndSeed();
+
+      const tokens = [await tokenA.getAddress(), await tokenB.getAddress()];
+      await expect(
+        basket.connect(alice).rebalance(tokens, [5000n, 5000n])
+      ).to.be.revertedWithCustomError(basket, "Unauthorized");
+    });
+
+    it("reverts with InvalidWeights when weights do not sum to 10000", async function () {
+      await deployAndSeed();
+
+      const tokens = [await tokenA.getAddress(), await tokenB.getAddress()];
+      await expect(
+        basket.rebalance(tokens, [5000n, 4000n])
+      ).to.be.revertedWithCustomError(basket, "InvalidWeights");
+    });
+
+    it("reverts with DuplicateConstituent when newTokens contains duplicates", async function () {
+      await deployAndSeed();
+
+      const addr = await tokenA.getAddress();
+      await expect(
+        basket.rebalance([addr, addr], [5000n, 5000n])
+      ).to.be.revertedWithCustomError(basket, "DuplicateConstituent");
+    });
+
+    it("reverts with ZeroAddress when any entry is address(0)", async function () {
+      await deployAndSeed();
+
+      await expect(
+        basket.rebalance([ethers.ZeroAddress, await tokenB.getAddress()], [5000n, 5000n])
+      ).to.be.revertedWithCustomError(basket, "ZeroAddress");
+    });
+  });
+
+  // ---- Preview Functions ----
+
+  describe("Preview Functions", function () {
+    it("previewContribute returns values consistent with contribute", async function () {
+      await deployAndSeed();
+
+      const amounts = [ethers.parseEther("10"), ethers.parseEther("5")];
+      const preview = await basket.previewContribute(amounts);
+
+      await tokenA.transfer(alice.address, amounts[0]);
+      await tokenB.transfer(alice.address, amounts[1]);
+      await tokenA.connect(alice).approve(await basket.getAddress(), amounts[0]);
+      await tokenB.connect(alice).approve(await basket.getAddress(), amounts[1]);
+
+      await basket.connect(alice).contribute(amounts, alice.address, 0n);
+      const actual = await basket.balanceOf(alice.address);
+
+      expect(actual).to.equal(preview);
+    });
+
+    it("previewWithdraw returns values consistent with withdraw", async function () {
+      await deployAndSeed();
+
+      const lpBal = await basket.balanceOf(owner.address);
+      const half = lpBal / 2n;
+      const preview = await basket.previewWithdraw(half);
+
+      const balABefore = await tokenA.balanceOf(owner.address);
+      const balBBefore = await tokenB.balanceOf(owner.address);
+
+      await basket.withdraw(half, owner.address, [0n, 0n]);
+
+      const gotA = (await tokenA.balanceOf(owner.address)) - balABefore;
+      const gotB = (await tokenB.balanceOf(owner.address)) - balBBefore;
+
+      expect(gotA).to.equal(preview[0]);
+      expect(gotB).to.equal(preview[1]);
+    });
+
+    it("previewContribute with zero inputs returns zero", async function () {
+      await deployAndSeed();
+      expect(await basket.previewContribute([0n, 0n])).to.equal(0n);
+    });
+
+    it("previewWithdraw with zero returns zero amounts", async function () {
+      await deployAndSeed();
+      const amounts = await basket.previewWithdraw(0n);
+      expect(amounts[0]).to.equal(0n);
+      expect(amounts[1]).to.equal(0n);
+    });
+  });
+
+  // ---- View Function Edge Cases ----
+
+  describe("View Edge Cases", function () {
+    it("getReserve returns zero for non-constituent tokens", async function () {
+      await deployAndSeed();
+      expect(await basket.getReserve(await tokenC.getAddress())).to.equal(0n);
+    });
+
+    it("getWeight reverts with NotConstituent for non-constituent tokens", async function () {
+      await deployAndSeed();
+      await expect(
+        basket.getWeight(await tokenC.getAddress())
+      ).to.be.revertedWithCustomError(basket, "NotConstituent");
+    });
+
+    it("getConstituents ordering is stable across calls", async function () {
+      await deployAndSeed();
+
+      const [tokens1] = await basket.getConstituents();
+      const [tokens2] = await basket.getConstituents();
+
+      expect(tokens1[0]).to.equal(tokens2[0]);
+      expect(tokens1[1]).to.equal(tokens2[1]);
+    });
+
+    it("totalBasketValue is consistent with previewContribute", async function () {
+      await deployAndSeed();
+
+      const value = await basket.totalBasketValue();
+      // totalBasketValue = sum of reserves
+      const resA = await basket.getReserve(await tokenA.getAddress());
+      const resB = await basket.getReserve(await tokenB.getAddress());
+      expect(value).to.equal(resA + resB);
+    });
+  });
+
+  // ---- Ownership (ERC-173) ----
+
+  describe("Ownership (ERC-173)", function () {
+    it("owner() and transferOwnership() conform to ERC-173", async function () {
+      await deployAndSeed();
+
+      expect(await basket.owner()).to.equal(owner.address);
+
+      await basket.transferOwnership(alice.address);
+      expect(await basket.owner()).to.equal(alice.address);
+
+      // New owner can rebalance
+      const tokens = [await tokenA.getAddress(), await tokenB.getAddress()];
+      await expect(
+        basket.connect(alice).rebalance(tokens, [5000n, 5000n])
+      ).to.emit(basket, "Rebalanced");
+
+      // Old owner cannot
+      await expect(
+        basket.rebalance(tokens, [5000n, 5000n])
+      ).to.be.revertedWithCustomError(basket, "Unauthorized");
+    });
+
+    it("ownership renunciation makes rebalance permanently unavailable", async function () {
+      await deployAndSeed();
+
+      await basket.transferOwnership(ethers.ZeroAddress);
+      expect(await basket.owner()).to.equal(ethers.ZeroAddress);
+
+      const tokens = [await tokenA.getAddress(), await tokenB.getAddress()];
+      await expect(
+        basket.rebalance(tokens, [5000n, 5000n])
+      ).to.be.revertedWithCustomError(basket, "Unauthorized");
+    });
+
+    it("emits OwnershipTransferred(address(0), initialOwner) at creation", async function () {
+      const tokens = [await tokenA.getAddress()];
+      const weights = [10000n];
+      const BasketToken = await ethers.getContractFactory("BasketToken");
+      const b = await BasketToken.deploy("Test", "T", owner.address, tokens, weights);
+      const receipt = await b.deploymentTransaction().wait();
+
+      // Check logs for OwnershipTransferred event
+      const iface = b.interface;
+      const event = receipt.logs
+        .map(log => { try { return iface.parseLog(log); } catch { return null; } })
+        .find(e => e && e.name === "OwnershipTransferred");
+
+      expect(event).to.not.be.undefined;
+      expect(event.args.previousOwner).to.equal(ethers.ZeroAddress);
+      expect(event.args.newOwner).to.equal(owner.address);
+    });
+  });
+
+  // ---- Initialization ----
+
+  describe("Initialization", function () {
+    it("first contribution to empty basket mints shares deterministically", async function () {
+      const tokens = [await tokenA.getAddress(), await tokenB.getAddress()];
+      const weights = [5000n, 5000n];
+      basket = await deployBasket(tokens, weights);
+
+      const amounts = [ethers.parseEther("100"), ethers.parseEther("100")];
+      const preview = await basket.previewContribute(amounts);
+
+      await tokenA.approve(await basket.getAddress(), amounts[0]);
+      await tokenB.approve(await basket.getAddress(), amounts[1]);
+      await basket.contribute(amounts, owner.address, 0n);
+
+      const actual = await basket.balanceOf(owner.address);
+      expect(actual).to.equal(preview);
+
+      // Dead shares are minted
+      const deadBal = await basket.balanceOf("0x000000000000000000000000000000000000dEaD");
+      expect(deadBal).to.equal(DEAD_SHARES);
+    });
+  });
+
+  // ---- ERC-165 ----
+
+  describe("ERC-165", function () {
+    it("reports support for IERC7621 (0xc9c80f73)", async function () {
+      await deployAndSeed();
+      expect(await basket.supportsInterface("0xc9c80f73")).to.be.true;
+    });
+
+    it("reports support for IERC173 (0x7f5828d0)", async function () {
+      await deployAndSeed();
+      expect(await basket.supportsInterface("0x7f5828d0")).to.be.true;
+    });
+
+    it("reports support for IERC165 (0x01ffc9a7)", async function () {
+      await deployAndSeed();
+      expect(await basket.supportsInterface("0x01ffc9a7")).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Replace the comparison table in the Rationale section with bullet-format descriptions. The table rendered poorly on the EIPs site due to narrow column widths causing word breaks.