### PR TITLE
Update ERC-5485: fix grammar and spelling

### DIFF
--- a/ERCS/erc-5485.md
+++ b/ERCS/erc-5485.md
@@ -34,7 +34,7 @@ By standardizing how smart contracts declare sovereignty, jurisdiction, accredit
 
 ### Use Cases (Primary)
 
-The primary use cases address the questions related to the status of a contract themselves. 
+The primary use cases address questions related to the status of a contract itself.
 
 - **Stablecoins (e.g., USDC):** Require jurisdiction because reserve custody, redemptions, freezes, and regulatory compliance depend on a specific legal authority.
 - **Tokenized Stocks / RWAs:** Require jurisdiction because securities laws, transfer restrictions, investor rights, and enforcement vary entirely by legal venue.
@@ -50,13 +50,13 @@ The secondary use cases address the questions related to the interactions betwee
 - **Good-Standing Verification:** Validating whether a contract is accredited and in compliance under its declared jurisdiction.
 - **Jurisdiction-Based Access Control:** Allowing or restricting participation based on jurisdiction or accreditation metadata.
 - **Cross-Contract Legal Cohesion:** Ensuring coherent jurisdictional alignment across multi-contract systems, federated DAOs, or hierarchical governance structures.
-- **Automated Dispute-Path Selection:** Determining which arbitration venue, legal process, or enforcement route applies when disputes ar
+- **Automated Dispute-Path Selection:** Determining which arbitration venue, legal process, or enforcement route applies when disputes arise
 
 ## Specification
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-A contract compliant with this ERC MUST implement the interface defined below.  
+A contract compliant with this ERC MUST implement the interface defined below.
 The interface provides standardized primitives for declaring a contract’s accreditation source, its observed jurisdiction, and a mechanism for receiving structured enforcement proposals. When the jurisdiction is absent, a contract is self-sovereign.
 
 ### 1. Data Structures
@@ -67,8 +67,8 @@ the `IERC5247Executable` and `IERC5247Executables` data structures.
 
 #### `IERC5247Executable`
 
-Represents a single action that MAY be proposed as part of an enforcement submission.  
-This structure follows a generic “executable call” pattern: a target address, an optional ETH value, a gas limit, and calldata for invocation.  
+Represents a single action that MAY be proposed as part of an enforcement submission.
+This structure follows a generic “executable call” pattern: a target address, an optional ETH value, a gas limit, and calldata for invocation.
 No guarantees are made regarding execution; implementations MAY ignore or reinterpret these fields.
 
 ```solidity
@@ -136,23 +136,23 @@ A standardized entry point for submitting an enforcement proposal to the contrac
 ```solidity
 interface IERC5485 {
     /// @notice Returns the address that accredited this contract, if any.
-    /// @dev MUST return address(0) if the contract does not recognize 
-    ///      an external accreditation source. SHOULD remain stable or change 
+    /// @dev MUST return address(0) if the contract does not recognize
+    ///      an external accreditation source. SHOULD remain stable or change
     ///      only via defined governance.
     function sourceOfAccreditation() external view returns (address);
 
-    /// @notice Returns the jurisdiction or higher-order system this contract 
+    /// @notice Returns the jurisdiction or higher-order system this contract
     ///      observes.
-    /// @dev MAY be the same as `sourceOfAccreditation()`. MUST return address(0) 
-    ///      when the contract claims no external jurisdiction (self-sovereign 
+    /// @dev MAY be the same as `sourceOfAccreditation()`. MUST return address(0)
+    ///      when the contract claims no external jurisdiction (self-sovereign
     ///      behavior). SHOULD remain stable or change only via defined governance.
     function jurisdiction() external view returns (address);
 
     /// @notice Submits an enforcement proposal to this contract.
     /// @dev Implementations MUST define access control. Implementations MAY execute,
-    ///      schedule, partially honor, reject, or only record `_proposal`. 
-    /// @dev Implementations SHOULD emit events or store state acknowledging receipt of 
-    ///      enforcement proposals. Payable to allow ETH forwarding for executables that 
+    ///      schedule, partially honor, reject, or only record `_proposal`.
+    /// @dev Implementations SHOULD emit events or store state acknowledging receipt of
+    ///      enforcement proposals. Payable to allow ETH forwarding for executables that
     ///      specify non-zero value.
     function imposeEnforcement(IERC5247Executables _proposal) external payable;
 }
@@ -162,22 +162,22 @@ interface IERC5485 {
 
 ### Separation of Jurisdiction and Accreditation
 
-This ERC separates **jurisdiction** from **accreditation** because 
+This ERC separates **jurisdiction** from **accreditation** because
 they represent fundamentally different relationships:
 
-- **Jurisdiction is voluntary.**  
-  A contract may unilaterally declare that it observes the rules or 
+- **Jurisdiction is voluntary.**
+  A contract may unilaterally declare that it observes the rules or
   norms of a particular system.
 
-- **Accreditation requires external approval.**  
+- **Accreditation requires external approval.**
   Only the authority itself can grant formal recognition that a contract
   is an accepted participant within its system.
 
-- **Jurisdiction expresses alignment; accreditation expresses acceptance.**  
+- **Jurisdiction expresses alignment; accreditation expresses acceptance.**
   Declaring jurisdiction does not imply the authority recognizes the contract.
   Accreditation establishes the reciprocal relationship.
 
-- **Accreditation enables enforcement.**  
+- **Accreditation enables enforcement.**
   Authorities typically issue enforcement only to contracts they have
   accredited. Jurisdiction alone does not create this binding pathway.
 
@@ -197,15 +197,15 @@ jurisdiction, by default showing no accreditation and is considered
 self-sovereign.
 
 2. Using [ERC-5247](./eip-5247.md) as a base interface for enforcement proposals is backward
-compatible with existing contracts that implement [ERC-5247](./eip-5247.md), such as Multi-Sig 
-wallets such as treasury of a DAO.
+compatible with existing contracts that implement [ERC-5247](./eip-5247.md), such as Multi-Sig
+wallets such as the treasury of a DAO.
 
 ## Security Considerations
 
-Similar to a real world scenario, when observing a jurisdiction 
+Similar to a real-world scenario, when observing a jurisdiction
 practically gives the contract the ability to enforce rules on the
-contract's behavior. Simlar to "Ownable" ([ERC-173](./eip-173.md)) or "AccessControl", 
-implementations MUST be aware of the security implications of this: the 
+contract's behavior. Similar to "Ownable" ([ERC-173](./eip-173.md)) or "AccessControl",
+implementations MUST be aware of the security implications of this: the
 security of a contract is compromised if the jurisdiction is compromised.
 
 ## Copyright


### PR DESCRIPTION
## Summary
- fix grammar and spelling in ERC-5485 only
- keep this PR limited to a single ERC file by design
- avoid technical or semantic changes

## Testing
- markdown-only change
- limited to one file: ERCS/erc-5485.md