### PR TITLE
Update ERC-7813: Move to Last Call

### DIFF
--- a/ERCS/erc-7813.md
+++ b/ERCS/erc-7813.md
@@ -5,7 +5,7 @@ description: On-chain tables for automatic indexing and introspectable state
 author: alvarius (@alvrs), dk1a (@dk1a), frolic (@frolic), ludens (@ludns), vdrg (@vdrg), yonada <yonada@proton.me>
 discussions-to: https://ethereum-magicians.org/t/erc-7813-store-table-based-introspectable-storage/21628
 status: Last Call
-last-call-deadline: 2026-04-30
+last-call-deadline: 2026-05-30
 type: Standards Track
 category: ERC
 created: 2024-11-08
@@ -95,7 +95,7 @@ Single byte that represents the type of a specific static or dynamic field.
 enum SchemaType { ... }
 ```
 
-**Type Encoding:**
+##### Type Encoding
 
 | Value Range      | Type                                        |
 | ---------------- | ------------------------------------------- |
@@ -240,7 +240,7 @@ This standard defines three core operations for manipulating records in a table:
 
 The fundamental requirement is that for on-chain tables the Record data retrieved through the Store interface methods at any given block MUST be consistent with the Record data that would be obtained by applying the operations implied by the Store events up to that block. This ensures data integrity and allows for accurate off-chain state reconstruction.
 
-#### Store_SetRecord
+#### `Store_SetRecord`
 
 Setting a Record means overwriting all of its fields. This operation can be performed whether the record has been set before or not (the standard does not enforce existence checks).
 
@@ -266,7 +266,7 @@ Parameters:
 | encodedLengths | EncodedLengths | The encoded lengths of the dynamic data of the record                                        |
 | dynamicData    | bytes          | The dynamic data of the record, using [custom packed encoding](#packed-data-encoding)        |
 
-#### Store_SpliceStaticData
+#### `Store_SpliceStaticData`
 
 Splicing the static data of a Record consists in overwriting bytes of the packed encoded static fields. The total length of static data does not change as it is determined by the table’s value schema.
 
@@ -290,7 +290,7 @@ Parameters:
 | start    | uint48     | The start position in bytes for the splice operation          |
 | data     | bytes      | Packed ABI encoding of a tuple with the value's static fields |
 
-#### Store_SpliceDynamicData
+#### `Store_SpliceDynamicData`
 
 Splicing the dynamic data of a Record involves modifying the packed encoded representation of its dynamic fields by removing, replacing, and/or inserting new bytes in place.
 
@@ -320,7 +320,7 @@ Parameters:
 | encodedLengths    | EncodedLengths | The resulting encoded lengths of the dynamic data of the record                                                                                          |
 | data              | bytes          | The data to insert into the dynamic data of the record at the start byte                                                                                 |
 
-#### Store_DeleteRecord
+#### `Store_DeleteRecord`
 
 The `Store_DeleteRecord` event MUST be emitted whenever the Record has been deleted from the Table.
 

--- a/ERCS/erc-7813.md
+++ b/ERCS/erc-7813.md
@@ -4,7 +4,8 @@ title: Store, Table-Based Introspectable Storage
 description: On-chain tables for automatic indexing and introspectable state
 author: alvarius (@alvrs), dk1a (@dk1a), frolic (@frolic), ludens (@ludns), vdrg (@vdrg), yonada <yonada@proton.me>
 discussions-to: https://ethereum-magicians.org/t/erc-7813-store-table-based-introspectable-storage/21628
-status: Review
+status: Last Call
+last-call-deadline: 2026-04-30
 type: Standards Track
 category: ERC
 created: 2024-11-08


### PR DESCRIPTION
  Moves ERC-7813 from Review to Last Call.

  - Status: `Review` → `Last Call`
  - `last-call-deadline`: 2026-04-30 (14 days)
  - Discussion: https://ethereum-magicians.org/t/erc-7813-store-table-based-introspectable-storage/21628

  The specification has been stable since the move to Review, and the standard is in production use by MUD projects. No further normative changes are planned.