### PR TITLE
Update ERC-8183: clarify integer widths are normative for external ABI

### DIFF
--- a/ERCS/erc-8183.md
+++ b/ERCS/erc-8183.md
@@ -70,6 +70,8 @@ Each job SHALL have at least:
 
 Payment SHALL use a single [ERC-20](./eip-20.md) token (global for the contract or specified at creation). Implementations MAY support a per-job token; the specification only requires one token per contract.
 
+**Field widths in the external ABI.** The integer widths shown in the field list above (notably `uint256` for `budget`, `expiredAt`, and `jobId`) are normative for external function signatures, event topics, and any return values exposed across the contract boundary. Implementations MAY pack fields differently in internal storage for gas optimization, provided the externally observable ABI matches this specification. This requirement ensures cross-implementation interoperability for SDKs, indexers, and downstream attestation consumers.
+
 ### Optional provider (set later)
 
 Jobs MAY be created **without a provider** by passing `provider = address(0)` to `createJob`. In that case the client SHALL set the provider later via `setProvider(jobId, provider)` before funding. This supports flows such as bidding or assignment after creation.


### PR DESCRIPTION
## What this PR changes

Adds one paragraph to the **Job Data** section of `ERCS/erc-8183.md` clarifying that the integer widths shown in the field list (notably `uint256` for `budget`, `expiredAt`, and `jobId`) are normative for the external ABI — function signatures, event topic hashes, and any return values exposed across the contract boundary. Implementations remain free to pack fields differently in internal storage for gas optimization, provided the externally observable ABI matches the spec.

The reference implementation already uses `uint256` consistently, so this is a clarification of existing intent rather than a behavioural change.

## Motivation

The current spec wording reads like field-type annotations rather than normative ABI requirements. At least two production-track implementations diverged on the `expiredAt` width (`uint256` vs `uint64`). The divergence is observable not just at storage but at the **wire layer** — selectors and event topic hashes differ between widths, breaking interoperability for SDKs, indexers, reputation aggregators, and any tooling that relies on a stable ABI across compliant implementations.

Concrete evidence: during production deployment of an ERC-8183-compatible escrow on Base mainnet, an SDK assumed `uint64 expiredAt` while the contract (following the reference impl) used `uint256`. The selector mismatch produced a silent revert visible only after on-chain execution. A peer team using `uint64` end-to-end interpreted the choice as an implementation detail — exactly the reading the current wording permits.

## Diff preview

\`\`\`diff
 Payment SHALL use a single [ERC-20](./eip-20.md) token ...

+**Field widths in the external ABI.** The integer widths shown in the
+field list above (notably \`uint256\` for \`budget\`, \`expiredAt\`, and
+\`jobId\`) are normative for external function signatures, event topics,
+and any return values exposed across the contract boundary.
+Implementations MAY pack fields differently in internal storage for gas
+optimization, provided the externally observable ABI matches this
+specification. This requirement ensures cross-implementation
+interoperability for SDKs, indexers, and downstream attestation
+consumers.

 ### Optional provider (set later)
\`\`\`

## Out of scope

- No change to internal storage layout — implementations may still pack \`uint64 expiredAt\` co-located with status flags, etc., as long as external view functions and events expose the normative widths.
- No change to function semantics, error conditions, or state machine.
- The same clarification could later extend to \`bytes32 reason\` and \`bytes32 deliverable\` if similar divergence appears; this PR intentionally scopes to integer widths.

## Discussion

- Issue: ethereum/ERCs#1725 (closed by @AndrewCoathup with redirect to the magicians thread)
- Magicians thread (origin): https://ethereum-magicians.org/t/erc-8183-agentic-commerce/27902/237
- Status: ERC-8183 is `Draft`, no last-call deadline; this is a surgical wording edit.

cc @dcrapis @ai-virtual-b @twx-virtuals @Zuhwa

## Related clarification — scoring-rules metadata shape (from magicians discussion)

Surfaced in the thread (post #239+): the protocol-wide `SCORING_RULES_HASH` commitment and a per-evaluator `EvaluatorRegistry.setMetadata(url/CID)` design are **not competing mechanisms**. Per-evaluator metadata is the strictly more general pattern; a single protocol-wide rules hash is the degenerate case where the registry has exactly one entry — the rules hash is just an evaluator's metadata commitment with a stricter shape.

Folded here as a sub-note rather than a sibling PR to keep one review surface (per discussion with @Bakugo32). This is **not** part of the +2 line normative diff above, which stays scoped to integer widths; it records the agreed framing so the resolution is captured on the PR for @dcrapis and reviewers.
