### PR TITLE
Update ERC-7984: fix typos

### DIFF
--- a/ERCS/erc-7984.md
+++ b/ERCS/erc-7984.md
@@ -130,7 +130,7 @@ Compliant tokens MUST implement the following methods, unless otherwise specifie
 
 - #### `confidentialTransferFrom(address,address,bytes32)`
 
-  Transfers `amount` of tokens from address `from` to address `to`. The function MAY revert if the `from`'s account balance does not have enough tokens to spend.
+  Transfers `amount` of tokens from address `from` to address `to`. The function MAY revert if the `from` account's balance does not have enough tokens to spend.
 
   Returns the actual amount that was transferred.
 
@@ -144,7 +144,7 @@ Compliant tokens MUST implement the following methods, unless otherwise specifie
 
 - #### `confidentialTransferFrom(address,address,bytes32,bytes)`
 
-  Transfers `amount` of tokens from address `from` to address `to`. The function MAY revert if the `from`'s account balance does not have enough tokens to spend.
+  Transfers `amount` of tokens from address `from` to address `to`. The function MAY revert if the `from` account's balance does not have enough tokens to spend.
 
   The `data` parameter contains implementation-specific information such as cryptographic proofs.
 
@@ -192,7 +192,7 @@ Compliant tokens MUST implement the following methods, unless otherwise specifie
 
 - #### `confidentialTransferFromAndCall(address,address,bytes32,bytes)`
 
-  Transfers `amount` of tokens from address `from` to address `to`. The function MAY revert if the `from`'s account balance does not have enough tokens to spend.
+  Transfers `amount` of tokens from address `from` to address `to`. The function MAY revert if the `from` account's balance does not have enough tokens to spend.
 
   See [Callback Details](#callback-details) below for details on the callback flow.
 
@@ -208,7 +208,7 @@ Compliant tokens MUST implement the following methods, unless otherwise specifie
 
 - #### `confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)`
 
-  Transfers `amount` of tokens from address `from` to address `to`. The function MAY revert if the `from`'s account balance does not have enough tokens to spend.
+  Transfers `amount` of tokens from address `from` to address `to`. The function MAY revert if the `from` account's balance does not have enough tokens to spend.
 
   The `data` parameter contains implementation-specific information such as cryptographic proofs.
 
@@ -254,7 +254,7 @@ Compliant tokens MUST implement the following methods, unless otherwise specifie
 
 ### Callback Details
 
-Transfer functions suffixed with `andCall` execute a callback to the `to` address AFTER all transfer logic is completed. The callback calls the `onConfidentialTransferReceived` function with the transfer initiator (operator), from address, actual amount sent, and given `callData` bytes (the last parameter for `andCall` functions). The callback flow is as follows:
+Transfer functions suffixed with `AndCall` execute a callback to the `to` address AFTER all transfer logic is completed. The callback calls the `onConfidentialTransferReceived` function with the transfer initiator (operator), from address, actual amount sent, and given `callData` bytes (the last parameter for `AndCall` functions). The callback flow is as follows:
 
 - If `address(to).code.length == 0` the callback is a no-op and returns successfully.
 - Call [`onConfidentialTransferReceived(address, address, bytes32, bytes)`](#onconfidentialtransferreceived) on `to`.


### PR DESCRIPTION
This ERC fixes a few typos in the ERC-7984 spec:
- MAY revert if the `from`'s account -> MAY revert if the `from` account's
- `andCall` -> `AndCall` (as the functions are actually written)