### PR TITLE
Update ERC-8255: add a section to erc-8255 backwards compatibility to break max approvals

### DIFF
--- a/ERCS/erc-8255.md
+++ b/ERCS/erc-8255.md
@@ -144,6 +144,8 @@ Upgradeable contracts that already store each allowance as a single `uint256` va
 
 Existing allowance values greater than or equal to `type(uint192).max` do not have a meaningful packed interpretation unless the implementation defines one. This behavior does not affect effective allowance safety because such values either expire by default, are rejected or remapped by migration logic, or are treated under the implementation's maximum-allowance sentinel rules.
 
+Packed implementations that reserve a lower-192-bit sentinel for `type(uint256).max` MUST NOT treat a legacy single-slot maximum approval as a valid unexpired approval merely because decoding the old slot yields expiration `type(uint64).max`. An expiration farther than `maxApprovalDuration()` seconds after the current block timestamp cannot have been produced by compliant post-upgrade approval logic. Implementations SHOULD revert when such a stored value is encountered, or otherwise require explicit migration before treating it as a live approval. Using `type(uint32).max` as the rejection threshold is a weaker alternative, but `maxApprovalDuration()` is preferred because it matches the contract's actual approval bound.
+
 ## Test Cases
 
 1. If `maxApprovalDuration()` returns `86400` and `approve(spender, 100)` is called at timestamp `1_000_000`, then `allowanceAndExpiration(owner, spender)` returns expiration `1_086_400` and allowance `100`.


### PR DESCRIPTION
for upgrades we will break max approve compat