### PR TITLE
Update ERC-8048: AI agent NFT metadata example (context + endpoint keys)

### DIFF
--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -70,18 +70,34 @@ The Diamond Storage pattern provides predictable storage locations for data, whi
 
 ### Examples
 
-The inspiration for this standard was trustless AI agents. The registry extends [ERC-721](./eip-721.md) by adding `metadata` and `setMetadata` functions for optional extra onchain agent metadata.
+It is possible to use this standard to tokenize an agent as an NFT: each token ID is the agent, and `metadata` holds agent fields as UTF-8 in `bytes`.
 
-#### Example: Context for LLM-Facing Agent Metadata
+#### Example: AI agent metadata (NFT as agent)
 
-Examples of keys are "agentWallet" or "agentName".
+Two key patterns:
 
-**Example:**
+- **`context`** — one key. UTF-8 Markdown is enough for humans and models; issuers MAY also embed a JSON code block so clients can parse token lists, policy URIs, or version fields without a second key.
+- **`endpoint[<type>]`** — one URL per protocol; `<type>` is lowercase (`mcp`, `a2a`, `ag-ui`, …).
 
-- Key: `"agentWallet"`
-- Value: `bytes("0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6")`
-- Key: `"agentName"`
-- Value: `bytes("DeFi Trading Agent")`
+Example for `tokenId == 1`: store the UTF-8 encoding of a Markdown document like the following as the `bytes` value for `"context"` (shown as a file; not a Solidity literal):
+
+~~~~markdown
+I am an agent that can swap tokens on Ethereum mainnet. I maintain an official token list and only suggest swaps where both assets appear on that list.
+
+```json
+{
+  "tokenListUri": "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/tokenlist.json",
+  "network": "mainnet",
+  "defaultSlippageBps": 50
+}
+```
+~~~~
+
+Endpoint keys for the same token:
+
+- `"endpoint[mcp]"` → `bytes("https://agents.example.com/mcp/1")`
+- `"endpoint[a2a]"` → `bytes("https://agents.example.com/a2a/1")`
+- `"endpoint[ag-ui]"` → `bytes("https://agents.example.com/ui/1")`
 
 #### Example: Biometric Identity for Proof of Personhood
 


### PR DESCRIPTION
## Summary
Adds a concrete **Examples** subsection for tokenizing an agent as an NFT: each token ID is the agent; `metadata` stores UTF-8 in `bytes`.
## Changes
- Replaces the old short `agentWallet` / `agentName` snippet with **AI agent metadata (NFT as agent)**.
- Documents two key patterns: **`context`** (Markdown, optional embedded JSON for machine-readable fields) and **`endpoint[<type>]`** (lowercase types: `mcp`, `a2a`, `ag-ui`, …).
- Includes a fenced **Markdown + `json`** sample for `context` (swap agent, official token list, `tokenListUri` as **IPFS**).
- Lists example `endpoint[mcp]`, `endpoint[a2a]`, `endpoint[ag-ui]` values.

## Commit
`dca35709` — erc-8048: add concise AI agent NFT metadata example
