### PR TITLE
Update ERC-5453: fix grammar and spelling

### DIFF
--- a/ERCS/erc-5453.md
+++ b/ERCS/erc-5453.md
@@ -1,7 +1,7 @@
 ---
 eip: 5453
 title: Endorsement - Permit for Any Functions
-description: A general protocol for approving function calls in the same transaction rely on ERC-5750.
+description: A general protocol for approving function calls in the same transaction relying on ERC-5750.
 author: Zainan Victor Zhou (@xinbenlv)
 discussions-to: https://ethereum-magicians.org/t/erc-5453-endorsement-standard/10355
 status: Last Call
@@ -14,8 +14,8 @@ requires: 165, 712, 1271, 5750
 
 ## Abstract
 
-This EIP establish a general protocol for permitting approving function calls in the same transaction rely on [ERC-5750](./eip-5750.md).
-Unlike a few prior art ([ERC-2612](./eip-2612.md) for [ERC-20](./eip-20.md), `ERC-4494` for [ERC-721](./eip-721.md) that
+This EIP establishes a general protocol for permitting and approving function calls in the same transaction relying on [ERC-5750](./eip-5750.md).
+Unlike a few prior art ([ERC-2612](./eip-2612.md) for [ERC-20](./eip-20.md), [ERC-4494](./eip-4494.md) for [ERC-721](./eip-721.md) that
 usually only permit for a single behavior (`transfer` for ERC-20 and `safeTransferFrom` for ERC-721) and a single approver in two transactions (first a `permit(...)` TX, then a `transfer`-like TX), this EIP provides a way to permit arbitrary behaviors and aggregating multiple approvals from arbitrary number of approvers in the same transaction, allowing for Multi-Sig or Threshold Signing behavior.
 
 ## Motivation
@@ -34,7 +34,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Interfaces
 
-The interfaces and structure referenced here are as followed
+The interfaces and structures referenced here are as follows
 
 ```solidity
 pragma solidity ^0.8.9;
@@ -105,11 +105,11 @@ See [`IERC5453.sol`](../assets/eip-5453/IERC5453.sol).
 
 ### Behavior specification
 
-As specified in [ERC-5750 General Extensibility for Method Behaviors](./eip-5750.md), any compliant method that has an `bytes extraData` as its
-last method designated for extending behaviors can conform to [ERC-5453](./eip-5453.md) as the way to indicate a permit from certain user.
+As specified in [ERC-5750 General Extensibility for Method Behaviors](./eip-5750.md), any compliant method that has a `bytes extraData` parameter as its
+last designated parameter for extending behaviors can conform to [ERC-5453](./eip-5453.md) as the way to indicate a permit from a certain user.
 
 1. Any compliant method of this EIP MUST be a [ERC-5750](./eip-5750.md) compliant method.
-2. Caller MUST pass in the last parameter `bytes extraData` conforming a solidity memory encoded layout bytes of `GeneralExtensionDataStruct` specified in _Section Interfaces_. The following descriptions are based on when decoding `bytes extraData` into a `GeneralExtensionDataStruct`
+2. Caller MUST pass in the last parameter `bytes extraData` conforming to Solidity memory-encoded bytes of `GeneralExtensionDataStruct` specified in _Section Interfaces_. The following descriptions are based on when decoding `bytes extraData` into a `GeneralExtensionDataStruct`
 3. In the `GeneralExtensionDataStruct`-decoded `extraData`, caller MUST set the value of `GeneralExtensionDataStruct.erc5453MagicWord` to be the `keccak256("ERC5453-ENDORSEMENT")`.
 4. Caller MUST set the value of `GeneralExtensionDataStruct.erc5453Type` to be one of the supported values.
 
@@ -123,7 +123,7 @@ uint256 constant ERC5453_TYPE_B = 2;
 
 7. Each `SingleEndorsementData` MUST have a `address endorserAddress;` and a 65-bytes `bytes sig` signature.
 
-8. Each `bytes sig` MUST be an ECDSA (secp256k1) signature using private key of signer whose corresponding address is `endorserAddress` signing `validityDigest` which is the a hashTypeDataV4 of [EIP-712](./eip-712.md) of hashStruct of `ValidityBound` data structure as followed:
+8. Each `bytes sig` MUST be an ECDSA (secp256k1) signature using private key of signer whose corresponding address is `endorserAddress` signing `validityDigest` which is the hashTypeDataV4 of [EIP-712](./eip-712.md) of hashStruct of `ValidityBound` data structure as follows:
 
 ```solidity
 bytes32 validityDigest =
@@ -142,7 +142,7 @@ bytes32 validityDigest =
     );
 ```
 
-9. The `functionParamStructHash` MUST be computed as followed
+9. The `functionParamStructHash` MUST be computed as follows
 
 ```solidity
         bytes32 functionParamStructHash = keccak256(
@@ -162,14 +162,14 @@ whereas
 10. Upon validating that `endorserAddress == ecrecover(validityDigest, signature)` or `EIP1271(endorserAddress).isValidSignature(validityDigest, signature) == ERC1271.MAGICVALUE`, the single endorsement MUST be deemed valid.
 11. Compliant method MAY choose to impose a threshold for a number of endorsements needs to be valid in the same `ERC5453_TYPE_B` kind of `endorsementPayload`.
 
-12. The `validSince` and `validBy` are both inclusive. Implementer MAY choose to use blocknumber or timestamp. Implementor SHOULD find away to indicate whether `validSince` and `validBy` is blocknumber or timestamp.
+12. The `validSince` and `validBy` are both inclusive. Implementer MAY choose to use blocknumber or timestamp. Implementors SHOULD find a way to indicate whether `validSince` and `validBy` is blocknumber or timestamp.
 
 ## Rationale
 
 1. We chose to have both `ERC5453_TYPE_A`(single-endorsement) and `ERC5453_TYPE_B`(multiple-endorsements, same nonce for entire contract) so we
-could balance a wider range of use cases. E.g. the same use cases of ERC-2612 and `ERC-4494` can be supported by `ERC5453_TYPE_A`. And threshold approvals can be done via `ERC5453_TYPE_B`. More complicated approval types can also be extended by defining new `ERC5453_TYPE_?`
+could balance a wider range of use cases. E.g. the same use cases of ERC-2612 and [ERC-4494](./eip-4494.md) can be supported by `ERC5453_TYPE_A`. And threshold approvals can be done via `ERC5453_TYPE_B`. More complicated approval types can also be extended by defining new `ERC5453_TYPE_?`
 
-2. We chose to include both `validSince` and `validBy` to allow maximum flexibility in expiration. This can be also be supported by EVM natively at if adopted `ERC-5081` but `ERC-5081` will not be adopted anytime soon, we choose to add these two numbers in our protocol to allow
+2. We chose to include both `validSince` and `validBy` to allow maximum flexibility in expiration. This can also be supported natively by the EVM if [ERC-5081](./eip-5081.md) is adopted, but [ERC-5081](./eip-5081.md) will not be adopted anytime soon, so we choose to add these two numbers in our protocol to allow
 smart contract level support.
 
 ## Backwards Compatibility
@@ -257,7 +257,7 @@ See [`AERC5453.sol`](../assets/eip-5453/AERC5453.sol)
 
 ### Reference Implementation of `EndorsableERC721`
 
-Here is a reference implementation of `EndorsableERC721` that achieves similar behavior of `ERC-4494`.
+Here is a reference implementation of `EndorsableERC721` that achieves similar behavior to [ERC-4494](./eip-4494.md).
 
 ```solidity
 pragma solidity ^0.8.9;
@@ -333,7 +333,7 @@ A replay attack is a type of attack on cryptography authentication. In a narrow 
 
 ### Phishing
 
-It's worth pointing out a special form of replay attack by phishing. An adversary can design another smart contract in a way that the user be tricked into signing a smart endorsement for a seemingly legitimate purpose, but the data-to-designed matches the target application
+It's worth pointing out a special form of replay attack by phishing. An adversary can design another smart contract in a way that the user may be tricked into signing a smart endorsement for a seemingly legitimate purpose, but the data-to-designed matches the target application
 
 ## Copyright
 


### PR DESCRIPTION
## Summary
- fix grammar and spelling in `ERC-5453` only
- keep this PR limited to a single ERC file by design
- avoid technical or semantic changes

## Testing
- markdown-only change
- limited to one file: `ERCS/erc-5453.md`