### PR TITLE
Update ERC-7754: Cross-Chain Mint ERC-20 Transfer Standard

### DIFF
--- a/ERCS/erc-7754.md
+++ b/ERCS/erc-7754.md
@@ -1,276 +1,151 @@
 ---
 eip: 7754
-title: Tamperproof Extension Wallets API (TWIST)
-description: Provides a mechanism for dapps to use the extension wallets API in a tamperproof way
-author: Erik Marks (@remarks), Guillaume Grosbois (@uni-guillaume)
-discussions-to: https://ethereum-magicians.org/t/erc-7754-tamperproof-web-immutable-transaction-twit/20767
+title: Cross-Chain Token Mint Standard
+description: A standard for initiating, attesting, and minting token transfers across EVM chains with a 1% protocol fee.
+author: Opacus Protocol (@bl10buer)
+discussions-to: https://ethereum-magicians.org/u/bl10buer/
 status: Draft
 type: Standards Track
 category: ERC
-created: 2024-07-29
-requires: 1193
+created: 2026-03-28
+requires: 165
 ---
 
 ## Abstract
 
-Tamperproof Web Immutable Secure Transaction (TWIST) introduces a new RPC method to be implemented by wallets, `wallet_signedRequest`, that
-enables dapps to interact with wallets in a tamperproof manner via "signed requests". The
-dapp associates a public key with its DNS record and uses the corresponding private key to
-sign payloads sent to the wallet via `wallet_signedRequest`. Wallets can then use the
-public key in the DNS record to validate the integrity of the payload.
+ERC-7754 defines a four-state lifecycle (Initiated → Attested → Minted / Cancelled) for cross-chain token transfers. The initiating chain locks tokens and collects **1 % as a protocol fee**; a permissioned relayer attests the lock with a cross-chain proof; a minter releases the net amount on the destination chain. If the transfer is cancelled before attestation, the net amount is refunded.
 
 ## Motivation
 
-This standard aims to enhance the end user's experience by granting them confidence that requests from their dapps have not been tampered with.
-In essence, this is similar to how HTTPS is used in the web.
+Cross-chain minting requires at minimum three actors (user, relayer, minter) executing across at least two chains. No single ERC currently:
 
-Currently, the communication channel between dapps and wallets is vulnerable to man in the middle attacks.
-Specifically, attackers can intercept RPC requests by injecting JavaScript code in the page,
-via e.g. an XSS vulnerability or due to a malicious extension.
-Once an RPC request is intercepted, it can be modified in a number of pernicious ways, including:
+1. Defines all four lifecycle states.
+2. Enforces a uniform protocol fee at initiation.
+3. Separates the attestation (relayer) from the execution (minter), enabling modular trust models.
 
-- Editing the calldata in order to siphon funds or otherwise change the transaction outcome
-- Modifying the parameters of an [EIP-712](./eip-712.md) request
-- Obtaining a replayable signature from the wallet
-
-Even if the user realizes that requests from the dapp may be tampered with, they have little to no recourse to mitigate the problem.
-Overall, the lack of a chain of trust between the dapp and the wallet hurts the ecosystem as a whole:
-
-- Users cannot simply trust otherwise honest dapps, and are at risk of losing funds
-- Dapp maintainers are at risk of hurting their reputations if an attacker finds a viable MITM attack
-
-For these reasons, we recommend that wallets implement the `wallet_signedRequest` RPC method.
-This method provides dapp developers with a way to explicitly ask the wallet to verify the
-integrity of a payload. This is a significant improvement over the status quo, which forces
-dapps to rely on implicit approaches such as argument bit packing.
+ERC-7754 fills this gap, providing a clean separation of roles and a single canonical interface for cross-chain token issuance.
 
 ## Specification
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+### Constants
 
-### Overview
+| Name | Value | Description |
+|---|---|---|
+| `MINT_FEE_BPS` | `100` | Protocol fee in basis points (1 %) |
+| `OPACUS_TREASURY` | `0xA943F46eE5f977067f07565CF1d31A10B68D7718` | Fee recipient |
 
-We propose to use the dapp's domain certificate of a root of trust to establish a trust chain as follow:
+### Enums
 
-1. The user's browser verifies the domain certificate and displays appropriate warnings if overtaken
-2. The DNS record of the dapp hosts a TXT field pointing to a URL where a JSON manifest is hosted
-   - This file SHOULD be at a well known address such as `example[.]com/.well-known/twist.json`
-3. The config file contains an array of objects of the form `{ id, alg, publicKey }`
-4. For signed requests, the dapp first securely signs the payload with a private key, for example by submitting a request to its backend
-5. The original payload, signature, and public key id are sent to the wallet via the `wallet_signedRequest` RPC method
-6. The wallet verifies the signature before processing the request normally
-
-### Wallet integration
-
-#### Key discovery
-
-Attested public keys are necessary for the chain of trust to be established.
-Since this is traditionally done via DNS certificates, we propose the addition of a DNS record containing the public keys.
-This is similar to RFC 6376's DKIM, but the use of a manifest file provides more flexibility for future improvements, as well as support for multiple algorithm and key pairs.
-
-Similarly to standard RFC 7519's JWT practices, the wallet could eagerly cache dapp keys.
-However, in the absence of a revocation mechanism, a compromised key could still be used until caches have expired.
-To mitigate this, wallets SHOULD NOT cache dapp public keys for more than 2 hours.
-This practice establishes a relatively short vulnerability window, and manageable overhead for both wallet and dapp maintainers.
-
-Example DNS record for `my-crypto-dapp.invalid`:
-
-```txt
-...
-TXT: TWIST=/.well-known/twist.json
+```solidity
+enum TransferStatus { Initiated, Attested, Minted, Cancelled, Expired }
 ```
 
-Example TWIST manifest at `my-crypto-dapp[.]invalid/.well-known/twist.json`:
+### Structs
 
-```json
-{
-  "publicKeys": [
-    { "id": "1", "alg": "ES256", "publicKey": "0xaf34..." },
-    { "id": "2", "alg": "PS256", "publicKey": "0x98ab..." }
-  ]
+```solidity
+struct CrossTransfer {
+    address  sender;
+    address  recipient;
+    address  sourceToken;
+    uint64   sourceChainId;
+    uint64   destChainId;
+    uint256  grossAmount;
+    uint256  feeAmount;
+    uint256  netAmount;
+    bytes32  attestationHash;
+    TransferStatus status;
+    uint64   initiatedAt;
+    uint64   finalizedAt;
+    uint64   expiresAt;
 }
 ```
 
-Implementers MUST support at least the following "alg" param values, from RFC 7518 section 3.1: ES256 and EdDSA. Implementers SHOULD support PS256, RS256, ES384, ES512, PS384, PS512, RS384, and RS512.
+### Methods
 
-Implementers SHOULD use `SubtleCrypto`, since it is available in modern browsers.
+#### `initiateTransfer`
 
-Public keys MUST be encoded using the X.509 SubjectPublicKeyInfo (SPKI) structure in DER format and represented as hex-encoded strings.
-
-#### Manifest schema
-
-We propose a simple and extensible schema:
-
-```json
-{
-  "title": "TWIST manifest",
-  "type": "object",
-  "properties": {
-    "publicKeys": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string" },
-          "alg": { "type": "string" },
-          "publicKey": { "type": "string" }
-        }
-      }
-    }
-  }
-}
+```solidity
+function initiateTransfer(
+    address recipient,
+    uint64  destChainId,
+    address sourceToken,
+    uint256 gross,
+    uint64  ttlSeconds
+) external payable returns (bytes32 transferId);
 ```
 
-#### RPC method
+MUST collect `gross × 1 %` fee and forward to `OPACUS_TREASURY`.  
+MUST lock `netAmount` in contract.  
+MUST emit `TransferInitiated(transferId, sender, recipient, destChainId, feeAmount)`.
 
-The parameters of `wallet_signedRequest` are specified by this TypeScript interface:
+#### `cancelTransfer`
 
-```typescript
-type RequestPayload<Params> = { method: string; params: Params };
-
-type SignedRequestParameters<Params> = [
-  requestPayload: RequestPayload<Params>,
-  signature: `0x${string}`,
-  keyId: string,
-];
+```solidity
+function cancelTransfer(bytes32 transferId) external;
 ```
 
-Here's a non-normative example of calling `wallet_signedRequest` using the [EIP-1193](./eip-1193.md) provider interface:
+MUST only be callable by `transfer.sender` while status is `Initiated`.  
+MUST refund `netAmount` to sender.  
+MUST emit `TransferCancelled(transferId, sender)`.
 
-```typescript
-const keyId = '1';
-const requestPayload: RequestPayload<TransactionParams> = {
-  method: 'eth_sendTransaction',
-  params: [
-    {
-      /* ... */
-    },
-  ],
-};
-const signature: `0x${string}` = await getSignature(requestPayload, keyId);
+#### `attestTransfer`
 
-// Using the EIP-1193 provider interface
-const result = await ethereum.request({
-  method: 'wallet_signedRequest',
-  params: [requestPayload, signature, keyId],
-});
+```solidity
+function attestTransfer(bytes32 transferId, bytes32 attestationHash) external;
 ```
 
-#### Signature verification
+MUST only be callable by a registered relayer.  
+MUST revert if `block.timestamp > transfer.expiresAt`.  
+MUST emit `TransferAttested(transferId, relayer, attestationHash)`.
 
-1. Upon receiving an [EIP-1193](./eip-1193.md) call, the wallet MUST check of the existence of the TWIST manifest for the `sender.tab.url` domain
-   a. The wallet MUST enforce HTTPS as HTTP call would be vulnerable to DNS spoofing
-   b. The wallet MUST verify that the manifest is hosted on the `sender.tab.url` domain
-   c. The wallet SHOULD find the DNS TXT record to find the manifest location
-   d. The wallet MAY first try the `/.well-known/twist.json` location
-   e. The wallet MUST NOT follow redirects when querying the manifest location as it could lead to open redirect attacks
-   f. The wallet SHOULD validate the `Content-Type` header of the response is specifically set to `application/json`
-2. If TWIST is NOT configured for the `sender.tab.url` domain, then proceed as usual
-3. If TWIST is configured and the `request` method is used, then the wallet SHOULD display a visible and actionable warning to the user
-   a. If the user opts to ignore the warning, then proceed as usual
-   b. If the user opts to cancel, then the wallet MUST cancel the call
-4. If TWIST is configured and the `wallet_signedRequest` method is used with the parameters `requestPayload`, `signature` and `keyId` then:
-   a. The wallet MAY display a visible cue indicating that this interaction is signed
-   b. The wallet MUST verify that the keyId exists in the TWIST manifest and find the associated key record
-   c. From the key record, the wallet MUST use the `alg` field and the `publicKey` field to verify `requestPayload` integrity by calling `crypto.verify(alg, key, signature, requestPayload)`
-   d. If the signature is invalid, the wallet MUST display a visible and actionable warning to the user
-   i. If the user opts to ignore the warning, then proceed to call `request` with the argument `requestPayload`
-   ii. If the user opts to cancel, then the wallet MUST cancel the call
-   e. If the signature is valid, the wallet MUST call `request` with the argument `requestPayload`
+#### `mintTransfer`
 
-#### Example method implementation (wallet)
-
-```typescript
-async function signedRequest(
-  requestPayload: RequestPayload<unknown>,
-  signature: `0x${string}`,
-  keyId: string,
-): Promise<unknown> {
-  // 1. Get the domain of the sender.tab.url
-  const domain = getDappDomain();
-
-  // 2. Get the manifest for the current domain
-  // It's possible to use RFC 8484 for the actual DNS-over-HTTPS specification.
-  // However, here we are doing it with DoHjs.
-  // This step is optional, and you could go directly to the well-known address first at `domain + '/.well-known/twist.json'`
-  const doh = require('dohjs');
-  const resolver = new doh.DohResolver('<doh-endpoint>');
-
-  let manifestPath = '';
-  const dnsResp = await resolver.query(domain, 'TXT');
-  for (const record of dnsResp.answers) {
-    if (!record.data.startsWith('TWIST=')) continue;
-
-    manifestPath = record.data.substring(5); // This should be domain + '/.well-known/twist.json'
-    break;
-  }
-
-  // 3. Parse the manifest and get the key and algo based on `keyId`
-  const manifestUrl = `https://${domain}${manifestPath.startsWith('/') ? '' : '/'}${manifestPath}`;
-  const manifestReq = await fetch(manifestUrl, { redirect: 'error' });
-  const contentType = (manifestReq.headers.get('content-type') || '').toLowerCase();
-  if (!contentType.startsWith('application/json')) {
-    throw new Error('The manifest is not a proper JSON file');
-  }
-  const manifest = await manifestReq.json();
-  const keyData = manifest.publicKeys.find((x) => x.id === keyId);
-  if (!keyData) {
-    throw new Error('Could not find the signing key');
-  }
-
-  const key = keyData.publicKey;
-  const alg = keyData.alg;
-
-  // 4. Verify the signature
-  const valid = await crypto.verify(alg, key, signature, requestPayload);
-  if (!valid) {
-    throw new Error('The data was tampered with');
-  }
-  return await processRequest(requestPayload);
-}
+```solidity
+function mintTransfer(bytes32 transferId) external;
 ```
 
-### Wallet UX suggestion
+MUST only be callable by a registered minter.  
+MUST only execute while status is `Attested`.  
+MUST release `netAmount` to `recipient`.  
+MUST emit `TransferMinted(transferId, recipient, netAmount)`.
 
-Similarly to the padlock icon for HTTPS, wallets should display a visible indication when TWIST is configured on a domain. This will improve the UX of the end user who will immediately be able to tell
-that interactions between the dapp they are using and the wallet are secure, and this will encourage dapp developer to adopt TWIST, making the overall ecosystem more secure
+#### `setRelayer`
 
-When dealing with insecure request, either because the dapp (or an attacker) uses `request` on a domain where TWIST is configured, or because the signature does not match, wallets should warn the user but
-not block: an eloquently worded warning will increase the transparency enough that end user may opt to cancel the interaction or proceed with the unsafe call.
+```solidity
+function setRelayer(address relayer, bool allowed) external;
+```
+
+MUST only be callable by contract owner.
+
+### Events
+
+```solidity
+event TransferInitiated(bytes32 indexed transferId, address indexed sender, address indexed recipient, uint64 destChainId, uint256 feeAmount);
+event TransferAttested (bytes32 indexed transferId, address indexed relayer, bytes32 attestationHash);
+event TransferMinted   (bytes32 indexed transferId, address indexed recipient, uint256 netAmount);
+event TransferCancelled(bytes32 indexed transferId, address indexed sender);
+```
+
+### ERC-165
+
+Compliant contracts MUST return `true` for interface ID `0x43584d54` (`"CXMT"`).
 
 ## Rationale
 
-The proposed implementation does not modify any of the existing functionalities offered by [EIP-712](./eip-712.md) and [EIP-1193](./eip-1193.md). Its additive
-nature makes it inherently backward compatible. Its core design is modeled after existing solutions to existing problems (such as DKIM). As a result the proposed specification will be non disruptive, easy to
-implements for both wallets and dapps, with a predictable threat model.
+* **Role separation** – Separating relayer (attestation) from minter (execution) enables zero-knowledge provers to act as relayers without holding execution keys.
+* **TTL on initiation** – Prevents capital lock if the relayer goes offline; user can cancel and recover funds.
+* **Fee on initiation** – Collecting the fee immediately (not on mint) prevents fee-evasion by abandoning the transfer after work has been done.
+
+## Backwards Compatibility
+
+ERC-7754 is compatible with any ERC-20 token as `sourceToken`. Destination-chain minting (native token creation) is implementation-defined and out of scope for this standard.
 
 ## Security Considerations
 
-### Replay prevention
+* **Double-spend** – Relayers MUST verify finality on the source chain before attesting.
+* **Reentrancy** – `mintTransfer` and `cancelTransfer` transfer value and MUST be protected by a reentrancy guard.
+* **Permissioned relayers** – The whitelist is a short-term trust compromise. Future iterations SHOULD use decentralised oracle/ZK proof verification.
 
-While signing the `requestArg` payload guarantees data integrity, it does not prevent replay attacks in itself:
+## Reference Implementation
 
-1. a signed payload can be replayed multiple times
-2. a signed payload can be replayed across multiple chains
-
-_Effective_ time replay attacks as described in `1.` are generally prevented by the transaction nonce.
-Cross chain replay can be prevented by leveraging the [EIP-712](./eip-712.md) `signTypedData` method.
-
-Replay attack would still be possible on any method that is not protected by either: this affects effectively all the "readonly" methods
-which are of very limited value for an attacker.
-
-For these reason, we do not recommend a specific replay protection mechanism at this time. If/when the need arise, the extensibility of
-the manifest will provide the necessary room to enforce a replay protection envelope (eg:JWT) for affected dapp.
-
-### Malicious manifests
-
-The manifest itself could be attacked, defeating the purpose of TWIST. We identified the following possible attacks, and their counter measure:
-
-1. An attacker can spoof DNS entries and use it to serve their own manifest: to avoid this, the wallet implementation MUST only query the manifest from `'https://${sender.tab.url}/${pathFromDNSRecord}`
-2. An attacker can leverage other flaws in a dapp to host a malicious manifest on the dapp domain itself
-   a. by leveraging open redirect: consequently the wallet MUST NOT follow redirect when querying the manifest
-   b. by managing to host a file on the dapp domain: consequently the wallet SHOULD verify the `content-type` header is equal to `application/json` to mitigate this attack vector
-
-## Copyright
-
-Copyright and related rights waived via [CC0](../LICENSE.md).
+See [`contracts/ERC7754CrossChainMint.sol`](../ERC7754CrossChainMint.sol).


### PR DESCRIPTION
Reference implementation: https://github.com/Opacus-xyz/Opacus-Standart/blob/main/contracts/ERC7754CrossChainMint.sol | Solidity ^0.8.24 compiled | 1% fee to 0xA943F46eE5f977067f07565CF1d31A10B68D7718