### PR TITLE
ERC-8210: Add multi-hop workflow reference scenarios

### DIFF
--- a/assets/erc-8210/scenarios/.gitignore
+++ b/assets/erc-8210/scenarios/.gitignore
@@ -1,0 +1,3 @@
+out/
+cache/
+lib/

--- a/assets/erc-8210/scenarios/.gitignore
+++ b/assets/erc-8210/scenarios/.gitignore
@@ -1,3 +1,4 @@
 out/
 cache/
 lib/
+foundry.lock

--- a/assets/erc-8210/scenarios/README.md
+++ b/assets/erc-8210/scenarios/README.md
@@ -18,12 +18,12 @@ author of ERC-8210, in post #107 of the ERC-8183 Ethereum Magicians thread):
 | **2** | **Behavior** | Evaluates behavioral independence and risk through hooks and oracles (`IRiskHook`, off-chain scorers) | Risk hooks, evaluator registries, scoring oracles |
 | **3** | **Recovery** | Provides post-hoc redress when Layers 1 and 2 do not catch the attack in time | ERC-8210 / AAP |
 
-The three scenarios below demonstrate how Layer 3 (recovery) **composes** with
-the other two layers through concrete, tested patterns. All three scenarios use
+The scenarios below demonstrate how Layer 3 (recovery) **composes** with
+the other two layers through concrete, tested patterns. All scenarios use
 the canonical ERC-8210 v1 interface, encoding their composition metadata
-(upstream references, slash record references, off-chain scoring CIDs) into
-the opaque `bytes calldata evidence` payload that AAP's `fileClaim` already
-defines.
+(upstream references, slash record references, off-chain scoring CIDs,
+solvency snapshots) into the opaque `bytes calldata evidence` payload
+that AAP's `fileClaim` already defines.
 
 ## Scenarios
 
@@ -32,6 +32,7 @@ defines.
 | 1 | [Multi-Hop Dependency Tracking](docs/scenario-1-multi-hop-dependency.md) | 3 (+ 1, 2 context) | Upstream reference encoded in `evidence` traces root cause across A→B→C→D pipeline |
 | 2 | [EvaluatorSlashed → fileClaim](docs/scenario-2-evaluator-slash-claim.md) | 2 → 3 | Slash event serves as automatic proof for AAP claim — no re-adjudication |
 | 3 | [Hybrid Off-chain Scoring](docs/scenario-3-hybrid-offchain-scoring.md) | 1 + 2 + 3 | Same `reasoningCID` consumed by task rejection and claim filing |
+| 4 | [Solvency-Aware Claim Assessment](docs/scenario-4-solvency-aware-claim.md) | 2 → 3 | `EvaluatorSlashed` + `EvaluatorStakeUpdated` in the same tx enable stateless solvency assessment |
 
 ## Project Structure
 
@@ -49,16 +50,19 @@ scenarios/
 │       ├── AAPMockMinimal.sol                 # Minimal AAP implementation (deposit, commit, file, resolve, payout)
 │       ├── MockERC20.sol                      # ERC-20 with mint
 │       ├── EvaluatorRegistryMock.sol          # Slash events (Scenario 2)
+│       ├── EvaluatorRegistryWithStake.sol     # Slash + stake tracking (Scenario 4)
 │       ├── OffchainScorerMock.sol             # AHS-style scoring (Scenario 3)
 │       └── ChainedJobsMock.sol                # Job pipeline A→B→C→D (Scenario 1)
 ├── docs/
 │   ├── scenario-1-multi-hop-dependency.md
 │   ├── scenario-2-evaluator-slash-claim.md
-│   └── scenario-3-hybrid-offchain-scoring.md
+│   ├── scenario-3-hybrid-offchain-scoring.md
+│   └── scenario-4-solvency-aware-claim.md
 └── test/
     ├── Scenario1_MultiHopDependency.t.sol
     ├── Scenario2_EvaluatorSlashClaim.t.sol
-    └── Scenario3_HybridOffchainScoring.t.sol
+    ├── Scenario3_HybridOffchainScoring.t.sol
+    └── Scenario4_SolvencyAwareClaimAssessment.t.sol
 ```
 
 ## Build & Test
@@ -79,6 +83,8 @@ forge test -vv
 [PASS] test_MultiHopDependencyTracking()
 [PASS] test_EvaluatorSlashToClaim()
 [PASS] test_HybridOffchainScoring()
+[PASS] test_SolvencyAwareClaimAssessment()
+[PASS] test_ZeroStakePostSlash_FullWipeout()
 ```
 
 ## Spec Reference

--- a/assets/erc-8210/scenarios/README.md
+++ b/assets/erc-8210/scenarios/README.md
@@ -15,17 +15,21 @@ author of ERC-8210, in post #107 of the ERC-8183 Ethereum Magicians thread):
 | Layer | Name | What it does | Enforced by |
 |-------|------|-------------|-------------|
 | **1** | **Structure** | Enforces what contracts can verify directly: auto-assignment, role separation, state machines | ERC-8183 core |
-| **2** | **Behavior** | Evaluates behavioral independence and risk through hooks and oracles (`IRiskHook`, off-chain scorers) | Risk hooks, evaluator registries, AHS oracles |
+| **2** | **Behavior** | Evaluates behavioral independence and risk through hooks and oracles (`IRiskHook`, off-chain scorers) | Risk hooks, evaluator registries, scoring oracles |
 | **3** | **Recovery** | Provides post-hoc redress when Layers 1 and 2 do not catch the attack in time | ERC-8210 / AAP |
 
 The three scenarios below demonstrate how Layer 3 (recovery) **composes** with
-the other two layers through concrete, tested patterns.
+the other two layers through concrete, tested patterns. All three scenarios use
+the canonical ERC-8210 v1 interface, encoding their composition metadata
+(upstream references, slash record references, off-chain scoring CIDs) into
+the opaque `bytes calldata evidence` payload that AAP's `fileClaim` already
+defines.
 
 ## Scenarios
 
 | # | Scenario | Layers | Key pattern |
 |---|----------|--------|-------------|
-| 1 | [Multi-Hop Dependency Tracking](docs/scenario-1-multi-hop-dependency.md) | 3 (+ 1, 2 context) | `upstream` field traces root cause across A→B→C→D pipeline |
+| 1 | [Multi-Hop Dependency Tracking](docs/scenario-1-multi-hop-dependency.md) | 3 (+ 1, 2 context) | Upstream reference encoded in `evidence` traces root cause across A→B→C→D pipeline |
 | 2 | [EvaluatorSlashed → fileClaim](docs/scenario-2-evaluator-slash-claim.md) | 2 → 3 | Slash event serves as automatic proof for AAP claim — no re-adjudication |
 | 3 | [Hybrid Off-chain Scoring](docs/scenario-3-hybrid-offchain-scoring.md) | 1 + 2 + 3 | Same `reasoningCID` consumed by task rejection and claim filing |
 
@@ -39,10 +43,10 @@ scenarios/
 ├── .gitignore
 ├── contracts/
 │   ├── interfaces/
-│   │   ├── IAAP.sol                           # Minimal AAP interface
+│   │   ├── IAAP.sol                           # Minimal subset of ERC-8210 v1 interface
 │   │   └── IERC20.sol                         # Minimal ERC-20 interface
 │   └── mocks/
-│       ├── AAPMockMinimal.sol                 # AAP — just fileClaim + reviewClaim
+│       ├── AAPMockMinimal.sol                 # Minimal AAP implementation (deposit, commit, file, resolve, payout)
 │       ├── MockERC20.sol                      # ERC-20 with mint
 │       ├── EvaluatorRegistryMock.sol          # Slash events (Scenario 2)
 │       ├── OffchainScorerMock.sol             # AHS-style scoring (Scenario 3)

--- a/assets/erc-8210/scenarios/README.md
+++ b/assets/erc-8210/scenarios/README.md
@@ -1,0 +1,83 @@
+# ERC-8210 — Reference Scenarios for Multi-Hop Workflows
+
+> **Disclaimer:** These scenarios are independent of the test vectors in
+> [PR #1647](https://github.com/ethereum/ERCs/pull/1647) and provide their own
+> minimal mocks. They demonstrate composition patterns between ERC-8210 (Agent
+> Assurance Protocol) and other specs — primarily ERC-8183 — using concrete,
+> end-to-end Foundry tests.
+
+## Architectural Context
+
+The ERC-8183 discussion thread has converged on a **3-layer architecture** for
+autonomous agent safety (articulated by [@wangbin9953](https://github.com/wangbin9953),
+author of ERC-8210, in post #107 of the ERC-8183 Ethereum Magicians thread):
+
+| Layer | Name | What it does | Enforced by |
+|-------|------|-------------|-------------|
+| **1** | **Structure** | Enforces what contracts can verify directly: auto-assignment, role separation, state machines | ERC-8183 core |
+| **2** | **Behavior** | Evaluates behavioral independence and risk through hooks and oracles (`IRiskHook`, off-chain scorers) | Risk hooks, evaluator registries, AHS oracles |
+| **3** | **Recovery** | Provides post-hoc redress when Layers 1 and 2 do not catch the attack in time | ERC-8210 / AAP |
+
+The three scenarios below demonstrate how Layer 3 (recovery) **composes** with
+the other two layers through concrete, tested patterns.
+
+## Scenarios
+
+| # | Scenario | Layers | Key pattern |
+|---|----------|--------|-------------|
+| 1 | [Multi-Hop Dependency Tracking](docs/scenario-1-multi-hop-dependency.md) | 3 (+ 1, 2 context) | `upstream` field traces root cause across A→B→C→D pipeline |
+| 2 | [EvaluatorSlashed → fileClaim](docs/scenario-2-evaluator-slash-claim.md) | 2 → 3 | Slash event serves as automatic proof for AAP claim — no re-adjudication |
+| 3 | [Hybrid Off-chain Scoring](docs/scenario-3-hybrid-offchain-scoring.md) | 1 + 2 + 3 | Same `reasoningCID` consumed by task rejection and claim filing |
+
+## Project Structure
+
+```
+scenarios/
+├── README.md                                  # This file
+├── foundry.toml
+├── remappings.txt
+├── .gitignore
+├── contracts/
+│   ├── interfaces/
+│   │   ├── IAAP.sol                           # Minimal AAP interface
+│   │   └── IERC20.sol                         # Minimal ERC-20 interface
+│   └── mocks/
+│       ├── AAPMockMinimal.sol                 # AAP — just fileClaim + reviewClaim
+│       ├── MockERC20.sol                      # ERC-20 with mint
+│       ├── EvaluatorRegistryMock.sol          # Slash events (Scenario 2)
+│       ├── OffchainScorerMock.sol             # AHS-style scoring (Scenario 3)
+│       └── ChainedJobsMock.sol                # Job pipeline A→B→C→D (Scenario 1)
+├── docs/
+│   ├── scenario-1-multi-hop-dependency.md
+│   ├── scenario-2-evaluator-slash-claim.md
+│   └── scenario-3-hybrid-offchain-scoring.md
+└── test/
+    ├── Scenario1_MultiHopDependency.t.sol
+    ├── Scenario2_EvaluatorSlashClaim.t.sol
+    └── Scenario3_HybridOffchainScoring.t.sol
+```
+
+## Build & Test
+
+```bash
+cd assets/erc-8210/scenarios
+
+# Install dependencies (first time only)
+forge install foundry-rs/forge-std --no-commit
+
+# Run all scenario tests
+forge test -vv
+```
+
+### Expected output
+
+```
+[PASS] test_MultiHopDependencyTracking()
+[PASS] test_EvaluatorSlashToClaim()
+[PASS] test_HybridOffchainScoring()
+```
+
+## Spec Reference
+
+- [ERC-8210: Agent Assurance Protocol](https://eips.ethereum.org/ERCS/erc-8210)
+- [ERC-8183: Agent Task Coordination](https://eips.ethereum.org/ERCS/erc-8183)

--- a/assets/erc-8210/scenarios/contracts/interfaces/IAAP.sol
+++ b/assets/erc-8210/scenarios/contracts/interfaces/IAAP.sol
@@ -1,53 +1,151 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.24;
 
-/// @title Minimal IAAP interface – only the subset used by multi-hop scenarios.
-/// @dev This is NOT the full ERC-8210 interface. It covers fileClaim,
-///      reviewClaim, and the events/structs consumed by the three reference
-///      scenarios in this folder.
+/// @title IAAP — Minimal subset of the ERC-8210 (Agent Assurance Protocol) interface
+/// @notice This is a faithful subset of the ERC-8210 v1 specification, including
+///         only the types and functions exercised by the three reference scenarios
+///         in this folder. All function signatures, struct fields, and enum values
+///         match the canonical spec at:
+///         https://github.com/ethereum/ERCs/pull/1632
+///
+///         For the full interface (including AssuranceAccount lifecycle, JobAssurance
+///         expiry, payout, and additional getters), refer to the canonical spec.
 interface IAAP {
-    // ── Enums ──────────────────────────────────────────────────────────
-    enum ClaimStatus { Filed, UnderReview, Approved, Rejected, Appealed, Resolved }
-    enum Verdict     { Pending, Approve, Deny }
+    // ─────────────────────────────────────────────────────────────────
+    // Enums (matching ERC-8210 v1 spec)
+    // ─────────────────────────────────────────────────────────────────
 
-    // ── Structs ────────────────────────────────────────────────────────
-    struct Claim {
-        address claimant;
-        uint256 amount;
-        ClaimStatus status;
-        bytes32 evidenceHash;
-        bytes32 upstream;          // traceability to upstream cause
+    enum CoverageType {
+        JobFailure,        // Provider non-performance
+        EvaluatorDispute,  // Evaluator decision challenged
+        SettlementDefault, // Fund release failure after valid completion
+        AMLFreeze,         // Extension-reserved
+        SlashingLoss       // Extension-reserved
     }
 
-    // ── Events ─────────────────────────────────────────────────────────
+    enum AssuranceState {
+        Active,
+        Claimed,
+        Paid,
+        Released,
+        Expired
+    }
+
+    enum ClaimState {
+        None,
+        Filed,
+        Challenged,
+        Approved,
+        Denied,
+        Paid
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Structs (matching ERC-8210 v1 spec)
+    // ─────────────────────────────────────────────────────────────────
+
+    struct JobAssurance {
+        bytes32      assuranceId;
+        address      assuredAgent;
+        address      beneficiary;
+        bytes32      coveredJob;
+        CoverageType coverageType;
+        uint256      committedAmount;
+        uint64       expiry;
+        uint256      chainId;
+        bytes32      claimId;
+        AssuranceState state;
+    }
+
+    struct Claim {
+        bytes32    claimId;
+        bytes32    assuranceId;
+        address    beneficiary;
+        uint256    requestedAmount;
+        uint256    approvedAmount;
+        ClaimState state;
+        uint64     filedAt;
+        uint64     resolvedAt;
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Events (matching ERC-8210 v1 spec)
+    // ─────────────────────────────────────────────────────────────────
+
+    event AssuranceCommitted(
+        bytes32 indexed assuranceId,
+        address indexed assuredAgent,
+        bytes32 jobId,
+        address indexed beneficiary,
+        CoverageType coverageType,
+        uint256 committedAmount,
+        uint64 expiry
+    );
+
     event ClaimFiled(
-        uint256 indexed claimId,
-        address indexed claimant,
+        bytes32 indexed claimId,
+        bytes32 indexed assuranceId,
+        address indexed beneficiary,
+        uint256 requestedAmount
+    );
+
+    event ClaimResolved(
+        bytes32 indexed claimId,
+        bytes32 indexed assuranceId,
+        bool approved,
+        uint256 approvedAmount,
+        address indexed resolver
+    );
+
+    event ClaimPaid(
+        bytes32 indexed claimId,
+        bytes32 indexed assuranceId,
+        address indexed beneficiary,
+        uint256 amount
+    );
+
+    // ─────────────────────────────────────────────────────────────────
+    // Functions used by scenarios (matching ERC-8210 v1 spec)
+    // ─────────────────────────────────────────────────────────────────
+
+    /// @notice Deposit collateral into the caller's AssuranceAccount.
+    function depositAssurance(uint256 amount) external;
+
+    /// @notice Create an assurance commitment for a specific Job.
+    function commitToJob(
+        bytes32 jobId,
+        CoverageType coverageType,
+        address beneficiary,
         uint256 amount,
-        bytes32 evidenceHash
-    );
+        uint64 expiry
+    ) external returns (bytes32 assuranceId);
 
-    event ClaimReviewed(
-        uint256 indexed claimId,
-        Verdict verdict,
-        bytes32 reason
-    );
-
-    // ── Functions ──────────────────────────────────────────────────────
-    /// @notice File a new claim with evidence and optional upstream reference.
+    /// @notice File a Claim against an active JobAssurance.
+    /// @dev    `evidence` is an opaque bytes payload. Scenarios in this folder
+    ///         encode upstream references, slash record references, and offchain
+    ///         scoring CIDs into this payload, demonstrating that all forms of
+    ///         provenance composition can be carried by `evidence` without
+    ///         expanding the core spec interface.
     function fileClaim(
-        uint256 amount,
-        bytes32 evidenceHash,
-        bytes32 upstream
-    ) external returns (uint256 claimId);
+        bytes32 assuranceId,
+        uint256 requestedAmount,
+        bytes calldata evidence
+    ) external returns (bytes32 claimId);
 
-    /// @notice Review an existing claim and render a verdict.
-    function reviewClaim(
-        uint256 claimId,
-        Verdict verdict,
-        bytes32 reason
+    /// @notice Resolve a pending Claim. Caller must be an authorized resolver.
+    function resolveClaim(
+        bytes32 claimId,
+        bool approved,
+        uint256 approvedAmount,
+        bytes calldata reason
     ) external;
 
-    /// @notice Read a claim by ID.
-    function getClaim(uint256 claimId) external view returns (Claim memory);
+    /// @notice Settle an approved Claim. Permissionless.
+    function payout(bytes32 claimId) external;
+
+    /// @notice Query a JobAssurance by its identifier.
+    function getJobAssurance(bytes32 assuranceId) external view returns (JobAssurance memory);
+
+    /// @notice Query a Claim by its identifier.
+    function getClaim(bytes32 claimId) external view returns (Claim memory);
 }

--- a/assets/erc-8210/scenarios/contracts/interfaces/IAAP.sol
+++ b/assets/erc-8210/scenarios/contracts/interfaces/IAAP.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+/// @title Minimal IAAP interface – only the subset used by multi-hop scenarios.
+/// @dev This is NOT the full ERC-8210 interface. It covers fileClaim,
+///      reviewClaim, and the events/structs consumed by the three reference
+///      scenarios in this folder.
+interface IAAP {
+    // ── Enums ──────────────────────────────────────────────────────────
+    enum ClaimStatus { Filed, UnderReview, Approved, Rejected, Appealed, Resolved }
+    enum Verdict     { Pending, Approve, Deny }
+
+    // ── Structs ────────────────────────────────────────────────────────
+    struct Claim {
+        address claimant;
+        uint256 amount;
+        ClaimStatus status;
+        bytes32 evidenceHash;
+        bytes32 upstream;          // traceability to upstream cause
+    }
+
+    // ── Events ─────────────────────────────────────────────────────────
+    event ClaimFiled(
+        uint256 indexed claimId,
+        address indexed claimant,
+        uint256 amount,
+        bytes32 evidenceHash
+    );
+
+    event ClaimReviewed(
+        uint256 indexed claimId,
+        Verdict verdict,
+        bytes32 reason
+    );
+
+    // ── Functions ──────────────────────────────────────────────────────
+    /// @notice File a new claim with evidence and optional upstream reference.
+    function fileClaim(
+        uint256 amount,
+        bytes32 evidenceHash,
+        bytes32 upstream
+    ) external returns (uint256 claimId);
+
+    /// @notice Review an existing claim and render a verdict.
+    function reviewClaim(
+        uint256 claimId,
+        Verdict verdict,
+        bytes32 reason
+    ) external;
+
+    /// @notice Read a claim by ID.
+    function getClaim(uint256 claimId) external view returns (Claim memory);
+}

--- a/assets/erc-8210/scenarios/contracts/interfaces/IERC20.sol
+++ b/assets/erc-8210/scenarios/contracts/interfaces/IERC20.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+/// @title Minimal ERC-20 interface for scenario mocks.
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/assets/erc-8210/scenarios/contracts/mocks/AAPMockMinimal.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/AAPMockMinimal.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+import "../interfaces/IAAP.sol";
+import "../interfaces/IERC20.sol";
+
+/// @title Minimal AAP mock — only the functions exercised by the three
+///        reference scenarios.  This is NOT the full ERC-8210 implementation.
+contract AAPMockMinimal is IAAP {
+    IERC20  public token;
+    address public reviewer;
+
+    uint256 private _nextClaimId;
+    mapping(uint256 => Claim) private _claims;
+
+    constructor(address _token, address _reviewer) {
+        token    = IERC20(_token);
+        reviewer = _reviewer;
+    }
+
+    // ── Core ───────────────────────────────────────────────────────────
+
+    function fileClaim(
+        uint256 amount,
+        bytes32 evidenceHash,
+        bytes32 upstream
+    ) external override returns (uint256 claimId) {
+        claimId = _nextClaimId++;
+        _claims[claimId] = Claim({
+            claimant:     msg.sender,
+            amount:       amount,
+            status:       ClaimStatus.Filed,
+            evidenceHash: evidenceHash,
+            upstream:     upstream
+        });
+        emit ClaimFiled(claimId, msg.sender, amount, evidenceHash);
+    }
+
+    function reviewClaim(
+        uint256 claimId,
+        Verdict verdict,
+        bytes32 reason
+    ) external override {
+        require(msg.sender == reviewer, "AAP: not reviewer");
+        Claim storage c = _claims[claimId];
+        require(c.status == ClaimStatus.Filed, "AAP: not filed");
+
+        if (verdict == Verdict.Approve) {
+            c.status = ClaimStatus.Approved;
+            token.transfer(c.claimant, c.amount);
+        } else {
+            c.status = ClaimStatus.Rejected;
+        }
+        emit ClaimReviewed(claimId, verdict, reason);
+    }
+
+    function getClaim(uint256 claimId) external view override returns (Claim memory) {
+        return _claims[claimId];
+    }
+}

--- a/assets/erc-8210/scenarios/contracts/mocks/AAPMockMinimal.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/AAPMockMinimal.sol
@@ -4,57 +4,208 @@ pragma solidity ^0.8.24;
 import "../interfaces/IAAP.sol";
 import "../interfaces/IERC20.sol";
 
-/// @title Minimal AAP mock — only the functions exercised by the three
-///        reference scenarios.  This is NOT the full ERC-8210 implementation.
+/// @title AAPMockMinimal — Minimal ERC-8210 implementation for reference scenarios.
+/// @notice Implements the subset of ERC-8210 v1 needed by the three scenarios in
+///         this folder. Behaves identically to the canonical spec for the covered
+///         operations but omits features not exercised by the scenarios (e.g.
+///         release/expire flows, account pausing, settlement asset management).
+///
+///         This mock is NOT a substitute for a production AAP implementation.
+///         It exists solely to validate that the composition patterns demonstrated
+///         in the scenarios remain expressible through the canonical spec interface.
 contract AAPMockMinimal is IAAP {
     IERC20  public token;
-    address public reviewer;
+    address public resolver;
 
-    uint256 private _nextClaimId;
-    mapping(uint256 => Claim) private _claims;
+    // ─────────────────────────────────────────────────────────────────
+    // State
+    // ─────────────────────────────────────────────────────────────────
 
-    constructor(address _token, address _reviewer) {
-        token    = IERC20(_token);
-        reviewer = _reviewer;
+    struct Account {
+        uint256 totalFunded;
+        uint256 availableAmount;
+        uint256 lockedAmount;
+        uint256 paidOutAmount;
     }
 
-    // ── Core ───────────────────────────────────────────────────────────
+    mapping(address => Account)      private _accounts;
+    mapping(bytes32 => JobAssurance) private _assurances;
+    mapping(bytes32 => Claim)        private _claims;
+    mapping(address => uint256)      private _assuranceNonce;
+    uint256 private _claimNonce;
+
+    /// @notice Hash of the evidence bytes payload, keyed by claimId.
+    /// @dev    Mirrors the canonical reference implementation. Scenarios verify
+    ///         that the encoded evidence (which carries upstream references,
+    ///         slash record references, or offchain scoring CIDs) is faithfully
+    ///         hashed and stored on chain.
+    mapping(bytes32 => bytes32) public evidenceHashes;
+
+    constructor(address _token, address _resolver) {
+        token    = IERC20(_token);
+        resolver = _resolver;
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // AssuranceAccount lifecycle
+    // ─────────────────────────────────────────────────────────────────
+
+    function depositAssurance(uint256 amount) external override {
+        require(amount > 0, "AAP: amount is 0");
+        token.transferFrom(msg.sender, address(this), amount);
+
+        Account storage acct = _accounts[msg.sender];
+        acct.totalFunded     += amount;
+        acct.availableAmount += amount;
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // JobAssurance lifecycle
+    // ─────────────────────────────────────────────────────────────────
+
+    function commitToJob(
+        bytes32 jobId,
+        CoverageType coverageType,
+        address beneficiary,
+        uint256 amount,
+        uint64 expiry
+    ) external override returns (bytes32 assuranceId) {
+        require(amount > 0, "AAP: amount is 0");
+        require(beneficiary != address(0), "AAP: zero beneficiary");
+        require(expiry > block.timestamp, "AAP: expiry in the past");
+
+        Account storage acct = _accounts[msg.sender];
+        require(acct.availableAmount >= amount, "AAP: insufficient available");
+
+        // Generate collision-resistant assuranceId (matches spec ID generation pattern)
+        assuranceId = keccak256(abi.encodePacked(
+            "AAP_ASSURANCE",
+            msg.sender,
+            jobId,
+            uint8(coverageType),
+            _assuranceNonce[msg.sender]++
+        ));
+
+        // Reserve funds
+        acct.availableAmount -= amount;
+        acct.lockedAmount    += amount;
+
+        _assurances[assuranceId] = JobAssurance({
+            assuranceId:     assuranceId,
+            assuredAgent:    msg.sender,
+            beneficiary:     beneficiary,
+            coveredJob:      jobId,
+            coverageType:    coverageType,
+            committedAmount: amount,
+            expiry:          expiry,
+            chainId:         block.chainid,
+            claimId:         bytes32(0),
+            state:           AssuranceState.Active
+        });
+
+        emit AssuranceCommitted(assuranceId, msg.sender, jobId, beneficiary, coverageType, amount, expiry);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Claim lifecycle
+    // ─────────────────────────────────────────────────────────────────
 
     function fileClaim(
-        uint256 amount,
-        bytes32 evidenceHash,
-        bytes32 upstream
-    ) external override returns (uint256 claimId) {
-        claimId = _nextClaimId++;
+        bytes32 assuranceId,
+        uint256 requestedAmount,
+        bytes calldata evidence
+    ) external override returns (bytes32 claimId) {
+        JobAssurance storage ja = _assurances[assuranceId];
+        require(ja.state == AssuranceState.Active, "AAP: assurance not Active");
+        require(ja.beneficiary == msg.sender, "AAP: caller is not beneficiary");
+        require(requestedAmount > 0, "AAP: requestedAmount is 0");
+        require(requestedAmount <= ja.committedAmount, "AAP: exceeds committedAmount");
+
+        claimId = keccak256(abi.encodePacked(
+            "AAP_CLAIM",
+            assuranceId,
+            _claimNonce++
+        ));
+
+        // Store evidence hash on chain. The opaque `evidence` bytes can carry
+        // any composition payload (upstream refs, slash record hashes, scoring
+        // CIDs) without expanding the spec interface.
+        evidenceHashes[claimId] = keccak256(evidence);
+
+        ja.state   = AssuranceState.Claimed;
+        ja.claimId = claimId;
+
         _claims[claimId] = Claim({
-            claimant:     msg.sender,
-            amount:       amount,
-            status:       ClaimStatus.Filed,
-            evidenceHash: evidenceHash,
-            upstream:     upstream
+            claimId:         claimId,
+            assuranceId:     assuranceId,
+            beneficiary:     msg.sender,
+            requestedAmount: requestedAmount,
+            approvedAmount:  0,
+            state:           ClaimState.Filed,
+            filedAt:         uint64(block.timestamp),
+            resolvedAt:      0
         });
-        emit ClaimFiled(claimId, msg.sender, amount, evidenceHash);
+
+        emit ClaimFiled(claimId, assuranceId, msg.sender, requestedAmount);
     }
 
-    function reviewClaim(
-        uint256 claimId,
-        Verdict verdict,
-        bytes32 reason
+    function resolveClaim(
+        bytes32 claimId,
+        bool approved,
+        uint256 approvedAmount,
+        bytes calldata /*reason*/
     ) external override {
-        require(msg.sender == reviewer, "AAP: not reviewer");
-        Claim storage c = _claims[claimId];
-        require(c.status == ClaimStatus.Filed, "AAP: not filed");
+        require(msg.sender == resolver, "AAP: caller is not resolver");
+        Claim storage claim = _claims[claimId];
+        require(claim.state == ClaimState.Filed, "AAP: claim not Filed");
 
-        if (verdict == Verdict.Approve) {
-            c.status = ClaimStatus.Approved;
-            token.transfer(c.claimant, c.amount);
+        JobAssurance storage ja = _assurances[claim.assuranceId];
+        claim.resolvedAt = uint64(block.timestamp);
+
+        if (approved) {
+            require(approvedAmount > 0, "AAP: approvedAmount is 0");
+            require(approvedAmount <= claim.requestedAmount, "AAP: exceeds requested");
+            require(approvedAmount <= ja.committedAmount, "AAP: exceeds committed");
+            claim.approvedAmount = approvedAmount;
+            claim.state          = ClaimState.Approved;
         } else {
-            c.status = ClaimStatus.Rejected;
+            claim.approvedAmount = 0;
+            claim.state          = ClaimState.Denied;
+            ja.state             = AssuranceState.Active;
         }
-        emit ClaimReviewed(claimId, verdict, reason);
+
+        emit ClaimResolved(claimId, claim.assuranceId, approved, claim.approvedAmount, msg.sender);
     }
 
-    function getClaim(uint256 claimId) external view override returns (Claim memory) {
+    function payout(bytes32 claimId) external override {
+        Claim storage claim = _claims[claimId];
+        require(claim.state == ClaimState.Approved, "AAP: claim not Approved");
+
+        JobAssurance storage ja   = _assurances[claim.assuranceId];
+        Account      storage acct = _accounts[ja.assuredAgent];
+
+        uint256 amt = claim.approvedAmount;
+        require(acct.lockedAmount >= amt, "AAP: insufficient locked");
+
+        acct.lockedAmount  -= amt;
+        acct.paidOutAmount += amt;
+        claim.state        = ClaimState.Paid;
+        ja.state           = AssuranceState.Paid;
+
+        token.transfer(claim.beneficiary, amt);
+
+        emit ClaimPaid(claimId, claim.assuranceId, claim.beneficiary, amt);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Views
+    // ─────────────────────────────────────────────────────────────────
+
+    function getJobAssurance(bytes32 assuranceId) external view override returns (JobAssurance memory) {
+        return _assurances[assuranceId];
+    }
+
+    function getClaim(bytes32 claimId) external view override returns (Claim memory) {
         return _claims[claimId];
     }
 }

--- a/assets/erc-8210/scenarios/contracts/mocks/ChainedJobsMock.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/ChainedJobsMock.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+/// @title Chained-jobs mock — simulates a pipeline of dependent jobs (Scenario 1).
+/// @dev   Models a simplified A → B → C → D pipeline where each job depends on
+///        the previous one.  When a job fails, downstream jobs can be traced back
+///        to the root cause via the `upstream` field.
+contract ChainedJobsMock {
+    // ── Enums ──────────────────────────────────────────────────────────
+    enum JobStatus { Pending, Running, Completed, Failed }
+
+    // ── Events ─────────────────────────────────────────────────────────
+    event JobCreated(uint256 indexed jobId, bytes32 indexed upstreamJobHash, bytes32 label);
+    event JobStatusChanged(uint256 indexed jobId, JobStatus status);
+
+    // ── State ──────────────────────────────────────────────────────────
+    struct Job {
+        bytes32   label;
+        JobStatus status;
+        uint256   upstreamJobId;    // 0 = root job (no upstream)
+        bool      exists;
+    }
+
+    mapping(uint256 => Job) public jobs;
+    uint256 public nextJobId;
+
+    // ── Functions ──────────────────────────────────────────────────────
+
+    /// @notice Create a new job in the pipeline.
+    function createJob(bytes32 label, uint256 upstreamJobId) external returns (uint256 jobId) {
+        if (upstreamJobId != 0) {
+            require(jobs[upstreamJobId].exists, "ChainedJobs: upstream does not exist");
+        }
+        jobId = ++nextJobId; // 1-based
+        jobs[jobId] = Job({
+            label:         label,
+            status:        JobStatus.Pending,
+            upstreamJobId: upstreamJobId,
+            exists:        true
+        });
+        bytes32 upHash = upstreamJobId == 0
+            ? bytes32(0)
+            : keccak256(abi.encode(upstreamJobId, jobs[upstreamJobId].label));
+        emit JobCreated(jobId, upHash, label);
+    }
+
+    /// @notice Transition a job to a new status.
+    function setStatus(uint256 jobId, JobStatus status) external {
+        require(jobs[jobId].exists, "ChainedJobs: job does not exist");
+        jobs[jobId].status = status;
+        emit JobStatusChanged(jobId, status);
+    }
+
+    /// @notice Walk the chain from a given job back to the root, returning all
+    ///         job IDs in reverse order (leaf → root).
+    function traceToRoot(uint256 jobId) external view returns (uint256[] memory chain) {
+        // First pass: count depth.
+        uint256 depth;
+        uint256 cursor = jobId;
+        while (cursor != 0) {
+            require(jobs[cursor].exists, "ChainedJobs: broken chain");
+            depth++;
+            cursor = jobs[cursor].upstreamJobId;
+        }
+
+        // Second pass: fill array.
+        chain  = new uint256[](depth);
+        cursor = jobId;
+        for (uint256 i = 0; i < depth; i++) {
+            chain[i] = cursor;
+            cursor   = jobs[cursor].upstreamJobId;
+        }
+    }
+
+    /// @notice Build a deterministic upstream hash that AAP can store.
+    function upstreamHash(uint256 jobId) external view returns (bytes32) {
+        require(jobs[jobId].exists, "ChainedJobs: job does not exist");
+        return keccak256(abi.encode(jobId, jobs[jobId].label, jobs[jobId].upstreamJobId));
+    }
+}

--- a/assets/erc-8210/scenarios/contracts/mocks/EvaluatorRegistryMock.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/EvaluatorRegistryMock.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+/// @title EvaluatorRegistry mock — emits slash events consumed by Scenario 2.
+/// @dev   Event signature agreed with Bakugo32 (Demsys) in the ERC-8183 thread.
+contract EvaluatorRegistryMock {
+    // ── Events ─────────────────────────────────────────────────────────
+    event EvaluatorSlashed(
+        address indexed evaluator,
+        uint256 indexed jobId,
+        uint256 slashedAmount,
+        bytes32 reason
+    );
+
+    // ── State ──────────────────────────────────────────────────────────
+    struct SlashRecord {
+        address evaluator;
+        uint256 jobId;
+        uint256 slashedAmount;
+        bytes32 reason;
+        uint256 timestamp;
+    }
+
+    mapping(uint256 => SlashRecord) public slashRecords; // jobId => record
+    uint256 public slashCount;
+
+    // ── Functions ──────────────────────────────────────────────────────
+
+    /// @notice Slash an evaluator for misconduct on a specific job.
+    function slashEvaluator(
+        address evaluator,
+        uint256 jobId,
+        uint256 slashedAmount,
+        bytes32 reason
+    ) external {
+        slashRecords[jobId] = SlashRecord({
+            evaluator:     evaluator,
+            jobId:         jobId,
+            slashedAmount: slashedAmount,
+            reason:        reason,
+            timestamp:     block.timestamp
+        });
+        slashCount++;
+        emit EvaluatorSlashed(evaluator, jobId, slashedAmount, reason);
+    }
+
+    /// @notice Build an evidence hash from a slash record for AAP claim filing.
+    function buildEvidenceHash(uint256 jobId) external view returns (bytes32) {
+        SlashRecord memory r = slashRecords[jobId];
+        return keccak256(abi.encode(r.evaluator, r.jobId, r.slashedAmount, r.reason, r.timestamp));
+    }
+}

--- a/assets/erc-8210/scenarios/contracts/mocks/EvaluatorRegistryMock.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/EvaluatorRegistryMock.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.24;
 
 /// @title EvaluatorRegistry mock — emits slash events consumed by Scenario 2.
-/// @dev   Event signature agreed with Bakugo32 (Demsys) in the ERC-8183 thread.
+/// @dev   Event signature agreed with Demsys (github.com/Demsys/agent-settlement-protocol)
+///        in the ERC-8183 Ethereum Magicians thread.
 contract EvaluatorRegistryMock {
     // ── Events ─────────────────────────────────────────────────────────
     event EvaluatorSlashed(

--- a/assets/erc-8210/scenarios/contracts/mocks/EvaluatorRegistryMock.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/EvaluatorRegistryMock.sol
@@ -9,7 +9,7 @@ contract EvaluatorRegistryMock {
     event EvaluatorSlashed(
         address indexed evaluator,
         uint256 indexed jobId,
-        uint256 slashedAmount,
+        uint256 amount,
         bytes32 reason
     );
 
@@ -17,7 +17,7 @@ contract EvaluatorRegistryMock {
     struct SlashRecord {
         address evaluator;
         uint256 jobId;
-        uint256 slashedAmount;
+        uint256 amount;
         bytes32 reason;
         uint256 timestamp;
     }
@@ -31,18 +31,18 @@ contract EvaluatorRegistryMock {
     function slashEvaluator(
         address evaluator,
         uint256 jobId,
-        uint256 slashedAmount,
+        uint256 amount,
         bytes32 reason
     ) external {
         slashRecords[jobId] = SlashRecord({
-            evaluator:     evaluator,
-            jobId:         jobId,
-            slashedAmount: slashedAmount,
-            reason:        reason,
-            timestamp:     block.timestamp
+            evaluator: evaluator,
+            jobId:     jobId,
+            amount:    amount,
+            reason:    reason,
+            timestamp: block.timestamp
         });
         slashCount++;
-        emit EvaluatorSlashed(evaluator, jobId, slashedAmount, reason);
+        emit EvaluatorSlashed(evaluator, jobId, amount, reason);
     }
 
     /// @notice Build an evidence hash from a slash record for AAP claim filing.
@@ -53,6 +53,6 @@ contract EvaluatorRegistryMock {
     function buildEvidenceHash(uint256 jobId) external view returns (bytes32) {
         SlashRecord memory r = slashRecords[jobId];
         if (r.timestamp == 0) return bytes32(0);
-        return keccak256(abi.encode(r.evaluator, r.jobId, r.slashedAmount, r.reason, r.timestamp));
+        return keccak256(abi.encode(r.evaluator, r.jobId, r.amount, r.reason, r.timestamp));
     }
 }

--- a/assets/erc-8210/scenarios/contracts/mocks/EvaluatorRegistryMock.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/EvaluatorRegistryMock.sol
@@ -46,8 +46,13 @@ contract EvaluatorRegistryMock {
     }
 
     /// @notice Build an evidence hash from a slash record for AAP claim filing.
+    /// @dev    Returns bytes32(0) for non-existent records to avoid collision
+    ///         with a "valid" hash of all-zero fields. Consumers can rely on a
+    ///         non-zero return value as proof that a slash actually occurred
+    ///         for the given jobId.
     function buildEvidenceHash(uint256 jobId) external view returns (bytes32) {
         SlashRecord memory r = slashRecords[jobId];
+        if (r.timestamp == 0) return bytes32(0);
         return keccak256(abi.encode(r.evaluator, r.jobId, r.slashedAmount, r.reason, r.timestamp));
     }
 }

--- a/assets/erc-8210/scenarios/contracts/mocks/EvaluatorRegistryWithStake.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/EvaluatorRegistryWithStake.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+/// @title EvaluatorRegistry mock with stake tracking — extends the slash
+///        pattern from Scenario 2 with an EvaluatorStakeUpdated event for
+///        stateless solvency assessment (Scenario 4).
+/// @dev   Event signatures:
+///        - EvaluatorSlashed: 4-field canonical signature agreed with
+///          Demsys (github.com/Demsys/agent-settlement-protocol) in the
+///          ERC-8183 Ethereum Magicians thread.
+///        - EvaluatorStakeUpdated: designed collaboratively in the same
+///          thread. oldBalance/newBalance refinement contributed by
+///          ThoughtProof for stateless-indexer compatibility.
+contract EvaluatorRegistryWithStake {
+    event EvaluatorSlashed(
+        address indexed evaluator,
+        uint256 indexed jobId,
+        uint256 amount,
+        bytes32 reason
+    );
+
+    event EvaluatorStakeUpdated(
+        address indexed evaluator,
+        uint256 oldBalance,
+        uint256 newBalance
+    );
+
+    struct SlashRecord {
+        address evaluator;
+        uint256 jobId;
+        uint256 amount;
+        bytes32 reason;
+        uint256 timestamp;
+    }
+
+    mapping(address => uint256) public stakeBalances;
+    mapping(uint256 => SlashRecord) public slashRecords;
+    uint256 public slashCount;
+
+    function depositStake(uint256 amount) external {
+        require(amount > 0, "Registry: amount is 0");
+        uint256 oldBalance = stakeBalances[msg.sender];
+        stakeBalances[msg.sender] = oldBalance + amount;
+        emit EvaluatorStakeUpdated(msg.sender, oldBalance, oldBalance + amount);
+    }
+
+    /// @dev Emits both EvaluatorSlashed and EvaluatorStakeUpdated in the
+    ///      same transaction for stateless solvency assessment.
+    function slashEvaluator(
+        address evaluator,
+        uint256 jobId,
+        uint256 amount,
+        bytes32 reason
+    ) external {
+        uint256 oldBalance = stakeBalances[evaluator];
+        require(oldBalance >= amount, "Registry: insufficient stake");
+        stakeBalances[evaluator] = oldBalance - amount;
+        slashRecords[jobId] = SlashRecord({
+            evaluator: evaluator,
+            jobId:     jobId,
+            amount:    amount,
+            reason:    reason,
+            timestamp: block.timestamp
+        });
+        slashCount++;
+        emit EvaluatorSlashed(evaluator, jobId, amount, reason);
+        emit EvaluatorStakeUpdated(evaluator, oldBalance, oldBalance - amount);
+    }
+
+    /// @dev Returns bytes32(0) for non-existent records.
+    function buildEvidenceHash(uint256 jobId) external view returns (bytes32) {
+        SlashRecord memory r = slashRecords[jobId];
+        if (r.timestamp == 0) return bytes32(0);
+        return keccak256(abi.encode(r.evaluator, r.jobId, r.amount, r.reason, r.timestamp));
+    }
+
+    function buildStakeEvidenceHash(address evaluator) external view returns (bytes32) {
+        return keccak256(abi.encode(evaluator, stakeBalances[evaluator]));
+    }
+}

--- a/assets/erc-8210/scenarios/contracts/mocks/MockERC20.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/MockERC20.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+import "../interfaces/IERC20.sol";
+
+/// @title Minimal ERC-20 mock for scenario tests.
+contract MockERC20 is IERC20 {
+    string public name;
+    string public symbol;
+    uint8  public decimals = 18;
+
+    uint256 public override totalSupply;
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) public override allowance;
+
+    constructor(string memory _name, string memory _symbol) {
+        name   = _name;
+        symbol = _symbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        totalSupply        += amount;
+        balanceOf[to]      += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external override returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external override returns (bool) {
+        return _transfer(msg.sender, to, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external override returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        return _transfer(from, to, amount);
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal returns (bool) {
+        balanceOf[from] -= amount;
+        balanceOf[to]   += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}

--- a/assets/erc-8210/scenarios/contracts/mocks/OffchainScorerMock.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/OffchainScorerMock.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.24;
 
 /// @title Off-chain scorer mock — simulates AHS-style scoring (Scenario 3).
-/// @notice Inspired by the conceptual AHS (Agent Health Score) approach.
+/// @notice Inspired by the conceptual AHS (Agent Health Score) approach by
+///         moonshot-cyber (project: agent-health-monitor,
+///         https://github.com/moonshot-cyber/agent-health-monitor).
 ///         RNWY is a separate project with related but distinct multidimensional
 ///         scoring (soulbound identity, explicit sybil signal weights, live
 ///         ERC-8183 hook integration) and will be referenced separately in the

--- a/assets/erc-8210/scenarios/contracts/mocks/OffchainScorerMock.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/OffchainScorerMock.sol
@@ -2,9 +2,13 @@
 pragma solidity ^0.8.24;
 
 /// @title Off-chain scorer mock — simulates AHS-style scoring (Scenario 3).
-/// @dev   Inspired by the Agent Health Score concept from RNWY (pablocactus).
-///        In production the score would be posted via an oracle; here we allow
-///        direct setting for test determinism.
+/// @notice Inspired by the conceptual AHS (Agent Health Score) approach.
+///         RNWY is a separate project with related but distinct multidimensional
+///         scoring (soulbound identity, explicit sybil signal weights, live
+///         ERC-8183 hook integration) and will be referenced separately in the
+///         AAP v2 IRiskHook section once their methodology document is published.
+/// @dev    In production the score would be posted via an oracle; here we allow
+///         direct setting for test determinism.
 contract OffchainScorerMock {
     // ── Enums ──────────────────────────────────────────────────────────
     enum ScorerVerdict { PENDING, APPROVE, DENY }

--- a/assets/erc-8210/scenarios/contracts/mocks/OffchainScorerMock.sol
+++ b/assets/erc-8210/scenarios/contracts/mocks/OffchainScorerMock.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+/// @title Off-chain scorer mock — simulates AHS-style scoring (Scenario 3).
+/// @dev   Inspired by the Agent Health Score concept from RNWY (pablocactus).
+///        In production the score would be posted via an oracle; here we allow
+///        direct setting for test determinism.
+contract OffchainScorerMock {
+    // ── Enums ──────────────────────────────────────────────────────────
+    enum ScorerVerdict { PENDING, APPROVE, DENY }
+
+    // ── Events ─────────────────────────────────────────────────────────
+    event ScorePosted(
+        address indexed subject,
+        ScorerVerdict verdict,
+        uint8 confidence,
+        bytes32 reasoningCID
+    );
+
+    // ── State ──────────────────────────────────────────────────────────
+    struct Score {
+        ScorerVerdict verdict;
+        uint8         confidence; // 0-100
+        bytes32       reasoningCID;
+    }
+
+    mapping(address => Score) public scores;
+
+    // ── Functions ──────────────────────────────────────────────────────
+
+    /// @notice Post a score for a subject (simulates oracle callback).
+    function postScore(
+        address subject,
+        ScorerVerdict verdict,
+        uint8 confidence,
+        bytes32 reasoningCID
+    ) external {
+        scores[subject] = Score({
+            verdict:      verdict,
+            confidence:   confidence,
+            reasoningCID: reasoningCID
+        });
+        emit ScorePosted(subject, verdict, confidence, reasoningCID);
+    }
+
+    /// @notice Read the latest score for a subject.
+    function score(address subject)
+        external
+        view
+        returns (ScorerVerdict verdict, uint8 confidence, bytes32 reasoningCID)
+    {
+        Score memory s = scores[subject];
+        return (s.verdict, s.confidence, s.reasoningCID);
+    }
+}

--- a/assets/erc-8210/scenarios/docs/scenario-1-multi-hop-dependency.md
+++ b/assets/erc-8210/scenarios/docs/scenario-1-multi-hop-dependency.md
@@ -1,0 +1,54 @@
+# Scenario 1 — Multi-Hop Dependency Tracking
+
+## Problem Statement
+
+In autonomous agent pipelines, jobs are frequently chained: Agent A produces output consumed by Agent B, whose output feeds Agent C, and so on. When a failure surfaces at the end of the pipeline (say, Agent D), the affected party needs **root-cause traceability** — a way to identify that the actual fault originated at Agent A, three hops upstream.
+
+Without structured traceability, the claim filed in the assurance layer (ERC-8210 / AAP) contains only local context. Reviewers cannot determine whether the harm was caused by the immediate agent or by a propagated upstream failure.
+
+## Actors
+
+| Actor | Role |
+|-------|------|
+| **Pipeline Operator** | Deploys and orchestrates the A → B → C → D job chain |
+| **Claimant** | End-user who suffers harm from the pipeline's final output |
+| **Reviewer** | AAP reviewer who must trace the root cause before ruling |
+| **ChainedJobs contract** | On-chain registry of job dependencies |
+| **AAP contract** | Assurance protocol that receives the claim with an `upstream` reference |
+
+## Flow (step by step)
+
+1. The Pipeline Operator creates four jobs in `ChainedJobsMock`:
+   - Job 1 (label `"DataIngest"`) — root, no upstream.
+   - Job 2 (label `"Transform"`) — upstream = Job 1.
+   - Job 3 (label `"Validate"`) — upstream = Job 2.
+   - Job 4 (label `"Publish"`) — upstream = Job 3.
+
+2. Jobs 1 and 2 complete successfully. Job 3 runs but produces a flawed validation. Job 4 publishes the flawed result.
+
+3. The Claimant discovers the harm and files a claim in AAP. The `upstream` field of the claim is set to the `upstreamHash(jobId=4)` from ChainedJobs — this encodes the full dependency pointer.
+
+4. The Reviewer calls `traceToRoot(4)` on ChainedJobs, obtaining the chain `[4, 3, 2, 1]`. Inspecting each job's status, the reviewer sees that Job 3 is marked `Failed`.
+
+5. The Reviewer approves the claim, citing Job 3 as the root cause.
+
+## What This Demonstrates
+
+- The `upstream` field in the AAP `Claim` struct is sufficient to link a claim to an external dependency graph without ERC-8210 needing to understand the graph's structure.
+- Root-cause analysis can be performed on-chain by walking the `traceToRoot` chain.
+- The pattern is generic: any system that produces a deterministic `bytes32` identifier for a causal chain can plug into AAP's `upstream` field.
+
+## Architectural Layers
+
+| Layer | Role in this scenario |
+|-------|----------------------|
+| **Layer 1 (Structure / ERC-8183)** | Defines the job roles and state machine that the pipeline operates under |
+| **Layer 2 (Behavior)** | Could have caught the flawed validation at Job 3 via a risk hook, but did not |
+| **Layer 3 (Recovery / ERC-8210)** | Provides post-hoc redress — the claim is filed and the upstream field enables root-cause tracing |
+
+This scenario is primarily a **Layer 3** demonstration, showing how the recovery layer composes with an external dependency graph to enable traceability across multi-hop pipelines.
+
+## References
+
+- The `upstream` field in the verification schema was discussed in the ERC-8183 Ethereum Magicians thread as a mechanism for cross-spec traceability.
+- The 3-layer architecture (Structure / Behavior / Recovery) was articulated by [@wangbin9953](https://github.com/wangbin9953) (ERC-8210 author) in post #107 of the ERC-8183 Ethereum Magicians thread.

--- a/assets/erc-8210/scenarios/docs/scenario-1-multi-hop-dependency.md
+++ b/assets/erc-8210/scenarios/docs/scenario-1-multi-hop-dependency.md
@@ -4,17 +4,18 @@
 
 In autonomous agent pipelines, jobs are frequently chained: Agent A produces output consumed by Agent B, whose output feeds Agent C, and so on. When a failure surfaces at the end of the pipeline (say, Agent D), the affected party needs **root-cause traceability** — a way to identify that the actual fault originated at Agent A, three hops upstream.
 
-Without structured traceability, the claim filed in the assurance layer (ERC-8210 / AAP) contains only local context. Reviewers cannot determine whether the harm was caused by the immediate agent or by a propagated upstream failure.
+Without structured traceability, the claim filed in the assurance layer (ERC-8210 / AAP) contains only local context. Resolvers cannot determine whether the harm was caused by the immediate agent or by a propagated upstream failure.
 
 ## Actors
 
 | Actor | Role |
 |-------|------|
 | **Pipeline Operator** | Deploys and orchestrates the A → B → C → D job chain |
-| **Claimant** | End-user who suffers harm from the pipeline's final output |
-| **Reviewer** | AAP reviewer who must trace the root cause before ruling |
+| **Assured Agent** | Posts collateral and commits a JobAssurance covering the leaf job |
+| **Beneficiary (Claimant)** | Party harmed by the pipeline's final output |
+| **AAP Resolver** | Resolves the claim after tracing the upstream chain |
 | **ChainedJobs contract** | On-chain registry of job dependencies |
-| **AAP contract** | Assurance protocol that receives the claim with an `upstream` reference |
+| **AAP contract** | Assurance protocol that receives the claim with an upstream-encoded evidence payload |
 
 ## Flow (step by step)
 
@@ -26,17 +27,27 @@ Without structured traceability, the claim filed in the assurance layer (ERC-821
 
 2. Jobs 1 and 2 complete successfully. Job 3 runs but produces a flawed validation. Job 4 publishes the flawed result.
 
-3. The Claimant discovers the harm and files a claim in AAP. The `upstream` field of the claim is set to the `upstreamHash(jobId=4)` from ChainedJobs — this encodes the full dependency pointer.
+3. The Assured Agent calls `depositAssurance()` and `commitToJob()` on AAP, binding a JobAssurance to Job 4 (the leaf job) with `coverageType = JobFailure`. The AAP spec stays 1:1 Job-scoped — the multi-hop dependency is composition metadata, not part of the JobAssurance.
 
-4. The Reviewer calls `traceToRoot(4)` on ChainedJobs, obtaining the chain `[4, 3, 2, 1]`. Inspecting each job's status, the reviewer sees that Job 3 is marked `Failed`.
+4. The Beneficiary obtains an upstream reference via `pipeline.upstreamHash(jobD)` and files a claim through `fileClaim(assuranceId, requestedAmount, evidence)`. The opaque `evidence` payload encodes the upstream pointer and a failure tag:
 
-5. The Reviewer approves the claim, citing Job 3 as the root cause.
+   ```solidity
+   bytes memory evidence = abi.encode(
+       "pipeline_failure",
+       jobD,
+       upstreamRef
+   );
+   ```
+
+5. The AAP Resolver inspects the evidence, then calls `traceToRoot(jobD)` on ChainedJobs to walk the upstream chain `[jobD, jobC, jobB, jobA]`. Inspecting each job's status, the Resolver identifies Job C (Validate) as the failed root cause.
+
+6. The Resolver calls `resolveClaim(claimId, true, approvedAmount, reason)`, citing Job C as the root cause in the reason payload. Anyone (typically the beneficiary) calls `payout(claimId)` to settle.
 
 ## What This Demonstrates
 
-- The `upstream` field in the AAP `Claim` struct is sufficient to link a claim to an external dependency graph without ERC-8210 needing to understand the graph's structure.
-- Root-cause analysis can be performed on-chain by walking the `traceToRoot` chain.
-- The pattern is generic: any system that produces a deterministic `bytes32` identifier for a causal chain can plug into AAP's `upstream` field.
+- The upstream reference travels through AAP's opaque `evidence` payload, linking a 1:1 Job-scoped JobAssurance to an external dependency graph **without ERC-8210 needing to model graphs at the protocol level**.
+- Root-cause analysis can be performed on-chain by walking `traceToRoot` from the leaf back to the failing ancestor.
+- The pattern is generic: any system that produces a deterministic `bytes32` reference into a causal chain can plug into AAP's evidence payload the same way.
 
 ## Architectural Layers
 
@@ -44,11 +55,11 @@ Without structured traceability, the claim filed in the assurance layer (ERC-821
 |-------|----------------------|
 | **Layer 1 (Structure / ERC-8183)** | Defines the job roles and state machine that the pipeline operates under |
 | **Layer 2 (Behavior)** | Could have caught the flawed validation at Job 3 via a risk hook, but did not |
-| **Layer 3 (Recovery / ERC-8210)** | Provides post-hoc redress — the claim is filed and the upstream field enables root-cause tracing |
+| **Layer 3 (Recovery / ERC-8210)** | Provides post-hoc redress — the claim is filed and the upstream reference enables root-cause tracing |
 
 This scenario is primarily a **Layer 3** demonstration, showing how the recovery layer composes with an external dependency graph to enable traceability across multi-hop pipelines.
 
 ## References
 
-- The `upstream` field in the verification schema was discussed in the ERC-8183 Ethereum Magicians thread as a mechanism for cross-spec traceability.
+- The upstream reference pattern in the verification schema was discussed in the ERC-8183 Ethereum Magicians thread as a mechanism for cross-spec traceability.
 - The 3-layer architecture (Structure / Behavior / Recovery) was articulated by [@wangbin9953](https://github.com/wangbin9953) (ERC-8210 author) in post #107 of the ERC-8183 Ethereum Magicians thread.

--- a/assets/erc-8210/scenarios/docs/scenario-2-evaluator-slash-claim.md
+++ b/assets/erc-8210/scenarios/docs/scenario-2-evaluator-slash-claim.md
@@ -1,0 +1,59 @@
+# Scenario 2 — EvaluatorSlashed → fileClaim
+
+## Problem Statement
+
+When an evaluator (an agent responsible for assessing other agents' work) is caught acting dishonestly, the EvaluatorRegistry slashes their stake. But the parties harmed by the evaluator's dishonest assessment — the agents who received unfair evaluations — still need a mechanism to recover damages.
+
+The key insight is that the **slash event itself is sufficient evidence** for filing a claim in the assurance layer. There is no need for re-adjudication: if the evaluator was already slashed for misconduct on a specific `jobId`, the corresponding claim should be auto-approvable based on that on-chain proof.
+
+## Actors
+
+| Actor | Role |
+|-------|------|
+| **Registry Operator** | Governance address that triggers evaluator slashing |
+| **Dishonest Evaluator** | The evaluator being slashed |
+| **Harmed Agent (Claimant)** | Agent who received an unfair evaluation and files a claim |
+| **AAP Reviewer** | Reviews the claim using the slash record as evidence |
+| **EvaluatorRegistry** | Contract that records slashes and emits `EvaluatorSlashed` events |
+| **AAP contract** | Assurance protocol where the claim is filed |
+
+## Flow (step by step)
+
+1. The Registry Operator calls `slashEvaluator()` on the EvaluatorRegistry, passing the dishonest evaluator's address, the `jobId` of the unfair evaluation, the slashed amount, and a reason hash.
+
+2. The EvaluatorRegistry emits `EvaluatorSlashed(evaluator, jobId, slashedAmount, reason)` and stores the slash record on-chain.
+
+3. The Harmed Agent calls `buildEvidenceHash(jobId)` on the EvaluatorRegistry to obtain a deterministic evidence hash derived from the slash record.
+
+4. The Harmed Agent files a claim in AAP using:
+   - `amount`: the damages suffered
+   - `evidenceHash`: the hash from step 3
+   - `upstream`: `keccak256(abi.encode("EvaluatorSlashed", jobId))` — a tagged reference to the slash event
+
+5. The AAP Reviewer verifies the claim by:
+   - Checking that a slash record exists for the referenced `jobId`
+   - Confirming the evidence hash matches
+   - Approving the claim without re-adjudication
+
+6. The AAP contract transfers the approved amount to the claimant.
+
+## What This Demonstrates
+
+- An indexed `EvaluatorSlashed` event with `jobId` serves as **automatic proof** for assurance claims, eliminating the need for a separate dispute process.
+- The `upstream` field in the AAP claim links back to the slash event, creating an auditable cross-contract trail.
+- The pattern separates concerns: the EvaluatorRegistry handles punishment (slashing), while AAP handles recovery (compensation). Neither needs to understand the other's internal logic.
+
+## Architectural Layers
+
+| Layer | Role in this scenario |
+|-------|----------------------|
+| **Layer 1 (Structure / ERC-8183)** | Defines evaluator roles and the job lifecycle |
+| **Layer 2 (Behavior)** | The EvaluatorRegistry acts as a behavioral check — it detects and punishes evaluator misconduct |
+| **Layer 3 (Recovery / ERC-8210)** | AAP provides compensation to the harmed party, using the Layer 2 slash as evidence |
+
+This scenario demonstrates **Layer 2 → Layer 3 composition**: the behavioral detection layer produces evidence that the recovery layer consumes directly, without duplication of effort.
+
+## References
+
+- The `EvaluatorSlashed` event signature and the "slash as proof" pattern were agreed upon with **Bakugo32** (Demsys) in the ERC-8183 Ethereum Magicians thread.
+- The 3-layer architecture was articulated by [@wangbin9953](https://github.com/wangbin9953) (ERC-8210 author) in post #107 of the ERC-8183 Ethereum Magicians thread.

--- a/assets/erc-8210/scenarios/docs/scenario-2-evaluator-slash-claim.md
+++ b/assets/erc-8210/scenarios/docs/scenario-2-evaluator-slash-claim.md
@@ -12,35 +12,42 @@ The key insight is that the **slash event itself is sufficient evidence** for fi
 |-------|------|
 | **Registry Operator** | Governance address that triggers evaluator slashing |
 | **Dishonest Evaluator** | The evaluator being slashed |
-| **Harmed Agent (Claimant)** | Agent who received an unfair evaluation and files a claim |
-| **AAP Reviewer** | Reviews the claim using the slash record as evidence |
+| **Assured Agent** | Posts collateral and commits a JobAssurance covering the disputed Job |
+| **Harmed Beneficiary (Claimant)** | Party harmed by the unfair evaluation, who files the claim |
+| **AAP Resolver** | Resolves the claim using the slash record as evidence |
 | **EvaluatorRegistry** | Contract that records slashes and emits `EvaluatorSlashed` events |
 | **AAP contract** | Assurance protocol where the claim is filed |
 
 ## Flow (step by step)
 
-1. The Registry Operator calls `slashEvaluator()` on the EvaluatorRegistry, passing the dishonest evaluator's address, the `jobId` of the unfair evaluation, the slashed amount, and a reason hash.
+1. The Assured Agent calls `depositAssurance()` and then `commitToJob()` on AAP, creating a JobAssurance bound to the disputed `jobId` with `coverageType = EvaluatorDispute`.
 
-2. The EvaluatorRegistry emits `EvaluatorSlashed(evaluator, jobId, slashedAmount, reason)` and stores the slash record on-chain.
+2. The Registry Operator calls `slashEvaluator()` on the EvaluatorRegistry, passing the dishonest evaluator's address, the `jobId` of the unfair evaluation, the slashed amount, and a reason hash.
 
-3. The Harmed Agent calls `buildEvidenceHash(jobId)` on the EvaluatorRegistry to obtain a deterministic evidence hash derived from the slash record.
+3. The EvaluatorRegistry emits `EvaluatorSlashed(evaluator, jobId, slashedAmount, reason)` and stores the slash record on-chain.
 
-4. The Harmed Agent files a claim in AAP using:
-   - `amount`: the damages suffered
-   - `evidenceHash`: the hash from step 3
-   - `upstream`: `keccak256(abi.encode("EvaluatorSlashed", jobId))` — a tagged reference to the slash event
+4. The Harmed Beneficiary calls `buildEvidenceHash(jobId)` on the EvaluatorRegistry to obtain a deterministic hash of the slash record, then files a claim via `fileClaim(assuranceId, requestedAmount, evidence)`. The opaque `evidence` payload encodes a tagged reference to the slash event:
 
-5. The AAP Reviewer verifies the claim by:
-   - Checking that a slash record exists for the referenced `jobId`
-   - Confirming the evidence hash matches
-   - Approving the claim without re-adjudication
+   ```solidity
+   bytes memory evidence = abi.encode(
+       "EvaluatorSlashed",
+       address(registry),
+       jobId,
+       slashHash
+   );
+   ```
 
-6. The AAP contract transfers the approved amount to the claimant.
+5. The AAP Resolver verifies the claim by:
+   - Re-deriving the slash hash from the registry via `buildEvidenceHash(jobId)`
+   - Confirming the re-derived hash matches the one encoded in the evidence payload
+   - Calling `resolveClaim(claimId, true, approvedAmount, reason)` — no re-adjudication of the underlying evaluation
+
+6. Anyone (typically the beneficiary) calls `payout(claimId)` to settle the approved claim.
 
 ## What This Demonstrates
 
 - An indexed `EvaluatorSlashed` event with `jobId` serves as **automatic proof** for assurance claims, eliminating the need for a separate dispute process.
-- The `upstream` field in the AAP claim links back to the slash event, creating an auditable cross-contract trail.
+- The slash record reference travels through AAP's opaque `evidence` payload, creating an auditable cross-contract trail without expanding the AAP interface.
 - The pattern separates concerns: the EvaluatorRegistry handles punishment (slashing), while AAP handles recovery (compensation). Neither needs to understand the other's internal logic.
 
 ## Architectural Layers

--- a/assets/erc-8210/scenarios/docs/scenario-2-evaluator-slash-claim.md
+++ b/assets/erc-8210/scenarios/docs/scenario-2-evaluator-slash-claim.md
@@ -55,5 +55,5 @@ This scenario demonstrates **Layer 2 → Layer 3 composition**: the behavioral d
 
 ## References
 
-- The `EvaluatorSlashed` event signature and the "slash as proof" pattern were agreed upon with **Bakugo32** (Demsys) in the ERC-8183 Ethereum Magicians thread.
+- The `EvaluatorSlashed` event signature and the "slash as proof" pattern were agreed upon with [@Demsys](https://github.com/Demsys) in the ERC-8183 Ethereum Magicians thread. Reference implementation: [agent-settlement-protocol](https://github.com/Demsys/agent-settlement-protocol).
 - The 3-layer architecture was articulated by [@wangbin9953](https://github.com/wangbin9953) (ERC-8210 author) in post #107 of the ERC-8183 Ethereum Magicians thread.

--- a/assets/erc-8210/scenarios/docs/scenario-3-hybrid-offchain-scoring.md
+++ b/assets/erc-8210/scenarios/docs/scenario-3-hybrid-offchain-scoring.md
@@ -14,7 +14,7 @@ The challenge is encapsulating off-chain scoring as an on-chain "assessor rule" 
 | **Suspect Agent** | Agent whose behavior is being evaluated |
 | **Task Manager** | Entity that uses the score to decide on task completion/rejection |
 | **Claimant** | Party harmed by the suspect agent, who files a claim using the score as evidence |
-| **AAP Reviewer** | Reviews the claim using the posted score |
+| **AAP Resolver** | Resolves the claim using the posted score |
 | **OffchainScorer contract** | On-chain record of scores posted by the oracle |
 | **AAP contract** | Assurance protocol where the claim is filed |
 
@@ -29,25 +29,31 @@ The challenge is encapsulating off-chain scoring as an on-chain "assessor rule" 
 
 3. The Task Manager reads the score and, seeing a DENY verdict with high confidence, rejects the suspect agent's task output (in an ERC-8183 context, this would be a `reject()` call).
 
-4. The Claimant — a party harmed by the suspect agent's non-compliant behavior — files a claim in AAP using:
-   - `amount`: the damages suffered
-   - `evidenceHash`: the `reasoningCID` from the score (same CID used in step 3)
-   - `upstream`: `keccak256(abi.encode("OffchainScore", subject))` — links back to the scoring event
+4. The Claimant — a party harmed by the suspect agent's non-compliant behavior — files a claim in AAP via `fileClaim(assuranceId, requestedAmount, evidence)`. The opaque `evidence` payload encodes the same `reasoningCID` used in step 3, together with a marker for the score type and the scorer address:
 
-5. The AAP Reviewer verifies the claim by:
-   - Reading the score from the OffchainScorer contract
+   ```solidity
+   bytes memory evidence = abi.encode(
+       "OffchainScore",
+       address(scorer),
+       suspectAgent,
+       REASONING_CID
+   );
+   ```
+
+5. The AAP Resolver verifies the claim by:
+   - Re-reading the score from the OffchainScorer contract using `scorer.score(suspectAgent)`
    - Confirming the verdict is DENY and confidence exceeds a threshold
-   - Confirming the `reasoningCID` matches the claim's `evidenceHash`
-   - Approving the claim
+   - Confirming the on-chain `reasoningCID` matches the one encoded in the evidence payload
+   - Calling `resolveClaim(claimId, true, approvedAmount, reason)`
 
-6. The AAP contract transfers the approved amount to the claimant.
+6. The Claimant (or anyone) calls `payout(claimId)` to settle the approved claim.
 
 ## What This Demonstrates
 
 - Off-chain scoring can be encapsulated as an on-chain "assessor rule" that both the task layer (ERC-8183) and the assurance layer (ERC-8210) can consume.
 - The same `reasoningCID` serves as evidence in both task rejection and claim filing, ensuring consistency and avoiding redundant evaluation.
 - The confidence score provides a quantitative basis for claim review, enabling threshold-based automation in the future.
-- The pattern is oracle-agnostic: any off-chain scoring system (AHS, reputation models, ML classifiers) can post scores in this format.
+- The composition pattern lives entirely in the `evidence` payload, not in the AAP interface — the spec stays minimal and any off-chain scoring system (AHS, reputation models, ML classifiers) can plug in by encoding its result the same way.
 
 ## Architectural Layers
 
@@ -61,5 +67,6 @@ This scenario demonstrates **full 3-layer composition**: the off-chain scorer br
 
 ## References
 
-- The AHS (Agent Health Score) concept is inspired by **pablocactus** (RNWY) contributions to the ERC-8183 Ethereum Magicians thread, where off-chain scoring was discussed as an assessor rule pattern.
+- The AHS (Agent Health Score) concept is inspired by contributions from **pablocactus** to the ERC-8183 Ethereum Magicians thread, where off-chain scoring was discussed as an assessor rule pattern.
+- **RNWY is a separate project** with related but distinct multidimensional scoring (soulbound identity, explicit sybil signal weights, live ERC-8183 hook integration). It will be referenced separately in the AAP v2 IRiskHook section once their methodology document is published. The two efforts overlap conceptually but are independent.
 - The 3-layer architecture was articulated by [@wangbin9953](https://github.com/wangbin9953) (ERC-8210 author) in post #107 of the ERC-8183 Ethereum Magicians thread.

--- a/assets/erc-8210/scenarios/docs/scenario-3-hybrid-offchain-scoring.md
+++ b/assets/erc-8210/scenarios/docs/scenario-3-hybrid-offchain-scoring.md
@@ -1,0 +1,65 @@
+# Scenario 3 — Hybrid Off-chain Scoring + On-chain Assurance
+
+## Problem Statement
+
+Some evaluations cannot be performed entirely on-chain. Complex behavioral assessments — such as an Agent Health Score (AHS) that analyzes interaction patterns, response quality, and compliance metrics — require off-chain computation. However, the **result** of that computation must be consumable by on-chain contracts for both task completion (ERC-8183) and assurance claims (ERC-8210).
+
+The challenge is encapsulating off-chain scoring as an on-chain "assessor rule" so that the same CID (content identifier for the reasoning) can be used as evidence in both `complete()`/`reject()` flows (ERC-8183) and `fileClaim()` flows (ERC-8210).
+
+## Actors
+
+| Actor | Role |
+|-------|------|
+| **Off-chain Scorer** | Oracle-like service that computes an Agent Health Score and posts it on-chain |
+| **Suspect Agent** | Agent whose behavior is being evaluated |
+| **Task Manager** | Entity that uses the score to decide on task completion/rejection |
+| **Claimant** | Party harmed by the suspect agent, who files a claim using the score as evidence |
+| **AAP Reviewer** | Reviews the claim using the posted score |
+| **OffchainScorer contract** | On-chain record of scores posted by the oracle |
+| **AAP contract** | Assurance protocol where the claim is filed |
+
+## Flow (step by step)
+
+1. The Off-chain Scorer computes an Agent Health Score for the Suspect Agent. The result includes:
+   - `verdict`: DENY (the agent's behavior is non-compliant)
+   - `confidence`: 87 (out of 100)
+   - `reasoningCID`: a `bytes32` hash pointing to the full reasoning stored off-chain (e.g., on IPFS)
+
+2. The Off-chain Scorer posts the score on-chain via `postScore()`, which emits `ScorePosted(subject, verdict, confidence, reasoningCID)`.
+
+3. The Task Manager reads the score and, seeing a DENY verdict with high confidence, rejects the suspect agent's task output (in an ERC-8183 context, this would be a `reject()` call).
+
+4. The Claimant — a party harmed by the suspect agent's non-compliant behavior — files a claim in AAP using:
+   - `amount`: the damages suffered
+   - `evidenceHash`: the `reasoningCID` from the score (same CID used in step 3)
+   - `upstream`: `keccak256(abi.encode("OffchainScore", subject))` — links back to the scoring event
+
+5. The AAP Reviewer verifies the claim by:
+   - Reading the score from the OffchainScorer contract
+   - Confirming the verdict is DENY and confidence exceeds a threshold
+   - Confirming the `reasoningCID` matches the claim's `evidenceHash`
+   - Approving the claim
+
+6. The AAP contract transfers the approved amount to the claimant.
+
+## What This Demonstrates
+
+- Off-chain scoring can be encapsulated as an on-chain "assessor rule" that both the task layer (ERC-8183) and the assurance layer (ERC-8210) can consume.
+- The same `reasoningCID` serves as evidence in both task rejection and claim filing, ensuring consistency and avoiding redundant evaluation.
+- The confidence score provides a quantitative basis for claim review, enabling threshold-based automation in the future.
+- The pattern is oracle-agnostic: any off-chain scoring system (AHS, reputation models, ML classifiers) can post scores in this format.
+
+## Architectural Layers
+
+| Layer | Role in this scenario |
+|-------|----------------------|
+| **Layer 1 (Structure / ERC-8183)** | Uses the score to reject the task — the structural layer acts on the evaluation |
+| **Layer 2 (Behavior)** | The off-chain scorer IS the behavioral layer — it detects non-compliance through pattern analysis |
+| **Layer 3 (Recovery / ERC-8210)** | AAP uses the same evidence (reasoningCID) to compensate the harmed party |
+
+This scenario demonstrates **full 3-layer composition**: the off-chain scorer bridges Layer 2 (behavior detection) into both Layer 1 (task rejection) and Layer 3 (recovery), with the `reasoningCID` as the shared evidence artifact.
+
+## References
+
+- The AHS (Agent Health Score) concept is inspired by **pablocactus** (RNWY) contributions to the ERC-8183 Ethereum Magicians thread, where off-chain scoring was discussed as an assessor rule pattern.
+- The 3-layer architecture was articulated by [@wangbin9953](https://github.com/wangbin9953) (ERC-8210 author) in post #107 of the ERC-8183 Ethereum Magicians thread.

--- a/assets/erc-8210/scenarios/docs/scenario-3-hybrid-offchain-scoring.md
+++ b/assets/erc-8210/scenarios/docs/scenario-3-hybrid-offchain-scoring.md
@@ -67,6 +67,6 @@ This scenario demonstrates **full 3-layer composition**: the off-chain scorer br
 
 ## References
 
-- The AHS (Agent Health Score) concept is inspired by contributions from **pablocactus** to the ERC-8183 Ethereum Magicians thread, where off-chain scoring was discussed as an assessor rule pattern.
+- The AHS (Agent Health Score) concept is inspired by the [agent-health-monitor](https://github.com/moonshot-cyber/agent-health-monitor) project by [@moonshot-cyber](https://github.com/moonshot-cyber), discussed in the ERC-8183 Ethereum Magicians thread as an assessor rule pattern.
 - **RNWY is a separate project** with related but distinct multidimensional scoring (soulbound identity, explicit sybil signal weights, live ERC-8183 hook integration). It will be referenced separately in the AAP v2 IRiskHook section once their methodology document is published. The two efforts overlap conceptually but are independent.
 - The 3-layer architecture was articulated by [@wangbin9953](https://github.com/wangbin9953) (ERC-8210 author) in post #107 of the ERC-8183 Ethereum Magicians thread.

--- a/assets/erc-8210/scenarios/docs/scenario-4-solvency-aware-claim.md
+++ b/assets/erc-8210/scenarios/docs/scenario-4-solvency-aware-claim.md
@@ -1,0 +1,85 @@
+# Scenario 4 — Stateless Solvency-Aware Claim Assessment
+
+## Problem Statement
+
+When an evaluator is slashed, the `EvaluatorSlashed` event tells downstream consumers *what happened* (slash amount, reason, jobId), but not *what the evaluator's remaining capacity is*. Consumers like AHM (Agent Health Score), ThoughtProof's verification, or any AAP resolver that wants to assess future deterrent need a separate RPC call to query the evaluator's post-slash balance — or they need to maintain local state tracking all stake movements.
+
+Neither approach works well for stateless indexers: extra RPC calls add latency and cost, and local state tracking introduces complexity and failure modes.
+
+## Solution
+
+Emit `EvaluatorStakeUpdated(evaluator, oldBalance, newBalance)` in the **same transaction** as `EvaluatorSlashed`. A stateless consumer reading the tx logs sees both events together and can assess:
+
+1. **Misconduct details** — from `EvaluatorSlashed`: who was slashed, for which job, how much, and why.
+2. **Post-slash solvency** — from `EvaluatorStakeUpdated`: what the evaluator's balance was before and after the slash, without any additional query.
+
+The delta (`oldBalance - newBalance`) matches the slash `amount`, and the `newBalance` directly indicates remaining capacity. A zero `newBalance` signals total wipeout — the evaluator has no future deterrent.
+
+## Actors
+
+| Actor | Role |
+|-------|------|
+| **Dishonest Evaluator** | Evaluator being slashed; has staked into the registry |
+| **Registry Operator** | Triggers the slash |
+| **Assured Agent** | Posts collateral and commits a JobAssurance covering the disputed Job |
+| **Harmed Beneficiary** | Files a claim with enriched evidence referencing both events |
+| **AAP Resolver** | Verifies the claim using both the slash record AND the solvency snapshot |
+| **EvaluatorRegistryWithStake** | Registry that tracks stake balances and emits both events in slash transactions |
+| **AAP contract** | Assurance protocol where the claim is filed |
+
+## Flow (step by step)
+
+1. The Dishonest Evaluator calls `depositStake()` on the registry, which emits `EvaluatorStakeUpdated(evaluator, 0, 2000e18)`.
+
+2. The Assured Agent calls `depositAssurance()` and `commitToJob()` on AAP, binding a JobAssurance to the disputed job with `coverageType = EvaluatorDispute`.
+
+3. The Registry Operator calls `slashEvaluator()`. In a single transaction, the registry emits:
+   - `EvaluatorSlashed(evaluator, jobId, 800e18, "front_running")`
+   - `EvaluatorStakeUpdated(evaluator, 2000e18, 1200e18)`
+
+4. The Harmed Beneficiary builds an enriched evidence payload encoding references to **both** events:
+
+   ```solidity
+   bytes memory evidence = abi.encode(
+       "SolvencyAwareSlash",
+       address(registry),
+       jobId,
+       slashHash,
+       evaluator,
+       stakeHash
+   );
+   ```
+
+   Then files the claim via `fileClaim(assuranceId, requestedAmount, evidence)`.
+
+5. The AAP Resolver verifies both hashes:
+   - Re-derives `slashHash` from the registry — confirms the slash is authentic
+   - Re-derives `stakeHash` from the registry — confirms the solvency snapshot
+   - Reads `stakeBalances(evaluator)` — sees 1200e18 remaining (60% of original)
+   - Calls `resolveClaim(claimId, true, approvedAmount, reason)` with the solvency context encoded in the reason
+
+6. Anyone calls `payout(claimId)` to settle.
+
+## What This Demonstrates
+
+- **Stateless solvency assessment**: Two events in the same tx give a complete picture — misconduct details plus remaining capacity — without RPC calls or local state.
+- **Evidence-first composability**: The enriched evidence payload carries references to both events through AAP's opaque `bytes evidence` parameter, extending the pattern from Scenario 2.
+- **Consumer-agnostic design**: `EvaluatorStakeUpdated` fires on any stake movement (deposit, withdraw, slash), serving AHM scoring, ThoughtProof verification, and protocol-level risk assessment equally.
+- **Edge case handling**: The test includes a full-wipeout scenario where post-slash balance is zero — a stateless indexer seeing `EvaluatorStakeUpdated(evaluator, X, 0)` knows the evaluator has zero future deterrent.
+
+## Architectural Layers
+
+| Layer | Role in this scenario |
+|-------|----------------------|
+| **Layer 1 (Structure / ERC-8183)** | Defines evaluator roles and the job lifecycle |
+| **Layer 2 (Behavior)** | The slash event signals misconduct; the stake-update event signals solvency state |
+| **Layer 3 (Recovery / ERC-8210)** | AAP claim is filed with enriched evidence referencing both events |
+
+This scenario extends Scenario 2 (slash → claim) by adding **solvency context** to the evidence payload, demonstrating how `EvaluatorStakeUpdated` enriches the Layer 2 → Layer 3 composition without modifying the AAP interface.
+
+## References
+
+- The `EvaluatorStakeUpdated(address indexed evaluator, uint256 oldBalance, uint256 newBalance)` event was designed collaboratively in the ERC-8183 Ethereum Magicians thread. The `oldBalance/newBalance` dual-field refinement was contributed by [@ThoughtProof](https://github.com/ThoughtProof) for stateless-indexer compatibility.
+- The event is deployed in [@Demsys](https://github.com/Demsys)'s [agent-settlement-protocol](https://github.com/Demsys/agent-settlement-protocol) on Base Sepolia at `EvaluatorRegistry` `0xe5517C488a470D5eeB5Aa812bb87c09fc5c14D21`.
+- The `EvaluatorSlashed` 4-field canonical signature was agreed with @Demsys in the same thread.
+- The 3-layer architecture was articulated by [@wangbin9953](https://github.com/wangbin9953) (ERC-8210 author) in post #107 of the ERC-8183 Ethereum Magicians thread.

--- a/assets/erc-8210/scenarios/foundry.toml
+++ b/assets/erc-8210/scenarios/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "contracts"
+test = "test"
+out = "out"
+libs = ["lib"]
+solc = "0.8.24"

--- a/assets/erc-8210/scenarios/remappings.txt
+++ b/assets/erc-8210/scenarios/remappings.txt
@@ -1,0 +1,1 @@
+forge-std/=lib/forge-std/src/

--- a/assets/erc-8210/scenarios/test/Scenario1_MultiHopDependency.t.sol
+++ b/assets/erc-8210/scenarios/test/Scenario1_MultiHopDependency.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/mocks/AAPMockMinimal.sol";
+import "../contracts/mocks/MockERC20.sol";
+import "../contracts/mocks/ChainedJobsMock.sol";
+
+/// @title Scenario 1 — Multi-Hop Dependency Tracking
+/// @notice Demonstrates that AAP's `upstream` field can link a claim to an
+///         external dependency graph (A→B→C→D), enabling root-cause tracing.
+contract Scenario1_MultiHopDependency is Test {
+    AAPMockMinimal  aap;
+    MockERC20       token;
+    ChainedJobsMock pipeline;
+
+    address operator = makeAddr("operator");
+    address claimant = makeAddr("claimant");
+    address reviewer = makeAddr("reviewer");
+
+    uint256 constant CLAIM_AMOUNT = 500e18;
+
+    function setUp() public {
+        // Deploy token and AAP
+        token = new MockERC20("Assurance Token", "ASR");
+        aap   = new AAPMockMinimal(address(token), reviewer);
+
+        // Fund AAP with tokens for payouts
+        token.mint(address(aap), 10_000e18);
+
+        // Deploy pipeline
+        pipeline = new ChainedJobsMock();
+    }
+
+    function test_MultiHopDependencyTracking() public {
+        // ── Step 1: Operator creates a 4-job pipeline ──────────────────
+        vm.startPrank(operator);
+
+        uint256 jobA = pipeline.createJob(bytes32("DataIngest"), 0);
+        uint256 jobB = pipeline.createJob(bytes32("Transform"),  jobA);
+        uint256 jobC = pipeline.createJob(bytes32("Validate"),   jobB);
+        uint256 jobD = pipeline.createJob(bytes32("Publish"),    jobC);
+
+        assertEq(jobA, 1, "Job A should be ID 1");
+        assertEq(jobD, 4, "Job D should be ID 4");
+
+        // ── Step 2: Jobs A and B complete; C fails; D publishes bad data
+        pipeline.setStatus(jobA, ChainedJobsMock.JobStatus.Completed);
+        pipeline.setStatus(jobB, ChainedJobsMock.JobStatus.Completed);
+        pipeline.setStatus(jobC, ChainedJobsMock.JobStatus.Failed);
+        pipeline.setStatus(jobD, ChainedJobsMock.JobStatus.Completed);
+
+        vm.stopPrank();
+
+        // ── Step 3: Claimant files a claim referencing the pipeline ────
+        bytes32 upstreamRef = pipeline.upstreamHash(jobD);
+        bytes32 evidence    = keccak256(abi.encode("pipeline_failure", jobD));
+
+        vm.prank(claimant);
+        uint256 claimId = aap.fileClaim(CLAIM_AMOUNT, evidence, upstreamRef);
+
+        // Verify claim was stored correctly
+        IAAP.Claim memory c = aap.getClaim(claimId);
+        assertEq(c.claimant,     claimant);
+        assertEq(c.amount,       CLAIM_AMOUNT);
+        assertEq(c.upstream,     upstreamRef);
+        assertEq(uint8(c.status), uint8(IAAP.ClaimStatus.Filed));
+
+        // ── Step 4: Reviewer traces the root cause ─────────────────────
+        uint256[] memory chain = pipeline.traceToRoot(jobD);
+
+        // Chain should be [4, 3, 2, 1] (leaf → root)
+        assertEq(chain.length, 4, "Chain should have 4 hops");
+        assertEq(chain[0], jobD, "First element is the leaf job");
+        assertEq(chain[3], jobA, "Last element is the root job");
+
+        // Find the failed job in the chain
+        uint256 failedJobId;
+        for (uint256 i = 0; i < chain.length; i++) {
+            (, ChainedJobsMock.JobStatus status,,) = pipeline.jobs(chain[i]);
+            if (status == ChainedJobsMock.JobStatus.Failed) {
+                failedJobId = chain[i];
+                break;
+            }
+        }
+        assertEq(failedJobId, jobC, "Root cause should be Job C (Validate)");
+
+        // ── Step 5: Reviewer approves the claim ────────────────────────
+        bytes32 reason = keccak256(abi.encode("root_cause_job", failedJobId));
+
+        vm.prank(reviewer);
+        aap.reviewClaim(claimId, IAAP.Verdict.Approve, reason);
+
+        // Verify final state
+        IAAP.Claim memory resolved = aap.getClaim(claimId);
+        assertEq(uint8(resolved.status), uint8(IAAP.ClaimStatus.Approved));
+        assertEq(token.balanceOf(claimant), CLAIM_AMOUNT, "Claimant should receive payout");
+    }
+}

--- a/assets/erc-8210/scenarios/test/Scenario1_MultiHopDependency.t.sol
+++ b/assets/erc-8210/scenarios/test/Scenario1_MultiHopDependency.t.sol
@@ -5,76 +5,111 @@ import "forge-std/Test.sol";
 import "../contracts/mocks/AAPMockMinimal.sol";
 import "../contracts/mocks/MockERC20.sol";
 import "../contracts/mocks/ChainedJobsMock.sol";
+import "../contracts/interfaces/IAAP.sol";
 
 /// @title Scenario 1 — Multi-Hop Dependency Tracking
-/// @notice Demonstrates that AAP's `upstream` field can link a claim to an
-///         external dependency graph (A→B→C→D), enabling root-cause tracing.
+/// @notice Demonstrates that ERC-8210's opaque `evidence` payload can carry an
+///         upstream reference linking a Claim to a multi-job pipeline (A→B→C→D).
+///         The core spec stays 1:1 Job-scoped; provenance composition lives
+///         entirely in the evidence payload, not in the AAP interface.
+///
+///         Layer mapping (per the 3-layer architecture in the README):
+///           - Layer 1 (Structure): the pipeline contract (ERC-8183-equivalent)
+///           - Layer 2 (Behavior):  the reviewer reads the upstream chain to
+///             identify the root cause
+///           - Layer 3 (Recovery):  AAP claim is filed against a JobAssurance
+///             whose evidence encodes the upstream reference
 contract Scenario1_MultiHopDependency is Test {
     AAPMockMinimal  aap;
     MockERC20       token;
     ChainedJobsMock pipeline;
 
-    address operator = makeAddr("operator");
-    address claimant = makeAddr("claimant");
-    address reviewer = makeAddr("reviewer");
+    address operator    = makeAddr("operator");
+    address assuredAgent = makeAddr("assuredAgent");
+    address beneficiary = makeAddr("beneficiary");
+    address resolver    = makeAddr("resolver");
 
+    uint256 constant DEPOSIT      = 1000e18;
+    uint256 constant COMMIT       = 500e18;
+    uint64  constant FAR_FUTURE   = type(uint64).max;
     uint256 constant CLAIM_AMOUNT = 500e18;
 
     function setUp() public {
-        // Deploy token and AAP
         token = new MockERC20("Assurance Token", "ASR");
-        aap   = new AAPMockMinimal(address(token), reviewer);
+        aap   = new AAPMockMinimal(address(token), resolver);
 
-        // Fund AAP with tokens for payouts
-        token.mint(address(aap), 10_000e18);
+        // Fund the assured agent and approve AAP
+        token.mint(assuredAgent, DEPOSIT * 10);
+        vm.prank(assuredAgent);
+        token.approve(address(aap), type(uint256).max);
 
-        // Deploy pipeline
         pipeline = new ChainedJobsMock();
     }
 
     function test_MultiHopDependencyTracking() public {
         // ── Step 1: Operator creates a 4-job pipeline ──────────────────
         vm.startPrank(operator);
-
         uint256 jobA = pipeline.createJob(bytes32("DataIngest"), 0);
         uint256 jobB = pipeline.createJob(bytes32("Transform"),  jobA);
         uint256 jobC = pipeline.createJob(bytes32("Validate"),   jobB);
         uint256 jobD = pipeline.createJob(bytes32("Publish"),    jobC);
 
-        assertEq(jobA, 1, "Job A should be ID 1");
-        assertEq(jobD, 4, "Job D should be ID 4");
-
-        // ── Step 2: Jobs A and B complete; C fails; D publishes bad data
+        // Jobs A and B complete; C fails; D publishes bad data anyway
         pipeline.setStatus(jobA, ChainedJobsMock.JobStatus.Completed);
         pipeline.setStatus(jobB, ChainedJobsMock.JobStatus.Completed);
         pipeline.setStatus(jobC, ChainedJobsMock.JobStatus.Failed);
         pipeline.setStatus(jobD, ChainedJobsMock.JobStatus.Completed);
-
         vm.stopPrank();
 
-        // ── Step 3: Claimant files a claim referencing the pipeline ────
+        // ── Step 2: AssuredAgent deposits and commits assurance for Job D ──
+        // The JobAssurance is bound to jobD (the leaf job) at the spec level.
+        // The fact that jobD depends on a failed upstream job is composition
+        // metadata that lives in the evidence payload, not in the spec.
+        vm.startPrank(assuredAgent);
+        aap.depositAssurance(DEPOSIT);
+        bytes32 jobIdD = bytes32(jobD);
+        bytes32 assuranceId = aap.commitToJob(
+            jobIdD,
+            IAAP.CoverageType.JobFailure,
+            beneficiary,
+            COMMIT,
+            FAR_FUTURE
+        );
+        vm.stopPrank();
+
+        // ── Step 3: Beneficiary builds an evidence payload that encodes the
+        //           upstream reference and files a claim ────────────────
         bytes32 upstreamRef = pipeline.upstreamHash(jobD);
-        bytes32 evidence    = keccak256(abi.encode("pipeline_failure", jobD));
 
-        vm.prank(claimant);
-        uint256 claimId = aap.fileClaim(CLAIM_AMOUNT, evidence, upstreamRef);
+        // The evidence payload is opaque to AAP. Here it carries:
+        //   - the upstream root reference (pointing into the pipeline)
+        //   - a marker for the failure type
+        // A real implementation might encode an IPFS CID, an attestation, etc.
+        bytes memory evidence = abi.encode(
+            "pipeline_failure",
+            jobD,
+            upstreamRef
+        );
 
-        // Verify claim was stored correctly
+        vm.prank(beneficiary);
+        bytes32 claimId = aap.fileClaim(assuranceId, CLAIM_AMOUNT, evidence);
+
+        // Verify the claim was stored correctly
         IAAP.Claim memory c = aap.getClaim(claimId);
-        assertEq(c.claimant,     claimant);
-        assertEq(c.amount,       CLAIM_AMOUNT);
-        assertEq(c.upstream,     upstreamRef);
-        assertEq(uint8(c.status), uint8(IAAP.ClaimStatus.Filed));
+        assertEq(c.beneficiary,     beneficiary);
+        assertEq(c.requestedAmount, CLAIM_AMOUNT);
+        assertEq(uint8(c.state),    uint8(IAAP.ClaimState.Filed));
 
-        // ── Step 4: Reviewer traces the root cause ─────────────────────
+        // Verify the evidence hash matches what we submitted
+        assertEq(aap.evidenceHashes(claimId), keccak256(evidence),
+            "evidence hash must match the submitted payload");
+
+        // ── Step 4: Resolver traces the root cause using the upstream chain ──
         uint256[] memory chain = pipeline.traceToRoot(jobD);
+        assertEq(chain.length, 4, "chain should have 4 hops");
+        assertEq(chain[0], jobD, "leaf is jobD");
+        assertEq(chain[3], jobA, "root is jobA");
 
-        // Chain should be [4, 3, 2, 1] (leaf → root)
-        assertEq(chain.length, 4, "Chain should have 4 hops");
-        assertEq(chain[0], jobD, "First element is the leaf job");
-        assertEq(chain[3], jobA, "Last element is the root job");
-
-        // Find the failed job in the chain
         uint256 failedJobId;
         for (uint256 i = 0; i < chain.length; i++) {
             (, ChainedJobsMock.JobStatus status,,) = pipeline.jobs(chain[i]);
@@ -83,17 +118,24 @@ contract Scenario1_MultiHopDependency is Test {
                 break;
             }
         }
-        assertEq(failedJobId, jobC, "Root cause should be Job C (Validate)");
+        assertEq(failedJobId, jobC, "root cause should be jobC (Validate)");
 
-        // ── Step 5: Reviewer approves the claim ────────────────────────
-        bytes32 reason = keccak256(abi.encode("root_cause_job", failedJobId));
+        // ── Step 5: Resolver approves the claim ────────────────────────
+        bytes memory reason = abi.encode("root_cause_job", failedJobId);
 
-        vm.prank(reviewer);
-        aap.reviewClaim(claimId, IAAP.Verdict.Approve, reason);
+        vm.prank(resolver);
+        aap.resolveClaim(claimId, true, CLAIM_AMOUNT, reason);
 
-        // Verify final state
         IAAP.Claim memory resolved = aap.getClaim(claimId);
-        assertEq(uint8(resolved.status), uint8(IAAP.ClaimStatus.Approved));
-        assertEq(token.balanceOf(claimant), CLAIM_AMOUNT, "Claimant should receive payout");
+        assertEq(uint8(resolved.state),  uint8(IAAP.ClaimState.Approved));
+        assertEq(resolved.approvedAmount, CLAIM_AMOUNT);
+
+        // ── Step 6: Payout (permissionless) ────────────────────────────
+        aap.payout(claimId);
+
+        IAAP.Claim memory paid = aap.getClaim(claimId);
+        assertEq(uint8(paid.state), uint8(IAAP.ClaimState.Paid));
+        assertEq(token.balanceOf(beneficiary), CLAIM_AMOUNT,
+            "beneficiary should receive the payout");
     }
 }

--- a/assets/erc-8210/scenarios/test/Scenario2_EvaluatorSlashClaim.t.sol
+++ b/assets/erc-8210/scenarios/test/Scenario2_EvaluatorSlashClaim.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/mocks/AAPMockMinimal.sol";
+import "../contracts/mocks/MockERC20.sol";
+import "../contracts/mocks/EvaluatorRegistryMock.sol";
+
+/// @title Scenario 2 — EvaluatorSlashed → fileClaim
+/// @notice Demonstrates that a slash event from the EvaluatorRegistry serves as
+///         automatic proof for an AAP claim, without re-adjudication.
+contract Scenario2_EvaluatorSlashClaim is Test {
+    AAPMockMinimal        aap;
+    MockERC20             token;
+    EvaluatorRegistryMock registry;
+
+    address registryOperator = makeAddr("registryOperator");
+    address dishonestEval    = makeAddr("dishonestEvaluator");
+    address harmedAgent      = makeAddr("harmedAgent");
+    address reviewer         = makeAddr("reviewer");
+
+    uint256 constant JOB_ID         = 42;
+    uint256 constant SLASH_AMOUNT   = 1_000e18;
+    uint256 constant CLAIM_AMOUNT   = 750e18;
+    bytes32 constant SLASH_REASON   = bytes32("biased_scoring");
+
+    function setUp() public {
+        token    = new MockERC20("Assurance Token", "ASR");
+        aap      = new AAPMockMinimal(address(token), reviewer);
+        registry = new EvaluatorRegistryMock();
+
+        // Fund AAP
+        token.mint(address(aap), 10_000e18);
+    }
+
+    function test_EvaluatorSlashToClaim() public {
+        // ── Step 1: Registry operator slashes the dishonest evaluator ──
+        vm.prank(registryOperator);
+        vm.expectEmit(true, true, false, true, address(registry));
+        emit EvaluatorRegistryMock.EvaluatorSlashed(
+            dishonestEval, JOB_ID, SLASH_AMOUNT, SLASH_REASON
+        );
+        registry.slashEvaluator(dishonestEval, JOB_ID, SLASH_AMOUNT, SLASH_REASON);
+
+        // Verify slash record exists
+        (
+            address recEval,
+            uint256 recJob,
+            uint256 recAmount,
+            bytes32 recReason,
+        ) = registry.slashRecords(JOB_ID);
+        assertEq(recEval,   dishonestEval);
+        assertEq(recJob,    JOB_ID);
+        assertEq(recAmount, SLASH_AMOUNT);
+        assertEq(recReason, SLASH_REASON);
+
+        // ── Step 2: Harmed agent builds evidence from the slash record ─
+        bytes32 evidenceHash = registry.buildEvidenceHash(JOB_ID);
+        assertTrue(evidenceHash != bytes32(0), "Evidence hash should be non-zero");
+
+        // ── Step 3: Harmed agent files a claim in AAP ──────────────────
+        bytes32 upstreamRef = keccak256(abi.encode("EvaluatorSlashed", JOB_ID));
+
+        vm.prank(harmedAgent);
+        vm.expectEmit(true, true, false, true, address(aap));
+        emit IAAP.ClaimFiled(0, harmedAgent, CLAIM_AMOUNT, evidenceHash);
+        uint256 claimId = aap.fileClaim(CLAIM_AMOUNT, evidenceHash, upstreamRef);
+
+        // Verify claim references the slash
+        IAAP.Claim memory c = aap.getClaim(claimId);
+        assertEq(c.claimant,     harmedAgent);
+        assertEq(c.evidenceHash, evidenceHash);
+        assertEq(c.upstream,     upstreamRef);
+
+        // ── Step 4: Reviewer verifies & approves (no re-adjudication) ─
+        // The reviewer checks that the slash record matches the claim evidence.
+        bytes32 recomputedEvidence = registry.buildEvidenceHash(JOB_ID);
+        assertEq(recomputedEvidence, c.evidenceHash, "Evidence must match slash record");
+
+        bytes32 approvalReason = keccak256(
+            abi.encode("slash_verified", dishonestEval, JOB_ID)
+        );
+
+        vm.prank(reviewer);
+        vm.expectEmit(true, false, false, true, address(aap));
+        emit IAAP.ClaimReviewed(claimId, IAAP.Verdict.Approve, approvalReason);
+        aap.reviewClaim(claimId, IAAP.Verdict.Approve, approvalReason);
+
+        // ── Step 5: Verify payout ──────────────────────────────────────
+        IAAP.Claim memory resolved = aap.getClaim(claimId);
+        assertEq(uint8(resolved.status), uint8(IAAP.ClaimStatus.Approved));
+        assertEq(token.balanceOf(harmedAgent), CLAIM_AMOUNT, "Harmed agent should receive payout");
+    }
+}

--- a/assets/erc-8210/scenarios/test/Scenario2_EvaluatorSlashClaim.t.sol
+++ b/assets/erc-8210/scenarios/test/Scenario2_EvaluatorSlashClaim.t.sol
@@ -5,36 +5,62 @@ import "forge-std/Test.sol";
 import "../contracts/mocks/AAPMockMinimal.sol";
 import "../contracts/mocks/MockERC20.sol";
 import "../contracts/mocks/EvaluatorRegistryMock.sol";
+import "../contracts/interfaces/IAAP.sol";
 
 /// @title Scenario 2 — EvaluatorSlashed → fileClaim
-/// @notice Demonstrates that a slash event from the EvaluatorRegistry serves as
-///         automatic proof for an AAP claim, without re-adjudication.
+/// @notice Demonstrates that an `EvaluatorSlashed` event from an external
+///         evaluator registry can serve as automatic claim eligibility proof:
+///         the harmed party encodes the slash record into the AAP `evidence`
+///         payload, and the resolver verifies it directly against the registry.
+///
+///         Layer mapping:
+///           - Layer 1 (Structure): the evaluator registry (8183-side)
+///           - Layer 2 (Behavior):  the slash event itself, signaling misconduct
+///           - Layer 3 (Recovery):  AAP claim is filed with the slash record as
+///             evidence, no second adjudication needed
 contract Scenario2_EvaluatorSlashClaim is Test {
     AAPMockMinimal        aap;
     MockERC20             token;
     EvaluatorRegistryMock registry;
 
-    address registryOperator = makeAddr("registryOperator");
     address dishonestEval    = makeAddr("dishonestEvaluator");
-    address harmedAgent      = makeAddr("harmedAgent");
-    address reviewer         = makeAddr("reviewer");
+    address assuredAgent     = makeAddr("assuredAgent");
+    address harmedBeneficiary = makeAddr("harmedBeneficiary");
+    address resolver         = makeAddr("resolver");
+    address registryOperator = makeAddr("registryOperator");
 
-    uint256 constant JOB_ID         = 42;
-    uint256 constant SLASH_AMOUNT   = 1_000e18;
-    uint256 constant CLAIM_AMOUNT   = 750e18;
-    bytes32 constant SLASH_REASON   = bytes32("biased_scoring");
+    uint256 constant DEPOSIT      = 1000e18;
+    uint256 constant COMMIT       = 750e18;
+    uint64  constant FAR_FUTURE   = type(uint64).max;
+    uint256 constant CLAIM_AMOUNT = 750e18;
+    uint256 constant SLASH_AMOUNT = 1_000e18;
+    uint256 constant JOB_ID       = 42;
+    bytes32 constant SLASH_REASON = bytes32("biased_scoring");
 
     function setUp() public {
         token    = new MockERC20("Assurance Token", "ASR");
-        aap      = new AAPMockMinimal(address(token), reviewer);
+        aap      = new AAPMockMinimal(address(token), resolver);
         registry = new EvaluatorRegistryMock();
 
-        // Fund AAP
-        token.mint(address(aap), 10_000e18);
+        token.mint(assuredAgent, DEPOSIT * 10);
+        vm.prank(assuredAgent);
+        token.approve(address(aap), type(uint256).max);
     }
 
     function test_EvaluatorSlashToClaim() public {
-        // ── Step 1: Registry operator slashes the dishonest evaluator ──
+        // ── Step 1: AssuredAgent posts collateral and commits to the disputed Job ──
+        vm.startPrank(assuredAgent);
+        aap.depositAssurance(DEPOSIT);
+        bytes32 assuranceId = aap.commitToJob(
+            bytes32(JOB_ID),
+            IAAP.CoverageType.EvaluatorDispute,
+            harmedBeneficiary,
+            COMMIT,
+            FAR_FUTURE
+        );
+        vm.stopPrank();
+
+        // ── Step 2: Registry slashes the dishonest evaluator for misconduct ──
         vm.prank(registryOperator);
         vm.expectEmit(true, true, false, true, address(registry));
         emit EvaluatorRegistryMock.EvaluatorSlashed(
@@ -42,53 +68,52 @@ contract Scenario2_EvaluatorSlashClaim is Test {
         );
         registry.slashEvaluator(dishonestEval, JOB_ID, SLASH_AMOUNT, SLASH_REASON);
 
-        // Verify slash record exists
-        (
-            address recEval,
-            uint256 recJob,
-            uint256 recAmount,
-            bytes32 recReason,
-        ) = registry.slashRecords(JOB_ID);
-        assertEq(recEval,   dishonestEval);
-        assertEq(recJob,    JOB_ID);
-        assertEq(recAmount, SLASH_AMOUNT);
-        assertEq(recReason, SLASH_REASON);
+        bytes32 slashHash = registry.buildEvidenceHash(JOB_ID);
+        assertTrue(slashHash != bytes32(0), "slash hash should be non-zero");
 
-        // ── Step 2: Harmed agent builds evidence from the slash record ─
-        bytes32 evidenceHash = registry.buildEvidenceHash(JOB_ID);
-        assertTrue(evidenceHash != bytes32(0), "Evidence hash should be non-zero");
-
-        // ── Step 3: Harmed agent files a claim in AAP ──────────────────
-        bytes32 upstreamRef = keccak256(abi.encode("EvaluatorSlashed", JOB_ID));
-
-        vm.prank(harmedAgent);
-        vm.expectEmit(true, true, false, true, address(aap));
-        emit IAAP.ClaimFiled(0, harmedAgent, CLAIM_AMOUNT, evidenceHash);
-        uint256 claimId = aap.fileClaim(CLAIM_AMOUNT, evidenceHash, upstreamRef);
-
-        // Verify claim references the slash
-        IAAP.Claim memory c = aap.getClaim(claimId);
-        assertEq(c.claimant,     harmedAgent);
-        assertEq(c.evidenceHash, evidenceHash);
-        assertEq(c.upstream,     upstreamRef);
-
-        // ── Step 4: Reviewer verifies & approves (no re-adjudication) ─
-        // The reviewer checks that the slash record matches the claim evidence.
-        bytes32 recomputedEvidence = registry.buildEvidenceHash(JOB_ID);
-        assertEq(recomputedEvidence, c.evidenceHash, "Evidence must match slash record");
-
-        bytes32 approvalReason = keccak256(
-            abi.encode("slash_verified", dishonestEval, JOB_ID)
+        // ── Step 3: Beneficiary files a claim, encoding the slash reference
+        //           into the evidence payload ──────────────────────────
+        // The evidence payload binds the claim to the on-chain slash record.
+        // The resolver can re-derive the slash hash from the registry to
+        // verify that the evidence is authentic.
+        bytes memory evidence = abi.encode(
+            "EvaluatorSlashed",
+            address(registry),
+            JOB_ID,
+            slashHash
         );
 
-        vm.prank(reviewer);
-        vm.expectEmit(true, false, false, true, address(aap));
-        emit IAAP.ClaimReviewed(claimId, IAAP.Verdict.Approve, approvalReason);
-        aap.reviewClaim(claimId, IAAP.Verdict.Approve, approvalReason);
+        vm.prank(harmedBeneficiary);
+        bytes32 claimId = aap.fileClaim(assuranceId, CLAIM_AMOUNT, evidence);
 
-        // ── Step 5: Verify payout ──────────────────────────────────────
-        IAAP.Claim memory resolved = aap.getClaim(claimId);
-        assertEq(uint8(resolved.status), uint8(IAAP.ClaimStatus.Approved));
-        assertEq(token.balanceOf(harmedAgent), CLAIM_AMOUNT, "Harmed agent should receive payout");
+        IAAP.Claim memory c = aap.getClaim(claimId);
+        assertEq(c.beneficiary, harmedBeneficiary);
+        assertEq(aap.evidenceHashes(claimId), keccak256(evidence),
+            "stored evidence hash must match submitted payload");
+
+        // ── Step 4: Resolver verifies the slash and approves ──────────
+        // Re-derive the slash hash from the registry. If it matches the
+        // hash committed in the evidence payload, the slash is authentic
+        // and no further adjudication is needed.
+        bytes32 reDerivedSlashHash = registry.buildEvidenceHash(JOB_ID);
+        assertEq(reDerivedSlashHash, slashHash,
+            "registry must return same slash hash for replay verification");
+
+        bytes memory approvalReason = abi.encode(
+            "slash_verified",
+            dishonestEval,
+            JOB_ID
+        );
+
+        vm.prank(resolver);
+        aap.resolveClaim(claimId, true, CLAIM_AMOUNT, approvalReason);
+
+        // ── Step 5: Payout ─────────────────────────────────────────────
+        aap.payout(claimId);
+
+        IAAP.Claim memory paid = aap.getClaim(claimId);
+        assertEq(uint8(paid.state), uint8(IAAP.ClaimState.Paid));
+        assertEq(token.balanceOf(harmedBeneficiary), CLAIM_AMOUNT,
+            "harmed beneficiary should receive payout");
     }
 }

--- a/assets/erc-8210/scenarios/test/Scenario3_HybridOffchainScoring.t.sol
+++ b/assets/erc-8210/scenarios/test/Scenario3_HybridOffchainScoring.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/mocks/AAPMockMinimal.sol";
+import "../contracts/mocks/MockERC20.sol";
+import "../contracts/mocks/OffchainScorerMock.sol";
+
+/// @title Scenario 3 — Hybrid Off-chain Scoring + On-chain Assurance
+/// @notice Demonstrates that an off-chain score (AHS-style) can serve as shared
+///         evidence for both task rejection (Layer 1) and claim filing (Layer 3),
+///         using the same reasoningCID.
+contract Scenario3_HybridOffchainScoring is Test {
+    AAPMockMinimal     aap;
+    MockERC20          token;
+    OffchainScorerMock scorer;
+
+    address oracle       = makeAddr("oracle");
+    address suspectAgent = makeAddr("suspectAgent");
+    address taskManager  = makeAddr("taskManager");
+    address claimant     = makeAddr("claimant");
+    address reviewer     = makeAddr("reviewer");
+
+    uint256 constant CLAIM_AMOUNT     = 300e18;
+    uint8   constant CONFIDENCE_THRESHOLD = 70;
+
+    // Simulated CID for the full off-chain reasoning
+    bytes32 constant REASONING_CID = keccak256("ipfs://QmReasoningReport_SuspectAgent_v1");
+
+    function setUp() public {
+        token  = new MockERC20("Assurance Token", "ASR");
+        aap    = new AAPMockMinimal(address(token), reviewer);
+        scorer = new OffchainScorerMock();
+
+        // Fund AAP
+        token.mint(address(aap), 10_000e18);
+    }
+
+    function test_HybridOffchainScoring() public {
+        // ── Step 1: Oracle posts a DENY score for the suspect agent ────
+        vm.prank(oracle);
+        vm.expectEmit(true, false, false, true, address(scorer));
+        emit OffchainScorerMock.ScorePosted(
+            suspectAgent,
+            OffchainScorerMock.ScorerVerdict.DENY,
+            87,
+            REASONING_CID
+        );
+        scorer.postScore(
+            suspectAgent,
+            OffchainScorerMock.ScorerVerdict.DENY,
+            87,              // confidence
+            REASONING_CID
+        );
+
+        // ── Step 2: Task manager reads the score and rejects the task ──
+        // (In a real ERC-8183 setup this would call reject() on the task
+        //  contract. Here we just verify the score is readable and actionable.)
+        (
+            OffchainScorerMock.ScorerVerdict verdict,
+            uint8 confidence,
+            bytes32 reasoningCID
+        ) = scorer.score(suspectAgent);
+
+        assertEq(uint8(verdict), uint8(OffchainScorerMock.ScorerVerdict.DENY));
+        assertTrue(confidence >= CONFIDENCE_THRESHOLD, "Confidence should exceed threshold");
+        assertEq(reasoningCID, REASONING_CID, "CID should match posted value");
+
+        // Task manager would call reject() here — simulated as a logged action
+        emit log_named_string("Task Manager action", "Task rejected based on DENY score");
+
+        // ── Step 3: Claimant files a claim using the SAME reasoningCID ─
+        bytes32 upstreamRef = keccak256(abi.encode("OffchainScore", suspectAgent));
+
+        vm.prank(claimant);
+        uint256 claimId = aap.fileClaim(CLAIM_AMOUNT, REASONING_CID, upstreamRef);
+
+        // The evidenceHash in the claim IS the reasoningCID — same artifact
+        IAAP.Claim memory c = aap.getClaim(claimId);
+        assertEq(c.evidenceHash, REASONING_CID, "Claim evidence must be the same CID used for task rejection");
+
+        // ── Step 4: Reviewer verifies score and approves claim ─────────
+        // Reviewer reads the on-chain score to verify
+        (
+            OffchainScorerMock.ScorerVerdict reviewVerdict,
+            uint8 reviewConfidence,
+            bytes32 reviewCID
+        ) = scorer.score(suspectAgent);
+
+        // Verify the score matches the claim
+        assertEq(uint8(reviewVerdict), uint8(OffchainScorerMock.ScorerVerdict.DENY), "Verdict must be DENY");
+        assertTrue(reviewConfidence >= CONFIDENCE_THRESHOLD, "Confidence must exceed threshold");
+        assertEq(reviewCID, c.evidenceHash, "Score CID must match claim evidence");
+
+        bytes32 approvalReason = keccak256(
+            abi.encode("score_verified", suspectAgent, reviewConfidence)
+        );
+
+        vm.prank(reviewer);
+        aap.reviewClaim(claimId, IAAP.Verdict.Approve, approvalReason);
+
+        // ── Step 5: Verify final state ─────────────────────────────────
+        IAAP.Claim memory resolved = aap.getClaim(claimId);
+        assertEq(uint8(resolved.status), uint8(IAAP.ClaimStatus.Approved));
+        assertEq(token.balanceOf(claimant), CLAIM_AMOUNT, "Claimant should receive payout");
+
+        // The key invariant: both the task rejection and the claim used
+        // the same reasoningCID as their evidence, demonstrating that a
+        // single off-chain evaluation serves both Layer 1 and Layer 3.
+        assertEq(REASONING_CID, c.evidenceHash, "Shared evidence invariant holds");
+    }
+}

--- a/assets/erc-8210/scenarios/test/Scenario3_HybridOffchainScoring.t.sol
+++ b/assets/erc-8210/scenarios/test/Scenario3_HybridOffchainScoring.t.sol
@@ -5,39 +5,62 @@ import "forge-std/Test.sol";
 import "../contracts/mocks/AAPMockMinimal.sol";
 import "../contracts/mocks/MockERC20.sol";
 import "../contracts/mocks/OffchainScorerMock.sol";
+import "../contracts/interfaces/IAAP.sol";
 
 /// @title Scenario 3 — Hybrid Off-chain Scoring + On-chain Assurance
-/// @notice Demonstrates that an off-chain score (AHS-style) can serve as shared
-///         evidence for both task rejection (Layer 1) and claim filing (Layer 3),
-///         using the same reasoningCID.
+/// @notice Demonstrates the "evidence-first composability" principle: a single
+///         off-chain scoring artifact (referenced by `reasoningCID`) is used as
+///         shared evidence by both the task rejection path (Layer 2 prevention)
+///         and the AAP claim filing path (Layer 3 recovery), without requiring
+///         re-attestation or additional oracles.
+///
+///         The same `reasoningCID` is encoded into the AAP evidence payload,
+///         giving the resolver a direct lookup path back to the off-chain score
+///         that drove the rejection decision in the first place.
 contract Scenario3_HybridOffchainScoring is Test {
     AAPMockMinimal     aap;
     MockERC20          token;
     OffchainScorerMock scorer;
 
-    address oracle       = makeAddr("oracle");
-    address suspectAgent = makeAddr("suspectAgent");
-    address taskManager  = makeAddr("taskManager");
-    address claimant     = makeAddr("claimant");
-    address reviewer     = makeAddr("reviewer");
+    address oracle           = makeAddr("oracle");
+    address suspectAgent     = makeAddr("suspectAgent");
+    address assuredAgent     = makeAddr("assuredAgent");
+    address beneficiary      = makeAddr("beneficiary");
+    address resolver         = makeAddr("resolver");
 
-    uint256 constant CLAIM_AMOUNT     = 300e18;
+    uint256 constant DEPOSIT      = 1000e18;
+    uint256 constant COMMIT       = 300e18;
+    uint64  constant FAR_FUTURE   = type(uint64).max;
+    uint256 constant CLAIM_AMOUNT = 300e18;
     uint8   constant CONFIDENCE_THRESHOLD = 70;
+    uint256 constant SUSPECT_JOB_ID = 99;
 
-    // Simulated CID for the full off-chain reasoning
     bytes32 constant REASONING_CID = keccak256("ipfs://QmReasoningReport_SuspectAgent_v1");
 
     function setUp() public {
         token  = new MockERC20("Assurance Token", "ASR");
-        aap    = new AAPMockMinimal(address(token), reviewer);
+        aap    = new AAPMockMinimal(address(token), resolver);
         scorer = new OffchainScorerMock();
 
-        // Fund AAP
-        token.mint(address(aap), 10_000e18);
+        token.mint(assuredAgent, DEPOSIT * 10);
+        vm.prank(assuredAgent);
+        token.approve(address(aap), type(uint256).max);
     }
 
     function test_HybridOffchainScoring() public {
-        // ── Step 1: Oracle posts a DENY score for the suspect agent ────
+        // ── Step 1: AssuredAgent commits to the suspect job ────────────
+        vm.startPrank(assuredAgent);
+        aap.depositAssurance(DEPOSIT);
+        bytes32 assuranceId = aap.commitToJob(
+            bytes32(SUSPECT_JOB_ID),
+            IAAP.CoverageType.JobFailure,
+            beneficiary,
+            COMMIT,
+            FAR_FUTURE
+        );
+        vm.stopPrank();
+
+        // ── Step 2: Oracle posts a DENY score for the suspect agent ────
         vm.prank(oracle);
         vm.expectEmit(true, false, false, true, address(scorer));
         emit OffchainScorerMock.ScorePosted(
@@ -49,64 +72,75 @@ contract Scenario3_HybridOffchainScoring is Test {
         scorer.postScore(
             suspectAgent,
             OffchainScorerMock.ScorerVerdict.DENY,
-            87,              // confidence
+            87,
             REASONING_CID
         );
 
-        // ── Step 2: Task manager reads the score and rejects the task ──
-        // (In a real ERC-8183 setup this would call reject() on the task
-        //  contract. Here we just verify the score is readable and actionable.)
+        // ── Step 3: A downstream task manager reads the score and acts on it ──
+        // This is the Layer 2 (Behavior) consumption: the same score is used
+        // here as a prevention signal. In a real ERC-8183 deployment this would
+        // trigger a reject() call. Here we simply verify the score is readable.
         (
             OffchainScorerMock.ScorerVerdict verdict,
             uint8 confidence,
             bytes32 reasoningCID
         ) = scorer.score(suspectAgent);
-
         assertEq(uint8(verdict), uint8(OffchainScorerMock.ScorerVerdict.DENY));
-        assertTrue(confidence >= CONFIDENCE_THRESHOLD, "Confidence should exceed threshold");
-        assertEq(reasoningCID, REASONING_CID, "CID should match posted value");
+        assertTrue(confidence >= CONFIDENCE_THRESHOLD, "confidence must exceed threshold");
+        assertEq(reasoningCID, REASONING_CID);
 
-        // Task manager would call reject() here — simulated as a logged action
-        emit log_named_string("Task Manager action", "Task rejected based on DENY score");
+        emit log_named_string("Layer 2 action", "Task rejected based on DENY score");
 
-        // ── Step 3: Claimant files a claim using the SAME reasoningCID ─
-        bytes32 upstreamRef = keccak256(abi.encode("OffchainScore", suspectAgent));
-
-        vm.prank(claimant);
-        uint256 claimId = aap.fileClaim(CLAIM_AMOUNT, REASONING_CID, upstreamRef);
-
-        // The evidenceHash in the claim IS the reasoningCID — same artifact
-        IAAP.Claim memory c = aap.getClaim(claimId);
-        assertEq(c.evidenceHash, REASONING_CID, "Claim evidence must be the same CID used for task rejection");
-
-        // ── Step 4: Reviewer verifies score and approves claim ─────────
-        // Reviewer reads the on-chain score to verify
-        (
-            OffchainScorerMock.ScorerVerdict reviewVerdict,
-            uint8 reviewConfidence,
-            bytes32 reviewCID
-        ) = scorer.score(suspectAgent);
-
-        // Verify the score matches the claim
-        assertEq(uint8(reviewVerdict), uint8(OffchainScorerMock.ScorerVerdict.DENY), "Verdict must be DENY");
-        assertTrue(reviewConfidence >= CONFIDENCE_THRESHOLD, "Confidence must exceed threshold");
-        assertEq(reviewCID, c.evidenceHash, "Score CID must match claim evidence");
-
-        bytes32 approvalReason = keccak256(
-            abi.encode("score_verified", suspectAgent, reviewConfidence)
+        // ── Step 4: Beneficiary files a claim, encoding the SAME reasoningCID
+        //           into the evidence payload ──────────────────────────
+        // This is the key invariant of the scenario: the off-chain reasoning
+        // artifact serves both Layer 2 (prevention) and Layer 3 (recovery)
+        // through the same CID, with no re-attestation needed.
+        bytes memory evidence = abi.encode(
+            "OffchainScore",
+            address(scorer),
+            suspectAgent,
+            REASONING_CID
         );
 
-        vm.prank(reviewer);
-        aap.reviewClaim(claimId, IAAP.Verdict.Approve, approvalReason);
+        vm.prank(beneficiary);
+        bytes32 claimId = aap.fileClaim(assuranceId, CLAIM_AMOUNT, evidence);
 
-        // ── Step 5: Verify final state ─────────────────────────────────
-        IAAP.Claim memory resolved = aap.getClaim(claimId);
-        assertEq(uint8(resolved.status), uint8(IAAP.ClaimStatus.Approved));
-        assertEq(token.balanceOf(claimant), CLAIM_AMOUNT, "Claimant should receive payout");
+        IAAP.Claim memory c = aap.getClaim(claimId);
+        assertEq(c.beneficiary, beneficiary);
+        assertEq(aap.evidenceHashes(claimId), keccak256(evidence),
+            "stored evidence hash must match submitted payload");
 
-        // The key invariant: both the task rejection and the claim used
-        // the same reasoningCID as their evidence, demonstrating that a
-        // single off-chain evaluation serves both Layer 1 and Layer 3.
-        assertEq(REASONING_CID, c.evidenceHash, "Shared evidence invariant holds");
+        // ── Step 5: Resolver re-reads the score from the scorer to verify ──
+        (
+            OffchainScorerMock.ScorerVerdict reVerdict,
+            uint8 reConfidence,
+            bytes32 reCID
+        ) = scorer.score(suspectAgent);
+        assertEq(uint8(reVerdict), uint8(OffchainScorerMock.ScorerVerdict.DENY));
+        assertTrue(reConfidence >= CONFIDENCE_THRESHOLD);
+        assertEq(reCID, REASONING_CID,
+            "the CID consumed by the resolver must equal the one cited in the claim evidence");
+
+        bytes memory approvalReason = abi.encode(
+            "score_verified",
+            suspectAgent,
+            reConfidence,
+            REASONING_CID
+        );
+
+        vm.prank(resolver);
+        aap.resolveClaim(claimId, true, CLAIM_AMOUNT, approvalReason);
+
+        // ── Step 6: Payout ─────────────────────────────────────────────
+        aap.payout(claimId);
+
+        IAAP.Claim memory paid = aap.getClaim(claimId);
+        assertEq(uint8(paid.state), uint8(IAAP.ClaimState.Paid));
+        assertEq(token.balanceOf(beneficiary), CLAIM_AMOUNT);
+
+        // The shared-evidence invariant: the reasoningCID consumed by Layer 2
+        // (task rejection) and Layer 3 (claim filing) is identical.
+        emit log_bytes32(REASONING_CID);
     }
 }

--- a/assets/erc-8210/scenarios/test/Scenario4_SolvencyAwareClaimAssessment.t.sol
+++ b/assets/erc-8210/scenarios/test/Scenario4_SolvencyAwareClaimAssessment.t.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/mocks/AAPMockMinimal.sol";
+import "../contracts/mocks/MockERC20.sol";
+import "../contracts/mocks/EvaluatorRegistryWithStake.sol";
+import "../contracts/interfaces/IAAP.sol";
+
+/// @title Scenario 4 — Stateless Solvency-Aware Claim Assessment
+/// @notice Demonstrates that EvaluatorSlashed and EvaluatorStakeUpdated
+///         emitted in the same transaction enable stateless solvency
+///         assessment: a downstream consumer can determine both the slash
+///         details AND the evaluator's post-slash balance from log data
+///         alone, without local state or additional RPC calls.
+///
+///         Layer mapping:
+///           - Layer 1 (Structure): the evaluator registry manages stake
+///           - Layer 2 (Behavior):  slash + stake-update signals serve as
+///             behavioral evidence of misconduct and solvency state
+///           - Layer 3 (Recovery):  AAP claim is filed with enriched
+///             evidence containing both event references
+contract Scenario4_SolvencyAwareClaimAssessment is Test {
+    AAPMockMinimal              aap;
+    MockERC20                   token;
+    EvaluatorRegistryWithStake  registry;
+
+    address dishonestEval     = makeAddr("dishonestEvaluator");
+    address assuredAgent      = makeAddr("assuredAgent");
+    address harmedBeneficiary = makeAddr("harmedBeneficiary");
+    address resolver          = makeAddr("resolver");
+    address registryOperator  = makeAddr("registryOperator");
+
+    uint256 constant DEPOSIT       = 1000e18;
+    uint256 constant COMMIT        = 500e18;
+    uint64  constant FAR_FUTURE    = type(uint64).max;
+    uint256 constant CLAIM_AMOUNT  = 500e18;
+    uint256 constant STAKE_AMOUNT  = 2000e18;
+    uint256 constant SLASH_AMOUNT  = 800e18;
+    uint256 constant JOB_ID        = 77;
+    bytes32 constant SLASH_REASON  = bytes32("front_running");
+
+    function setUp() public {
+        token    = new MockERC20("Assurance Token", "ASR");
+        aap      = new AAPMockMinimal(address(token), resolver);
+        registry = new EvaluatorRegistryWithStake();
+
+        token.mint(assuredAgent, DEPOSIT * 10);
+        vm.prank(assuredAgent);
+        token.approve(address(aap), type(uint256).max);
+    }
+
+    function test_SolvencyAwareClaimAssessment() public {
+        // Step 1: Evaluator stakes
+        vm.prank(dishonestEval);
+        vm.expectEmit(true, false, false, true, address(registry));
+        emit EvaluatorRegistryWithStake.EvaluatorStakeUpdated(
+            dishonestEval, 0, STAKE_AMOUNT
+        );
+        registry.depositStake(STAKE_AMOUNT);
+        assertEq(registry.stakeBalances(dishonestEval), STAKE_AMOUNT);
+
+        // Step 2: Assured agent commits
+        vm.startPrank(assuredAgent);
+        aap.depositAssurance(DEPOSIT);
+        bytes32 assuranceId = aap.commitToJob(
+            bytes32(JOB_ID),
+            IAAP.CoverageType.EvaluatorDispute,
+            harmedBeneficiary,
+            COMMIT,
+            FAR_FUTURE
+        );
+        vm.stopPrank();
+
+        // Step 3: Slash — both events in one tx
+        // slashEvaluator() emits EvaluatorSlashed AND EvaluatorStakeUpdated
+        // in the same transaction. A stateless indexer reading the tx logs:
+        //   log[0]: EvaluatorSlashed(evaluator, jobId, 800e18, "front_running")
+        //   log[1]: EvaluatorStakeUpdated(evaluator, 2000e18, 1200e18)
+        // From these two logs alone, the indexer knows what happened, how
+        // much was slashed, and the evaluator's remaining stake — no RPC
+        // call, no local state.
+        vm.prank(registryOperator);
+        vm.expectEmit(true, true, false, true, address(registry));
+        emit EvaluatorRegistryWithStake.EvaluatorSlashed(
+            dishonestEval, JOB_ID, SLASH_AMOUNT, SLASH_REASON
+        );
+        vm.expectEmit(true, false, false, true, address(registry));
+        emit EvaluatorRegistryWithStake.EvaluatorStakeUpdated(
+            dishonestEval, STAKE_AMOUNT, STAKE_AMOUNT - SLASH_AMOUNT
+        );
+        registry.slashEvaluator(dishonestEval, JOB_ID, SLASH_AMOUNT, SLASH_REASON);
+        assertEq(registry.stakeBalances(dishonestEval), STAKE_AMOUNT - SLASH_AMOUNT);
+
+        // Step 4: Enriched evidence payload with both references
+        bytes32 slashHash = registry.buildEvidenceHash(JOB_ID);
+        assertTrue(slashHash != bytes32(0));
+        bytes32 stakeHash = registry.buildStakeEvidenceHash(dishonestEval);
+        assertTrue(stakeHash != bytes32(0));
+
+        bytes memory evidence = abi.encode(
+            "SolvencyAwareSlash",
+            address(registry),
+            JOB_ID,
+            slashHash,
+            dishonestEval,
+            stakeHash
+        );
+
+        vm.prank(harmedBeneficiary);
+        bytes32 claimId = aap.fileClaim(assuranceId, CLAIM_AMOUNT, evidence);
+
+        IAAP.Claim memory c = aap.getClaim(claimId);
+        assertEq(c.beneficiary, harmedBeneficiary);
+        assertEq(aap.evidenceHashes(claimId), keccak256(evidence));
+
+        // Step 5: Resolver verifies both slash and solvency
+        assertEq(registry.buildEvidenceHash(JOB_ID), slashHash);
+        assertEq(registry.buildStakeEvidenceHash(dishonestEval), stakeHash);
+
+        bytes memory approvalReason = abi.encode(
+            "slash_and_solvency_verified",
+            dishonestEval,
+            JOB_ID,
+            registry.stakeBalances(dishonestEval)
+        );
+        vm.prank(resolver);
+        aap.resolveClaim(claimId, true, CLAIM_AMOUNT, approvalReason);
+
+        // Step 6: Payout
+        aap.payout(claimId);
+        IAAP.Claim memory paid = aap.getClaim(claimId);
+        assertEq(uint8(paid.state), uint8(IAAP.ClaimState.Paid));
+        assertEq(token.balanceOf(harmedBeneficiary), CLAIM_AMOUNT);
+    }
+
+    function test_ZeroStakePostSlash_FullWipeout() public {
+        // Edge case: slash depletes entire stake. A stateless indexer
+        // seeing EvaluatorStakeUpdated(evaluator, X, 0) knows the
+        // evaluator has zero future deterrent — no additional query.
+        uint256 exactSlash = STAKE_AMOUNT;
+
+        vm.prank(dishonestEval);
+        registry.depositStake(STAKE_AMOUNT);
+
+        vm.startPrank(assuredAgent);
+        aap.depositAssurance(DEPOSIT);
+        bytes32 assuranceId = aap.commitToJob(
+            bytes32(JOB_ID),
+            IAAP.CoverageType.EvaluatorDispute,
+            harmedBeneficiary,
+            COMMIT,
+            FAR_FUTURE
+        );
+        vm.stopPrank();
+
+        vm.prank(registryOperator);
+        vm.expectEmit(true, false, false, true, address(registry));
+        emit EvaluatorRegistryWithStake.EvaluatorStakeUpdated(
+            dishonestEval, STAKE_AMOUNT, 0
+        );
+        registry.slashEvaluator(dishonestEval, JOB_ID, exactSlash, SLASH_REASON);
+        assertEq(registry.stakeBalances(dishonestEval), 0);
+
+        bytes32 stakeHash = registry.buildStakeEvidenceHash(dishonestEval);
+        bytes32 slashHash = registry.buildEvidenceHash(JOB_ID);
+        bytes memory evidence = abi.encode(
+            "SolvencyAwareSlash", address(registry), JOB_ID,
+            slashHash, dishonestEval, stakeHash
+        );
+
+        vm.prank(harmedBeneficiary);
+        bytes32 claimId = aap.fileClaim(assuranceId, CLAIM_AMOUNT, evidence);
+
+        vm.prank(resolver);
+        aap.resolveClaim(claimId, true, CLAIM_AMOUNT, "full_wipeout");
+
+        aap.payout(claimId);
+        IAAP.Claim memory paid = aap.getClaim(claimId);
+        assertEq(uint8(paid.state), uint8(IAAP.ClaimState.Paid));
+    }
+}


### PR DESCRIPTION
## Summary

Three reference scenarios demonstrating how ERC-8210 (Agent Assurance Protocol) composes with ERC-8183 and external behavior oracles, mapped onto the **3-layer architecture** articulated by @wangbin9953 in the [ERC-8183 forum thread](https://ethereum-magicians.org/t/erc-8183-agentic-commerce/27902).

This is a follow-up to [PR #1647](https://github.com/ethereum/ERCs/pull/1647) (test vectors), but is **fully self-contained** — it has its own minimal mocks and Foundry setup, and does not depend on the test vectors PR being merged first.

## Architectural Context

The scenarios are organized around the 3-layer architecture for autonomous agent safety:

| Layer | Name | Enforced by |
|-------|------|-------------|
| **1** | **Structure** | ERC-8183 core (auto-assignment, role separation, state machines) |
| **2** | **Behavior** | Risk hooks, evaluator registries, off-chain scoring oracles |
| **3** | **Recovery** | ERC-8210 / AAP (post-hoc redress when layers 1 and 2 don't catch the attack) |

The three scenarios are concrete examples of how Layer 3 (recovery) composes with the other two layers without coupling.

## Scenarios

| # | Scenario | Layers | Key pattern |
|---|----------|--------|-------------|
| 1 | Multi-Hop Dependency Tracking | 3 (+ 1, 2 context) | `upstream` field traces root cause across A→B→C→D pipeline |
| 2 | EvaluatorSlashed → fileClaim | 2 → 3 | Slash event serves as automatic proof for AAP claim — no re-adjudication |
| 3 | Hybrid Off-chain Scoring | 1 + 2 + 3 | Same `reasoningCID` consumed by task rejection and claim filing |

## What's included

Located in `assets/erc-8210/scenarios/`:

- `README.md` — Architectural context and scenario index
- `contracts/interfaces/` — Minimal IAAP and IERC20 interfaces (subset used by scenarios)
- `contracts/mocks/`:
  - `AAPMockMinimal.sol` — AAP mock with just `fileClaim` + `reviewClaim`
  - `MockERC20.sol` — Settlement asset
  - `EvaluatorRegistryMock.sol` — Slash events (Scenario 2). Event signature agreed with @Bakugo32 (Demsys) in the forum thread
  - `OffchainScorerMock.sol` — AHS-style scoring (Scenario 3). Inspired by @pablocactus (RNWY) AHS concept
  - `ChainedJobsMock.sol` — Job pipeline A→B→C→D (Scenario 1)
- `docs/` — Detailed `.md` documentation for each scenario (problem, actors, flow, layer mapping)
- `test/` — Three Foundry end-to-end tests, one per scenario

## How to run

```bash
cd assets/erc-8210/scenarios
forge install foundry-rs/forge-std --no-commit
forge test -vv
```

All three tests pass: `test_MultiHopDependencyTracking`, `test_EvaluatorSlashToClaim`, `test_HybridOffchainScoring`.

## Related

- Spec PR: #1632
- Test vectors PR: #1647
- Forum discussion: https://ethereum-magicians.org/t/erc-8210-agent-assurance/28097
- ERC-8183 thread (composition discussion): https://ethereum-magicians.org/t/erc-8183-agentic-commerce/27902

## Notes

- No modifications to the spec (`ERCS/erc-8210.md`)
- No modifications to the files in PR #1647
- All new content lives under `assets/erc-8210/scenarios/`
- Self-contained Foundry project with its own minimal mocks