### PR TITLE
Update ERC-8048: Rename `getMetadata` to `metadata` in ERC-8048

### DIFF
--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -2,7 +2,7 @@
 eip: 8048
 title: Onchain Metadata for Token Registries
 description: A key-value store interface that allows registries to store and retrieve arbitrary bytes as metadata directly onchain.
-author: Prem Makeig (@nxt3d), Rafael Abuawad (@rabuawad_)
+author: Prem Makeig (@nxt3d), Rafael Abuawad (@rafael-abuawad)
 discussions-to: https://ethereum-magicians.org/t/erc-8048-onchain-metadata-for-multi-token-and-nft-registries/25820
 status: Draft
 type: Standards Track

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -43,7 +43,7 @@ interface IOnchainMetadata {
 
 - `metadata(tokenId, key)`: Returns the metadata value for the given token ID and key as bytes
 
-Contracts implementing this ERC MAY also expose a `event MetadataSet(uint256 indexed tokenId, string indexed indexedKey, string key, bytes value);` function to allow metadata updates, with write policy determined by the contract.
+Contracts implementing this ERC MAY also expose a `MetadataSet(uint256 indexed tokenId, string indexed indexedKey, string key, bytes value);` function to allow metadata updates, with write policy determined by the contract.
 
 Contracts implementing this ERC MUST emit the following event when metadata is set:
 

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -66,7 +66,7 @@ The Diamond Storage pattern provides predictable storage locations for data, whi
 
 ### Examples
 
-The inspiration for this standard was trustless AI agents. The registry extends [ERC-721](./eip-721.md) by adding `metadata` and `setMetadata` functions for optional extra on-chain agent metadata.
+The inspiration for this standard was trustless AI agents. The registry extends [ERC-721](./eip-721.md) by adding `metadata` and `setMetadata` functions for optional extra onchain agent metadata.
 
 #### Example: Context for LLM-Facing Agent Metadata
 

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -43,7 +43,7 @@ interface IOnchainMetadata {
 
 - `metadata(tokenId, key)`: Returns the metadata value for the given token ID and key as bytes
 
-Contracts implementing this ERC MAY also expose a `MetadataSet(uint256 indexed tokenId, string indexed indexedKey, string key, bytes value);` function to allow metadata updates, with write policy determined by the contract.
+Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract.
 
 Contracts implementing this ERC MUST emit the following event when metadata is set:
 

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -8,6 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2025-09-30
+requires: 165
 ---
 
 ## Abstract
@@ -36,19 +37,22 @@ interface IOnchainMetadata {
     function metadata(uint256 tokenId, string calldata key) external view returns (bytes memory);
     
     /// @notice Emitted when metadata is set for a token.
-    event MetadataSet(uint256 indexed tokenId, string indexed key, bytes value);
+    event MetadataSet(uint256 indexed tokenId, string indexed indexedKey, string key, bytes value);
 }
 ```
 
 - `metadata(tokenId, key)`: Returns the metadata value for the given token ID and key as bytes
 
-Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract.
+Contracts implementing this ERC MAY also expose a `event MetadataSet(uint256 indexed tokenId, string indexed indexedKey, string key, bytes value);` function to allow metadata updates, with write policy determined by the contract.
 
 Contracts implementing this ERC MUST emit the following event when metadata is set:
 
 ```solidity
-event MetadataSet(uint256 indexed tokenId, string indexed key, bytes value);
+event MetadataSet(uint256 indexed tokenId, string indexed indexedKey, string key, bytes value);
 ```
+### Interface ID
+
+The interface ID is `0xdf670be1`.
 
 ### Key/Value Pairs
 
@@ -127,7 +131,7 @@ contract OnchainMetadataExample is IOnchainMetadata {
     function setMetadata(uint256 tokenId, string calldata key, bytes calldata value) 
         external {
         _metadata[tokenId][key] = value;
-        emit MetadataSet(tokenId, key, value);
+        emit MetadataSet(tokenId, key, key, value);
     }
 }
 ```
@@ -165,7 +169,7 @@ contract OnchainMetadataDiamondExample is IOnchainMetadata {
         external {
         OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
         $.metadata[tokenId][key] = value;
-        emit MetadataSet(tokenId, key, value);
+        emit MetadataSet(tokenId, key, key, value);
     }
 }
 ```

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -2,13 +2,12 @@
 eip: 8048
 title: Onchain Metadata for Token Registries
 description: A key-value store interface that allows registries to store and retrieve arbitrary bytes as metadata directly onchain.
-author: Prem Makeig (@nxt3d)
+author: Prem Makeig (@nxt3d), Rafael Abuawad (@rabuawad_)
 discussions-to: https://ethereum-magicians.org/t/erc-8048-onchain-metadata-for-multi-token-and-nft-registries/25820
 status: Draft
 type: Standards Track
 category: ERC
 created: 2025-09-30
-requires: 8042
 ---
 
 ## Abstract
@@ -34,21 +33,21 @@ Contracts implementing this ERC MUST implement the following interface:
 ```solidity
 interface IOnchainMetadata {
     /// @notice Get metadata value for a key.
-    function getMetadata(uint256 tokenId, string calldata key) external view returns (bytes memory);
+    function metadata(uint256 tokenId, string calldata key) external view returns (bytes memory);
     
     /// @notice Emitted when metadata is set for a token.
-    event MetadataSet(uint256 indexed tokenId, string indexed indexedKey, string key, bytes value);
+    event MetadataSet(uint256 indexed tokenId, string indexed key, bytes value);
 }
 ```
 
-- `getMetadata(tokenId, key)`: Returns the metadata value for the given token ID and key as bytes
+- `metadata(tokenId, key)`: Returns the metadata value for the given token ID and key as bytes
 
 Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract.
 
 Contracts implementing this ERC MUST emit the following event when metadata is set:
 
 ```solidity
-event MetadataSet(uint256 indexed tokenId, string indexed indexedKey, string key, bytes value);
+event MetadataSet(uint256 indexed tokenId, string indexed key, bytes value);
 ```
 
 ### Key/Value Pairs
@@ -67,7 +66,7 @@ The Diamond Storage pattern provides predictable storage locations for data, whi
 
 ### Examples
 
-The inspiration for this standard was trustless AI agents. The registry extends [ERC-721](./eip-721.md) by adding `getMetadata` and `setMetadata` functions for optional extra on-chain agent metadata.
+The inspiration for this standard was trustless AI agents. The registry extends [ERC-721](./eip-721.md) by adding `metadata` and `setMetadata` functions for optional extra on-chain agent metadata.
 
 #### Example: Context for LLM-Facing Agent Metadata
 
@@ -96,7 +95,7 @@ For the full specification of metadata hooks, see [ERC-8121](./eip-8121.md) (Met
 
 ## Rationale
 
-This design prioritizes simplicity and flexibility by using a string-key, bytes-value store that provides an intuitive interface for any type of metadata. The minimal interface with a single `getMetadata` function provides all necessary functionality while remaining backwards compatible with existing [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), and [ERC-6909](./eip-6909.md) standards. The optional `setMetadata` function enables flexible access control for metadata updates. The required `MetadataSet` event provides transparent audit trails with indexed tokenId and indexedKey for efficient filtering. This makes the standard suitable for diverse use cases including AI agents, proof of personhood systems, and custom metadata storage.
+This design prioritizes simplicity and flexibility by using a string-key, bytes-value store that provides an intuitive interface for any type of metadata. The minimal interface with a single `metadata` function provides all necessary functionality while remaining backwards compatible with existing [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), and [ERC-6909](./eip-6909.md) standards. The optional `setMetadata` function enables flexible access control for metadata updates. The required `MetadataSet` event provides transparent audit trails with indexed tokenId and indexed key for efficient filtering. This makes the standard suitable for diverse use cases including AI agents, proof of personhood systems, and custom metadata storage.
 
 ## Backwards Compatibility
 
@@ -119,7 +118,7 @@ contract OnchainMetadataExample is IOnchainMetadata {
     mapping(uint256 => mapping(string => bytes)) private _metadata;
     
     /// @notice Get metadata value for a key
-    function getMetadata(uint256 tokenId, string calldata key) 
+    function metadata(uint256 tokenId, string calldata key) 
         external view override returns (bytes memory) {
         return _metadata[tokenId][key];
     }
@@ -128,7 +127,7 @@ contract OnchainMetadataExample is IOnchainMetadata {
     function setMetadata(uint256 tokenId, string calldata key, bytes calldata value) 
         external {
         _metadata[tokenId][key] = value;
-        emit MetadataSet(tokenId, key, key, value);
+        emit MetadataSet(tokenId, key, value);
     }
 }
 ```
@@ -156,7 +155,7 @@ contract OnchainMetadataDiamondExample is IOnchainMetadata {
         }
     }
 
-    function getMetadata(uint256 tokenId, string calldata key) 
+    function metadata(uint256 tokenId, string calldata key) 
         external view override returns (bytes memory) {
         OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
         return $.metadata[tokenId][key];
@@ -166,7 +165,7 @@ contract OnchainMetadataDiamondExample is IOnchainMetadata {
         external {
         OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
         $.metadata[tokenId][key] = value;
-        emit MetadataSet(tokenId, key, key, value);
+        emit MetadataSet(tokenId, key, value);
     }
 }
 ```


### PR DESCRIPTION
This PR proposes two key improvements to align the proposal with established Ethereum standards and optimize gas efficiency.

## Proposed Changes

### 1. Standardize Getter Naming Convention
Renamed the metadata retrieval function from `getMetadata()` to `metadata()`. 

**Rationale:** To maintain consistency with established standards like **ERC-20**, **ERC-721**, and **ERC-1155**, which do not use the `get` prefix for view functions (e.g., `name()`, `decimals()`, `symbol()`).

### 2. Event Optimization
Refactored the `MetadataSet` event to reduce redundancy and gas costs.

**Current:**
`event MetadataSet(uint256 indexed tokenId, string key, string indexed indexedKey, bytes value);`

**Updated:**
`event MetadataSet(uint256 indexed tokenId, string indexed key, bytes value);`

**Rationale:** Having duplicate indexed keys in a single event is redundant and increases gas consumption during execution without providing additional utility for off-chain indexers.