### PR TITLE
Update ERC-7730: Widen fields to accept constants and map references

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -465,7 +465,7 @@ Legacy Schema attachment kept for backward compatibility. Authors SHOULD prefer 
 
 **`eip712.domain`**
 
-The `domain` constraint is a json object with simple key-value pairs, describing a set of values that the *EIP-712 Domain* of the message MUST match. 
+The `domain` constraint is a json object describing a set of values that the *EIP-712 Domain* of the message MUST match. Values are typically simple key-value pairs, but MAY also be constant references or map references (see [`metadata.constants`](#metadata-section) and [`metadata.maps`](#metadata-section)).
 
 A wallet MUST verify that each key-value pair in this `domain` binding matches the values of the `domain` key-value pairs of the message. Note that the message can have more keys in its `domain` than those listed in the ERC-7730 file. An EIP-712 domain is a free-form list of keys, but those are very common to include:
   
@@ -831,9 +831,10 @@ This key is purely internal and used to specify a human-readable identifier for 
 
 Use to specify the *intent* of the function call or message signature in a user-friendly way.
 
-An intent can take two forms:
-* A simple string with human-readable content
-* A json object with a flat list of string key-value pairs, representing more complex intents. Both keys and values should be human-readable and user-friendly.
+An intent can take three forms:
+* A simple string with human-readable content, or a constant reference / map reference resolving to a string
+* A json object with a flat list of key-value pairs, representing more complex intents. Both keys and values should be human-readable and user-friendly. Values MAY be constant references or map references.
+* A map reference resolving to a string
 
 Wallets SHOULD use this `intent` value to display a clear intent when reviewing the structured data before signature. When displaying a complex json intent, it is expected that keys represent labels, and values should be displayed after their label. 
 
@@ -887,6 +888,7 @@ The `fields` key defines formatting information for individual fields of the str
   * A single [*field format specification*](#field-format-specification)
   * A reference to a format specification in the `definitions` section: by declaring an object with two keys, a `path` key with the [path](#path-references) to the field being formatted, and a `$ref` key with a path to the internal definition. 
     * A reference object can override a field format specification `params` by including its own `params` sub-key, whose values will take precedence over the common definition
+    * A reference object can also carry an optional internal `$id` used to identify the field override
   * A group of fields, defined in [*Group format specification*](#group-format-specification) 
 
 *Grouping* fields allows for both control of the way wallets should order the display of fields and *recursivity* of fields definitions, which can be a more readable form for the 7730 file itself.
@@ -969,11 +971,11 @@ A *field format specification* is a json object defining how to format a single 
 
 **`path` / `value`** 
 
-The path is the absolute or relative location of the field in the structured data, following the rules in the [path section](#path-references). Instead of `path`, a literal `value` may be provided to display a constant without looking up a field.
+The path is the absolute or relative location of the field in the structured data, following the rules in the [path section](#path-references). Instead of `path`, a literal `value` may be provided to display a constant, a constant reference, or a map reference without looking up a field.
 
 **`label`** 
 
-A displayable string shown before the formatted field value.
+A displayable string shown before the formatted field value. May also be a constant reference or a map reference resolving to a string.
 
 **`format`** 
 

--- a/assets/erc-7730/erc7730-v1.schema.json
+++ b/assets/erc-7730/erc7730-v1.schema.json
@@ -495,6 +495,11 @@
                 "value": {
                     "$ref": "#/$format/value"
                 },
+                "label": {
+                    "title": "Field Label override",
+                    "description": "This value overrides the label in the referenced definition if set.",
+                    "type": "string"
+                },
                 "$ref": {
                     "title": "Internal Definition",
                     "description": "An internal definition that should be used as the field formatting definition. The value is the key in the display definitions section, as a path expression $.display.definitions.DEFINITION_NAME.",
@@ -867,7 +872,7 @@
             "properties": {
                 "base": {
                     "title": "Unit base symbol",
-                    "type": "integer",
+                    "type": "string",
                     "description": "The base symbol of the unit, displayed after the converted value. It can be an SI unit symbol or acceptable dimensionless symbols like % or bps."
                 },
                 "decimals": {
@@ -1000,12 +1005,13 @@
                             "function",
                             "constructor",
                             "receive",
-                            "fallback"
+                            "fallback",
+                            "error",
+                            "event"
                         ]
                     }
                 },
                 "required": [
-                    "inputs",
                     "type"
                 ]
             }

--- a/assets/erc-7730/erc7730-v2.schema.json
+++ b/assets/erc-7730/erc7730-v2.schema.json
@@ -350,10 +350,10 @@
                     "propertyNames": {
                         "anyOf": [
                             {
-                                "pattern": "^[A-Za-z_][A-Za-z0-9_]*\\(\\s*(?:(?:(?:tuple(?:\\s*\\((?:[^()]|\\([^()]*\\))*\\))?|[A-Za-z0-9_]+)(?:\\[[0-9]*\\])*(?:\\s+(?:memory|calldata|storage))?\\s+[A-Za-z_][A-Za-z0-9_]*)(?:\\s*,\\s*(?:(?:tuple(?:\\s*\\((?:[^()]|\\([^()]*\\))*\\))?|[A-Za-z0-9_]+)(?:\\[[0-9]*\\])*(?:\\s+(?:memory|calldata|storage))?\\s+[A-Za-z_][A-Za-z0-9_]*))*\\s*)?\\)$"
+                                "pattern": "^[A-Za-z_][A-Za-z0-9_:]*\\(\\s*(?:(?:(?:(?:tuple)?\\s*\\((?:[^()]|\\([^()]*\\))*\\)|[A-Za-z0-9_:]+)(?:\\[[0-9]*\\])*(?:\\s+(?:memory|calldata|storage))?\\s+[A-Za-z_][A-Za-z0-9_]*)(?:\\s*,\\s*(?:(?:(?:tuple)?\\s*\\((?:[^()]|\\([^()]*\\))*\\)|[A-Za-z0-9_:]+)(?:\\[[0-9]*\\])*(?:\\s+(?:memory|calldata|storage))?\\s+[A-Za-z_][A-Za-z0-9_]*))*\\s*)?\\)$"
                             },
                             {
-                                "pattern": "^\\s*[A-Za-z_][A-Za-z0-9_]*\\s*\\(\\s*(?:[A-Za-z_][A-Za-z0-9_]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*(?:,\\s*[A-Za-z_][A-Za-z0-9_]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*)*)?\\)\\s*(?:\\s+[A-Za-z_][A-Za-z0-9_]*\\s*\\(\\s*(?:[A-Za-z_][A-Za-z0-9_]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*(?:,\\s*[A-Za-z_][A-Za-z0-9_]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*)*)?\\)\\s*)*$"
+                                "pattern": "^\\s*[A-Za-z_][A-Za-z0-9_:]*\\s*\\(\\s*(?:[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*(?:,\\s*[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*)*)?\\)\\s*(?:\\s*[A-Za-z_][A-Za-z0-9_:]*\\s*\\(\\s*(?:[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*(?:,\\s*[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*)*)?\\)\\s*)*$"
                             }
                         ]
                         
@@ -472,16 +472,30 @@
                 "value": {
                     "$ref": "#/$format/value"
                 },
+                "label": {
+                    "description": "This value overrides the label in the referenced definition if set.",
+                    "type": "string"
+                },
                 "$ref": {
-                    "title": "Internal Definition",
                     "description": "An internal definition that should be used as the field formatting definition. The value is the key in the display definitions section, as a path expression $.display.definitions.DEFINITION_NAME.",
                     "type": "string"
                 },
                 "params": {
-                    "title": "Parameters",
                     "description": "Parameters override. These values takes precedence over the ones in the definition itself",
                     "type": "object",
                     "additionalProperties": { "type": "string" }
+                },
+                "separator": {
+                    "description": "Separator override for the referenced definition.",
+                    "type": "string"
+                },
+                "visible": {
+                    "description": "Visibility override for the referenced definition.",
+                    "$ref": "#/$format/rules"
+                },
+                "encryption": {
+                    "description": "Encryption override for the referenced definition.",
+                    "$ref": "#/$format/encryptionParameters"
                 }
             },
             "required": [ "$ref" ],

--- a/assets/erc-7730/erc7730-v2.schema.json
+++ b/assets/erc-7730/erc7730-v2.schema.json
@@ -127,10 +127,12 @@
 
                             "properties": {
                                 "name": {
-                                    "type": "string"
+                                    "$ref": "#/$definitions/stringValueOrMap",
+                                    "description": "The expected domain name. Can be a literal, constant reference, or map reference."
                                 },
                                 "version": {
-                                    "type": "string"
+                                    "$ref": "#/$definitions/stringValueOrMap",
+                                    "description": "The expected domain version. Can be a literal, constant reference, or map reference."
                                 },
                                 "chainId": {
                                     "type": "integer",
@@ -189,13 +191,13 @@
 
                 "owner": {
                     "title": "Owner display name",
-                    "type": "string",
+                    "$ref": "#/$definitions/stringValueOrMap",
                     "description": "The display name of the owner or target of the contract / message to be clear signed."
                 },
 
                 "contractName": {
                     "title": "Contract Name",
-                    "type": "string",
+                    "$ref": "#/$definitions/stringValueOrMap",
                     "description": "The name of the contract targeted by the transaction or message."
                 },
 
@@ -399,16 +401,20 @@
                     "description": "A description of the intent of the structured data signing, that will be displayed to the user.",
                     "type": "object",
                     "additionalProperties": {
-                        "type": "string"
+                        "$ref": "#/$definitions/stringValueOrMap"
                     }
+                },
+                {
+                    "title": "Map-resolved intent",
+                    "description": "A map reference resolving to the intent based on context.",
+                    "$ref": "#/$format/mapReference"
                 }
-
             ]
         },
         "interpolatedIntent": {
             "title": "Interpolated intent message",
-            "description": "An optional intent string with embedded field values using {path} interpolation syntax. This provides a dynamic, contextual description by embedding actual transaction/message values directly in the intent string. Wallets should prefer displaying interpolatedIntent when available and fall back to intent if interpolation fails. See the specification for detailed formatting behavior and security considerations.",
-            "type": "string"
+            "$ref": "#/$definitions/stringValueOrMap",
+            "description": "An optional intent string with embedded field values using {path} interpolation syntax. This provides a dynamic, contextual description by embedding actual transaction/message values directly in the intent string. Wallets should prefer displaying interpolatedIntent when available and fall back to intent if interpolation fails. See the specification for detailed formatting behavior and security considerations."
         },
         "fields": {
             "title": "Field Formats set",
@@ -466,6 +472,9 @@
             "title": "Reference",
             "description": "A reference to a shared definition that should be used as the field formatting definition. The value is the key in the display definitions section, as a path expression $.display.definitions.DEFINITION_NAME. It is used to share definitions between multiple messages / functions.",
             "properties": {
+                "$id": {
+                    "$ref": "#/$definitions/id"
+                },
                 "path": {
                     "$ref": "#/$format/path"
                 },
@@ -516,8 +525,8 @@
         },
         "value": {
             "title": "Value",
-            "type": ["string", "integer", "number", "boolean"],
-            "description": "A literal value on which the format should be applied instead of looking up a field in the structured data."
+            "$ref": "#/$definitions/scalarValueOrMap",
+            "description": "A literal value, constant reference, or map reference on which the format should be applied instead of looking up a field in the structured data."
         },
 
         "field": {
@@ -540,8 +549,8 @@
                 },
                 "label": {
                     "title": "Field Label",
-                    "description": "The label of the field, that will be displayed to the user in front of the formatted field value.",
-                    "type": "string"
+                    "$ref": "#/$definitions/stringValueOrMap",
+                    "description": "The label of the field, that will be displayed to the user in front of the formatted field value."
                 },
                 "format": {
                     "title": "Field Format",
@@ -691,7 +700,9 @@
                     "type": "string",
                     "description": "The path to the key used to resolve a value using the referenced map."
                 }
-            }
+            },
+            "required": ["map", "keyPath"],
+            "additionalProperties": false
         },
         "names": {
             "anyOf": [
@@ -786,19 +797,8 @@
                 },
                 "senderAddress": {
                     "title": "Sender Address",
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "description": "An address equal to this value is interpreted as the sender referenced by `@.from`."
-                        },
-                        {
-                            "type": "array",
-                            "description": "An array of addresses, any of which are interpreted as the sender referenced by `@.from`.",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    ]
+                    "$ref": "#/$definitions/stringOrArrayValueOrMap",
+                    "description": "An address (or array of addresses, constant reference, or map reference) interpreted as the sender referenced by `@.from`."
                 }
             },
             "additionalProperties": false
@@ -809,11 +809,7 @@
             "properties": {
                 "callee": {
                     "title": "Callee Address",
-                    "type": ["string", "object"],
-                    "anyOf": [
-                        { "type": "string" },
-                        { "$ref": "#/$format/mapReference" }
-                    ],
+                    "$ref": "#/$definitions/stringValueOrMap",
                     "description": "The address of the contract being called by this embedded calldata."
                 },
                 "calleePath": {
@@ -823,11 +819,7 @@
                 },
                 "selector": {
                     "title": "Called Selector (Optional)",
-                    "type": ["string", "object"],
-                    "anyOf": [
-                        { "type": "string" },
-                        { "$ref": "#/$format/mapReference" }
-                    ],
+                    "$ref": "#/$definitions/stringValueOrMap",
                     "description": "The selector being called, if not contained in the calldata. Hex string representation."
                 },
                 "selectorPath": {
@@ -837,11 +829,7 @@
                 },
                 "amount": {
                     "title": "Amount (Optional)",
-                    "type": ["integer", "object"],
-                    "anyOf": [
-                        { "type": "integer" },
-                        { "$ref": "#/$format/mapReference" }
-                    ],
+                    "$ref": "#/$definitions/integerValueOrMap",
                     "description": "The associated amount in native currency, if the calldata can be associated with a container value."
                 },
                 "amountPath": {
@@ -850,12 +838,8 @@
                     "description": "The path to the associated amount in native currency, if the calldata can be associated with a container value."
                 },
                 "spender": {
-                    "title": "Spender Path (Optional)",
-                    "type": ["string", "object"],
-                    "anyOf": [
-                        { "type": "string" },
-                        { "$ref": "#/$format/mapReference" }
-                    ],
+                    "title": "Spender (Optional)",
+                    "$ref": "#/$definitions/stringValueOrMap",
                     "description": "The associated spender, if the calldata can be associated with a container value."
                 },
                 "spenderPath": {
@@ -882,12 +866,8 @@
             "properties": {
                 "token": {
                     "title": "Token",
-                    "type": ["string", "object"],
-                    "anyOf": [
-                        { "type": "string" },
-                        { "$ref": "#/$format/mapReference" }
-                    ],
-                    "description": "The token address, or a path to a constant in the ERC 7730 file."
+                    "$ref": "#/$definitions/stringValueOrMap",
+                    "description": "The token address, a constant reference, or a map reference."
                 },
                 "tokenPath": {
                     "title": "Token Path",
@@ -896,37 +876,22 @@
                 },
                 "nativeCurrencyAddress": {
                     "title": "Native Currency Address",
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "description": "An address equal to this value is interpreted as an amount in native currency rather than a token."
-                        },
-                        {
-                            "type": "array",
-                            "description": "An array of addresses, any of which are interpreted as an amount in native currency rather than a token.",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    ]
+                    "$ref": "#/$definitions/stringOrArrayValueOrMap",
+                    "description": "An address (or array of addresses, constant reference, or map reference) equal to which the amount is interpreted as native currency rather than a token."
                 },
                 "threshold": {
                     "title": "Unlimited Threshold",
-                    "type": "string",
+                    "$ref": "#/$definitions/stringValueOrMap",
                     "description": "The threshold above which the amount should be displayed using the message parameter rather than the real amount."
                 },
                 "message": {
                     "title": "Unlimited Message",
-                    "type": "string",
+                    "$ref": "#/$definitions/stringValueOrMap",
                     "description": "The message to display when the amount is above the threshold."
                 },
                 "chainId": {
                     "title": "Chain ID",
-                    "type": ["integer", "object"],
-                    "anyOf": [
-                        { "type": "integer" },
-                        { "$ref": "#/$format/mapReference" }
-                    ],
+                    "$ref": "#/$definitions/integerValueOrMap",
                     "description": "Optional. The chain on which the token is deployed (constant, or a map reference). When present, the wallet SHOULD resolve token metadata (ticker, decimals) for this chain. Useful for cross-chain swap clear signing where the same token address may refer to different chains."
                 },
                 "chainIdPath": {
@@ -947,11 +912,7 @@
             "properties": {
                 "chainId": {
                     "title": "Chain ID",
-                    "type": ["integer", "object"],
-                    "anyOf": [
-                        { "type": "integer" },
-                        { "$ref": "#/$format/mapReference" }
-                    ],
+                    "$ref": "#/$definitions/integerValueOrMap",
                     "description": "Optional. The chain on which the token is deployed (constant, or a map reference). When present, the wallet SHOULD resolve the token ticker for this chain. Useful for cross-chain swap clear signing."
                 },
                 "chainIdPath": {
@@ -971,12 +932,8 @@
             "properties": {
                 "collection": {
                     "title": "Collection Address",
-                    "type": ["string", "object"],
-                    "anyOf": [
-                        { "type": "string" },
-                        { "$ref": "#/$format/mapReference" }
-                    ],
-                    "description": "The collection address, or a path to a constant in the ERC 7730 file."
+                    "$ref": "#/$definitions/stringValueOrMap",
+                    "description": "The collection address, a constant reference, or a map reference."
                 },
                 "collectionPath": {
                     "title": "Collection Path",
@@ -1077,19 +1034,8 @@
                 },
                 "senderAddress": {
                     "title": "Sender Address",
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "description": "An address equal to this value is interpreted as the sender referenced by `@.from`."
-                        },
-                        {
-                            "type": "array",
-                            "description": "An array of addresses, any of which are interpreted as the sender referenced by `@.from`.",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    ]
+                    "$ref": "#/$definitions/stringOrArrayValueOrMap",
+                    "description": "An address (or array of addresses, constant reference, or map reference) interpreted as the sender referenced by `@.from`."
                 }
             },
             "additionalProperties": false
@@ -1122,6 +1068,43 @@
             "title": "ID",
             "type": "string",
             "description": "An internal identifier that can be used either for clarity specifying what the element is or as a reference in device specific sections."
+        },
+
+        "stringValueOrMap": {
+            "title": "String Value or Map Reference",
+            "description": "A string literal, a constant reference ($.metadata.constants.*), or a map reference resolving to a string.",
+            "anyOf": [
+                { "type": "string" },
+                { "$ref": "#/$format/mapReference" }
+            ]
+        },
+
+        "integerValueOrMap": {
+            "title": "Integer Value or Map Reference",
+            "description": "An integer literal, or a map reference resolving to an integer.",
+            "anyOf": [
+                { "type": "integer" },
+                { "$ref": "#/$format/mapReference" }
+            ]
+        },
+
+        "stringOrArrayValueOrMap": {
+            "title": "String, String Array, or Map Reference",
+            "description": "A string literal, an array of strings, a constant reference, or a map reference.",
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } },
+                { "$ref": "#/$format/mapReference" }
+            ]
+        },
+
+        "scalarValueOrMap": {
+            "title": "Scalar Value or Map Reference",
+            "description": "A scalar literal (string, integer, number, boolean), or a map reference.",
+            "anyOf": [
+                { "type": ["string", "integer", "number", "boolean"] },
+                { "$ref": "#/$format/mapReference" }
+            ]
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add reusable JSON schema definitions (`stringValueOrMap`, `integerValueOrMap`, `stringOrArrayValueOrMap`, `scalarValueOrMap`) to factor constant/map reference support
- Widen parameter fields (`token`, `callee`, `selector`, `amount`, `spender`, `chainId`, `collection`, `nativeCurrencyAddress`, `threshold`, `message`, `senderAddress`) to accept map references
- Widen metadata fields (`owner`, `contractName`) and context fields (`domain.name`, `domain.version`) to accept constant and map references
- Widen display fields (`label`, `value`, `interpolatedIntent`, `intent`) to accept map references
- Tighten `mapReference` definition: enforce `required: ["map", "keyPath"]` and `additionalProperties: false`
- Allow optional `$id` on display `reference` entries
- Update spec wording for `eip712.domain`, `intent`, `label`, `value`, and reference overrides to document the new reference forms

Depends on #1662 (schema alignment).

Companion registry PR: https://github.com/LedgerHQ/clear-signing-erc7730-registry/pull/2503

## Test plan

- [x] Schema validates as valid JSON
- [x] Spec wording changes are minimal and backward-compatible
- [ ] Validate a descriptor using a map reference in a newly-widened field
- [ ] Linter updated and tested (LedgerHQ/python-erc7730#291)

🤖 Generated with [Claude Code](https://claude.com/claude-code)