### PR TITLE
Update ERC-5982: fix grammar and spelling

### DIFF
--- a/ERCS/erc-5982.md
+++ b/ERCS/erc-5982.md
@@ -13,8 +13,8 @@ requires: 165, 5750
 
 ## Abstract
 
-This EIP defines an interface for role-based access control for smart contracts. Roles are defined as `byte32`. The interface specifies how to read, grant, create and destroy roles. It specifies the sense of role power in the format of its ability to call a given method
-identified by `bytes4` method selector. It also specifies how metadata of roles are represented.
+This EIP defines an interface for role-based access control for smart contracts. Roles are defined as `byte32`. The interface specifies how to read, grant, create, and destroy roles. It specifies the meaning of role power in terms of the ability to call a given method
+identified by a `bytes4` method selector. It also specifies how metadata of roles are represented.
 
 ## Motivation
 
@@ -24,7 +24,7 @@ There are many ways to establish access control for privileged actions. One comm
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-Interfaces of reference is described as followed:
+The reference interfaces are described as follows:
 
 ```solidity
 interface IERC_ACL_CORE {
@@ -68,15 +68,15 @@ interface IERC_ACL_METADATA {
 1. Compliant contracts MUST implement `IERC_ACL_CORE`
 2. It is RECOMMENDED for compliant contracts to implement the optional extension `IERC_ACL_GENERAL`.
 3. Compliant contracts MAY implement the optional extension `IERC_ACL_METADATA`.
-4. A role in a compliant smart contract is represented in the format of `bytes32`. It's RECOMMENDED the value of such role is computed as a
-`keccak256` hash of a string of the role name, in this format: `bytes32 role = keccak256("<role_name>")`. such as `bytes32 role = keccak256("MINTER")`.
+4. A role in a compliant smart contract is represented in the format of `bytes32`. It is RECOMMENDED that the value of such a role be computed as a
+`keccak256` hash of the role name, in this format: `bytes32 role = keccak256("<role_name>")`, such as `bytes32 role = keccak256("MINTER")`.
 5. Compliant contracts SHOULD implement [ERC-165](./eip-165.md) identifier.
 
 ## Rationale
 
 1. The names and parameters of methods in `IERC_ACL_CORE` are chosen to allow backward compatibility with OpenZeppelin's implementation.
 2. The methods in `IERC_ACL_GENERAL` conform to [ERC-5750](./eip-5750.md) to allow extension.
-3. The method of `renounceRole` was not adopted, consolidating with `revokeRole` to simplify interface.
+3. The `renounceRole` method was not adopted, and was consolidated into `revokeRole` to simplify the interface.
 
 
 ## Backwards Compatibility


### PR DESCRIPTION
## Summary
- fix grammar and spelling in ERC-5982 only
- keep this PR limited to a single ERC file by design
- avoid technical or semantic changes

## Testing
- markdown-only change
- limited to one file: ERCS/erc-5982.md