### PR TITLE
Update ERC-5604: fix grammar and spelling

### DIFF
--- a/ERCS/erc-5604.md
+++ b/ERCS/erc-5604.md
@@ -1,7 +1,7 @@
 ---
 eip: 5604
 title: NFT Lien
-description: Extend ERC-721 to support putting liens on NFT
+description: Extend ERC-721 to support putting liens on NFTs
 author: Zainan Victor Zhou (@xinbenlv), Allen Zhou <allen@ubiloan.io>, Alex Qin <alex@ubiloan.io>
 discussions-to: https://ethereum-magicians.org/t/creating-a-new-erc-proposal-for-nft-lien/10683
 status: Draft
@@ -13,18 +13,18 @@ requires: 165, 721
 
 ## Abstract
 
-This ERC introduces NFT liens, a form of security interest over an item of property to secure the recovery of liability or performance of some other obligation. It introduces an interface to place and removes a lien, plus an event.
+This ERC introduces NFT liens, a form of security interest over an item of property to secure the recovery of liability or performance of some other obligation. It introduces an interface to place and remove a lien, plus an event.
 
 ## Motivation
 
-Liens are widely used for finance use cases, such as car and property liens. An example use case for an NFT lien is for a deed.
+Liens are widely used in financial use cases, such as car and property liens. An example use case for an NFT lien is for a deed.
 This ERC provides an interface to implement an interface that performs the lien holding relationships.
 
 ## Specification
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-1. Any compliant contract MUST implement `ERC-721`, and `ERC-165`.
+1. Any compliant contract MUST implement [ERC-721](./eip-721.md) and [ERC-165](./eip-165.md).
 
 2. Any compliant contract MUST implement the following interface:
 
@@ -72,19 +72,19 @@ interface IERC_LIEN is ERC721, ERC165 {
 
 ## Rationale
 
-1. We only support `ERC-721` NFTs for simplicity and gas efficiency. We have not considered other ERCs, which can be left for future extensions. For example, `ERC-20` and `ERC-1155` were not considered.
+1. We only support [ERC-721](./eip-721.md) NFTs for simplicity and gas efficiency. We have not considered other ERCs, which can be left for future extensions. For example, [ERC-20](./eip-20.md) and [ERC-1155](./eip-1155.md) were not considered.
 
-2. We choose separate "addLienHolder" and "removeLienHolder" instead of use a single `changeLienholder` with amount because we believe
-the add or remove action are significantly different and usually require different Access Control,
+2. We choose separate "addLienHolder" and "removeLienHolder" instead of using a single `changeLienholder` with amount because we believe
+the add and remove actions are significantly different and usually require different Access Control,
 for example, the token holder shall be able to add someone else as a lien holder but the lien holder of that token.
 
 3. We have not specified the "amount of debt" in this interface. We believe this is complex enough and worthy of an individual ERC by itself.
 
-4. We have not specified how endorsement can be applied to allow holder to signal their approval for transfer or swapping. We believe this is complex enough and worthy of an individual ERC by itself.
+4. We have not specified how endorsement can be applied to allow holders to signal their approval for transfer or swapping. We believe this is complex enough and worthy of an individual ERC by itself.
 
 ## Backwards Compatibility
 
-The ERC is designed as an extension of `ERC-721` and therefore compliant contracts need to fully comply with `ERC-721`.
+The ERC is designed as an extension of [ERC-721](./eip-721.md), and therefore compliant contracts need to fully comply with [ERC-721](./eip-721.md).
 
 ## Security Considerations
 


### PR DESCRIPTION
## Summary
- fix grammar and spelling in ERC-5604 only
- keep this PR limited to a single ERC file by design
- avoid technical or semantic changes

## Testing
- markdown-only change
- limited to one file: ERCS/erc-5604.md