### PR TITLE
Update ERC-1202: fix ERC-1202 grammar and spelling

### DIFF
--- a/ERCS/erc-1202.md
+++ b/ERCS/erc-1202.md
@@ -13,40 +13,37 @@ requires: 5269
 
 ## Abstract
 
-This EIP is an API for implementing voting with smart contract. This standard provides functionalities to voting as well as to view the vote result and set voting status.
+This EIP defines an API for implementing voting with smart contracts. This standard provides functionality for voting, viewing vote results, and setting voting status.
 
 ## Motivation
 
-Voting is one of the earliest example of EVM programming, and also a key to DAO/organizational governance process. We foresee many DAOs will ultimately need to leverage voting as one of the important part of their governance. By creating a voting standard for smart contract / token, we can have the following benefits
+Voting is one of the earliest examples of EVM programming and is also a key part of DAO and organizational governance processes. We expect many DAOs will ultimately need to leverage voting as an important part of their governance. By creating a voting standard for smart contracts and tokens, we can have the following benefits:
 
 ### Benefits of having a standard
 
-1. Allow general UI and applications to be built on top of a standardized voting to allow more general user to participate, and encourage more DApp and DAO to think about their governance
-2. Allow delegate voting / smart contract voting, automatic voting
-3. Allow voting results to be recorded on-chain, in a standard way, and allow DAOs and DApps to honor the voting result programmatically.
-4. Allow the compatibility with token standard such as [ERC-20](./eip-20.md) or other new standards([ERC-777](./eip-777.md)) and item standard such as [ERC-721](./eip-721.md)
-5. Create massive potential for interoperability within Ethereum echo systems and other system.
-6. Allow setting voting deadline, allow determine on single or multiple options. Allow requiring voting orders. (trade-off is interface complexity, we might need [ERC-20](./eip-20.md) approach and later a [ERC-777](./eip-777.md) for advanced voting)
-7. Recording the voting with weights with token amount.
-8. Possibly allow trust-worthy privacy-safe voting and anonymous voting (with either voter address being un-associated with the vote they cast, given a list of randomized/obfuscated voting options).
-9. Possibly allow result in reward by voting participation or voting result.
+1. Allow general UIs and applications to be built on top of a standardized voting interface so that more users can participate, and encourage more dApps and DAOs to think about their governance.
+2. Allow delegated voting, smart-contract voting, and automatic voting.
+3. Allow voting results to be recorded on-chain in a standard way, and allow DAOs and dApps to honor the voting results programmatically.
+4. Allow compatibility with token standards such as [ERC-20](./eip-20.md) and newer standards such as [ERC-777](./eip-777.md), as well as item standards such as [ERC-721](./eip-721.md).
+5. Create massive potential for interoperability within Ethereum ecosystems and other systems.
+6. Allow setting voting deadlines, determining single or multiple options, and requiring voting order. (The trade-off is interface complexity; we might need an [ERC-20](./eip-20.md)-style approach first and later an [ERC-777](./eip-777.md)-style approach for advanced voting.)
+7. Record voting weights based on token amounts.
+8. Possibly allow trustworthy, privacy-safe voting and anonymous voting (with the voter address not being associated with the vote they cast, given a list of randomized or obfuscated voting options).
+9. Possibly allow rewards based on voting participation or voting results.
 
 ### Non-Goal / Out of Scope
 
 1. **Delegation**: We intentionally leave delegation out of scope. A separate EIP could be proposed to address this particular use case.
-2. **Eligibility or Weights**: Some of the implementing want to have weights or eligibility to vote to be configurable. Such as OpenZeppelin's implementation of GovernorBravo uses snapshot. Aslo weights calculation such as quadratic voting is not within the scope of this EIP. This EIP is intend to be flexible for
-any current and new voting weights calculation.
-3. **Proposal**: We intentionally leave Proposal out of scope. Proposals are going to be identified by `proposalId` but what information of the proposal includes,
-whether they are on-chain or off-chain and whether they are exeutable, is leaved out from this proposal. A separate EIP could be proposed to address this particular use case. See one of such proposals [ERC-5247](./eip-5247.md)
-4. **Signature Aggregations / Endorsement**: When implementing contracts want to allow user to submit their vote or approval of vote offline and have some other
-account to generate the transaction, the signature aggregations or endorsements are not in scope of this EIP. A separate EIP could be proposed to address this particular use case. See one of such proposals here [ERC-5453](./eip-5453.md).
+2. **Eligibility or Weights**: Some implementations may want voting weights or voting eligibility to be configurable. For example, OpenZeppelin's implementation of GovernorBravo uses snapshots. Weight calculations such as quadratic voting are also outside the scope of this EIP. This EIP is intended to be flexible enough for current and future voting-weight calculations.
+3. **Proposal**: We intentionally leave proposals out of scope. Proposals are identified by `proposalId`, but the information included in a proposal, whether it is on-chain or off-chain, and whether it is executable are all left out of this proposal. A separate EIP could be proposed to address this particular use case. See one such proposal: [ERC-5247](./eip-5247.md).
+4. **Signature Aggregations / Endorsement**: When implementing contracts want to allow users to submit their vote or vote approval offline and have another account generate the transaction, signature aggregations or endorsements are outside the scope of this EIP. A separate EIP could be proposed to address this particular use case. See one such proposal here: [ERC-5453](./eip-5453.md).
 
 ### Use-cases
 
-1. Determine on issuing new token, issuing more token or issuing sub-token
-2. Determine on creating new item under [ERC-721](./eip-721.md)
-3. Determine on election on certain person or smart contract to be delegated leader for project or subproject
-4. Determine on auditing result ownership allowing migration of smart contract proxy address
+1. Decide on issuing a new token, issuing more tokens, or issuing a sub-token.
+2. Decide on creating a new item under [ERC-721](./eip-721.md).
+3. Decide on electing a certain person or smart contract to be the delegated leader for a project or subproject.
+4. Decide on audit-result ownership that allows migration of a smart-contract proxy address.
 
 ## Specification
 
@@ -108,7 +105,7 @@ interface IERC1202MultiVote {
 }
 ```
 
-3. the compliant contract SHOULD implement [ERC-5269](./eip-5269.md) interface.
+3. The compliant contract SHOULD implement the [ERC-5269](./eip-5269.md) interface.
 
 
 ### Getting Info: Voting Period, Eligibility, Weight
@@ -122,41 +119,41 @@ interface IERC1202Info {
 
 ## Rationale
 
-We made the following design decisions and here are the rationales.
+We made the following design decisions, and here are the rationales.
 
 ### Granularity and Anonymity
 
-We created a `view` function `ballotOf` primarily making it easier for people to check the vote from certain address. This has the following assumptions:
+We created a `view` function, `ballotOf`, primarily to make it easier for people to check the vote from a certain address. This has the following assumptions:
 
-- It's possible to check someone's vote directly given an address. If implementor don't want to make it so easily, they can simply reject all calls to this function. We want to make sure that we support both anonymous voting an non-anonymous voting. However since all calls to a smart contract is logged in block history, there is really no secrecy unless done with cryptography tricks. I am not cryptography-savvy enough to comment on the possibility. Please see "Second Feedback Questions 2018" for related topic.
+- It is possible to check someone's vote directly given an address. If implementers do not want to make this so easy, they can simply reject all calls to this function. We want to make sure that we support both anonymous and non-anonymous voting. However, since all calls to a smart contract are logged in block history, there is not much secrecy unless cryptographic techniques are used. I am not sufficiently cryptography-savvy to comment on that possibility. Please see "Second Feedback Questions 2018" for a related topic.
 
-- It's assumes for each individual address, they can only vote for one decision. They can distribute their available voting power into more granular level. If implementor wants allow this, they ask the user to create another wallet address and grant the new address certain power. For example, a token based voting where voting weight is determined by the amount of token held by a voter, a voter who wants to distribute its voting power in two different option(option set) can transfer some of the tokens to the new account and cast the votes from both accounts.
+- It assumes that each individual address can vote for only one decision. Users can distribute their available voting power at a more granular level. If implementers want to allow this, they can ask the user to create another wallet address and grant that new address a certain amount of power. For example, in token-based voting where voting weight is determined by the amount of tokens held by a voter, a voter who wants to distribute their voting power across two different options (or option sets) can transfer some of the tokens to the new account and cast votes from both accounts.
 
 ### Weights
 
-We assume there are `weight` of votes and can be checked by calling `eligibleVotingWeight(proposalId, address voter)`, and the weight distribution is either internally determined or determined by constructor.
+We assume votes have `weight`, which can be checked by calling `eligibleVotingWeight(proposalId, address voter)`, and that the weight distribution is either determined internally or set by the constructor.
 
 ## Backwards Compatibility
 
-1. The `support` options are chosen to be `uint8` for the purpose to be backward compatible for GovernorBravo. It can be increased in the future
+1. The `support` options are chosen to be `uint8` for the purpose of being backward-compatible with GovernorBravo. This can be increased in the future.
 
 ## Security Considerations
 
-We expect the voting standard to be used in connection with other contracts such as token distributions, conducting actions in consensus or on behalf of an entity, multi-signature wallets, etc.
+We expect the voting standard to be used in connection with other contracts such as token distributions, actions conducted by consensus or on behalf of an entity, multi-signature wallets, and similar systems.
 
-The major security consideration is to ensure only using the standard interface for performing downstream actions or receiving upstream input (vote casting). We expect future audit tool to be based on standard interfaces.
+The major security consideration is ensuring that the standard interface is used only for performing downstream actions or receiving upstream input (vote casting). We expect future audit tools to be based on standard interfaces.
 
-It's also important to note as discussed in this standard that for the sake of simplicity, this EIP is kept in the very basic form. It can be extended to support many different implementation variations. Such variations might contain different assumptions of the behavior and interpretation of actions. One example would be: What does it mean if someone votes multiple times through `vote`?
+It is also important to note, as discussed in this standard, that for the sake of simplicity this EIP is kept in a very basic form. It can be extended to support many different implementation variations. Such variations might contain different assumptions about the behavior and interpretation of actions. One example is: what does it mean if someone votes multiple times through `vote`?
 
-- Would that mean the voter is increasing their weight, or
-- vote multiple options in the meanwhile, or
+- Would that mean the voter is increasing their weight?
+- Would that mean they vote for multiple options in the meantime?
 - Does the latter vote override the previous vote?
 
-Because of the flexible nature of voting, we expect many subsequent standards need to be created as an extension of this EIP. We suggest any extension or implementations of this standard be thoroughly audited before included in large scale or high asset volume applications.
+Because of the flexible nature of voting, we expect that many subsequent standards will need to be created as extensions of this EIP. We suggest that any extension or implementation of this standard be thoroughly audited before being included in large-scale or high-asset-volume applications.
 
-The third consideration is non-triviality. Some voting applications assume **_anonymity_**, **_randomness_**, **_time-based deadline_**, **_ordering_**, etc, these requirements in Ethereum are known to be non-trivial to achieve. We suggest any applications or organizations rely on audited and time-proven shared libraries when these requirements need to be enforced in their applications.
+The third consideration is non-triviality. Some voting applications assume **_anonymity_**, **_randomness_**, **_time-based deadline_**, **_ordering_**, etc. These requirements are known to be non-trivial to achieve on Ethereum. We suggest that any applications or organizations rely on audited and time-proven shared libraries when these requirements need to be enforced in their applications.
 
-The fourth consideration is potential abuse. When voting is standardized and put on contract, it is possible to write another contract that rewards a voter to vote in a certain way. It creates potential issues of bribery and conflict of interest abuse that is previously hard to implement.
+The fourth consideration is potential abuse. When voting is standardized and put on-chain, it is possible to write another contract that rewards a voter for voting in a certain way. This creates potential issues of bribery and conflict-of-interest abuse that were previously hard to implement.
 
 ## Copyright
 


### PR DESCRIPTION
## Summary
- fix grammar and spelling issues throughout ERC-1202
- improve wording and punctuation without changing the proposal's technical intent

## Testing
- not run (documentation-only change)