### PR TITLE
Update ERC-5247: fix grammar and spelling in Victor-authored ERCs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,9 +154,7 @@ jobs:
             if [ ${#PATHS[@]} -gt 0 ]; then
               printf -v PATHS_NOTICE ' %q' "${PATHS[@]}"
               echo "::notice::Running HTMLProofer on changed files only:${PATHS_NOTICE}"
-              for path in "${PATHS[@]}"; do
-                bundle exec htmlproofer --root-dir ./_site --allow-missing-href --disable-external --assume-extension '.html' --log-level=:info --cache='{"timeframe":{"external":"6w"}}' --checks 'Links,Images,Scripts,OpenGraph' --no-check-sri --ignore-empty-alt --no-enforce_https "$path"
-              done
+              bundle exec htmlproofer --root-dir ./_site --allow-missing-href --disable-external --assume-extension '.html' --log-level=:info --cache='{"timeframe":{"external":"6w"}}' --checks 'Links,Images,Scripts,OpenGraph' --no-check-sri --ignore-empty-alt --no-enforce_https "${PATHS[@]}"
               exit $?
             fi
             echo "::warning::Changed ERC HTML files not found in build output, falling back to full check"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,9 @@ jobs:
             if [ ${#PATHS[@]} -gt 0 ]; then
               printf -v PATHS_NOTICE ' %q' "${PATHS[@]}"
               echo "::notice::Running HTMLProofer on changed files only:${PATHS_NOTICE}"
-              bundle exec htmlproofer --root-dir ./_site --allow-missing-href --disable-external --assume-extension '.html' --log-level=:info --cache='{"timeframe":{"external":"6w"}}' --checks 'Links,Images,Scripts,OpenGraph' --no-check-sri --ignore-empty-alt --no-enforce_https "${PATHS[@]}"
+              for path in "${PATHS[@]}"; do
+                bundle exec htmlproofer --root-dir ./_site --allow-missing-href --disable-external --assume-extension '.html' --log-level=:info --cache='{"timeframe":{"external":"6w"}}' --checks 'Links,Images,Scripts,OpenGraph' --no-check-sri --ignore-empty-alt --no-enforce_https "$path"
+              done
               exit $?
             fi
             echo "::warning::Changed ERC HTML files not found in build output, falling back to full check"

--- a/ERCS/erc-5247.md
+++ b/ERCS/erc-5247.md
@@ -19,7 +19,7 @@ function calls including the target contract address, ether value to be transmit
 
 It is oftentimes necessary to separate the code that is to be executed from the actual execution of the code.
 
-A typical use case for this EIP is in a Decentralized Autonomous Organization (DAO). A proposer will create a smart proposal and advocate for it. Members will then choose whether or not to endorse the proposal and vote accordingly (see `ERC-1202`). Finallym when consensus has been formed, the proposal is executed.
+A typical use case for this EIP is in a Decentralized Autonomous Organization (DAO). A proposer will create a smart proposal and advocate for it. Members will then choose whether or not to endorse the proposal and vote accordingly (see `ERC-1202`). Finally, when consensus has been formed, the proposal is executed.
 
 A second typical use-case is that one could have someone who they trust, such as a delegator, trustee, or an attorney-in-fact, or any bilateral collaboration format, where a smart proposal will be first composed, discussed, approved in some way, and then put into execution.
 
@@ -65,8 +65,8 @@ interface IERC5247 {
 
 ## Rationale
 
-* Originally, this interface was part of part of `ERC-1202`. However, the proposal itself can potentially have many use cases outside of voting. It is possible that voting may not need to be upon a proposal in any particular format. Hence, we decide to *decouple the voting interface and proposal interface*.
-* Arrays were used for `target`s, `value`s, `calldata`s instead of single variables, allowing a proposal to carry arbitrarily long multiple functional calls.
+* Originally, this interface was part of `ERC-1202`. However, the proposal itself can potentially have many use cases outside of voting. It is possible that voting may not need to be upon a proposal in any particular format. Hence, we decided to *decouple the voting interface and proposal interface*.
+* Arrays were used for `target`s, `value`s, `calldata`s instead of single variables, allowing a proposal to carry arbitrarily many function calls.
 * `registeredProposalId` is returned in `createProposal` so the standard can support implementation to decide their own format of proposal id.
 
 ## Test Cases
@@ -92,7 +92,7 @@ A simple test case can be found as
         });
 ```
 
-See [testProposalRegistry.ts](../assets/eip-5247/testProposalRegistry.ts) for the whole testset.
+See [testProposalRegistry.ts](../assets/eip-5247/testProposalRegistry.ts) for the whole test set.
 
 ## Reference Implementation
 

--- a/ERCS/erc-5247.md
+++ b/ERCS/erc-5247.md
@@ -19,7 +19,7 @@ function calls including the target contract address, ether value to be transmit
 
 It is oftentimes necessary to separate the code that is to be executed from the actual execution of the code.
 
-A typical use case for this EIP is in a Decentralized Autonomous Organization (DAO). A proposer will create a smart proposal and advocate for it. Members will then choose whether or not to endorse the proposal and vote accordingly (see `ERC-1202`). Finally, when consensus has been formed, the proposal is executed.
+A typical use case for this EIP is in a Decentralized Autonomous Organization (DAO). A proposer will create a smart proposal and advocate for it. Members will then choose whether or not to endorse the proposal and vote accordingly (see [ERC-1202](./eip-1202.md)). Finally, when consensus has been formed, the proposal is executed.
 
 A second typical use-case is that one could have someone who they trust, such as a delegator, trustee, or an attorney-in-fact, or any bilateral collaboration format, where a smart proposal will be first composed, discussed, approved in some way, and then put into execution.
 
@@ -65,7 +65,7 @@ interface IERC5247 {
 
 ## Rationale
 
-* Originally, this interface was part of `ERC-1202`. However, the proposal itself can potentially have many use cases outside of voting. It is possible that voting may not need to be upon a proposal in any particular format. Hence, we decided to *decouple the voting interface and proposal interface*.
+* Originally, this interface was part of [ERC-1202](./eip-1202.md). However, the proposal itself can potentially have many use cases outside of voting. It is possible that voting may not need to be upon a proposal in any particular format. Hence, we decided to *decouple the voting interface and proposal interface*.
 * Arrays were used for `target`s, `value`s, `calldata`s instead of single variables, allowing a proposal to carry arbitrarily many function calls.
 * `registeredProposalId` is returned in `createProposal` so the standard can support implementation to decide their own format of proposal id.
 

--- a/ERCS/erc-5269.md
+++ b/ERCS/erc-5269.md
@@ -13,10 +13,10 @@ requires: 5750
 
 ## Abstract
 
-An interface for better identification and detection of ERC by numbers.
-It designates a field in which it's called `majorERCIdentifier` which is normally known or referred to as "ERC number". For example, `ERC-721` aka [ERC-721](./eip-721.md) has a `majorERCIdentifier = 721`. This ERC has a `majorERCIdentifier = 5269`.
+An interface for better identification and detection of ERCs by number.
+It designates a field called `majorERCIdentifier` which is normally known or referred to as "ERC number". For example, `ERC-721` aka [ERC-721](./eip-721.md) has a `majorERCIdentifier = 721`. This ERC has a `majorERCIdentifier = 5269`.
 
-Calling it a `majorERCIdentifier` instead of `ERCNumber` makes it future-proof: anticipating there is a possibility where future ERC is not numbered or if we want to incorporate other types of standards.
+Calling it a `majorERCIdentifier` instead of `ERCNumber` makes it future-proof: anticipating there is a possibility where future ERCs are not numbered or if we want to incorporate other types of standards.
 
 It also proposes a new concept of `minorERCIdentifier` which is left for authors of
 individual ERC to define. For example, ERC-721's author may define `ERC721Metadata`
@@ -31,13 +31,13 @@ This ERC is created as a competing standard for [ERC-165](./eip-165.md).
 Here are the major differences between this ERC and [ERC-165](./eip-165.md).
 
 1. [ERC-165](./eip-165.md) uses the hash of a method's signature which declares the existence of one method or multiple methods,
-therefore it requires at least one method to *exist* in the first place. In some cases, some ERCs interface does not have a method, such as some ERCs related to data format and signature schemes or the "Soul-Bound-ness" aka SBT which could just revert a transfer call without needing any specific method.
+therefore it requires at least one method to *exist* in the first place. In some cases, some ERC interfaces do not have a method, such as some ERCs related to data format and signature schemes or the "Soul-Bound-ness" aka SBT which could just revert a transfer call without needing any specific method.
 1. [ERC-165](./eip-165.md) doesn't provide query ability based on the caller.
 The compliant contract of this ERC will respond to whether it supports certain ERC *based on* a given caller.
 
 Here is the motivation for this ERC given ERC-165 already exists:
 
-1. Using ERC numbers improves human readability as well as make it easier to work with named contract such as ENS.
+1. Using ERC numbers improves human readability as well as make it easier to work with named contracts such as ENS.
 
 2. Instead of using an ERC-165 identifier, we have seen an increasing interest to use ERC numbers as the way to identify or specify an ERC. For example
 
@@ -54,7 +54,7 @@ convert a function method or whole interface in any ERC in the bytes4 ERC-165 id
 
 ## Specification
 
-In the following description, we use ERC and ERC inter-exchangeably. This was because while most of the time the description applies to an ERC category of the Standards Track of ERC, the ERC number space is a subspace of ERC number space and we might sometimes encounter ERCs that aren't recognized as ERCs but has behavior that's worthy of a query.
+In the following description, we use ERC and ERC interchangeably. This was because while most of the time the description applies to an ERC category of the Standards Track of ERC, the ERC number space is a subspace of ERC number space and we might sometimes encounter ERCs that aren't recognized as ERCs but has behavior that's worthy of a query.
 
 1. Any compliant smart contract MUST implement the following interface
 
@@ -74,7 +74,7 @@ interface IERC5269 {
   /// @dev The core method of ERC Interface Detection
   /// @param caller, a `address` value of the address of a caller being queried whether the given ERC is supported.
   /// @param majorERCIdentifier, a `uint256` value and SHOULD BE the ERC number being queried. Unless superseded by future ERC, such ERC number SHOULD BE less or equal to (0, 2^32-1]. For a function call to `supportERC`, any value outside of this range is deemed unspecified and open to implementation's choice or for future ERCs to specify.
-  /// @param minorERCIdentifier, a `bytes32` value reserved for authors of individual ERC to specify. For example the author of [ERC-721](/ERCS/eip-721) MAY specify `keccak256("ERC721Metadata")` or `keccak256("ERC721Metadata.tokenURI")` as `minorERCIdentifier` to be quired for support. Author could also use this minorERCIdentifier to specify different versions, such as ERC-712 has its V1-V4 with different behavior.
+  /// @param minorERCIdentifier, a `bytes32` value reserved for authors of individual ERC to specify. For example the author of [ERC-721](/ERCS/eip-721) MAY specify `keccak256("ERC721Metadata")` or `keccak256("ERC721Metadata.tokenURI")` as `minorERCIdentifier` to be queried for support. Author could also use this minorERCIdentifier to specify different versions, such as ERC-712 has its V1-V4 with different behavior.
   /// @param extraData, a `bytes` for [ERC-5750](/ERCS/eip-5750) for future extensions.
   /// @return ercStatus, a `bytes32` indicating the status of ERC the contract supports.
   ///                    - For FINAL ERCs, it MUST return `keccak256("FINAL")`.
@@ -224,7 +224,7 @@ contract ERC5269 is IERC5269 {
 
 See [`ERC5269.sol`](../assets/eip-5269/contracts/ERC5269.sol).
 
-Here is an example where a contract of [ERC-721](./eip-721.md) also implement this ERC to make it easier
+Here is an example where a contract of [ERC-721](./eip-721.md) also implements this ERC to make it easier
 to detect and discover:
 
 ```solidity

--- a/ERCS/erc-5269.md
+++ b/ERCS/erc-5269.md
@@ -14,7 +14,7 @@ requires: 5750
 ## Abstract
 
 An interface for better identification and detection of ERCs by number.
-It designates a field called `majorERCIdentifier` which is normally known or referred to as "ERC number". For example, `ERC-721` aka [ERC-721](./eip-721.md) has a `majorERCIdentifier = 721`. This ERC has a `majorERCIdentifier = 5269`.
+It designates a field called `majorERCIdentifier` which is normally known or referred to as "ERC number". For example, [ERC-721](./eip-721.md) has a `majorERCIdentifier = 721`. This ERC has a `majorERCIdentifier = 5269`.
 
 Calling it a `majorERCIdentifier` instead of `ERCNumber` makes it future-proof: anticipating there is a possibility where future ERCs are not numbered or if we want to incorporate other types of standards.
 
@@ -45,7 +45,7 @@ Here is the motivation for this ERC given ERC-165 already exists:
 - [ERC-600](./eip-600.md), and [ERC-601](./eip-601.md) specify an `ERC` number in the `m / purpose' / subpurpose' / ERC' / wallet'` path.
 - [ERC-5568](./eip-5568.md) specifies `The instruction_id of an instruction defined by an ERC MUST be its ERC number unless there are exceptional circumstances (be reasonable)`
 - [ERC-6120](./eip-6120.md) specifies `struct Token { uint eip; ..., }` where `uint eip` is an ERC number to identify ERCs.
-- `ERC-867`(Stagnant) proposes to create `erpId: A string identifier for this ERP (likely the associated ERC number, e.g. “ERC-1234”).`
+- [ERC-867](./eip-867.md) (Stagnant) proposes creating an `erpId`, described as a string identifier for that ERP, likely based on the associated ERC number.
 
 3. Having an ERC/ERC number detection interface reduces the need for a lookup table in smart contract to
 convert a function method or whole interface in any ERC in the bytes4 ERC-165 identifier into its respective ERC number and massively simplifies the way to specify ERC for behavior expansion.

--- a/ERCS/erc-5298.md
+++ b/ERCS/erc-5298.md
@@ -13,7 +13,7 @@ requires: 137, 721, 1155
 
 ## Abstract
 
-This EIP standardizes an interface for smart contracts to hold of [EIP-721](./eip-721.md) and [EIP-1155](./eip-1155.md) tokens on behalf of ENS domains.
+This EIP standardizes an interface for smart contracts to hold [EIP-721](./eip-721.md) and [EIP-1155](./eip-1155.md) tokens on behalf of ENS domains.
 
 ## Motivation
 
@@ -39,7 +39,7 @@ interface IERC_ENS_TRUST is ERC721Receiver, ERC1155Receiver {
 1. ENS was chosen because it is a well-established scoped ownership namespace.
 This is nonetheless compatible with other scoped ownership namespaces.
 
-2. We didn't expose getters or setters for ensRoot because it is outside of the scope of this EIP.
+2. We didn't expose getters or setters for ensRoot because it is outside the scope of this EIP.
 
 ## Backwards Compatibility
 
@@ -61,7 +61,7 @@ describe("FirstENSBankAndTrust", function () {
             // Steps of testing:
             // mint to charlie
             // charlie send to ENSTrust and recorded under bob.xinbenlvethsf.eth
-            // bob try to claimTo alice, first time it should be rejected
+            // bob tries to claimTo alice, first time it should be rejected
             // bob then set the ENS record
             // bob claim to alice, second time it should be accepted
 
@@ -75,7 +75,7 @@ describe("FirstENSBankAndTrust", function () {
                 fakeReceiverENSNamehash
             );
 
-            // bob try to claimTo alice, first time it should be rejected
+            // bob tries to claimTo alice, first time it should be rejected
             await expect(firstENSBankAndTrust.connect(bob).claimTo(
                 alice.address,
                 fakeReceiverENSNamehash,
@@ -126,7 +126,7 @@ contract FirstENSBankAndTrust is IERC721Receiver, Ownable {
         require(data.length == 32, "ENSTokenHolder: last data field must be ENS node.");
         // --- START WARNING ---
         // DO NOT USE THIS IN PROD
-        // this is just a demo purpose of using extraData for node information
+        // this is only a demonstration of using extraData for node information
         // In prod, you should use a struct to store the data. struct should clearly identify the data is for ENS
         // rather than anything else.
         bytes32 ensNode = bytes32(data[0:32]);

--- a/ERCS/erc-5437.md
+++ b/ERCS/erc-5437.md
@@ -12,7 +12,7 @@ requires: 165
 ---
 
 ## Abstract
-An interface for security notice using asymmetric encryption. The interface exposes a asymmetric encryption key and a destination of delivery.
+An interface for security notice using asymmetric encryption. The interface exposes an asymmetric encryption key and a destination of delivery.
 
 ## Motivation
 Currently there is no consistent way to specify an official channel for security researchers to report security issues to smart contract maintainers.
@@ -116,14 +116,14 @@ MOA+HDqgA3a9kWbQKSloORq4unft1eu/FCra
 3. IF `setSecurityContact` is implemented and a call to it has succeeded in setting a new security contact, an event `SecurityContactChanged` MUST be emitted with the identical passed-in-parameters of `setSecurityContact`
 
 4. It's also RECOMMENDED that an on-chain security notify method `securityNotify`
-to implemented to receive security notice onchain. If it's implemented and a call
-has succeeded, it MUST emit an `OnSecurityNotification` with identical pass-in-parameter data.
+be implemented to receive security notice onchain. If it's implemented and a call
+has succeeded, it MUST emit an `OnSecurityNotification` with identical passed-in parameter data.
 
 5. Compliant interfaces MUST implement [EIP-165](./eip-165.md).
 <!-- TODO: add EIP-165 interfaces. -->
 <!-- TODO also consider requiring/recommending implementing EIP-5629 ERC-interface detection. -->
 
-6. It's recommended to set a bounty policy via `bountyPolicy` method. The `id = 0` is preserved for a full overview, while other digits are used for different individual bounty policies. The returned
+6. It's recommended to set a bounty policy via the `bountyPolicy` method. The `id = 0` is preserved for a full overview, while other digits are used for different individual bounty policies. The returned
 string will be URI to content of bounty policies.
 No particular format of bounty policy is specified.
 
@@ -131,7 +131,7 @@ No particular format of bounty policy is specified.
 1. For simplicity, this EIP specifies a simple GPG scheme with a given encryption scheme and uses email addresses as a contact method. It's possible that future EIPs will specify new encryption schemes or delivery methods.
 2. This EIP adds an optional method, `setSecurityContact`, to set the security contact, because it might change due to circumstances such as the expiration of the cryptographic keys.
 3. This EIP explicitly marks `securityNotify` as `payable`, in order to allow implementers to set a staking amount to report a security vulnerability.
-4. This EIP allows for future expansion by adding the `bountyPolicy` the `extraData` fields. Additional values of these fields may be added in future EIPs.
+4. This EIP allows for future expansion by adding the `bountyPolicy` and `extraData` fields. Additional values of these fields may be added in future EIPs.
 
 ## Backwards Compatibility
 Currently, existing solutions such as OpenZeppelin use plaintext in source code
@@ -140,7 +140,7 @@ Currently, existing solutions such as OpenZeppelin use plaintext in source code
 /// @custom:security-contact some-user@some-domain.com
 ```
 
-It's recommend that new versions of smart contracts adopt this EIP in addition to the legacy `@custom:security-contact` approach.
+It's recommended that new versions of smart contracts adopt this EIP in addition to the legacy `@custom:security-contact` approach.
 
 ## Security Considerations
 

--- a/ERCS/erc-5453.md
+++ b/ERCS/erc-5453.md
@@ -1,7 +1,7 @@
 ---
 eip: 5453
 title: Endorsement - Permit for Any Functions
-description: A general protocol for approving function calls in the same transaction rely on ERC-5750.
+description: A general protocol for approving function calls in the same transaction relying on ERC-5750.
 author: Zainan Victor Zhou (@xinbenlv)
 discussions-to: https://ethereum-magicians.org/t/erc-5453-endorsement-standard/10355
 status: Last Call
@@ -14,7 +14,7 @@ requires: 165, 712, 1271, 5750
 
 ## Abstract
 
-This EIP establish a general protocol for permitting approving function calls in the same transaction rely on [ERC-5750](./eip-5750.md).
+This EIP establishes a general protocol for permitting and approving function calls in the same transaction relying on [ERC-5750](./eip-5750.md).
 Unlike a few prior art ([ERC-2612](./eip-2612.md) for [ERC-20](./eip-20.md), `ERC-4494` for [ERC-721](./eip-721.md) that
 usually only permit for a single behavior (`transfer` for ERC-20 and `safeTransferFrom` for ERC-721) and a single approver in two transactions (first a `permit(...)` TX, then a `transfer`-like TX), this EIP provides a way to permit arbitrary behaviors and aggregating multiple approvals from arbitrary number of approvers in the same transaction, allowing for Multi-Sig or Threshold Signing behavior.
 
@@ -34,7 +34,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Interfaces
 
-The interfaces and structure referenced here are as followed
+The interfaces and structures referenced here are as follows
 
 ```solidity
 pragma solidity ^0.8.9;
@@ -105,11 +105,11 @@ See [`IERC5453.sol`](../assets/eip-5453/IERC5453.sol).
 
 ### Behavior specification
 
-As specified in [ERC-5750 General Extensibility for Method Behaviors](./eip-5750.md), any compliant method that has an `bytes extraData` as its
-last method designated for extending behaviors can conform to [ERC-5453](./eip-5453.md) as the way to indicate a permit from certain user.
+As specified in [ERC-5750 General Extensibility for Method Behaviors](./eip-5750.md), any compliant method that has a `bytes extraData` parameter as its
+last designated parameter for extending behaviors can conform to [ERC-5453](./eip-5453.md) as the way to indicate a permit from a certain user.
 
 1. Any compliant method of this EIP MUST be a [ERC-5750](./eip-5750.md) compliant method.
-2. Caller MUST pass in the last parameter `bytes extraData` conforming a solidity memory encoded layout bytes of `GeneralExtensionDataStruct` specified in _Section Interfaces_. The following descriptions are based on when decoding `bytes extraData` into a `GeneralExtensionDataStruct`
+2. Caller MUST pass in the last parameter `bytes extraData` conforming to Solidity memory-encoded bytes of `GeneralExtensionDataStruct` specified in _Section Interfaces_. The following descriptions are based on when decoding `bytes extraData` into a `GeneralExtensionDataStruct`
 3. In the `GeneralExtensionDataStruct`-decoded `extraData`, caller MUST set the value of `GeneralExtensionDataStruct.erc5453MagicWord` to be the `keccak256("ERC5453-ENDORSEMENT")`.
 4. Caller MUST set the value of `GeneralExtensionDataStruct.erc5453Type` to be one of the supported values.
 
@@ -123,7 +123,7 @@ uint256 constant ERC5453_TYPE_B = 2;
 
 7. Each `SingleEndorsementData` MUST have a `address endorserAddress;` and a 65-bytes `bytes sig` signature.
 
-8. Each `bytes sig` MUST be an ECDSA (secp256k1) signature using private key of signer whose corresponding address is `endorserAddress` signing `validityDigest` which is the a hashTypeDataV4 of [EIP-712](./eip-712.md) of hashStruct of `ValidityBound` data structure as followed:
+8. Each `bytes sig` MUST be an ECDSA (secp256k1) signature using private key of signer whose corresponding address is `endorserAddress` signing `validityDigest` which is the hashTypeDataV4 of [EIP-712](./eip-712.md) of hashStruct of `ValidityBound` data structure as follows:
 
 ```solidity
 bytes32 validityDigest =
@@ -142,7 +142,7 @@ bytes32 validityDigest =
     );
 ```
 
-9. The `functionParamStructHash` MUST be computed as followed
+9. The `functionParamStructHash` MUST be computed as follows
 
 ```solidity
         bytes32 functionParamStructHash = keccak256(
@@ -162,14 +162,14 @@ whereas
 10. Upon validating that `endorserAddress == ecrecover(validityDigest, signature)` or `EIP1271(endorserAddress).isValidSignature(validityDigest, signature) == ERC1271.MAGICVALUE`, the single endorsement MUST be deemed valid.
 11. Compliant method MAY choose to impose a threshold for a number of endorsements needs to be valid in the same `ERC5453_TYPE_B` kind of `endorsementPayload`.
 
-12. The `validSince` and `validBy` are both inclusive. Implementer MAY choose to use blocknumber or timestamp. Implementor SHOULD find away to indicate whether `validSince` and `validBy` is blocknumber or timestamp.
+12. The `validSince` and `validBy` are both inclusive. Implementer MAY choose to use blocknumber or timestamp. Implementors SHOULD find a way to indicate whether `validSince` and `validBy` is blocknumber or timestamp.
 
 ## Rationale
 
 1. We chose to have both `ERC5453_TYPE_A`(single-endorsement) and `ERC5453_TYPE_B`(multiple-endorsements, same nonce for entire contract) so we
 could balance a wider range of use cases. E.g. the same use cases of ERC-2612 and `ERC-4494` can be supported by `ERC5453_TYPE_A`. And threshold approvals can be done via `ERC5453_TYPE_B`. More complicated approval types can also be extended by defining new `ERC5453_TYPE_?`
 
-2. We chose to include both `validSince` and `validBy` to allow maximum flexibility in expiration. This can be also be supported by EVM natively at if adopted `ERC-5081` but `ERC-5081` will not be adopted anytime soon, we choose to add these two numbers in our protocol to allow
+2. We chose to include both `validSince` and `validBy` to allow maximum flexibility in expiration. This can also be supported natively by the EVM if adopted `ERC-5081` but `ERC-5081` will not be adopted anytime soon, we choose to add these two numbers in our protocol to allow
 smart contract level support.
 
 ## Backwards Compatibility
@@ -333,7 +333,7 @@ A replay attack is a type of attack on cryptography authentication. In a narrow 
 
 ### Phishing
 
-It's worth pointing out a special form of replay attack by phishing. An adversary can design another smart contract in a way that the user be tricked into signing a smart endorsement for a seemingly legitimate purpose, but the data-to-designed matches the target application
+It's worth pointing out a special form of replay attack by phishing. An adversary can design another smart contract in a way that the user may be tricked into signing a smart endorsement for a seemingly legitimate purpose, but the data-to-designed matches the target application
 
 ## Copyright
 

--- a/ERCS/erc-5453.md
+++ b/ERCS/erc-5453.md
@@ -15,7 +15,7 @@ requires: 165, 712, 1271, 5750
 ## Abstract
 
 This EIP establishes a general protocol for permitting and approving function calls in the same transaction relying on [ERC-5750](./eip-5750.md).
-Unlike a few prior art ([ERC-2612](./eip-2612.md) for [ERC-20](./eip-20.md), `ERC-4494` for [ERC-721](./eip-721.md) that
+Unlike a few prior art ([ERC-2612](./eip-2612.md) for [ERC-20](./eip-20.md), [ERC-4494](./eip-4494.md) for [ERC-721](./eip-721.md) that
 usually only permit for a single behavior (`transfer` for ERC-20 and `safeTransferFrom` for ERC-721) and a single approver in two transactions (first a `permit(...)` TX, then a `transfer`-like TX), this EIP provides a way to permit arbitrary behaviors and aggregating multiple approvals from arbitrary number of approvers in the same transaction, allowing for Multi-Sig or Threshold Signing behavior.
 
 ## Motivation
@@ -167,9 +167,9 @@ whereas
 ## Rationale
 
 1. We chose to have both `ERC5453_TYPE_A`(single-endorsement) and `ERC5453_TYPE_B`(multiple-endorsements, same nonce for entire contract) so we
-could balance a wider range of use cases. E.g. the same use cases of ERC-2612 and `ERC-4494` can be supported by `ERC5453_TYPE_A`. And threshold approvals can be done via `ERC5453_TYPE_B`. More complicated approval types can also be extended by defining new `ERC5453_TYPE_?`
+could balance a wider range of use cases. E.g. the same use cases of ERC-2612 and [ERC-4494](./eip-4494.md) can be supported by `ERC5453_TYPE_A`. And threshold approvals can be done via `ERC5453_TYPE_B`. More complicated approval types can also be extended by defining new `ERC5453_TYPE_?`
 
-2. We chose to include both `validSince` and `validBy` to allow maximum flexibility in expiration. This can also be supported natively by the EVM if adopted `ERC-5081` but `ERC-5081` will not be adopted anytime soon, we choose to add these two numbers in our protocol to allow
+2. We chose to include both `validSince` and `validBy` to allow maximum flexibility in expiration. This can also be supported natively by the EVM if [ERC-5081](./eip-5081.md) is adopted, but [ERC-5081](./eip-5081.md) will not be adopted anytime soon, so we choose to add these two numbers in our protocol to allow
 smart contract level support.
 
 ## Backwards Compatibility
@@ -257,7 +257,7 @@ See [`AERC5453.sol`](../assets/eip-5453/AERC5453.sol)
 
 ### Reference Implementation of `EndorsableERC721`
 
-Here is a reference implementation of `EndorsableERC721` that achieves similar behavior of `ERC-4494`.
+Here is a reference implementation of `EndorsableERC721` that achieves similar behavior to [ERC-4494](./eip-4494.md).
 
 ```solidity
 pragma solidity ^0.8.9;

--- a/ERCS/erc-5485.md
+++ b/ERCS/erc-5485.md
@@ -34,7 +34,7 @@ By standardizing how smart contracts declare sovereignty, jurisdiction, accredit
 
 ### Use Cases (Primary)
 
-The primary use cases address the questions related to the status of a contract themselves. 
+The primary use cases address questions related to the status of a contract itself.
 
 - **Stablecoins (e.g., USDC):** Require jurisdiction because reserve custody, redemptions, freezes, and regulatory compliance depend on a specific legal authority.
 - **Tokenized Stocks / RWAs:** Require jurisdiction because securities laws, transfer restrictions, investor rights, and enforcement vary entirely by legal venue.
@@ -50,13 +50,13 @@ The secondary use cases address the questions related to the interactions betwee
 - **Good-Standing Verification:** Validating whether a contract is accredited and in compliance under its declared jurisdiction.
 - **Jurisdiction-Based Access Control:** Allowing or restricting participation based on jurisdiction or accreditation metadata.
 - **Cross-Contract Legal Cohesion:** Ensuring coherent jurisdictional alignment across multi-contract systems, federated DAOs, or hierarchical governance structures.
-- **Automated Dispute-Path Selection:** Determining which arbitration venue, legal process, or enforcement route applies when disputes ar
+- **Automated Dispute-Path Selection:** Determining which arbitration venue, legal process, or enforcement route applies when disputes arise
 
 ## Specification
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-A contract compliant with this ERC MUST implement the interface defined below.  
+A contract compliant with this ERC MUST implement the interface defined below.
 The interface provides standardized primitives for declaring a contract’s accreditation source, its observed jurisdiction, and a mechanism for receiving structured enforcement proposals. When the jurisdiction is absent, a contract is self-sovereign.
 
 ### 1. Data Structures
@@ -67,8 +67,8 @@ the `IERC5247Executable` and `IERC5247Executables` data structures.
 
 #### `IERC5247Executable`
 
-Represents a single action that MAY be proposed as part of an enforcement submission.  
-This structure follows a generic “executable call” pattern: a target address, an optional ETH value, a gas limit, and calldata for invocation.  
+Represents a single action that MAY be proposed as part of an enforcement submission.
+This structure follows a generic “executable call” pattern: a target address, an optional ETH value, a gas limit, and calldata for invocation.
 No guarantees are made regarding execution; implementations MAY ignore or reinterpret these fields.
 
 ```solidity
@@ -136,23 +136,23 @@ A standardized entry point for submitting an enforcement proposal to the contrac
 ```solidity
 interface IERC5485 {
     /// @notice Returns the address that accredited this contract, if any.
-    /// @dev MUST return address(0) if the contract does not recognize 
-    ///      an external accreditation source. SHOULD remain stable or change 
+    /// @dev MUST return address(0) if the contract does not recognize
+    ///      an external accreditation source. SHOULD remain stable or change
     ///      only via defined governance.
     function sourceOfAccreditation() external view returns (address);
 
-    /// @notice Returns the jurisdiction or higher-order system this contract 
+    /// @notice Returns the jurisdiction or higher-order system this contract
     ///      observes.
-    /// @dev MAY be the same as `sourceOfAccreditation()`. MUST return address(0) 
-    ///      when the contract claims no external jurisdiction (self-sovereign 
+    /// @dev MAY be the same as `sourceOfAccreditation()`. MUST return address(0)
+    ///      when the contract claims no external jurisdiction (self-sovereign
     ///      behavior). SHOULD remain stable or change only via defined governance.
     function jurisdiction() external view returns (address);
 
     /// @notice Submits an enforcement proposal to this contract.
     /// @dev Implementations MUST define access control. Implementations MAY execute,
-    ///      schedule, partially honor, reject, or only record `_proposal`. 
-    /// @dev Implementations SHOULD emit events or store state acknowledging receipt of 
-    ///      enforcement proposals. Payable to allow ETH forwarding for executables that 
+    ///      schedule, partially honor, reject, or only record `_proposal`.
+    /// @dev Implementations SHOULD emit events or store state acknowledging receipt of
+    ///      enforcement proposals. Payable to allow ETH forwarding for executables that
     ///      specify non-zero value.
     function imposeEnforcement(IERC5247Executables _proposal) external payable;
 }
@@ -162,22 +162,22 @@ interface IERC5485 {
 
 ### Separation of Jurisdiction and Accreditation
 
-This ERC separates **jurisdiction** from **accreditation** because 
+This ERC separates **jurisdiction** from **accreditation** because
 they represent fundamentally different relationships:
 
-- **Jurisdiction is voluntary.**  
-  A contract may unilaterally declare that it observes the rules or 
+- **Jurisdiction is voluntary.**
+  A contract may unilaterally declare that it observes the rules or
   norms of a particular system.
 
-- **Accreditation requires external approval.**  
+- **Accreditation requires external approval.**
   Only the authority itself can grant formal recognition that a contract
   is an accepted participant within its system.
 
-- **Jurisdiction expresses alignment; accreditation expresses acceptance.**  
+- **Jurisdiction expresses alignment; accreditation expresses acceptance.**
   Declaring jurisdiction does not imply the authority recognizes the contract.
   Accreditation establishes the reciprocal relationship.
 
-- **Accreditation enables enforcement.**  
+- **Accreditation enables enforcement.**
   Authorities typically issue enforcement only to contracts they have
   accredited. Jurisdiction alone does not create this binding pathway.
 
@@ -197,15 +197,15 @@ jurisdiction, by default showing no accreditation and is considered
 self-sovereign.
 
 2. Using [ERC-5247](./eip-5247.md) as a base interface for enforcement proposals is backward
-compatible with existing contracts that implement [ERC-5247](./eip-5247.md), such as Multi-Sig 
-wallets such as treasury of a DAO.
+compatible with existing contracts that implement [ERC-5247](./eip-5247.md), such as Multi-Sig
+wallets such as the treasury of a DAO.
 
 ## Security Considerations
 
-Similar to a real world scenario, when observing a jurisdiction 
+Similar to a real-world scenario, when observing a jurisdiction
 practically gives the contract the ability to enforce rules on the
-contract's behavior. Simlar to "Ownable" ([ERC-173](./eip-173.md)) or "AccessControl", 
-implementations MUST be aware of the security implications of this: the 
+contract's behavior. Similar to "Ownable" ([ERC-173](./eip-173.md)) or "AccessControl",
+implementations MUST be aware of the security implications of this: the
 security of a contract is compromised if the jurisdiction is compromised.
 
 ## Copyright

--- a/ERCS/erc-5604.md
+++ b/ERCS/erc-5604.md
@@ -1,7 +1,7 @@
 ---
 eip: 5604
 title: NFT Lien
-description: Extend ERC-721 to support putting liens on NFT
+description: Extend ERC-721 to support putting liens on NFTs
 author: Zainan Victor Zhou (@xinbenlv), Allen Zhou <allen@ubiloan.io>, Alex Qin <alex@ubiloan.io>
 discussions-to: https://ethereum-magicians.org/t/creating-a-new-erc-proposal-for-nft-lien/10683
 status: Draft
@@ -13,11 +13,11 @@ requires: 165, 721
 
 ## Abstract
 
-This ERC introduces NFT liens, a form of security interest over an item of property to secure the recovery of liability or performance of some other obligation. It introduces an interface to place and removes a lien, plus an event.
+This ERC introduces NFT liens, a form of security interest over an item of property to secure the recovery of liability or performance of some other obligation. It introduces an interface to place and remove a lien, plus an event.
 
 ## Motivation
 
-Liens are widely used for finance use cases, such as car and property liens. An example use case for an NFT lien is for a deed.
+Liens are widely used in financial use cases, such as car and property liens. An example use case for an NFT lien is for a deed.
 This ERC provides an interface to implement an interface that performs the lien holding relationships.
 
 ## Specification
@@ -74,13 +74,13 @@ interface IERC_LIEN is ERC721, ERC165 {
 
 1. We only support `ERC-721` NFTs for simplicity and gas efficiency. We have not considered other ERCs, which can be left for future extensions. For example, `ERC-20` and `ERC-1155` were not considered.
 
-2. We choose separate "addLienHolder" and "removeLienHolder" instead of use a single `changeLienholder` with amount because we believe
-the add or remove action are significantly different and usually require different Access Control,
+2. We choose separate "addLienHolder" and "removeLienHolder" instead of using a single `changeLienholder` with amount because we believe
+the add and remove actions are significantly different and usually require different Access Control,
 for example, the token holder shall be able to add someone else as a lien holder but the lien holder of that token.
 
 3. We have not specified the "amount of debt" in this interface. We believe this is complex enough and worthy of an individual ERC by itself.
 
-4. We have not specified how endorsement can be applied to allow holder to signal their approval for transfer or swapping. We believe this is complex enough and worthy of an individual ERC by itself.
+4. We have not specified how endorsement can be applied to allow holders to signal their approval for transfer or swapping. We believe this is complex enough and worthy of an individual ERC by itself.
 
 ## Backwards Compatibility
 

--- a/ERCS/erc-5604.md
+++ b/ERCS/erc-5604.md
@@ -24,7 +24,7 @@ This ERC provides an interface to implement an interface that performs the lien 
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-1. Any compliant contract MUST implement `ERC-721`, and `ERC-165`.
+1. Any compliant contract MUST implement [ERC-721](./eip-721.md) and [ERC-165](./eip-165.md).
 
 2. Any compliant contract MUST implement the following interface:
 
@@ -72,7 +72,7 @@ interface IERC_LIEN is ERC721, ERC165 {
 
 ## Rationale
 
-1. We only support `ERC-721` NFTs for simplicity and gas efficiency. We have not considered other ERCs, which can be left for future extensions. For example, `ERC-20` and `ERC-1155` were not considered.
+1. We only support [ERC-721](./eip-721.md) NFTs for simplicity and gas efficiency. We have not considered other ERCs, which can be left for future extensions. For example, [ERC-20](./eip-20.md) and [ERC-1155](./eip-1155.md) were not considered.
 
 2. We choose separate "addLienHolder" and "removeLienHolder" instead of using a single `changeLienholder` with amount because we believe
 the add and remove actions are significantly different and usually require different Access Control,
@@ -84,7 +84,7 @@ for example, the token holder shall be able to add someone else as a lien holder
 
 ## Backwards Compatibility
 
-The ERC is designed as an extension of `ERC-721` and therefore compliant contracts need to fully comply with `ERC-721`.
+The ERC is designed as an extension of [ERC-721](./eip-721.md), and therefore compliant contracts need to fully comply with [ERC-721](./eip-721.md).
 
 ## Security Considerations
 

--- a/ERCS/erc-5982.md
+++ b/ERCS/erc-5982.md
@@ -13,8 +13,8 @@ requires: 165, 5750
 
 ## Abstract
 
-This EIP defines an interface for role-based access control for smart contracts. Roles are defined as `byte32`. The interface specifies how to read, grant, create and destroy roles. It specifies the sense of role power in the format of its ability to call a given method
-identified by `bytes4` method selector. It also specifies how metadata of roles are represented.
+This EIP defines an interface for role-based access control for smart contracts. Roles are defined as `byte32`. The interface specifies how to read, grant, create, and destroy roles. It specifies the meaning of role power in terms of the ability to call a given method
+identified by a `bytes4` method selector. It also specifies how metadata of roles are represented.
 
 ## Motivation
 
@@ -24,7 +24,7 @@ There are many ways to establish access control for privileged actions. One comm
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-Interfaces of reference is described as followed:
+The reference interfaces are described as follows:
 
 ```solidity
 interface IERC_ACL_CORE {
@@ -68,15 +68,15 @@ interface IERC_ACL_METADATA {
 1. Compliant contracts MUST implement `IERC_ACL_CORE`
 2. It is RECOMMENDED for compliant contracts to implement the optional extension `IERC_ACL_GENERAL`.
 3. Compliant contracts MAY implement the optional extension `IERC_ACL_METADATA`.
-4. A role in a compliant smart contract is represented in the format of `bytes32`. It's RECOMMENDED the value of such role is computed as a
-`keccak256` hash of a string of the role name, in this format: `bytes32 role = keccak256("<role_name>")`. such as `bytes32 role = keccak256("MINTER")`.
+4. A role in a compliant smart contract is represented in the format of `bytes32`. It is RECOMMENDED that the value of such a role be computed as a
+`keccak256` hash of the role name, in this format: `bytes32 role = keccak256("<role_name>")`, such as `bytes32 role = keccak256("MINTER")`.
 5. Compliant contracts SHOULD implement [ERC-165](./eip-165.md) identifier.
 
 ## Rationale
 
 1. The names and parameters of methods in `IERC_ACL_CORE` are chosen to allow backward compatibility with OpenZeppelin's implementation.
 2. The methods in `IERC_ACL_GENERAL` conform to [ERC-5750](./eip-5750.md) to allow extension.
-3. The method of `renounceRole` was not adopted, consolidating with `revokeRole` to simplify interface.
+3. The `renounceRole` method was not adopted, and was consolidated into `revokeRole` to simplify the interface.
 
 
 ## Backwards Compatibility

--- a/ERCS/erc-6047.md
+++ b/ERCS/erc-6047.md
@@ -15,24 +15,24 @@ requires: 721
 
 This EIP extends [ERC-721](./eip-721.md) to allow the tracking and indexing of NFTs by mandating that a pre-existing event be emitted during contract creation.
 
-ERC-721 requires a `Transfer` event to be emitted whenever a transfer or mint (i.e. transfer from `0x0`) or burn (i.g. transfer to `0x0`) occurs, **except during contract creation**. This EIP mandates that compliant contracts emit a `Transfer` event **regardless of whether it occurs during or after contract creation.**
+ERC-721 requires a `Transfer` event to be emitted whenever a transfer or mint (i.e. transfer from `0x0`) or burn (i.e. transfer to `0x0`) occurs, **except during contract creation**. This EIP mandates that compliant contracts emit a `Transfer` event **regardless of whether it occurs during or after contract creation.**
 
 ## Motivation
 
 [ERC-721](./eip-721.md) requires a `Transfer` event to be emitted whenever a transfer or mint (i.e. transfer from `0x0`) or burn (i.e. transfer to `0x0`) occurs, EXCEPT for during contract creation. Due to this exception, contracts can mint NFTs during contract creation without the event being emitted. Unlike ERC-721, the [ERC-1155](./eip-1155.md) standard mandates events to be emitted regardless of whether such minting occurs during or outside of contract creation. This allows an indexing service or any off-chain service to reliably capture and account for token creation.
 
-This EIP removes this exception granted by ERC-721 and mandates emitting the `Transfer` for ERC-721 during contract creation. In this manner, indexers and off-chain applications can track token minting, burning, and transferring while relying only on ERC-721's `Transfer` event log.
+This EIP removes this exception granted by ERC-721 and mandates emitting the `Transfer` event for ERC-721 during contract creation. In this manner, indexers and off-chain applications can track token minting, burning, and transferring while relying only on ERC-721's `Transfer` event log.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 1. Compliant contracts MUST implement [ERC-721](./eip-721.md)
-2. Compliant contracts MUST emit a `Transfer` event whenever a token is transferred, minted (i.e. transferred from `0x0`), or burned (i.g. transferred to `0x0`), **including during contract creation.**
+2. Compliant contracts MUST emit a `Transfer` event whenever a token is transferred, minted (i.e. transferred from `0x0`), or burned (i.e. transferred to `0x0`), **including during contract creation.**
 
 ## Rationale
 
-Using the existing `Transfer` event instead of creating a new event (e.g. `Creation`) allows this EIP to be backward compatible with existing indexers.E
+Using the existing `Transfer` event instead of creating a new event (e.g. `Creation`) allows this EIP to be backward compatible with existing indexers.
 
 ## Backwards Compatibility
 

--- a/ERCS/erc-7632.md
+++ b/ERCS/erc-7632.md
@@ -13,20 +13,20 @@ requires: 165
 
 ## Abstract
 
-Extends tokens using `uint256 tokenId` to support `tokenName` in type `string` and be able to convert backward to `tokenId`.
+Extends tokens using `uint256 tokenId` to support `tokenName` of type `string` and to convert back to `tokenId`.
 
 ## Motivation
 
-For Marketplaces, Explorers, Wallets, DeFi and dApps to better display and operate NFTs that comes with a name.
+For Marketplaces, Explorers, Wallets, DeFi and dApps to better display and operate NFTs that come with a name.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 1. Compliant contracts MUST support `tokenName` and
-mapping between `tokenName` and `tokenId` in one of the following ways:
-  - 1a all compliant contracts are RECOMMENDED to implement the following 
-interfaces: `IERC_NamedTokenCore`, 
+a mapping between `tokenName` and `tokenId` in one of the following ways:
+  - 1a all compliant contracts are RECOMMENDED to implement the following
+interfaces: `IERC_NamedTokenCore`,
 ```solidity
 interface IERC_NamedTokenCore {
   function idToName(uint256 _tokenId) external view returns (string);
@@ -35,22 +35,22 @@ interface IERC_NamedTokenCore {
 ```
 
 and it should satisfy the behavior rules that:
-    - 1a.1. when a new name is instroduced, it is RECOMMENDED to emit an event `newName(uint256 indexed tokenId, string tokenName)`.
+    - 1a.1. when a new name is introduced, it is RECOMMENDED to emit an event `newName(uint256 indexed tokenId, string tokenName)`.
     - 1a.2. tokenId and tokenName MUST be two-way single mapping, meaning if tokenId exists, tokenName MUST exist and vice versa and
-      `tokenId = nameToId(idToName(tokenId))` and 
+      `tokenId = nameToId(idToName(tokenId))` and
       `tokenName = idToName(nameToId(tokenName))` MUST hold true.
 
-  - 1b. if the compliant doesn't implement `IERC_NamedTokenCore`,
+  - 1b. if the compliant contract does not implement `IERC_NamedTokenCore`,
 it MAY follow the default mapping rule between `tokenId` and `tokenName`
 `uint256 tokenId = uint256(keccak256(tokenName))`.
 
-2. All method involving `tokenId` for a compliant contract is RECOMMENDED to
-have a counterpart method end with `ByName` that substitute all
-pamameters of `uint256 tokenId` with `string memory tokenName`, 
+2. All methods involving `tokenId` for a compliant contract are RECOMMENDED to
+have a counterpart method ending with `ByName` that substitutes all
+parameters of `uint256 tokenId` with `string memory tokenName`,
 and the behavior of the counterpart method MUST be consistent
 with the original method.
 
-3. Compliant contract MAY implement one or more of following extra interface
+3. A compliant contract MAY implement one or more of the following extra interfaces
 
 ```solidity
 interface IERC_NamedTokenExtension {
@@ -61,11 +61,11 @@ interface IERC_NamedTokenExtension {
 
 ## Rationale
 
-1. We allow default way to map `tokenId` and `tokenName` for convenience, but
-we also allow contract to implement their own way to map `tokenId` and
+1. We allow a default way to map `tokenId` and `tokenName` for convenience, but
+we also allow contracts to implement their own ways of mapping `tokenId` and
 `tokenName` for flexibility.
 
-2. We consider providing an interface for 
+2. We consider providing an interface for
 
 ## Backwards Compatibility
 
@@ -74,11 +74,11 @@ This proposal is fully backwards compatible with token contracts using
 
 ## Security Considerations
 
-This proposal assume that both `tokenName` and `tokenId` are
+This proposal assumes that both `tokenName` and `tokenId` are
 unique amongst all tokens.
 
-If tokenNames are not normalize, two distinct tokenNames may confuse users
-as they look alike. Contract developer shall declare normalization mechanism if
+If token names are not normalized, two distinct token names may confuse users
+as they look alike. Contract developers shall declare a normalization mechanism if
 non-unique `tokenName` is allowed using `IERC_NamedTokenExtension`.
 
 ## Copyright

--- a/ERCS/erc-8117.md
+++ b/ERCS/erc-8117.md
@@ -63,7 +63,7 @@ The notation SHOULD be applied when an EVM address has $n$ consecutive leading z
 
 The value $n$ is the **total count of leading zero nibbles** — it includes every `0` nibble from the start of the address body up to (but not including) the first non-zero nibble.
 
-**Scope:** This ERC deliberately limits its scope to leading zeros in order to focus on the primary security concern: address poisoning. Non-leading repeated sequences (trailing, middle) and non-zero repeated characters are out of scope. However, the industry is RECOMMENDED to follow the same subscript/parenthesis convention defined here should they choose to handle those cases.
+**Scope:** This ERC deliberately limits its scope to leading zeros in order to focus on the primary security concern: address poisoning. Non-leading repeated sequences (trailing, middle) and non-zero repeated characters are out of scope. However, the industry is RECOMMENDED to follow the same subscript/parenthesis convention defined here should it choose to handle those cases.
 
 ### 2. Formatting Rules
 
@@ -117,7 +117,7 @@ This ERC selects **Subscript** (`0x0₈`) rather than superscript notation for t
 
 **Industry Alignment:** As described in the Motivation's "Industry Adoption Gap", block explorers already use subscript for token amounts. Reusing that convention here gives users a single, consistent mental model across the ecosystem.
 
-**Chemical/Scientific Metaphor:** Subscript notation in chemistry (H₂O) universally means "count of the preceding atom." Applied here — `0x0₈` — it intuitively reads as "eight zeros." Superscripts, by contrast, carry a mathematical power-of metaphor (`x⁸ = x to the power of 8`) that conflicts with the intended meaning.
+**Chemical/Scientific Metaphor:** Subscript notation in chemistry (H₂O) universally means "count of the preceding atom." Applied here — `0x0₈` — it intuitively reads as "eight zeros." Superscripts, by contrast, carry a mathematical power metaphor (`x⁸ = x to the power of 8`) that conflicts with the intended meaning.
 
 **Baseline Conflict Avoidance:** Superscripts can visually collide with EIP-55 checksummed capitals when rendered in compact fonts or small UI elements. Subscripts sit below the text baseline and remain visually distinct.
 


### PR DESCRIPTION
## Summary
- sync this PR to the latest `master`
- exclude ERC-1202 because its grammar/spelling fix was already merged separately
- fix grammar and spelling in the remaining Victor-authored non-final ERCs
- keep changes limited to documentation wording and punctuation
- avoid technical or semantic changes

## Testing
- git diff --check
- no code/tests run (markdown-only changes)