### PR TITLE
Update ERC-7632: fix grammar and spelling

### DIFF
--- a/ERCS/erc-7632.md
+++ b/ERCS/erc-7632.md
@@ -13,20 +13,20 @@ requires: 165
 
 ## Abstract
 
-Extends tokens using `uint256 tokenId` to support `tokenName` in type `string` and be able to convert backward to `tokenId`.
+Extends tokens using `uint256 tokenId` to support `tokenName` of type `string` and to convert back to `tokenId`.
 
 ## Motivation
 
-For Marketplaces, Explorers, Wallets, DeFi and dApps to better display and operate NFTs that comes with a name.
+For Marketplaces, Explorers, Wallets, DeFi and dApps to better display and operate NFTs that come with a name.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 1. Compliant contracts MUST support `tokenName` and
-mapping between `tokenName` and `tokenId` in one of the following ways:
-  - 1a all compliant contracts are RECOMMENDED to implement the following 
-interfaces: `IERC_NamedTokenCore`, 
+a mapping between `tokenName` and `tokenId` in one of the following ways:
+  - 1a all compliant contracts are RECOMMENDED to implement the following
+interfaces: `IERC_NamedTokenCore`,
 ```solidity
 interface IERC_NamedTokenCore {
   function idToName(uint256 _tokenId) external view returns (string);
@@ -35,22 +35,22 @@ interface IERC_NamedTokenCore {
 ```
 
 and it should satisfy the behavior rules that:
-    - 1a.1. when a new name is instroduced, it is RECOMMENDED to emit an event `newName(uint256 indexed tokenId, string tokenName)`.
+    - 1a.1. when a new name is introduced, it is RECOMMENDED to emit an event `newName(uint256 indexed tokenId, string tokenName)`.
     - 1a.2. tokenId and tokenName MUST be two-way single mapping, meaning if tokenId exists, tokenName MUST exist and vice versa and
-      `tokenId = nameToId(idToName(tokenId))` and 
+      `tokenId = nameToId(idToName(tokenId))` and
       `tokenName = idToName(nameToId(tokenName))` MUST hold true.
 
-  - 1b. if the compliant doesn't implement `IERC_NamedTokenCore`,
+  - 1b. if the compliant contract does not implement `IERC_NamedTokenCore`,
 it MAY follow the default mapping rule between `tokenId` and `tokenName`
 `uint256 tokenId = uint256(keccak256(tokenName))`.
 
-2. All method involving `tokenId` for a compliant contract is RECOMMENDED to
-have a counterpart method end with `ByName` that substitute all
-pamameters of `uint256 tokenId` with `string memory tokenName`, 
+2. All methods involving `tokenId` for a compliant contract are RECOMMENDED to
+have a counterpart method ending with `ByName` that substitutes all
+parameters of `uint256 tokenId` with `string memory tokenName`,
 and the behavior of the counterpart method MUST be consistent
 with the original method.
 
-3. Compliant contract MAY implement one or more of following extra interface
+3. A compliant contract MAY implement one or more of the following extra interfaces
 
 ```solidity
 interface IERC_NamedTokenExtension {
@@ -61,11 +61,11 @@ interface IERC_NamedTokenExtension {
 
 ## Rationale
 
-1. We allow default way to map `tokenId` and `tokenName` for convenience, but
-we also allow contract to implement their own way to map `tokenId` and
+1. We allow a default way to map `tokenId` and `tokenName` for convenience, but
+we also allow contracts to implement their own ways of mapping `tokenId` and
 `tokenName` for flexibility.
 
-2. We consider providing an interface for 
+2. We consider providing an interface for
 
 ## Backwards Compatibility
 
@@ -74,11 +74,11 @@ This proposal is fully backwards compatible with token contracts using
 
 ## Security Considerations
 
-This proposal assume that both `tokenName` and `tokenId` are
+This proposal assumes that both `tokenName` and `tokenId` are
 unique amongst all tokens.
 
-If tokenNames are not normalize, two distinct tokenNames may confuse users
-as they look alike. Contract developer shall declare normalization mechanism if
+If token names are not normalized, two distinct token names may confuse users
+as they look alike. Contract developers shall declare a normalization mechanism if
 non-unique `tokenName` is allowed using `IERC_NamedTokenExtension`.
 
 ## Copyright


### PR DESCRIPTION
## Summary
- fix grammar and spelling in ERC-7632 only
- keep this PR limited to a single ERC file by design
- avoid technical or semantic changes

## Testing
- markdown-only change
- limited to one file: ERCS/erc-7632.md