### PR TITLE
Update ERC-5298: fix grammar and spelling

### DIFF
--- a/ERCS/erc-5298.md
+++ b/ERCS/erc-5298.md
@@ -13,7 +13,7 @@ requires: 137, 721, 1155
 
 ## Abstract
 
-This EIP standardizes an interface for smart contracts to hold of [EIP-721](./eip-721.md) and [EIP-1155](./eip-1155.md) tokens on behalf of ENS domains.
+This EIP standardizes an interface for smart contracts to hold [EIP-721](./eip-721.md) and [EIP-1155](./eip-1155.md) tokens on behalf of ENS domains.
 
 ## Motivation
 
@@ -39,7 +39,7 @@ interface IERC_ENS_TRUST is ERC721Receiver, ERC1155Receiver {
 1. ENS was chosen because it is a well-established scoped ownership namespace.
 This is nonetheless compatible with other scoped ownership namespaces.
 
-2. We didn't expose getters or setters for ensRoot because it is outside of the scope of this EIP.
+2. We didn't expose getters or setters for ensRoot because it is outside the scope of this EIP.
 
 ## Backwards Compatibility
 
@@ -61,7 +61,7 @@ describe("FirstENSBankAndTrust", function () {
             // Steps of testing:
             // mint to charlie
             // charlie send to ENSTrust and recorded under bob.xinbenlvethsf.eth
-            // bob try to claimTo alice, first time it should be rejected
+            // bob tries to claimTo alice, first time it should be rejected
             // bob then set the ENS record
             // bob claim to alice, second time it should be accepted
 
@@ -75,7 +75,7 @@ describe("FirstENSBankAndTrust", function () {
                 fakeReceiverENSNamehash
             );
 
-            // bob try to claimTo alice, first time it should be rejected
+            // bob tries to claimTo alice, first time it should be rejected
             await expect(firstENSBankAndTrust.connect(bob).claimTo(
                 alice.address,
                 fakeReceiverENSNamehash,
@@ -126,7 +126,7 @@ contract FirstENSBankAndTrust is IERC721Receiver, Ownable {
         require(data.length == 32, "ENSTokenHolder: last data field must be ENS node.");
         // --- START WARNING ---
         // DO NOT USE THIS IN PROD
-        // this is just a demo purpose of using extraData for node information
+        // this is only a demonstration of using extraData for node information
         // In prod, you should use a struct to store the data. struct should clearly identify the data is for ENS
         // rather than anything else.
         bytes32 ensNode = bytes32(data[0:32]);


### PR DESCRIPTION
## Summary
- fix grammar and spelling in `ERC-5298` only
- keep this PR limited to a single ERC file by design
- avoid technical or semantic changes

## Testing
- markdown-only change
- limited to one file: `ERCS/erc-5298.md`