### PR TITLE
Update ERC-8049: Rename `getContractMetadata` to `contractMetadata` in ERC-8049

### DIFF
--- a/ERCS/erc-8049.md
+++ b/ERCS/erc-8049.md
@@ -2,12 +2,13 @@
 eip: 8049
 title: Contract-Level Onchain Metadata
 description: Onchain metadata for arbitrary contracts with optional Diamond Storage for predictable data storage locations.
-author: Prem Makeig (@nxt3d)
+author: Prem Makeig (@nxt3d), Rafael Abuawad (@rafael-abuawad)
 discussions-to: https://ethereum-magicians.org/t/erc-8049-contract-level-metadata-with-diamond-storage/25819
 status: Draft
 type: Standards Track
 category: ERC
 created: 2025-10-10
+requires: 165
 ---
 
 ## Abstract
@@ -29,7 +30,7 @@ Contracts implementing this ERC MUST implement the following interface:
 ```solidity
 interface IERC8049 {
     /// @notice Get contract metadata value for a key.
-    function getContractMetadata(string calldata key) external view returns (bytes memory);
+    function contractMetadata(string calldata key) external view returns (bytes memory);
     
     /// @notice Emitted when contract metadata is updated.
     event ContractMetadataUpdated(string indexed indexedKey, string key, bytes value);
@@ -43,6 +44,11 @@ Contracts implementing this ERC MUST emit the following event when metadata is s
 ```solidity
 event ContractMetadataUpdated(string indexed indexedKey, string key, bytes value);
 ```
+
+### Interface ID
+
+The interface ID is `0x8ec3f882`.
+
 ### Key/Value Pairs
 
 This ERC specifies that the key is a string type and the value is bytes type. This provides flexibility for storing any type of data while maintaining an intuitive string-based key interface.
@@ -81,11 +87,11 @@ This allows clients to discover the contract's ENS name and resolve it to get ad
 
 ### Optional Metadata Hooks
 
-Contracts implementing this ERC MAY use hooks to redirect metadata resolution to a different contract. For the full specification, see [ERC-8121](./eip-8121.md). When using hooks with contract metadata, the target function MUST be `getContractMetadata(string)` returning `bytes`. The hook selector is `0x9e574b14`.
+Contracts implementing this ERC MAY use hooks to redirect metadata resolution to a different contract. For the full specification, see [ERC-8121](./eip-8121.md). When using hooks with contract metadata, the target function MUST be `contractMetadata(string)` returning `bytes`. The hook selector is `0x9e574b14`.
 
 ## Rationale
 
-This design prioritizes simplicity and flexibility by using a string-key, bytes-value store that provides an intuitive interface for any type of contract metadata. The minimal interface with a single `getContractMetadata` function provides all necessary functionality. The optional `setContractMetadata` function enables flexible access control for metadata updates. The required `ContractMetadataUpdated` event provides transparent audit trails with indexed key for efficient filtering. Contracts that need predictable storage locations can optionally use Diamond Storage pattern. This makes the standard suitable for diverse use cases including contract identification, collaboration tracking, and custom metadata storage.
+This design prioritizes simplicity and flexibility by using a string-key, bytes-value store that provides an intuitive interface for any type of contract metadata. The minimal interface with a single `contractMetadata` function provides all necessary functionality. The optional `setContractMetadata` function enables flexible access control for metadata updates. The required `ContractMetadataUpdated` event provides transparent audit trails with indexed key for efficient filtering. Contracts that need predictable storage locations can optionally use Diamond Storage pattern. This makes the standard suitable for diverse use cases including contract identification, collaboration tracking, and custom metadata storage.
 
 ## Backwards Compatibility
 
@@ -107,7 +113,7 @@ contract BasicContractMetadata is IERC8049 {
     // Simple mapping for contract-level metadata
     mapping(string key => bytes value) private _metadata;
 
-    function getContractMetadata(string calldata key) external view override returns (bytes memory) {
+    function contractMetadata(string calldata key) external view override returns (bytes memory) {
         return _metadata[key];
     }
 
@@ -134,20 +140,20 @@ contract DiamondContractMetadata is IERC8049 {
     bytes32 private constant CONTRACT_METADATA_STORAGE_LOCATION =
         keccak256("erc8049.contract.metadata.storage");
 
-    function _getContractMetadataStorage() private pure returns (ContractMetadataStorage storage $) {
+    function _contractMetadataStorage() private pure returns (ContractMetadataStorage storage $) {
         bytes32 location = CONTRACT_METADATA_STORAGE_LOCATION;
         assembly {
             $.slot := location
         }
     }
 
-    function getContractMetadata(string calldata key) external view override returns (bytes memory) {
-        ContractMetadataStorage storage $ = _getContractMetadataStorage();
+    function contractMetadata(string calldata key) external view override returns (bytes memory) {
+        ContractMetadataStorage storage $ = _contractMetadataStorage();
         return $.metadata[key];
     }
 
     function setContractMetadata(string calldata key, bytes calldata value) external {
-        ContractMetadataStorage storage $ = _getContractMetadataStorage();
+        ContractMetadataStorage storage $ = _contractMetadataStorage();
         $.metadata[key] = value;
         emit ContractMetadataUpdated(key, key, value);
     }


### PR DESCRIPTION
This PR proposes two key improvements to align the proposal with established Ethereum standards and optimize compatability.

## Proposed Changes

### 1. Standardize Getter Naming Convention
Renamed the metadata retrieval function from `getContractMetadata()` to `contractMetadata()`. 

**Rationale:** To maintain consistency with established standards like **ERC-20**, **ERC-721**, and **ERC-1155**, which do not use the `get` prefix for view functions (e.g., `name()`, `decimals()`, `symbol()`). Something really similar can be seen in the **ERC-6909** with the `contractURI()`

### 2. Implement ERC-165
Implements the **ERC-165** contract ID, the signature was calculated using [cast](https://www.getfoundry.sh/reference/cast/cast): `cast sig "contractMetadata(string)"`