### PR TITLE
Update ERC-8048: Add Onchain Metadata Contract Reference extension

### DIFF
--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -32,7 +32,7 @@ This ERC is an optional extension that MAY be implemented by any [ERC-721](./eip
 Contracts implementing this ERC MUST implement the following interface:
 
 ```solidity
-interface IOnchainMetadata {
+interface IERC8048Metadata {
     /// @notice Get metadata value for a key.
     function metadata(uint256 tokenId, string calldata key) external view returns (bytes memory);
     
@@ -113,14 +113,56 @@ Contracts implementing this ERC MAY use metadata hooks to redirect record resolu
 
 For the full specification of metadata hooks, see [ERC-8121](./eip-8121.md) (Metadata Hooks). Hooks are encoded in the metadata value itself and allow clients to **jump** to another contract to resolve the metadata value. When using hooks for token metadata with this ERC, the return type MUST be `bytes` and the hook encoding MUST be `bytes`.
 
+### Onchain Metadata Contract Reference (Optional Extension)
+
+Many [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), and [ERC-6909](./eip-6909.md) registries are already deployed without the `metadata` function or without storage reserved for the onchain key-value mapping. Adding that interface or storage layout is often impossible without an upgrade path, so those contracts cannot adopt the core pattern of this ERC on the token contract itself.
+
+This optional extension keeps discovery compatible with existing `tokenURI` / `uri` flows while directing clients to a separate **metadata contract** that implements `metadata(uint256,string)` as defined in this ERC. The target is identified by an [ERC-7930](./eip-7930.md) _Interoperable Address_ carried in JSON. The function to call and its signature are fixed by this specification.
+
+#### `tokenURI` / `uri` JSON field
+
+When `tokenURI` ([ERC-721](./eip-721.md)), `uri` ([ERC-1155](./eip-1155.md)), or the equivalent URI function for [ERC-6909](./eip-6909.md) returns a string that resolves to a JSON document (including JSON embedded in a `data:` URL), the document MAY include a top-level string property named `"metadata_contract"`.
+
+The value of `"metadata_contract"` MUST be the interoperable address encoded as a single JSON string: a `0x` prefix followed by the hex encoding of the [ERC-7930](./eip-7930.md) bytes, all lowercase.
+
+Example:
+
+```json
+{
+  "name": "Example",
+  "image": "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+  "metadata_contract": "0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045"
+}
+```
+
+#### Client behavior
+
+Clients that support this extension:
+
+1. Obtain and parse the JSON from `tokenURI` / `uri` as they already do for display metadata.
+2. If a top-level `"metadata_contract"` string is present, decode the value as [ERC-7930](./eip-7930.md) interoperable address bytes from the `0x`-prefixed hex string.
+3. Parse the interoperable address to obtain the target chain and contract address.
+4. Read `metadata(uint256 tokenId, string key)` from that contract on the target chain, using the same `tokenId` as for the `tokenURI` / `uri` call and the metadata key from this ERC. The return value is the same as if the token contract had stored the mapping locally.
+
+In most cases the metadata contract SHOULD be on the same chain as the NFT token registry, but it is possible to use a metadata contract on a different chain, depending on support for cross-chain reads in clients and in the ecosystem in general.
+
+Clients that do not implement this extension or do not trust the target contract address MAY ignore `"metadata_contract"` and continue to use other JSON fields.
+
+#### Relationship to `IERC8048Metadata`
+
+Registries using only this extension are NOT required to implement `IERC8048Metadata` on the token contract. The contract referenced by `metadata_contract` MUST implement the `metadata(uint256,string) external view returns (bytes)` function from this ERC (or a compatible implementation).
+
+Security: clients SHOULD only call metadata contracts they consider trustworthy; a malicious or mistaken `metadata_contract` could return attacker-controlled `bytes`. Clients SHOULD show or verify the target address the same as for any new contract interaction.
+
 ## Rationale
 
-This design prioritizes simplicity and flexibility by using a string-key, bytes-value store that provides an intuitive interface for any type of metadata. The minimal interface with a single `metadata` function provides all necessary functionality while remaining backwards compatible with existing [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), and [ERC-6909](./eip-6909.md) standards. The optional `setMetadata` function enables flexible access control for metadata updates. The required `MetadataSet` event provides transparent audit trails with indexed tokenId and indexed key for efficient filtering. This makes the standard suitable for diverse use cases including AI agents, proof of personhood systems, and custom metadata storage.
+This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract’s chosen write policy, and `MetadataSet` provides an onchain audit trail. **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
 
 ## Backwards Compatibility
 
 - Fully compatible with [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), and [ERC-6909](./eip-6909.md).
 - Non-supporting clients can ignore the scheme.
+- The **Onchain Metadata Contract Reference** extension only adds an optional JSON property; clients that do not read `"metadata_contract"` behave as they do today.
 
 ## Reference Implementation
 
@@ -131,9 +173,9 @@ The interface is defined in the Required Metadata Function and Event section abo
 ```solidity
 pragma solidity ^0.8.25;
 
-import "./IOnchainMetadata.sol";
+import "./IERC8048Metadata.sol";
 
-contract OnchainMetadataExample is IOnchainMetadata {
+contract OnchainMetadataExample is IERC8048Metadata {
     // Mapping from tokenId => key => value
     mapping(uint256 => mapping(string => bytes)) private _metadata;
     
@@ -157,9 +199,9 @@ contract OnchainMetadataExample is IOnchainMetadata {
 ```solidity
 pragma solidity ^0.8.20;
 
-import "./IOnchainMetadata.sol";
+import "./IERC8048Metadata.sol";
 
-contract OnchainMetadataDiamondExample is IOnchainMetadata {
+contract OnchainMetadataDiamondExample is IERC8048Metadata {
     struct OnchainMetadataStorage {
         mapping(uint256 tokenId => mapping(string key => bytes value)) metadata;
     }


### PR DESCRIPTION
- Rename interface IOnchainMetadata to IERC8048Metadata
- Add optional Onchain Metadata Contract Reference extension that uses a metadata_contract JSON field (ERC-7930 interoperable address) in tokenURI / uri JSON, so already-deployed registries can adopt ERC-8048 via a sidecar contract
- Update Rationale and Backwards Compatibility accordingly

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
