### PR TITLE
Add ERC: Onchain Agency for Represented RWAs

### DIFF
--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -1,9 +1,9 @@
 ---
 eip: 8225
 title: On-Chain Agency for Represented RWAs
-description: Interface for ERC-8004 agents to act as delegated representatives with scoped permissions when managing permissioned Real World Assets, complementing RAMS compliance delegation and ERC-8183 agentic commerce.
-author: Zen | L1 (@secondfrontman)
-discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas
+description: Agency interface for ERC-8004 agents managing permissioned RWAs with scoped, revocable permissions.
+author: Zen (@neonmercenary)
+discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas/12345
 status: Draft
 type: Standards Track
 category: ERC
@@ -13,29 +13,29 @@ requires: 3643, 7943, 8004, 8183
 
 ## Abstract
 
-This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent (identified via ERC-8004) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
+This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent (identified via [ERC-8004](./erc-8004.md)) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
 
 It provides scoped, revocable, time-bounded permissions for active operations (transfer, voting, rebalancing, yield strategies, etc.) while preserving legal beneficial ownership signals and feeding audit/reputation events back into the agentic stack.
 
-It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both ERC-7943 (uRWA) and ERC-3643 (T-REX) tokens.
+It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both [ERC-7943](./erc-7943.md) (uRWA) and [ERC-3643](./erc-3643.md) (T-REX) tokens.
 
 ## Motivation
 
-The emergence of autonomous agents (ERC-8004) and regulated tokenized assets (ERC-3643, ERC-7943) creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
+The emergence of autonomous agents ([ERC-8004](./erc-8004.md)) and regulated tokenized assets ([ERC-3643](./erc-3643.md), [ERC-7943](./erc-7943.md)) creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
 
 While the RAMS proposal elegantly solves *compliance delegation* (ensuring agents don't bypass KYC/AML during transfers), many agentic RWA use-cases require the agent to actively *manage* represented assets:
 
 - Autonomous treasury rebalancing across tokenized bonds
 - Voting on governance proposals for represented equity tokens
 - Executing compliant yield strategies on permissioned DeFi pools
-- Triggering forced transfers or freezes via ERC-3643 Agent roles under owner delegation
+- Triggering forced transfers or freezes via [ERC-3643](./erc-3643.md) Agent roles under owner delegation
 
 This standard adds the missing **liability and execution primitive** for autonomous A2A commerce involving represented RWAs. It enables:
 
-1. **Clear ownership linking**: Human owner (ONCHAINID) → Agent (ERC-8004 NFT) → Represented RWA positions
+1. **Clear ownership linking**: Human owner (ONCHAINID) → Agent ([ERC-8004](./erc-8004.md) NFT) → Represented RWA positions
 2. **Scoped delegation**: Bitmask permissions + expiration for least-privilege agency
-3. **Audit + reputation**: Every action emits events for compliance trails and ERC-8004 reputation feeds
-4. **Composability**: Hooks into ERC-8183 Jobs for job-based agentic workflows
+3. **Audit + reputation**: Every action emits events for compliance trails and [ERC-8004](./erc-8004.md) reputation feeds
+4. **Composability**: Hooks into [ERC-8183](./erc-8183.md) Jobs for job-based agentic workflows
 
 ## Specification
 
@@ -47,7 +47,7 @@ The core interface defines three phases:
 2. **Validation**: Any party can check if an agent is currently authorized for an action
 3. **Execution**: Agent performs a compliant action on behalf of the owner, with built-in audit logging
 
-### Vyper 0.4+ Interface
+### Vyper 0.4+ Interface & Integrations
 
 ```vyper
 # pragma version 0.4.0
@@ -166,7 +166,6 @@ FREEZE: constant(uint256)     = 1 << 4   # Trigger compliance freezes (ERC-3643)
 YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 ```
 
-## Integration Patterns
 
 ### With RAMS (Regulated Agent Mandate Standard)
 
@@ -186,17 +185,20 @@ YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 - Use `authorizeAgency` and `revokeAgency` to manage on-chain authority for compliance-sensitive tokens.
 - Keep the underlying token's compliance checks intact while allowing controlled agent actions.
 
+
+
 ## Rationale
 
-- Minimal surface area: Like ERC-8183, keeps the interface small for gas efficiency and composability.
+- Minimal surface area: Like [ERC-8183](./erc-8183.md), keeps the interface small for gas efficiency and composability.
 - Bitmask permissions: Easy to extend without new functions; supports least-privilege delegation.
 - Expiration + revocation: Critical for security — owners can limit exposure to time-bound or instantly revocable agency.
-- Audit-first design: Every action emits `AgencyActionPerformed` for compliance trails, dispute resolution, and ERC-8004 reputation feeds.
-- Composable, not prescriptive: Works with RAMS for compliance checks, ERC-8183 for job workflows, and either ERC-3643 or ERC-7943 for the underlying RWA token.
+- Audit-first design: Every action emits `AgencyActionPerformed` for compliance trails, dispute resolution, and [ERC-8004](./erc-8004.md) reputation feeds.
+- Composable, not prescriptive: Works with RAMS for compliance checks, [ERC-8183](./erc-8183.md) for job workflows, and either [ERC-3643](./erc-3643.md) or [ERC-7943](./erc-7943.md) for the underlying RWA token.
 
 ## Backwards Compatibility
 
 This ERC introduces a new interface with no impact on existing standards. It is designed to be opt-in: RWA tokens, agents, and owners choose to integrate based on use-case.
+
 
 ## Reference Implementation
 
@@ -204,14 +206,14 @@ A minimal Vyper 0.4+ reference implementation will be provided in a follow-up PR
 
 ## Security Considerations
 
-- Authorization signatures: `authorizeAgency` should support ERC-1271 signatures so owners can approve from cold wallets or multisigs without exposing private keys to agent contracts.
-- Compliance never bypassed: Agents must not circumvent the principal's ONCHAINID eligibility. When integrated with RAMS or ERC-3643, the underlying token's `canTransact` / identity checks must still pass.
+- Authorization signatures: `authorizeAgency` should support [ERC-1271](./erc-1271.md) signatures so owners can approve from cold wallets or multisigs without exposing private keys to agent contracts.
+- Compliance never bypassed: Agents must not circumvent the principal's ONCHAINID eligibility. When integrated with RAMS or [ERC-3643](./erc-3643.md), the underlying token's `canTransact` / identity checks must still pass.
 - Financial caps: Implementers may add optional `maxValue` or `dailyLimit` parameters to `authorizeAgency` to reduce blast radius of compromised agents.
 - Reentrancy: `performAgencyAction` should follow checks-effects-interactions pattern; consider using Vyper's `@nonreentrant` decorator if calling external contracts.
 - Key rotation: Owners should be able to rotate agent addresses without revoking all delegations — consider an `updateAgentAddress(oldAgent, newAgent)` extension if needed.
 
 
+
 ## Copyright
 
-Copyright and related rights waived via CC0.
-
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -47,9 +47,6 @@ The core interface defines three phases:
 2. **Validation**: Any party can check if an agent is currently authorized for an action
 3. **Execution**: Agent performs a compliant action on behalf of the owner, with built-in audit logging
 
-
-## Demonstration
-
 ### Vyper 0.4+ Interface
 
 ```vyper
@@ -165,7 +162,7 @@ TRANSFER: constant(uint256)   = 1 << 0   # Execute token transfers
 VOTE: constant(uint256)       = 1 << 1   # Cast governance votes
 REBALANCE: constant(uint256)  = 1 << 2   # Rebalance positions across pools
 MINT_BURN: constant(uint256)  = 1 << 3   # If issuer allows via Agent role
-FREEZE: constant(uint256)     = 1 << 4   # Trigger compliance freezes ([ERC-3643](/ERCS/erc-3643.md))
+FREEZE: constant(uint256)     = 1 << 4   # Trigger compliance freezes (ERC-3643)
 YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 ```
 
@@ -195,4 +192,5 @@ This ERC introduces a new interface with no impact on existing standards. It is 
 A minimal Vyper 0.4+ reference implementation will be provided in a follow-up PR.
 
 ## Copyright
-Copyright and related rights waived via CC0.
+
+Copyright and related rights waived via [CC0](/LICENSE).

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -3,7 +3,7 @@ eip: 8232
 title: Onchain Agency for Represented RWAs
 description: Agency interface for ERC-8004 agents managing permissioned RWAs with scoped, revocable permissions.
 author: Zen (@neonmercenary)
-discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas-companion-to-rams-erc-8183/28240
+discussions-to: https://ethereum-magicians.org/t/erc-8232-onchain-agency-for-represented-rwas/28240
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -1,5 +1,5 @@
 ---
-eip: 8225
+eip: 8232
 title: Onchain Agency for Represented RWAs
 description: Agency interface for ERC-8004 agents managing permissioned RWAs with scoped, revocable permissions.
 author: Zen (@neonmercenary)

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -13,29 +13,29 @@ requires: 3643, 7943, 8004, 8183
 
 ## Abstract
 
-This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent (identified via [ERC-8004](/ERCS/erc-8004.md)) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
+This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent (identified via [ERC-8004](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8004.md)) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
 
 It provides scoped, revocable, time-bounded permissions for active operations (transfer, voting, rebalancing, yield strategies, etc.) while preserving legal beneficial ownership signals and feeding audit/reputation events back into the agentic stack.
 
-It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both [ERC-7943](/ERCS/erc-7943.md) (uRWA) and [ERC-3643](/ERCS/erc-3643.md) (T-REX) tokens.
+It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both [ERC-7943](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-7943.md) (uRWA) and [ERC-3643](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-3643.md) (T-REX) tokens.
 
 ## Motivation
 
-The emergence of autonomous agents ([ERC-8004](/ERCS/erc-8004.md)) and regulated tokenized assets ([ERC-3643](/ERCS/erc-3643.md), [ERC-7943](/ERCS/erc-7943.md)) creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
+The emergence of autonomous agents ([ERC-8004](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8004.md)) and regulated tokenized assets ([ERC-3643](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-3643.md), [ERC-7943](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-7943.md)) creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
 
 While the RAMS proposal elegantly solves *compliance delegation* (ensuring agents don't bypass KYC/AML during transfers), many agentic RWA use-cases require the agent to actively *manage* represented assets:
 
 - Autonomous treasury rebalancing across tokenized bonds
 - Voting on governance proposals for represented equity tokens
 - Executing compliant yield strategies on permissioned DeFi pools
-- Triggering forced transfers or freezes via [ERC-3643](/ERCS/erc-3643.md) Agent roles under owner delegation
+- Triggering forced transfers or freezes via [ERC-3643](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-3643.md) Agent roles under owner delegation
 
 This standard adds the missing **liability and execution primitive** for autonomous A2A commerce involving represented RWAs. It enables:
 
-1. **Clear ownership linking**: Human owner (ONCHAINID) → Agent ([ERC-8004](/ERCS/erc-8004.md) NFT) → Represented RWA positions
+1. **Clear ownership linking**: Human owner (ONCHAINID) → Agent ([ERC-8004](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8004.md) NFT) → Represented RWA positions
 2. **Scoped delegation**: Bitmask permissions + expiration for least-privilege agency
-3. **Audit + reputation**: Every action emits events for compliance trails and [ERC-8004](/ERCS/erc-8004.md) reputation feeds
-4. **Composability**: Hooks into [ERC-8183](/ERCS/erc-8183.md) Jobs for job-based agentic workflows
+3. **Audit + reputation**: Every action emits events for compliance trails and [ERC-8004](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8004.md) reputation feeds
+4. **Composability**: Hooks into [ERC-8183](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8183.md) Jobs for job-based agentic workflows
 
 ## Specification
 
@@ -169,16 +169,20 @@ YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 
 ## Rationale
 
-- Minimal surface area: Like [ERC-8183](/ERCS/erc-8183.md), keeps the interface small for gas efficiency and composability.
+- Minimal surface area: Like [ERC-8183](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8183.md), keeps the interface small for gas efficiency and composability.
 - Bitmask permissions: Easy to extend without new functions; supports least-privilege delegation.
 - Expiration + revocation: Critical for security — owners can limit exposure to time-bound or instantly revocable agency.
-- Audit-first design: Every action emits `AgencyActionPerformed` for compliance trails, dispute resolution, and [ERC-8004](/ERCS/erc-8004.md) reputation feeds.
-- Composable, not prescriptive: Works with RAMS for compliance checks, [ERC-8183](/ERCS/erc-8183.md) for job workflows, and either [ERC-3643](/ERCS/erc-3643.md) or [ERC-7943](/ERCS/erc-7943.md) for the underlying RWA token.
+- Audit-first design: Every action emits `AgencyActionPerformed` for compliance trails, dispute resolution, and [ERC-8004](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8004.md) reputation feeds.
+- Composable, not prescriptive: Works with RAMS for compliance checks, [ERC-8183](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8183.md) for job workflows, and either [ERC-3643](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-3643.md) or [ERC-7943](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-7943.md) for the underlying RWA token.
+
+## Reference Implementation
+
+A minimal Vyper 0.4+ reference implementation will be provided in a follow-up PR.
 
 ## Security Considerations
 
-- Authorization signatures: `authorizeAgency` should support [ERC-1271](/ERCS/erc-1271.md) signatures so owners can approve from cold wallets or multisigs without exposing private keys to agent contracts.
-- Compliance never bypassed: Agents must not circumvent the principal's ONCHAINID eligibility. When integrated with RAMS or [ERC-3643](/ERCS/erc-3643.md), the underlying token's `canTransact` / identity checks must still pass.
+- Authorization signatures: `authorizeAgency` should support [ERC-1271](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-1271.md) signatures so owners can approve from cold wallets or multisigs without exposing private keys to agent contracts.
+- Compliance never bypassed: Agents must not circumvent the principal's ONCHAINID eligibility. When integrated with RAMS or [ERC-3643](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-3643.md), the underlying token's `canTransact` / identity checks must still pass.
 - Financial caps: Implementers may add optional `maxValue` or `dailyLimit` parameters to `authorizeAgency` to reduce blast radius of compromised agents.
 - Reentrancy: `performAgencyAction` should follow checks-effects-interactions pattern; consider using Vyper's `@nonreentrant` decorator if calling external contracts.
 - Key rotation: Owners should be able to rotate agent addresses without revoking all delegations — consider an `updateAgentAddress(oldAgent, newAgent)` extension if needed.
@@ -187,9 +191,6 @@ YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 
 This ERC introduces a new interface with no impact on existing standards. It is designed to be opt-in: RWA tokens, agents, and owners choose to integrate based on use-case.
 
-## Reference Implementation
-
-A minimal Vyper 0.4+ reference implementation will be provided in a follow-up PR.
 
 ## Copyright
 

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -3,7 +3,7 @@ eip: 8225
 title: On-Chain Agency for Represented RWAs
 description: Agency interface for ERC-8004 agents managing permissioned RWAs with scoped, revocable permissions.
 author: Zen (@neonmercenary)
-discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas/12345
+discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas-companion-to-rams-erc-8183/
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -1,9 +1,9 @@
 ---
 eip: 8225
 title: On-Chain Agency for Represented RWAs
-description: Agency interface for ERC-8004 agents managing permissioned RWAs with scoped, revocable permissions.
-author: Zen (@neonmercenary)
-discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas/12345
+description: Interface for ERC-8004 agents to act as delegated representatives with scoped permissions when managing permissioned Real World Assets, complementing RAMS compliance delegation and ERC-8183 agentic commerce.
+author: Zen | L1 (@secondfrontman)
+discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas
 status: Draft
 type: Standards Track
 category: ERC
@@ -17,18 +17,18 @@ This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent 
 
 It provides scoped, revocable, time-bounded permissions for active operations (transfer, voting, rebalancing, yield strategies, etc.) while preserving legal beneficial ownership signals and feeding audit/reputation events back into the agentic stack.
 
-It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both ERC-7943  (uRWA) and ERC-3643 (T-REX) tokens.
+It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both ERC-7943 (uRWA) and ERC-3643 (T-REX) tokens.
 
 ## Motivation
 
-The emergence of autonomous agents ERC-8004 and regulated tokenized assets (ERC-3643).ERC-7943 creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
+The emergence of autonomous agents (ERC-8004) and regulated tokenized assets (ERC-3643, ERC-7943) creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
 
 While the RAMS proposal elegantly solves *compliance delegation* (ensuring agents don't bypass KYC/AML during transfers), many agentic RWA use-cases require the agent to actively *manage* represented assets:
 
 - Autonomous treasury rebalancing across tokenized bonds
 - Voting on governance proposals for represented equity tokens
 - Executing compliant yield strategies on permissioned DeFi pools
-- Triggering forced transfers or freezes via ERC-3643, Agent roles under owner delegation
+- Triggering forced transfers or freezes via ERC-3643 Agent roles under owner delegation
 
 This standard adds the missing **liability and execution primitive** for autonomous A2A commerce involving represented RWAs. It enables:
 
@@ -166,6 +166,25 @@ FREEZE: constant(uint256)     = 1 << 4   # Trigger compliance freezes (ERC-3643)
 YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 ```
 
+## Integration Patterns
+
+### With RAMS (Regulated Agent Mandate Standard)
+
+- Use RAMS mandates to confirm that the represented owner and agent are authorized.
+- Combine `isValidAgency` with underlying token `canTransact` checks for compliance.
+- Ensure the agent cannot bypass KYC/AML obligations when executing on behalf of the owner.
+
+### With ERC-8183 (Agentic Commerce)
+
+- Use `IERC8225` as the execution layer for job-based workflows.
+- Jobs can authorize agents for scoped actions and record audit traces.
+- `performAgencyAction` can be invoked by ERC-8183 job executors once the agent is validated.
+
+### With ERC-3643 (T-REX) Agent Role
+
+- Map ERC-3643 agent roles to `IERC8225` delegation permissions.
+- Use `authorizeAgency` and `revokeAgency` to manage on-chain authority for compliance-sensitive tokens.
+- Keep the underlying token's compliance checks intact while allowing controlled agent actions.
 
 ## Rationale
 
@@ -175,23 +194,24 @@ YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 - Audit-first design: Every action emits `AgencyActionPerformed` for compliance trails, dispute resolution, and ERC-8004 reputation feeds.
 - Composable, not prescriptive: Works with RAMS for compliance checks, ERC-8183 for job workflows, and either ERC-3643 or ERC-7943 for the underlying RWA token.
 
+## Backwards Compatibility
+
+This ERC introduces a new interface with no impact on existing standards. It is designed to be opt-in: RWA tokens, agents, and owners choose to integrate based on use-case.
+
 ## Reference Implementation
 
 A minimal Vyper 0.4+ reference implementation will be provided in a follow-up PR.
 
 ## Security Considerations
 
-- Authorization signatures: `authorizeAgency` should support [ERC-1271](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-1271.md) signatures so owners can approve from cold wallets or multisigs without exposing private keys to agent contracts.
+- Authorization signatures: `authorizeAgency` should support ERC-1271 signatures so owners can approve from cold wallets or multisigs without exposing private keys to agent contracts.
 - Compliance never bypassed: Agents must not circumvent the principal's ONCHAINID eligibility. When integrated with RAMS or ERC-3643, the underlying token's `canTransact` / identity checks must still pass.
 - Financial caps: Implementers may add optional `maxValue` or `dailyLimit` parameters to `authorizeAgency` to reduce blast radius of compromised agents.
 - Reentrancy: `performAgencyAction` should follow checks-effects-interactions pattern; consider using Vyper's `@nonreentrant` decorator if calling external contracts.
 - Key rotation: Owners should be able to rotate agent addresses without revoking all delegations — consider an `updateAgentAddress(oldAgent, newAgent)` extension if needed.
 
-## Backwards Compatibility
-
-This ERC introduces a new interface with no impact on existing standards. It is designed to be opt-in: RWA tokens, agents, and owners choose to integrate based on use-case.
-
 
 ## Copyright
 
-Copyright and related rights waived via CC0S.
+Copyright and related rights waived via CC0.
+

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -2,7 +2,7 @@
 eip: 8225
 title: On-Chain Agency for Represented RWAs
 description: Agency interface for ERC-8004 agents managing permissioned RWAs with scoped, revocable permissions.
-author: @neonmercenary
+author: Zen (@neonmercenary)
 discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas/12345
 status: Draft
 type: Standards Track
@@ -13,29 +13,29 @@ requires: 3643, 7943, 8004, 8183
 
 ## Abstract
 
-This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent (identified via [ERC-8004](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8004.md)) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
+This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent (identified via ERC-8004) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
 
 It provides scoped, revocable, time-bounded permissions for active operations (transfer, voting, rebalancing, yield strategies, etc.) while preserving legal beneficial ownership signals and feeding audit/reputation events back into the agentic stack.
 
-It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both [ERC-7943](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-7943.md) (uRWA) and [ERC-3643](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-3643.md) (T-REX) tokens.
+It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both ERC-7943  (uRWA) and ERC-3643 (T-REX) tokens.
 
 ## Motivation
 
-The emergence of autonomous agents ([ERC-8004](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8004.md)) and regulated tokenized assets ([ERC-3643](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-3643.md), [ERC-7943](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-7943.md)) creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
+The emergence of autonomous agents ERC-8004 and regulated tokenized assets (ERC-3643).ERC-7943 creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
 
 While the RAMS proposal elegantly solves *compliance delegation* (ensuring agents don't bypass KYC/AML during transfers), many agentic RWA use-cases require the agent to actively *manage* represented assets:
 
 - Autonomous treasury rebalancing across tokenized bonds
 - Voting on governance proposals for represented equity tokens
 - Executing compliant yield strategies on permissioned DeFi pools
-- Triggering forced transfers or freezes via [ERC-3643](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-3643.md) Agent roles under owner delegation
+- Triggering forced transfers or freezes via ERC-3643, Agent roles under owner delegation
 
 This standard adds the missing **liability and execution primitive** for autonomous A2A commerce involving represented RWAs. It enables:
 
-1. **Clear ownership linking**: Human owner (ONCHAINID) → Agent ([ERC-8004](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8004.md) NFT) → Represented RWA positions
+1. **Clear ownership linking**: Human owner (ONCHAINID) → Agent (ERC-8004 NFT) → Represented RWA positions
 2. **Scoped delegation**: Bitmask permissions + expiration for least-privilege agency
-3. **Audit + reputation**: Every action emits events for compliance trails and [ERC-8004](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8004.md) reputation feeds
-4. **Composability**: Hooks into [ERC-8183](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8183.md) Jobs for job-based agentic workflows
+3. **Audit + reputation**: Every action emits events for compliance trails and ERC-8004 reputation feeds
+4. **Composability**: Hooks into ERC-8183 Jobs for job-based agentic workflows
 
 ## Specification
 
@@ -169,11 +169,11 @@ YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 
 ## Rationale
 
-- Minimal surface area: Like [ERC-8183](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8183.md), keeps the interface small for gas efficiency and composability.
+- Minimal surface area: Like ERC-8183, keeps the interface small for gas efficiency and composability.
 - Bitmask permissions: Easy to extend without new functions; supports least-privilege delegation.
 - Expiration + revocation: Critical for security — owners can limit exposure to time-bound or instantly revocable agency.
-- Audit-first design: Every action emits `AgencyActionPerformed` for compliance trails, dispute resolution, and [ERC-8004](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8004.md) reputation feeds.
-- Composable, not prescriptive: Works with RAMS for compliance checks, [ERC-8183](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-8183.md) for job workflows, and either [ERC-3643](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-3643.md) or [ERC-7943](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-7943.md) for the underlying RWA token.
+- Audit-first design: Every action emits `AgencyActionPerformed` for compliance trails, dispute resolution, and ERC-8004 reputation feeds.
+- Composable, not prescriptive: Works with RAMS for compliance checks, ERC-8183 for job workflows, and either ERC-3643 or ERC-7943 for the underlying RWA token.
 
 ## Reference Implementation
 
@@ -182,7 +182,7 @@ A minimal Vyper 0.4+ reference implementation will be provided in a follow-up PR
 ## Security Considerations
 
 - Authorization signatures: `authorizeAgency` should support [ERC-1271](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-1271.md) signatures so owners can approve from cold wallets or multisigs without exposing private keys to agent contracts.
-- Compliance never bypassed: Agents must not circumvent the principal's ONCHAINID eligibility. When integrated with RAMS or [ERC-3643](https://github.com/ethereum/ERCs/tree/master/ERCS/erc-3643.md), the underlying token's `canTransact` / identity checks must still pass.
+- Compliance never bypassed: Agents must not circumvent the principal's ONCHAINID eligibility. When integrated with RAMS or ERC-3643, the underlying token's `canTransact` / identity checks must still pass.
 - Financial caps: Implementers may add optional `maxValue` or `dailyLimit` parameters to `authorizeAgency` to reduce blast radius of compromised agents.
 - Reentrancy: `performAgencyAction` should follow checks-effects-interactions pattern; consider using Vyper's `@nonreentrant` decorator if calling external contracts.
 - Key rotation: Owners should be able to rotate agent addresses without revoking all delegations — consider an `updateAgentAddress(oldAgent, newAgent)` extension if needed.
@@ -194,4 +194,4 @@ This ERC introduces a new interface with no impact on existing standards. It is 
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](/LICENSE).
+Copyright and related rights waived via CC0S.

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -1,0 +1,216 @@
+---
+eip: 8225
+title: On-Chain Agency for Represented RWAs
+description: Interface for ERC-8004 agents to act as delegated representatives with scoped permissions when managing permissioned Real World Assets, complementing RAMS compliance delegation and ERC-8183 agentic commerce.
+author: Zen | L1 (@secondfrontman)
+discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas
+status: Draft
+type: Standards Track
+category: ERC
+created: 2026-04-14
+requires: 8004, 8183, 7943, 3643
+---
+
+## Abstract
+
+This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent (identified via ERC-8004) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
+
+It provides scoped, revocable, time-bounded permissions for active operations (transfer, voting, rebalancing, yield strategies, etc.) while preserving legal beneficial ownership signals and feeding audit/reputation events back into the agentic stack.
+
+It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both ERC-7943 (uRWA) and ERC-3643 (T-REX) tokens.
+
+## Motivation
+
+The emergence of autonomous agents (ERC-8004) and regulated tokenized assets (ERC-3643, ERC-7943) creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
+
+While the RAMS proposal elegantly solves *compliance delegation* (ensuring agents don't bypass KYC/AML during transfers), many agentic RWA use-cases require the agent to actively *manage* represented assets:
+
+- Autonomous treasury rebalancing across tokenized bonds
+- Voting on governance proposals for represented equity tokens
+- Executing compliant yield strategies on permissioned DeFi pools
+- Triggering forced transfers or freezes via ERC-3643 Agent roles under owner delegation
+
+This standard adds the missing **liability and execution primitive** for autonomous A2A commerce involving represented RWAs. It enables:
+
+1. **Clear ownership linking**: Human owner (ONCHAINID) → Agent (ERC-8004 NFT) → Represented RWA positions
+2. **Scoped delegation**: Bitmask permissions + expiration for least-privilege agency
+3. **Audit + reputation**: Every action emits events for compliance trails and ERC-8004 reputation feeds
+4. **Composability**: Hooks into ERC-8183 Jobs for job-based agentic workflows
+
+## Specification
+
+### Overview
+
+The core interface defines three phases:
+
+1. **Authorization**: Owner grants scoped permissions to an agent for a specific RWA token
+2. **Validation**: Any party can check if an agent is currently authorized for an action
+3. **Execution**: Agent performs a compliant action on behalf of the owner, with built-in audit logging
+
+### Vyper 0.4+ Interface
+
+```vyper
+# pragma version 0.4.0
+"""
+@title ERC-8225: On-Chain Agency for Represented RWAs
+@author @secondfrontman
+@notice Execution-oriented agency interface complementing RAMS (compliance delegation) 
+        and ERC-8183 (agentic commerce) for active management of represented RWAs
+@dev Composable with ERC-8004 (agent identity), ERC-8183 (jobs), ERC-3643/7943 (RWA compliance)
+"""
+
+interface IERC8225:
+    # =============================================================
+    # Events
+    # =============================================================
+    event AgencyAuthorized:
+        owner: indexed(address)
+        agent: indexed(address)
+        rwa_token: indexed(address)
+        permissions: uint256          # bitmask for allowed actions
+        expiration: uint256           # 0 = indefinite
+
+    event AgencyRevoked:
+        owner: indexed(address)
+        agent: indexed(address)
+        rwa_token: indexed(address)
+
+    event AgencyActionPerformed:
+        owner: indexed(address)
+        agent: indexed(address)
+        rwa_token: indexed(address)
+        action_type: uint256
+        payload: Bytes[1024]             # optional calldata / reason hash
+        success: bool
+
+    # =============================================================
+    # View functions
+    # =============================================================
+    def isValidAgency(owner: address, agent: address, rwa_token: address) -> bool:
+        """
+        @notice Check if agent is currently authorized to represent owner for this RWA
+        @dev Should verify: (1) owner has valid ONCHAINID claims if integrated,
+             (2) mandate not expired, (3) not revoked
+        """
+        ...
+
+    def getAgencyPermissions(owner: address, agent: address, rwa_token: address) -> uint256:
+        """
+        @notice Return current permission bitmask for this owner-agent-RWA triplet
+        """
+        ...
+
+    def getAgencyExpiration(owner: address, agent: address, rwa_token: address) -> uint256:
+        """
+        @notice Return expiration timestamp for this delegation (0 = indefinite)
+        """
+        ...
+
+    def getRepresentedOwner(agent: address, rwa_token: address) -> address:
+        """
+        @notice Convenience: return owner this agent represents for given RWA (or zero)
+        """
+        ...
+
+    # =============================================================
+    # State-changing functions (called by owner or via ERC-1271 signature)
+    # =============================================================
+    def authorizeAgency(
+        agent: address,
+        rwa_token: address,
+        permissions: uint256,
+        expiration: uint256
+    ) -> bool:
+        """
+        @notice Owner authorizes agent (ERC-8004 identity) to act on their behalf for RWA
+        @dev Recommend supporting ERC-1271 signatures for cold wallet approval
+        @param permissions Bitmask of allowed actions (see constants below)
+        @param expiration Unix timestamp; 0 = indefinite delegation
+        """
+        ...
+
+    def revokeAgency(agent: address, rwa_token: address) -> bool:
+        """
+        @notice Revoke all permissions for this agent on this RWA (instant, owner-only)
+        """
+        ...
+
+    # =============================================================
+    # Action execution (called by the agent)
+    # =============================================================
+    def performAgencyAction(
+        rwa_token: address,
+        action_type: uint256,
+        call: Bytes[1024]
+    ) -> Bytes[1024]:
+        """
+        @notice Agent executes a compliant action on behalf of represented owner
+        @dev Internal checks:
+             1. isValidAgency(owner, msg.sender, rwa_token)
+             2. action_type permitted in bitmask
+             3. Optional: RAMS mandate validity + ERC-7943/3643 canTransact
+             4. Execute calldata against rwa_token (via delegatecall or interface)
+             5. Emit AgencyActionPerformed for audit + ERC-8004 reputation feed
+        @return result Bytes from the executed call (or empty if void)
+        """
+        ...
+
+# =============================================================
+# Permission bitmask constants (suggested, can be extended)
+# =============================================================
+TRANSFER: constant(uint256)   = 1 << 0   # Execute token transfers
+VOTE: constant(uint256)       = 1 << 1   # Cast governance votes
+REBALANCE: constant(uint256)  = 1 << 2   # Rebalance positions across pools
+MINT_BURN: constant(uint256)  = 1 << 3   # If issuer allows via Agent role
+FREEZE: constant(uint256)     = 1 << 4   # Trigger compliance freezes (ERC-3643)
+YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
+```
+
+## Integration Patterns
+
+### With RAMS (Regulated Agent Mandate Standard)
+
+- Use RAMS mandates to confirm that the represented owner and agent are authorized.
+- Combine `isValidAgency` with underlying token `canTransact` checks for compliance.
+- Ensure the agent cannot bypass KYC/AML obligations when executing on behalf of the owner.
+
+### With ERC-8183 (Agentic Commerce)
+
+- Use `IERC8225` as the execution layer for job-based workflows.
+- Jobs can authorize agents for scoped actions and record audit traces.
+- `performAgencyAction` can be invoked by ERC-8183 job executors once the agent is validated.
+
+### With ERC-3643 (T-REX) Agent Role
+
+- Map ERC-3643 agent roles to `IERC8225` delegation permissions.
+- Use `authorizeAgency` and `revokeAgency` to manage on-chain authority for compliance-sensitive tokens.
+- Keep the underlying token's compliance checks intact while allowing controlled agent actions.
+
+## Rationale
+
+- Minimal surface area: Like ERC-8183, keeps the interface small for gas efficiency and composability.
+- Bitmask permissions: Easy to extend without new functions; supports least-privilege delegation.
+- Expiration + revocation: Critical for security — owners can limit exposure to time-bound or instantly revocable agency.
+- Audit-first design: Every action emits `AgencyActionPerformed` for compliance trails, dispute resolution, and ERC-8004 reputation feeds.
+- Composable, not prescriptive: Works with RAMS for compliance checks, ERC-8183 for job workflows, and either ERC-3643 or ERC-7943 for the underlying RWA token.
+
+## Security Considerations
+
+- Authorization signatures: `authorizeAgency` should support ERC-1271 signatures so owners can approve from cold wallets or multisigs without exposing private keys to agent contracts.
+- Compliance never bypassed: Agents must not circumvent the principal's ONCHAINID eligibility. When integrated with RAMS or ERC-3643, the underlying token's `canTransact` / identity checks must still pass.
+- Financial caps: Implementers may add optional `maxValue` or `dailyLimit` parameters to `authorizeAgency` to reduce blast radius of compromised agents.
+- Reentrancy: `performAgencyAction` should follow checks-effects-interactions pattern; consider using Vyper's `@nonreentrant` decorator if calling external contracts.
+- Key rotation: Owners should be able to rotate agent addresses without revoking all delegations — consider an `updateAgentAddress(oldAgent, newAgent)` extension if needed.
+
+## Backwards Compatibility
+
+This ERC introduces a new interface with no impact on existing standards. It is designed to be opt-in: RWA tokens, agents, and owners choose to integrate based on use-case.
+
+## Reference Implementation
+
+A minimal Vyper 0.4+ reference implementation will be provided in a follow-up PR.
+
+## Copyright
+
+Copyright and related rights waived via CC0.
+

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -3,7 +3,7 @@ eip: 8225
 title: On-Chain Agency for Represented RWAs
 description: Agency interface for ERC-8004 agents managing permissioned RWAs with scoped, revocable permissions.
 author: Zen (@neonmercenary)
-discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas-companion-to-rams-erc-8183/
+discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas-companion-to-rams-erc-8183/28240
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -1,6 +1,6 @@
 ---
 eip: 8225
-title: On-Chain Agency for Represented RWAs
+title: Onchain Agency for Represented RWAs
 description: Agency interface for ERC-8004 agents managing permissioned RWAs with scoped, revocable permissions.
 author: Zen (@neonmercenary)
 discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas-companion-to-rams-erc-8183/28240

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -1,41 +1,41 @@
 ---
 eip: 8225
 title: On-Chain Agency for Represented RWAs
-description: Interface for ERC-8004 agents to act as delegated representatives with scoped permissions when managing permissioned Real World Assets, complementing RAMS compliance delegation and ERC-8183 agentic commerce.
-author: Zen <xphinix1@gmail.com>
-discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas
+description: Agency interface for ERC-8004 agents managing permissioned RWAs with scoped, revocable permissions.
+author: @neonmercenary
+discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas/12345
 status: Draft
 type: Standards Track
 category: ERC
 created: 2026-04-14
-requires: 8004, 8183, 7943, 3643
+requires: 3643, 7943, 8004, 8183
 ---
 
 ## Abstract
 
-This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent (identified via ERC-8004) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
+This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent (identified via [ERC-8004](/ERCS/erc-8004.md)) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
 
 It provides scoped, revocable, time-bounded permissions for active operations (transfer, voting, rebalancing, yield strategies, etc.) while preserving legal beneficial ownership signals and feeding audit/reputation events back into the agentic stack.
 
-It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both ERC-7943 (uRWA) and ERC-3643 (T-REX) tokens.
+It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both [ERC-7943](/ERCS/erc-7943.md) (uRWA) and [ERC-3643](/ERCS/erc-3643.md) (T-REX) tokens.
 
 ## Motivation
 
-The emergence of autonomous agents (ERC-8004) and regulated tokenized assets (ERC-3643, ERC-7943) creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
+The emergence of autonomous agents ([ERC-8004](/ERCS/erc-8004.md)) and regulated tokenized assets ([ERC-3643](/ERCS/erc-3643.md), [ERC-7943](/ERCS/erc-7943.md)) creates a new primitive need: **how do agents act as true on-chain representatives** for verified owners when managing legal RWAs?
 
 While the RAMS proposal elegantly solves *compliance delegation* (ensuring agents don't bypass KYC/AML during transfers), many agentic RWA use-cases require the agent to actively *manage* represented assets:
 
 - Autonomous treasury rebalancing across tokenized bonds
 - Voting on governance proposals for represented equity tokens
 - Executing compliant yield strategies on permissioned DeFi pools
-- Triggering forced transfers or freezes via ERC-3643 Agent roles under owner delegation
+- Triggering forced transfers or freezes via [ERC-3643](/ERCS/erc-3643.md) Agent roles under owner delegation
 
 This standard adds the missing **liability and execution primitive** for autonomous A2A commerce involving represented RWAs. It enables:
 
-1. **Clear ownership linking**: Human owner (ONCHAINID) → Agent (ERC-8004 NFT) → Represented RWA positions
+1. **Clear ownership linking**: Human owner (ONCHAINID) → Agent ([ERC-8004](/ERCS/erc-8004.md) NFT) → Represented RWA positions
 2. **Scoped delegation**: Bitmask permissions + expiration for least-privilege agency
-3. **Audit + reputation**: Every action emits events for compliance trails and ERC-8004 reputation feeds
-4. **Composability**: Hooks into ERC-8183 Jobs for job-based agentic workflows
+3. **Audit + reputation**: Every action emits events for compliance trails and [ERC-8004](/ERCS/erc-8004.md) reputation feeds
+4. **Composability**: Hooks into [ERC-8183](/ERCS/erc-8183.md) Jobs for job-based agentic workflows
 
 ## Specification
 
@@ -46,6 +46,9 @@ The core interface defines three phases:
 1. **Authorization**: Owner grants scoped permissions to an agent for a specific RWA token
 2. **Validation**: Any party can check if an agent is currently authorized for an action
 3. **Execution**: Agent performs a compliant action on behalf of the owner, with built-in audit logging
+
+
+## Demonstration
 
 ### Vyper 0.4+ Interface
 
@@ -162,42 +165,23 @@ TRANSFER: constant(uint256)   = 1 << 0   # Execute token transfers
 VOTE: constant(uint256)       = 1 << 1   # Cast governance votes
 REBALANCE: constant(uint256)  = 1 << 2   # Rebalance positions across pools
 MINT_BURN: constant(uint256)  = 1 << 3   # If issuer allows via Agent role
-FREEZE: constant(uint256)     = 1 << 4   # Trigger compliance freezes (ERC-3643)
+FREEZE: constant(uint256)     = 1 << 4   # Trigger compliance freezes ([ERC-3643](/ERCS/erc-3643.md))
 YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 ```
 
-## Integration Patterns
-
-### With RAMS (Regulated Agent Mandate Standard)
-
-- Use RAMS mandates to confirm that the represented owner and agent are authorized.
-- Combine `isValidAgency` with underlying token `canTransact` checks for compliance.
-- Ensure the agent cannot bypass KYC/AML obligations when executing on behalf of the owner.
-
-### With ERC-8183 (Agentic Commerce)
-
-- Use `IERC8225` as the execution layer for job-based workflows.
-- Jobs can authorize agents for scoped actions and record audit traces.
-- `performAgencyAction` can be invoked by ERC-8183 job executors once the agent is validated.
-
-### With ERC-3643 (T-REX) Agent Role
-
-- Map ERC-3643 agent roles to `IERC8225` delegation permissions.
-- Use `authorizeAgency` and `revokeAgency` to manage on-chain authority for compliance-sensitive tokens.
-- Keep the underlying token's compliance checks intact while allowing controlled agent actions.
 
 ## Rationale
 
-- Minimal surface area: Like ERC-8183, keeps the interface small for gas efficiency and composability.
+- Minimal surface area: Like [ERC-8183](/ERCS/erc-8183.md), keeps the interface small for gas efficiency and composability.
 - Bitmask permissions: Easy to extend without new functions; supports least-privilege delegation.
 - Expiration + revocation: Critical for security — owners can limit exposure to time-bound or instantly revocable agency.
-- Audit-first design: Every action emits `AgencyActionPerformed` for compliance trails, dispute resolution, and ERC-8004 reputation feeds.
-- Composable, not prescriptive: Works with RAMS for compliance checks, ERC-8183 for job workflows, and either ERC-3643 or ERC-7943 for the underlying RWA token.
+- Audit-first design: Every action emits `AgencyActionPerformed` for compliance trails, dispute resolution, and [ERC-8004](/ERCS/erc-8004.md) reputation feeds.
+- Composable, not prescriptive: Works with RAMS for compliance checks, [ERC-8183](/ERCS/erc-8183.md) for job workflows, and either [ERC-3643](/ERCS/erc-3643.md) or [ERC-7943](/ERCS/erc-7943.md) for the underlying RWA token.
 
 ## Security Considerations
 
-- Authorization signatures: `authorizeAgency` should support ERC-1271 signatures so owners can approve from cold wallets or multisigs without exposing private keys to agent contracts.
-- Compliance never bypassed: Agents must not circumvent the principal's ONCHAINID eligibility. When integrated with RAMS or ERC-3643, the underlying token's `canTransact` / identity checks must still pass.
+- Authorization signatures: `authorizeAgency` should support [ERC-1271](/ERCS/erc-1271.md) signatures so owners can approve from cold wallets or multisigs without exposing private keys to agent contracts.
+- Compliance never bypassed: Agents must not circumvent the principal's ONCHAINID eligibility. When integrated with RAMS or [ERC-3643](/ERCS/erc-3643.md), the underlying token's `canTransact` / identity checks must still pass.
 - Financial caps: Implementers may add optional `maxValue` or `dailyLimit` parameters to `authorizeAgency` to reduce blast radius of compromised agents.
 - Reentrancy: `performAgencyAction` should follow checks-effects-interactions pattern; consider using Vyper's `@nonreentrant` decorator if calling external contracts.
 - Key rotation: Owners should be able to rotate agent addresses without revoking all delegations — consider an `updateAgentAddress(oldAgent, newAgent)` extension if needed.
@@ -211,6 +195,4 @@ This ERC introduces a new interface with no impact on existing standards. It is 
 A minimal Vyper 0.4+ reference implementation will be provided in a follow-up PR.
 
 ## Copyright
-
 Copyright and related rights waived via CC0.
-

--- a/ERCS/erc-8225.md
+++ b/ERCS/erc-8225.md
@@ -2,7 +2,7 @@
 eip: 8225
 title: On-Chain Agency for Represented RWAs
 description: Interface for ERC-8004 agents to act as delegated representatives with scoped permissions when managing permissioned Real World Assets, complementing RAMS compliance delegation and ERC-8183 agentic commerce.
-author: Zen | L1 (@secondfrontman)
+author: Zen <xphinix1@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas
 status: Draft
 type: Standards Track

--- a/ERCS/erc-8232.md
+++ b/ERCS/erc-8232.md
@@ -13,7 +13,7 @@ requires: 3643, 7943, 8004, 8183
 
 ## Abstract
 
-This ERC defines a minimal interface (`IERC8225`) that allows an on-chain agent (identified via [ERC-8004](./erc-8004.md)) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
+This ERC defines a minimal interface (`IERC8232`) that allows an on-chain agent (identified via [ERC-8004](./erc-8004.md)) to act as a programmable **agency** or delegated representative for a verified human owner when interacting with tokenized regulated Real World Assets (RWAs).
 
 It provides scoped, revocable, time-bounded permissions for active operations (transfer, voting, rebalancing, yield strategies, etc.) while preserving legal beneficial ownership signals and feeding audit/reputation events back into the agentic stack.
 
@@ -52,14 +52,14 @@ The core interface defines three phases:
 ```vyper
 # pragma version 0.4.0
 """
-@title ERC-8225: On-Chain Agency for Represented RWAs
+@title ERC-8232: On-Chain Agency for Represented RWAs
 @author @secondfrontman
 @notice Execution-oriented agency interface complementing RAMS (compliance delegation) 
         and ERC-8183 (agentic commerce) for active management of represented RWAs
 @dev Composable with ERC-8004 (agent identity), ERC-8183 (jobs), ERC-3643/7943 (RWA compliance)
 """
 
-interface IERC8225:
+interface IERC8232:
     # =============================================================
     # Events
     # =============================================================
@@ -175,13 +175,13 @@ YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 
 ### With ERC-8183 (Agentic Commerce)
 
-- Use `IERC8225` as the execution layer for job-based workflows.
+- Use `IERC8232` as the execution layer for job-based workflows.
 - Jobs can authorize agents for scoped actions and record audit traces.
 - `performAgencyAction` can be invoked by ERC-8183 job executors once the agent is validated.
 
 ### With ERC-3643 (T-REX) Agent Role
 
-- Map ERC-3643 agent roles to `IERC8225` delegation permissions.
+- Map ERC-3643 agent roles to `IERC8232` delegation permissions.
 - Use `authorizeAgency` and `revokeAgency` to manage on-chain authority for compliance-sensitive tokens.
 - Keep the underlying token's compliance checks intact while allowing controlled agent actions.
 

--- a/ERCS/erc-8232.md
+++ b/ERCS/erc-8232.md
@@ -200,9 +200,7 @@ YIELD_STRATEGY: constant(uint256) = 1 << 5  # Execute yield-optimizing actions
 This ERC introduces a new interface with no impact on existing standards. It is designed to be opt-in: RWA tokens, agents, and owners choose to integrate based on use-case.
 
 
-## Reference Implementation
-
-A minimal Vyper 0.4+ reference implementation will be provided in a follow-up PR.
+<!-- TODO: reference implementation -->
 
 ## Security Considerations
 

--- a/ERCS/erc-8232.md
+++ b/ERCS/erc-8232.md
@@ -17,7 +17,7 @@ This ERC defines a minimal interface (`IERC8232`) that allows an on-chain agent 
 
 It provides scoped, revocable, time-bounded permissions for active operations (transfer, voting, rebalancing, yield strategies, etc.) while preserving legal beneficial ownership signals and feeding audit/reputation events back into the agentic stack.
 
-It is designed as a **higher-layer execution companion** to the RAMS proposal (compliance mandates + dual `canTransact` checks) and works with both [ERC-7943](./erc-7943.md) (uRWA) and [ERC-3643](./erc-3643.md) (T-REX) tokens.
+It is designed as a **higher-layer execution companion** to the Regulated Agent Mandate Standard (RAMS) proposal (compliance mandates + dual `canTransact` checks) and works with both [ERC-7943](./erc-7943.md) (uRWA) and [ERC-3643](./erc-3643.md) (T-REX) tokens.
 
 ## Motivation
 


### PR DESCRIPTION
## Description
Adds ERC-8225: On-Chain Agency for Represented RWAs — an execution-oriented agency interface for ERC-8004 agents managing permissioned RWAs. Complements RAMS (compliance delegation) and ERC-8183 (agentic commerce).

## Discussion Thread
https://ethereum-magicians.org/t/erc-8225-on-chain-agency-for-represented-rwas-companion-to-rams-erc-8183/28240 

## Type
[x] Standards Track
[ ] Informational
[ ] Meta

## Category
[x] ERC