### PR TITLE
Update ERC-6357: Fix delegatecall to use individual data elements

### DIFF
--- a/ERCS/erc-6357.md
+++ b/ERCS/erc-6357.md
@@ -73,7 +73,7 @@ abstract contract Multicall is IMulticall {
     function multicall(bytes[] calldata data) external virtual returns (bytes[] memory results) {
         results = new bytes[](data.length);
         for (uint256 i = 0; i < data.length; i++) {
-            (bool success, bytes memory returndata) = address(this).delegatecall(data);
+            (bool success, bytes memory returndata) = address(this).delegatecall(data[i]);
             require(success);
             results[i] = returndata;
         }


### PR DESCRIPTION
The reference implementation didn't actually split out the different calls. It fed the entire call data array into the delegate call each time.