### PR TITLE
Update ERC-8126: Move to Last Call

### DIFF
--- a/ERCS/erc-8126.md
+++ b/ERCS/erc-8126.md
@@ -5,6 +5,7 @@ description: Specialized multi-layer verification for AI Agent security
 author: Leigh Cronian (@cybercentry) <leigh.cronian@cybercentry.co.uk>, Chris Johnson <chris@virtuals.io>
 discussions-to: https://ethereum-magicians.org/t/erc-8126-ai-agent-verification/27445
 status: Last Call
+last-call-deadline: 2026-05-23
 type: Standards Track
 category: ERC
 created: 2026-01-15

--- a/ERCS/erc-8126.md
+++ b/ERCS/erc-8126.md
@@ -5,7 +5,7 @@ description: Specialized multi-layer verification for AI Agent security
 author: Leigh Cronian (@cybercentry) <leigh.cronian@cybercentry.co.uk>, Chris Johnson <chris@virtuals.io>
 discussions-to: https://ethereum-magicians.org/t/erc-8126-ai-agent-verification/27445
 status: Last Call
-last-call-deadline: 2026-05-23
+last-call-deadline: 2026-05-26
 type: Standards Track
 category: ERC
 created: 2026-01-15

--- a/ERCS/erc-8126.md
+++ b/ERCS/erc-8126.md
@@ -4,7 +4,7 @@ title: AI Agent Verification
 description: Specialized multi-layer verification for AI Agent security
 author: Leigh Cronian (@cybercentry) <leigh.cronian@cybercentry.co.uk>, Chris Johnson <chris@virtuals.io>
 discussions-to: https://ethereum-magicians.org/t/erc-8126-ai-agent-verification/27445
-status: Review
+status: Last Call
 type: Standards Track
 category: ERC
 created: 2026-01-15


### PR DESCRIPTION
Update ERC-8126: Move to Last Call. 

Status: Review → Last Call.

last-call-deadline: 2026-05-26 (14 days).

The specification has been stable since the move to Review.
