### PR TITLE
Update ERC-5437: fix grammar and spelling

### DIFF
--- a/ERCS/erc-5437.md
+++ b/ERCS/erc-5437.md
@@ -12,7 +12,7 @@ requires: 165
 ---
 
 ## Abstract
-An interface for security notice using asymmetric encryption. The interface exposes a asymmetric encryption key and a destination of delivery.
+An interface for security notice using asymmetric encryption. The interface exposes an asymmetric encryption key and a destination of delivery.
 
 ## Motivation
 Currently there is no consistent way to specify an official channel for security researchers to report security issues to smart contract maintainers.
@@ -116,14 +116,14 @@ MOA+HDqgA3a9kWbQKSloORq4unft1eu/FCra
 3. IF `setSecurityContact` is implemented and a call to it has succeeded in setting a new security contact, an event `SecurityContactChanged` MUST be emitted with the identical passed-in-parameters of `setSecurityContact`
 
 4. It's also RECOMMENDED that an on-chain security notify method `securityNotify`
-to implemented to receive security notice onchain. If it's implemented and a call
-has succeeded, it MUST emit an `OnSecurityNotification` with identical pass-in-parameter data.
+be implemented to receive security notice onchain. If it's implemented and a call
+has succeeded, it MUST emit an `OnSecurityNotification` with identical passed-in parameter data.
 
 5. Compliant interfaces MUST implement [EIP-165](./eip-165.md).
 <!-- TODO: add EIP-165 interfaces. -->
 <!-- TODO also consider requiring/recommending implementing EIP-5629 ERC-interface detection. -->
 
-6. It's recommended to set a bounty policy via `bountyPolicy` method. The `id = 0` is preserved for a full overview, while other digits are used for different individual bounty policies. The returned
+6. It's recommended to set a bounty policy via the `bountyPolicy` method. The `id = 0` is preserved for a full overview, while other digits are used for different individual bounty policies. The returned
 string will be URI to content of bounty policies.
 No particular format of bounty policy is specified.
 
@@ -131,7 +131,7 @@ No particular format of bounty policy is specified.
 1. For simplicity, this EIP specifies a simple GPG scheme with a given encryption scheme and uses email addresses as a contact method. It's possible that future EIPs will specify new encryption schemes or delivery methods.
 2. This EIP adds an optional method, `setSecurityContact`, to set the security contact, because it might change due to circumstances such as the expiration of the cryptographic keys.
 3. This EIP explicitly marks `securityNotify` as `payable`, in order to allow implementers to set a staking amount to report a security vulnerability.
-4. This EIP allows for future expansion by adding the `bountyPolicy` the `extraData` fields. Additional values of these fields may be added in future EIPs.
+4. This EIP allows for future expansion by adding the `bountyPolicy` and `extraData` fields. Additional values of these fields may be added in future EIPs.
 
 ## Backwards Compatibility
 Currently, existing solutions such as OpenZeppelin use plaintext in source code
@@ -140,7 +140,7 @@ Currently, existing solutions such as OpenZeppelin use plaintext in source code
 /// @custom:security-contact some-user@some-domain.com
 ```
 
-It's recommend that new versions of smart contracts adopt this EIP in addition to the legacy `@custom:security-contact` approach.
+It's recommended that new versions of smart contracts adopt this EIP in addition to the legacy `@custom:security-contact` approach.
 
 ## Security Considerations
 


### PR DESCRIPTION
## Summary
- fix grammar and spelling in `ERC-5437` only
- keep this PR limited to a single ERC file by design
- avoid technical or semantic changes

## Testing
- markdown-only change
- limited to one file: `ERCS/erc-5437.md`