### PR TITLE
Update ERC-8048: expand metadata_contract tokenURI example

### DIFF
--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -125,15 +125,19 @@ When `tokenURI` ([ERC-721](./eip-721.md)), `uri` ([ERC-1155](./eip-1155.md)), or
 
 The value of `"metadata_contract"` MUST be the interoperable address encoded as a single JSON string: a `0x` prefix followed by the hex encoding of the [ERC-7930](./eip-7930.md) bytes, all lowercase.
 
-Example:
+Agent NFT Example:
 
 ```json
 {
   "name": "Example",
   "image": "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
-  "metadata_contract": "0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045"
+  "metadata_contract": "0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045",
+  "endpoint[mcp]": "https://agents.example.com/mcp/1",
+  "context": "I am an agent that can swap tokens on Ethereum mainnet."
 }
 ```
+
+It is possible to include metadata both directly in the `tokenURI` / `uri` JSON and in the `metadata_contract` for additional metadata.
 
 #### Client behavior
 


### PR DESCRIPTION

## Summary

Expands the Agent NFT JSON example under the metadata_contract section to include `endpoint[mcp]` and `context`.
Adds a short note that issuers can combine inline tokenURI / uri JSON metadata with metadata_contract onchain metadata for extra fields.