### PR TITLE
Add ERC: 0G Cross-Chain Bridge Intent Standard

### DIFF
--- a/ERCS/erc-7752.md
+++ b/ERCS/erc-7752.md
@@ -1,0 +1,142 @@
+---
+eip: 7752
+title: 0G Cross-Chain Bridge Intent Standard
+description: A standard interface for intent-based cross-chain asset and data bridging with a 1% protocol fee and TTL-bounded intents.
+author: Opacus Protocol (@bl10buer)
+discussions-to: https://ethereum-magicians.org/u/bl10buer/
+status: Draft
+type: Standards Track
+category: ERC
+created: 2026-03-28
+requires: 165
+---
+
+## Abstract
+
+ERC-7752 defines an intent-based bridging standard optimised for 0G network data availability proofs. A submitter locks a gross payment on the source chain; **1 % is immediately collected as a protocol fee**; the remaining 99 % is escrowed until a permissioned fulfiller submits a cross-chain proof. If the intent expires or is cancelled, the net amount is refunded.
+
+## Motivation
+
+Cross-chain bridging is plagued by fragmented interfaces, inconsistent fee models, and lack of TTL semantics. ERC-7752 proposes a minimal, composable standard that:
+
+* **Unifies intent expression** – a single `submitIntent` covers token transfers, data payloads, and NFT bridges.
+* **Integrates with 0G DA** – the `proofHash` field anchors the 0G data-availability proof receipt on-chain.
+* **Enforces fee uniformity** – a hardcoded 1 % fee removes negotiation overhead and front-running surface.
+
+## Specification
+
+### Constants
+
+| Name | Value | Description |
+|---|---|---|
+| `BRIDGE_FEE_BPS` | `100` | Protocol fee in basis points (1 %) |
+| `OPACUS_TREASURY` | `0xA943F46eE5f977067f07565CF1d31A10B68D7718` | Fee recipient |
+
+### Enums
+
+```solidity
+enum IntentStatus { Pending, Fulfilled, Cancelled, Failed, Expired }
+enum IntentType   { TokenTransfer, DataPayload, NFTBridge }
+```
+
+### Structs
+
+```solidity
+struct BridgeIntent {
+    address     submitter;
+    IntentType  intentType;
+    bytes       payload;
+    uint64      sourceChainId;
+    uint64      destChainId;
+    address     token;
+    uint256     grossAmount;
+    uint256     feeAmount;
+    uint256     netAmount;
+    bytes32     proofHash;
+    IntentStatus status;
+    uint64      createdAt;
+    uint64      fulfilledAt;
+    uint64      expiresAt;
+}
+```
+
+### Methods
+
+#### `submitIntent`
+
+```solidity
+function submitIntent(
+    IntentType intentType,
+    bytes calldata payload,
+    uint64 destChainId,
+    uint64 ttlSeconds,
+    address token,
+    uint256 gross
+) external payable returns (bytes32 intentId);
+```
+
+MUST collect `gross × 1 %` and forward to `OPACUS_TREASURY` atomically.  
+MUST set `expiresAt = block.timestamp + ttlSeconds`.  
+MUST emit `IntentSubmitted(intentId, submitter, destChainId, feeAmount)`.
+
+#### `fulfillIntent`
+
+```solidity
+function fulfillIntent(bytes32 intentId, bytes32 proofHash) external;
+```
+
+MUST only be callable by a registered fulfiller.  
+MUST revert if `block.timestamp > intent.expiresAt`.  
+MUST release `netAmount` to fulfiller.  
+MUST emit `IntentFulfilled(intentId, fulfiller, proofHash)`.
+
+#### `cancelIntent`
+
+```solidity
+function cancelIntent(bytes32 intentId) external;
+```
+
+MUST only be callable by `intent.submitter`.  
+MUST refund `netAmount` to submitter (fee is non-refundable).  
+MUST emit `IntentCancelled(intentId, submitter)`.
+
+#### `setFulfiller`
+
+```solidity
+function setFulfiller(address fulfiller, bool allowed) external;
+```
+
+MUST only be callable by contract owner. Manages trusted fulfiller set.
+
+### Events
+
+```solidity
+event IntentSubmitted(bytes32 indexed intentId, address indexed submitter, uint64 destChainId, uint256 feeAmount);
+event IntentFulfilled(bytes32 indexed intentId, address indexed fulfiller, bytes32 proofHash);
+event IntentCancelled(bytes32 indexed intentId, address indexed submitter);
+event IntentFailed   (bytes32 indexed intentId, bytes reason);
+```
+
+### ERC-165
+
+Compliant contracts MUST return `true` for interface ID `0x30474252` (`"0GBR"`).
+
+## Rationale
+
+* **TTL-bounded intents** – prevents capital lock indefinitely; enables solver competition.
+* **Permissioned fulfillers** – a whitelist prevents griefing while the permissionless fulfiller model matures.
+* **0G DA anchoring** – `proofHash` stores the DA proof CID, enabling on-chain verification of data availability.
+
+## Backwards Compatibility
+
+No existing bridge standard (LayerZero, Hyperlane, Axelar) is modified. ERC-7752 is composable as a transport layer above existing messaging protocols.
+
+## Security Considerations
+
+* **Fulfiller trust** – The whitelist is a centralisation risk; future versions should integrate decentralised solver auctions.
+* **Reorg safety** – Fulfillers MUST wait for sufficient source-chain confirmations before calling `fulfillIntent`.
+* **Fee finality** – Fees are forwarded immediately; a fee-on-settlement model should be considered for high-value transfers.
+
+## Reference Implementation
+
+See [`contracts/ERC7752ZeroGBridge.sol`](../ERC7752ZeroGBridge.sol).


### PR DESCRIPTION
Reference implementation: https://github.com/Opacus-xyz/Opacus-Standart/blob/main/contracts/ERC7752ZeroGBridge.sol | Solidity ^0.8.24 compiled | 1% fee to 0xA943F46eE5f977067f07565CF1d31A10B68D7718