### PR TITLE
Update ERC-6047: fix grammar and spelling

### DIFF
--- a/ERCS/erc-6047.md
+++ b/ERCS/erc-6047.md
@@ -15,24 +15,24 @@ requires: 721
 
 This EIP extends [ERC-721](./eip-721.md) to allow the tracking and indexing of NFTs by mandating that a pre-existing event be emitted during contract creation.
 
-ERC-721 requires a `Transfer` event to be emitted whenever a transfer or mint (i.e. transfer from `0x0`) or burn (i.g. transfer to `0x0`) occurs, **except during contract creation**. This EIP mandates that compliant contracts emit a `Transfer` event **regardless of whether it occurs during or after contract creation.**
+ERC-721 requires a `Transfer` event to be emitted whenever a transfer or mint (i.e. transfer from `0x0`) or burn (i.e. transfer to `0x0`) occurs, **except during contract creation**. This EIP mandates that compliant contracts emit a `Transfer` event **regardless of whether it occurs during or after contract creation.**
 
 ## Motivation
 
 [ERC-721](./eip-721.md) requires a `Transfer` event to be emitted whenever a transfer or mint (i.e. transfer from `0x0`) or burn (i.e. transfer to `0x0`) occurs, EXCEPT for during contract creation. Due to this exception, contracts can mint NFTs during contract creation without the event being emitted. Unlike ERC-721, the [ERC-1155](./eip-1155.md) standard mandates events to be emitted regardless of whether such minting occurs during or outside of contract creation. This allows an indexing service or any off-chain service to reliably capture and account for token creation.
 
-This EIP removes this exception granted by ERC-721 and mandates emitting the `Transfer` for ERC-721 during contract creation. In this manner, indexers and off-chain applications can track token minting, burning, and transferring while relying only on ERC-721's `Transfer` event log.
+This EIP removes this exception granted by ERC-721 and mandates emitting the `Transfer` event for ERC-721 during contract creation. In this manner, indexers and off-chain applications can track token minting, burning, and transferring while relying only on ERC-721's `Transfer` event log.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 1. Compliant contracts MUST implement [ERC-721](./eip-721.md)
-2. Compliant contracts MUST emit a `Transfer` event whenever a token is transferred, minted (i.e. transferred from `0x0`), or burned (i.g. transferred to `0x0`), **including during contract creation.**
+2. Compliant contracts MUST emit a `Transfer` event whenever a token is transferred, minted (i.e. transferred from `0x0`), or burned (i.e. transferred to `0x0`), **including during contract creation.**
 
 ## Rationale
 
-Using the existing `Transfer` event instead of creating a new event (e.g. `Creation`) allows this EIP to be backward compatible with existing indexers.E
+Using the existing `Transfer` event instead of creating a new event (e.g. `Creation`) allows this EIP to be backward compatible with existing indexers.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
## Summary
- fix grammar and spelling in ERC-6047 only
- keep this PR limited to a single ERC file by design
- avoid technical or semantic changes

## Testing
- markdown-only change
- limited to one file: ERCS/erc-6047.md