### PR TITLE
Update ERC-7730: Fix inconsistencies in ERC-7730 and its examples

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -587,7 +587,7 @@ Sometimes constants are dependant on some part of the context of the transaction
 Each key under the `maps` object is a *map* name. 
 
 A map is a json object with two keys:
-* The `keyType` key contains an non normative indication of the expected type of the map key passed when referencing the map.
+* The `$keyType` key contains an non normative indication of the expected type of the map key passed when referencing the map.
 * The `values` key contains a list of key / value pairs, each key being used to match the data pointed to in the reference `keyPath` key. The corresponding value is used as the context-dependent constant when referenced in the `display` section.
 
 Maps references can be used anywhere a parameter with constant value would be used. A map reference is a json object with two keys:
@@ -605,7 +605,7 @@ An example can be found in [example-maps.json](../assets/eip-7730/example-maps.j
     "metadata": {
         "maps": {
             "underlyingToken": {
-                "keyPath": "@.chainId",
+                "$keyType": "Chain ID",
                 "values" : {
                     "1": "0xaabbccddeeff...",
                     "17000": "0x112233445566..."
@@ -615,7 +615,7 @@ An example can be found in [example-maps.json](../assets/eip-7730/example-maps.j
     },
     "display": {
         "formats": {
-            "deposit(amount)" : {
+            "deposit(uint256 amount)" : {
                 "intent": "Deposit",
                 "fields": [
                     {
@@ -623,7 +623,10 @@ An example can be found in [example-maps.json](../assets/eip-7730/example-maps.j
                         "label": "Deposit Amount",
                         "format": "tokenAmount",
                         "params": {
-                            "token": "$.metadata.maps.underlyingToken"
+                            "token": {
+                                "map": "$.metadata.maps.underlyingToken",
+                                "keyPath": "@.chainId"
+                            }
                         }
                     }
                 ]
@@ -711,7 +714,7 @@ Definitions don't usually include the `path` or `value` key of a [*field format 
                 "format": "tokenAmount",
                 "params": {
                     "tokenPath": "fromToken",
-                    "nativeCurrencyAddress": "$.display.constants.addressAsEth"
+                    "nativeCurrencyAddress": "$.metadata.constants.addressAsEth"
                 }
             }
         }
@@ -1125,7 +1128,7 @@ This examples uses an array slice to indicate that only the last element of the 
 {
     "display": {
         "formats": {
-            "PermitBatch(PermitDetails[] details,address spender,uint256 sigDeadline) PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)": {
+            "PermitBatch(PermitDetails[] details,address spender,uint256 sigDeadline)PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)": {
                 "intent": "Approve token spending",
                 "interpolatedIntent": "Approve {spender} to spend multiple tokens until {sigDeadline}",
                 "fields": [
@@ -1337,7 +1340,7 @@ Formats applicable to `uint`/`int` solidity types.
 |---------------|--------------------------------------------------------------------------------------------|
 | *Description* | Value is converted using referenced constant enumeration values                            |
 | *Parameters*  | ---                                                                                        |
-| `$ref`        | An internal path (starting with root node `$.`) to an enumerations in `metadata.constants` |
+| `$ref`        | An internal path (starting with root node `$.`) to an enumerations in `metadata.enums` |
 | *Examples*    |                                                                                            |
 
 | **`chainId`**      |                                                                                            |

--- a/assets/erc-7730/erc7730-v2.schema.json
+++ b/assets/erc-7730/erc7730-v2.schema.json
@@ -658,7 +658,7 @@
                         },
                         "minItems": 1
                     },
-                    "mustBe": {
+                    "mustMatch": {
                         "type": "array",
                         "description": "Always skip display, but value MUST match one of these values.",
                         "items": {
@@ -671,11 +671,11 @@
                 "allOf": [
                     {
                     "not": {
-                        "required": ["notIn", "mustBe"]
+                        "required": ["ifNotIn", "mustMatch"]
                     }
                     }
                 ],
-                "description": "Conditional display rules. Either 'notIn' or 'mustBe' must be defined, but not both."
+                "description": "Conditional display rules. Either 'ifNotIn' or 'mustMatch' must be defined, but not both."
                 }
             ]    
         },

--- a/assets/erc-7730/example-eip712.json
+++ b/assets/erc-7730/example-eip712.json
@@ -22,7 +22,7 @@
     },
     "display": {
       "formats": {
-        "PermitSingle(PermitDetails details,address spender,uint256 sigDeadline) PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)": {
+        "PermitSingle(PermitDetails details,address spender,uint256 sigDeadline)PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)": {
           "$id": "Permit2 Permit Single",
           "intent": "Authorize spending of token",
           "fields": [
@@ -33,7 +33,7 @@
             { "path": "sigDeadline", "visible": "never" }
           ]
         },
-        "PermitBatch(PermitDetails[] details,address spender,uint256 sigDeadline) PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)": {
+        "PermitBatch(PermitDetails[] details,address spender,uint256 sigDeadline)PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)": {
           "$id": "Permit2 Permit Batch",
           "intent": "Authorize spending of tokens",
           "fields": [

--- a/assets/erc-7730/example-maps-pools.json
+++ b/assets/erc-7730/example-maps-pools.json
@@ -5,7 +5,7 @@
 
     "context": {
         "$id": "Example Maps for Pools",
-        "contract" : {
+        "contract": {
             "deployments": [ 
                 {
                     "chainId": 1,
@@ -53,7 +53,7 @@
                         "params": {
                             "token": {
                                 "map": "$.metadata.maps.underlyingToken",
-                                "key": "@.chainId"
+                                "keyPath": "@.chainId"
                             }   
                         }
                     },
@@ -64,7 +64,7 @@
                         "params": {
                             "token": {
                                 "map": "$.metadata.maps.shareToken",
-                                "key": "@.chainId"
+                                "keyPath": "@.chainId"
                             }
                         }
                     }

--- a/assets/erc-7730/example-maps.json
+++ b/assets/erc-7730/example-maps.json
@@ -5,7 +5,7 @@
 
     "context": {
         "$id": "Example Maps",
-        "contract" : {
+        "contract": {
             "deployments": [ 
                 {
                     "chainId": 1,
@@ -61,7 +61,7 @@
                         "params": {
                             "token": {
                                 "map": "$.metadata.maps.underlyingToken",
-                                "key": "@.chainId"
+                                "keyPath": "@.chainId"
                             }
                         }
                     },
@@ -72,7 +72,7 @@
                         "params": {
                             "token": {
                                 "map": "$.metadata.maps.shareToken",
-                                "key": "@.chainId"
+                                "keyPath": "@.chainId"
                             }
                         }
                     }

--- a/assets/erc-7730/example-visibility-rules.json
+++ b/assets/erc-7730/example-visibility-rules.json
@@ -4,7 +4,7 @@
     "$comment": "This example ERC-7730 showcases usage of visibility rules.",
 
     "context": {
-        "contract" : {
+        "contract": {
             "deployments": [ 
                 {
                     "chainId": 1,
@@ -64,7 +64,7 @@
                         "label": "Legacy Amount",
                         "format": "raw",
                         "visible": {
-                            "mustBe": [0]
+                            "mustMatch": [0]
                         }
                     },
                     {


### PR DESCRIPTION
While implementing the clear signing library, I came across a few inconsistencies in the standard, mostly in its examples. This PR addresses these inconsistencies.

- Alligns naming of map keywords across examples
- The EIP-712 examples had a whitespace between types. This doesn't follow the `encodeType` function of EIP-712. Also, made the EIP-712 key regex much stricter in regards to whitespaces. 
- Fixes schema and the examples using wrong keywords for the visibility parameters