### PR TITLE
Update ERC-5269: fix grammar and spelling

### DIFF
--- a/ERCS/erc-5269.md
+++ b/ERCS/erc-5269.md
@@ -13,10 +13,10 @@ requires: 5750
 
 ## Abstract
 
-An interface for better identification and detection of ERC by numbers.
-It designates a field in which it's called `majorERCIdentifier` which is normally known or referred to as "ERC number". For example, `ERC-721` aka [ERC-721](./eip-721.md) has a `majorERCIdentifier = 721`. This ERC has a `majorERCIdentifier = 5269`.
+An interface for better identification and detection of ERCs by number.
+It designates a field called `majorERCIdentifier` which is normally known or referred to as "ERC number". For example, [ERC-721](./eip-721.md) has a `majorERCIdentifier = 721`. This ERC has a `majorERCIdentifier = 5269`.
 
-Calling it a `majorERCIdentifier` instead of `ERCNumber` makes it future-proof: anticipating there is a possibility where future ERC is not numbered or if we want to incorporate other types of standards.
+Calling it a `majorERCIdentifier` instead of `ERCNumber` makes it future-proof: anticipating there is a possibility where future ERCs are not numbered or if we want to incorporate other types of standards.
 
 It also proposes a new concept of `minorERCIdentifier` which is left for authors of
 individual ERC to define. For example, ERC-721's author may define `ERC721Metadata`
@@ -31,13 +31,13 @@ This ERC is created as a competing standard for [ERC-165](./eip-165.md).
 Here are the major differences between this ERC and [ERC-165](./eip-165.md).
 
 1. [ERC-165](./eip-165.md) uses the hash of a method's signature which declares the existence of one method or multiple methods,
-therefore it requires at least one method to *exist* in the first place. In some cases, some ERCs interface does not have a method, such as some ERCs related to data format and signature schemes or the "Soul-Bound-ness" aka SBT which could just revert a transfer call without needing any specific method.
+therefore it requires at least one method to *exist* in the first place. In some cases, some ERC interfaces do not have a method, such as some ERCs related to data format and signature schemes or the "Soul-Bound-ness" aka SBT which could just revert a transfer call without needing any specific method.
 1. [ERC-165](./eip-165.md) doesn't provide query ability based on the caller.
 The compliant contract of this ERC will respond to whether it supports certain ERC *based on* a given caller.
 
 Here is the motivation for this ERC given ERC-165 already exists:
 
-1. Using ERC numbers improves human readability as well as make it easier to work with named contract such as ENS.
+1. Using ERC numbers improves human readability as well as make it easier to work with named contracts such as ENS.
 
 2. Instead of using an ERC-165 identifier, we have seen an increasing interest to use ERC numbers as the way to identify or specify an ERC. For example
 
@@ -45,7 +45,7 @@ Here is the motivation for this ERC given ERC-165 already exists:
 - [ERC-600](./eip-600.md), and [ERC-601](./eip-601.md) specify an `ERC` number in the `m / purpose' / subpurpose' / ERC' / wallet'` path.
 - [ERC-5568](./eip-5568.md) specifies `The instruction_id of an instruction defined by an ERC MUST be its ERC number unless there are exceptional circumstances (be reasonable)`
 - [ERC-6120](./eip-6120.md) specifies `struct Token { uint eip; ..., }` where `uint eip` is an ERC number to identify ERCs.
-- `ERC-867`(Stagnant) proposes to create `erpId: A string identifier for this ERP (likely the associated ERC number, e.g. “ERC-1234”).`
+- [ERC-867](./eip-867.md) (Stagnant) proposes creating an `erpId`, described as a string identifier for that ERP, likely based on the associated ERC number.
 
 3. Having an ERC/ERC number detection interface reduces the need for a lookup table in smart contract to
 convert a function method or whole interface in any ERC in the bytes4 ERC-165 identifier into its respective ERC number and massively simplifies the way to specify ERC for behavior expansion.
@@ -54,7 +54,7 @@ convert a function method or whole interface in any ERC in the bytes4 ERC-165 id
 
 ## Specification
 
-In the following description, we use ERC and ERC inter-exchangeably. This was because while most of the time the description applies to an ERC category of the Standards Track of ERC, the ERC number space is a subspace of ERC number space and we might sometimes encounter ERCs that aren't recognized as ERCs but has behavior that's worthy of a query.
+In the following description, we use ERC and ERC interchangeably. This was because while most of the time the description applies to an ERC category of the Standards Track of ERC, the ERC number space is a subspace of ERC number space and we might sometimes encounter ERCs that aren't recognized as ERCs but has behavior that's worthy of a query.
 
 1. Any compliant smart contract MUST implement the following interface
 
@@ -74,7 +74,7 @@ interface IERC5269 {
   /// @dev The core method of ERC Interface Detection
   /// @param caller, a `address` value of the address of a caller being queried whether the given ERC is supported.
   /// @param majorERCIdentifier, a `uint256` value and SHOULD BE the ERC number being queried. Unless superseded by future ERC, such ERC number SHOULD BE less or equal to (0, 2^32-1]. For a function call to `supportERC`, any value outside of this range is deemed unspecified and open to implementation's choice or for future ERCs to specify.
-  /// @param minorERCIdentifier, a `bytes32` value reserved for authors of individual ERC to specify. For example the author of [ERC-721](/ERCS/eip-721) MAY specify `keccak256("ERC721Metadata")` or `keccak256("ERC721Metadata.tokenURI")` as `minorERCIdentifier` to be quired for support. Author could also use this minorERCIdentifier to specify different versions, such as ERC-712 has its V1-V4 with different behavior.
+  /// @param minorERCIdentifier, a `bytes32` value reserved for authors of individual ERC to specify. For example the author of [ERC-721](/ERCS/eip-721) MAY specify `keccak256("ERC721Metadata")` or `keccak256("ERC721Metadata.tokenURI")` as `minorERCIdentifier` to be queried for support. Author could also use this minorERCIdentifier to specify different versions, such as ERC-712 has its V1-V4 with different behavior.
   /// @param extraData, a `bytes` for [ERC-5750](/ERCS/eip-5750) for future extensions.
   /// @return ercStatus, a `bytes32` indicating the status of ERC the contract supports.
   ///                    - For FINAL ERCs, it MUST return `keccak256("FINAL")`.
@@ -224,7 +224,7 @@ contract ERC5269 is IERC5269 {
 
 See [`ERC5269.sol`](../assets/eip-5269/contracts/ERC5269.sol).
 
-Here is an example where a contract of [ERC-721](./eip-721.md) also implement this ERC to make it easier
+Here is an example where a contract of [ERC-721](./eip-721.md) also implements this ERC to make it easier
 to detect and discover:
 
 ```solidity


### PR DESCRIPTION
## Summary
- fix grammar and spelling in `ERC-5269` only
- keep this PR limited to a single ERC file by design
- avoid technical or semantic changes

## Testing
- markdown-only change
- limited to one file: `ERCS/erc-5269.md`