### PR TITLE
Add ERC: Onchain Proof Layer for AI Agents

### DIFF
--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -3,7 +3,7 @@ eip: 8263
 title: Onchain Proof Layer for AI Agents
 description: Anchor AI agent actions to Ethereum with cryptographic proofs and verifiable identity registry.
 author: Vincent Wu (@VincentWu) <wuxiaoyu8816@gmail.com>
-discussions-to: https://ethereum-magicians.org/t/erc-8263-on-chain-inference-attestation-registry-for-ai-agents/28577
+discussions-to: https://ethereum-magicians.org/t/erc-8263-onchain-proof-layer-for-ai-agents/28577
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -2,7 +2,7 @@
 eip: 8263
 title: Onchain Proof Layer for AI Agents
 description: Anchor AI agent actions to Ethereum with cryptographic proofs and verifiable identity registry.
-author: Vincent Wu (@VincentWu) <wuxiaoyu8816@gmail.com>
+author: Vincent Wu (@TruthAnchor-AI) <wuxiaoyu8816@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/erc-8263-onchain-proof-layer-for-ai-agents/28577
 status: Draft
 type: Standards Track

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -149,10 +149,10 @@ No backwards compatibility issues: this is a new proposal and defines a new even
 
 Reference contracts verified on Etherscan, both implementing the interface above:
 
-- Ethereum Mainnet: `0xe95d6a15966984c209a62a2c188828555eb5ec3d` (source: etherscan.io/address/0xe95d6a15966984c209a62a2c188828555eb5ec3d#code)
+- Ethereum Mainnet: `0xe95d6a15966984c209a62a2c188828555eb5ec3d`
 - Sepolia Testnet: `0x89EE9b68c3b2f50cbE9D0fC4Dc134939a0475c1C`
 
-Both deployments emit the `AnchorProof` event with the topic0 above and accept the two entrypoints unchanged. Independent verifiers can confirm the contract surface by reading the verified source on the linked block explorers.
+Both deployments are verified on Etherscan and emit the `AnchorProof` event with the topic0 above, accepting the two entrypoints unchanged. Independent verifiers can confirm the contract surface by reading the verified source on the corresponding block explorers.
 
 ## Security Considerations
 
@@ -262,13 +262,13 @@ This ERC is a write-side standard: it defines how an anchor is emitted on-chain.
 > OCP does not define identity, authorship, sanitization, or data availability. It defines an extraction interface for observation commitments and a re-checkable digest profile over them. Composition with identity layers, signing layers, or anchoring layers is out of OCP's scope.
 > — Damon Zwicker (OCP author)
 
-#### This ERC does not embed OCP
+#### Independence from OCP
 
 This ERC does not import an OCP verification interface, does not require OCP-compatible verifiers, and does not assume an OCP-shaped verifier is deployed. Every anchor is OCP-extractable by construction (the extraction rule is a function of the event topology already defined in *Canonical Event*), but anchors remain valid for verifiers that ignore OCP entirely and check `proofHash` against their own profile.
 
 #### Out-of-scope boundary
 
-| Concern                                  | In scope for this ERC | Handled by adjacent layer |
+| Concern                                  | In scope | Handled by adjacent layer |
 |:--|:-:|:-:|
 | Event shape, scheme registry             | ✓ | — |
 | Identity binding under scheme `0x01`     | — | identity registry ([ERC-8004](./eip-8004.md) and compatible) |
@@ -298,7 +298,7 @@ preImage = canonical_encode({
 proofHash = H(preImage)
 ```
 
-`identitySentinel` is a profile-level constant (recommended value: `IDENTITY_SENTINEL = keccak256("identity.passthrough.v1")`) used to mark pre-images in which identity is intentionally pass-through rather than bound at the commitment layer. Verifiers MUST branch on the sentinel: when present, identity is resolved at the chain layer via `(agentIdScheme, agentId)` and the pre-image identity slot carries the sentinel value verbatim; when absent, identity is bound at the commitment layer and the slot carries the binding payload directly. This invariant prevents silent identity confusion across implementations of the same profile.
+`identitySentinel` is a profile-level constant (recommended value: `IDENTITY_SENTINEL = keccak256("erc8263.identity.passthrough.v1")`) used to mark pre-images in which identity is intentionally pass-through rather than bound at the commitment layer. Verifiers MUST branch on the sentinel: when present, identity is resolved at the chain layer via `(agentIdScheme, agentId)` and the pre-image identity slot carries the sentinel value verbatim; when absent, identity is bound at the commitment layer and the slot carries the binding payload directly. This invariant prevents silent identity confusion across implementations of the same profile.
 
 #### Profile: Merkle batch root
 

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -10,30 +10,21 @@ category: ERC
 created: 2026-05-14
 ---
 
-
 ## Abstract
-
 
 This proposal specifies a minimal on-chain proof layer for AI agents. It allows agents to anchor their actions (decisions, outputs, or state transitions) to the Ethereum blockchain by submitting a cryptographic commitment (SHA-256 hash). This creates a verifiable, immutable timeline of agent activity, enabling trustless auditing and reputation systems for autonomous agents.
 
-
 ## Motivation
-
 
 As AI agents increasingly perform high-value tasks (e.g., DeFi trading, content creation, governance voting), there is a critical need for a standard way to prove that an agent performed a specific action at a specific time. Current agent activities are often opaque or stored in centralized databases. Implementations provide a decentralized "black box recorder" for AI agents, ensuring that their history cannot be retroactively altered.
 
-
 ## Specification
-
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-
 ### Interface
 
-
 The protocol contract MUST implement the following interface:
-
 
 ```solidity
 interface IOnChainProof {
@@ -45,14 +36,12 @@ interface IOnChainProof {
      */
     event ProofAnchored(bytes32 indexed agentId, bytes32 indexed proofHash, uint256 timestamp);
 
-
     /**
      * @dev Anchors a single proof to the blockchain.
      * @param agentId The unique identifier of the AI agent.
      * @param proofHash The SHA-256 hash of the action/data.
      */
     function anchorProof(bytes32 agentId, bytes32 proofHash) external;
-
 
     /**
      * @dev Anchors multiple proofs in a single transaction to save gas.
@@ -63,12 +52,9 @@ interface IOnChainProof {
 }
 ```
 
-
 ### Data Schema
 
-
 The data being hashed SHOULD follow a structured JSON format to ensure interoperability:
-
 
 ```json
 {
@@ -85,24 +71,17 @@ The data being hashed SHOULD follow a structured JSON format to ensure interoper
 }
 ```
 
-
 ## Rationale
-
 
 ### SHA-256 vs Keccak256
 
-
 The use of SHA-256 is recommended for compatibility with off-chain AI systems and web standards, although Keccak256 is more common in Ethereum.
-
 
 ## Backwards Compatibility
 
-
 No backwards compatibility issues as this is a new proposal.
 
-
 ## Reference Implementation
-
 
 Contracts deployed on:
 
@@ -112,36 +91,25 @@ Contracts deployed on:
 
 As of May 2026, the reference implementation has anchored 700+ confirmed proofs across 5 chains. All anchors are publicly verifiable on the corresponding block explorers.
 
-
 ## Security Considerations
-
 
 Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
 
 The agent_id field MUST be validated against the [ERC-8004](./eip-8004.md) registry before reputation aggregation; unverified IDs MUST be flagged.
 
+## Appendix: Compatibility and Verification Notes
 
----
+This appendix is **informative**. It describes how this ERC composes with adjacent standards and how anchors can be independently verified. It introduces no new normative requirements on the contract surface; the canonical event and the scheme registry are unchanged.
 
-## 10. Compatibility with ERC-8004
+### Compatibility with [ERC-8004](./eip-8004.md)
 
-This section is **informative**. It describes a compatibility profile for
-deployments that compose ERC-8263 anchors with [ERC-8004 (Agent Identity
-Registry)][erc-8004] identities. It introduces no new normative requirements
-on the ERC-8263 contract surface; the canonical event in §2 and the scheme
-registry in §3 are unchanged.
+This section describes a compatibility profile for deployments that compose anchors with [ERC-8004](./eip-8004.md) (Agent Identity Registry) identities.
 
-ERC-8263 is identity-registry-agnostic by construction: the canonical event
-carries `(agentIdScheme, agentId)` as opaque bytes and assigns no on-chain
-meaning beyond the scheme registry. ERC-8004 is one such registry, and the
-two standards compose cleanly when an implementer chooses to use both.
+This ERC is identity-registry-agnostic by construction: the canonical event carries `(agentIdScheme, agentId)` as opaque bytes and assigns no on-chain meaning beyond the scheme registry. [ERC-8004](./eip-8004.md) is one such registry, and the two standards compose cleanly when an implementer chooses to use both.
 
-### 10.1 Scheme `0x01` compatibility bridge
+**Scheme `0x01` compatibility bridge**
 
-When an implementation chooses to populate ERC-8263 anchors with ERC-8004
-identities under `agentIdScheme = 0x01` (REGISTRY), the recommended
-encoding of the 32-byte `agentId` payload is a zero-padded ERC-8004
-record id:
+When an implementation chooses to populate anchors with [ERC-8004](./eip-8004.md) identities under `agentIdScheme = 0x01` (REGISTRY), the recommended encoding of the 32-byte `agentId` payload is a zero-padded [ERC-8004](./eip-8004.md) record id:
 
 ```
 agentId = bytes32(uint256(agentId8004))
@@ -153,67 +121,32 @@ Equivalently in Solidity:
 bytes32 agentId = bytes32(uint256(agentId8004));
 ```
 
-This is the canonical compatibility bridge between the two standards'
-on-chain representations. It is offered as a recommendation, not a
-mandatory path: ERC-8263 anchors do not require an ERC-8004 record,
-and ERC-8004 is one of several registries that can populate scheme
-`0x01`. The contract accepts any 32-byte `agentId`; tooling that
-resolves scheme `0x01` anchors against an ERC-8004 registry should
-apply this cast for round-trip consistency. Future revisions may
-refine this compatibility profile as ERC-8004 stabilizes.
+This is the canonical compatibility bridge between the two standards' on-chain representations. It is offered as a recommendation, not a mandatory path: anchors do not require an [ERC-8004](./eip-8004.md) record, and [ERC-8004](./eip-8004.md) is one of several registries that can populate scheme `0x01`. The contract accepts any 32-byte `agentId`; tooling that resolves scheme `0x01` anchors against an [ERC-8004](./eip-8004.md) registry should apply this cast for round-trip consistency.
 
-### 10.2 Resolution direction
+**Resolution direction**
 
-Resolution is one-way at the protocol layer. An ERC-8263 anchor with
-scheme `0x01` can reference an ERC-8004 record; ERC-8004 does not need
-to reference ERC-8263 in return. ERC-8004 records carry no contract-layer
-back-reference to their ERC-8263 anchors, and ERC-8263 does not ask
-ERC-8004 to add one. Indexers that want a bidirectional view can build a
-reverse index off-chain from the `AnchorProof` event log.
+Resolution is one-way at the protocol layer. An anchor with scheme `0x01` can reference an [ERC-8004](./eip-8004.md) record; [ERC-8004](./eip-8004.md) does not need to reference this ERC in return. Indexers that want a bidirectional view can build a reverse index off-chain from the event log.
 
-### 10.3 Identity vs commitment separation
+**Identity vs commitment separation**
 
-ERC-8004 governs *who the agent is*. ERC-8263 governs *what the agent
-committed to on-chain*. The two standards are deliberately separable:
+[ERC-8004](./eip-8004.md) governs *who the agent is*. This ERC governs *what the agent committed to on-chain*. The two standards are deliberately separable:
 
-- An ERC-8263 anchor with `agentIdScheme = 0x00` (ANONYMOUS) is a valid
-  anchor with no identity-registry dependency.
-- An ERC-8263 anchor with `agentIdScheme = 0x02` (URI_HASH) binds to an
-  off-chain canonical identity and does not require an ERC-8004 record.
-- Future schemes allocated in the `0x03+` reserved range may bind to
-  other identity systems (e.g., DID methods) without disturbing the
-  ERC-8004 compatibility profile in §10.1.
-- An ERC-8004 record can exist without any ERC-8263 anchors against it.
+- An anchor with `agentIdScheme = 0x00` (ANONYMOUS) is a valid anchor with no identity-registry dependency.
+- An anchor with `agentIdScheme = 0x02` (URI_HASH) binds to an off-chain canonical identity and does not require an [ERC-8004](./eip-8004.md) record.
+- Future schemes allocated in the `0x03+` reserved range may bind to other identity systems (e.g., DID methods) without disturbing the [ERC-8004](./eip-8004.md) compatibility profile above.
+- An [ERC-8004](./eip-8004.md) record can exist without any anchors against it.
 
-Implementations that choose to compose registered identity (ERC-8004) with
-on-chain commitment (ERC-8263) should verify each layer independently;
-neither standard's validity check substitutes for the other's.
+Implementations that choose to compose registered identity ([ERC-8004](./eip-8004.md)) with on-chain commitment (this ERC) should verify each layer independently; neither standard's validity check substitutes for the other's.
 
-[erc-8004]: https://eips.ethereum.org/EIPS/eip-8004
+### Compatible Identity Registries
 
----
+This section generalizes the above to any identity registry that an implementer might compose with anchors, and describes an optional off-chain convention for resolving `(agentIdScheme, agentId)` back to a wallet address.
 
-## 11. Compatible Identity Registries
+The scheme registry is intentionally identity-system-agnostic. Scheme `0x01` is reserved for "REGISTRY" without naming a specific registry, so the same anchor format can compose with [ERC-8004](./eip-8004.md), with other on-chain agent registries (proprietary or future-standard), and with registry adapters that front external identity systems.
 
-This section is **informative**. It generalizes §10 to any identity registry
-that an implementer might compose with ERC-8263 anchors, and describes an
-optional off-chain convention for resolving `(agentIdScheme, agentId)` back
-to a wallet address. It introduces no new contract interface; ERC-8263's
-canonical event and scheme registry are unchanged.
+**Recommended resolution interface**
 
-### 11.1 Why generalize
-
-The scheme registry in §3 is intentionally identity-system-agnostic. Scheme
-`0x01` is reserved for "REGISTRY" without naming a specific registry, so the
-same anchor format can compose with ERC-8004, with other on-chain agent
-registries (proprietary or future-standard), and with registry adapters that
-front external identity systems. This section describes the shape of a
-compatible registry, not which registry to use.
-
-### 11.2 Recommended resolution interface
-
-A registry is considered compatible with ERC-8263 scheme `0x01` when it
-exposes a resolution function with the following shape:
+A registry is considered compatible with scheme `0x01` when it exposes a resolution function with the following shape:
 
 ```solidity
 interface IAgentWalletResolver {
@@ -223,54 +156,27 @@ interface IAgentWalletResolver {
 }
 ```
 
-`getAgentWallet` is the minimal convention an indexer or verifier needs to
-move from an ERC-8263 anchor's `(agentIdScheme = 0x01, agentId)` pair to an
-authoritative wallet for that agent. The recommendation is `should`, not
-`must`: registries may expose richer interfaces (e.g., ERC-8004's full
-agent record), and verifiers that only need to display an anchor without
-resolving identity can ignore the registry entirely.
+`getAgentWallet` is the minimal convention an indexer or verifier needs to move from an anchor's `(agentIdScheme = 0x01, agentId)` pair to an authoritative wallet for that agent. The recommendation is `should`, not `must`: registries may expose richer interfaces (e.g., [ERC-8004](./eip-8004.md)'s full agent record), and verifiers that only need to display an anchor without resolving identity can ignore the registry entirely.
 
-The function lives at the registry, not at the ERC-8263 contract. ERC-8263
-does not call into registries on-chain and does not depend on any specific
-registry being deployed.
+The function lives at the registry, not at this ERC's contract. This ERC does not call into registries on-chain and does not depend on any specific registry being deployed.
 
-### 11.3 Off-chain resolution flow
+**Off-chain resolution flow**
 
 A typical off-chain resolution flow for a scheme `0x01` anchor is:
 
-1. Read the `AnchorProof` event log from a node (chain-state-only).
+1. Read the event log from a node (chain-state-only).
 2. Parse `(agentIdScheme, agentId)` from the event topics.
-3. If `agentIdScheme == 0x01`, look up the registry the implementation has
-   bound to scheme `0x01` (a tooling-side choice; ERC-8263 does not encode
-   the registry address on-chain in scheme `0x01`).
+3. If `agentIdScheme == 0x01`, look up the registry the implementation has bound to scheme `0x01` (a tooling-side choice; this ERC does not encode the registry address on-chain in scheme `0x01`).
 4. Call `registry.getAgentWallet(agentId)` against that registry.
-5. Use the returned wallet for any downstream check the verifier cares
-   about (signature verification, reputation lookup, display).
+5. Use the returned wallet for any downstream check the verifier cares about (signature verification, reputation lookup, display).
 
-Each step is independent and any verifier may stop at step 2 if it only
-needs to display the anchor.
+Each step is independent and any verifier may stop at step 2 if it only needs to display the anchor.
 
-### 11.4 Reference implementation
+A live reference implementation of this flow exists at https://gateway.ensub.org (operated by Tiago Merlini in the [ERC-8004](./eip-8004.md) working group). It exposes an HTTP attestation endpoint keyed on `(registry, agentId)` and demonstrates the off-chain resolution flow above against an [ERC-8004](./eip-8004.md) registry. This ERC does not require this gateway or any other gateway; it is cited here as evidence that the compatibility profile is implementable end-to-end.
 
-A live reference implementation of this flow exists at
-[`gateway.ensub.org`](https://gateway.ensub.org) (operated by Tiago Merlini
-in the ERC-8004 working group). It exposes an HTTP attestation endpoint
-keyed on `(registry, agentId)` and demonstrates the off-chain resolution
-flow above against an ERC-8004 registry. ERC-8263 does not require this
-gateway or any other gateway; it is cited here as evidence that the
-compatibility profile in §10 and §11 is implementable end-to-end.
+### Independent Verification
 
----
-
-## 12. Independent Verification
-
-This section is **informative**. It describes how an ERC-8263 anchor can be
-verified end-to-end using chain state alone, with no dependency on the
-issuing service, the indexer, or any hosted gateway. It introduces no new
-contract interface; verification is a property of the published event data
-and is performed entirely by the verifier.
-
-### 12.1 What "independent" means here
+This section describes how an anchor can be verified end-to-end using chain state alone, with no dependency on the issuing service, the indexer, or any hosted gateway.
 
 A verification step is *independent* when it relies only on:
 
@@ -278,143 +184,63 @@ A verification step is *independent* when it relies only on:
 - the verifier's own access to a node serving the relevant chain, and
 - the verifier's own implementation of the declared hash function.
 
-It does *not* depend on the operator that issued the anchor, the indexer
-that surfaced it, or any HTTP gateway in between. The verifier may use
-those services for convenience, but the verification result is identical
-when none of them are reachable, as long as the chain is.
+It does *not* depend on the operator that issued the anchor, the indexer that surfaced it, or any HTTP gateway in between.
 
-### 12.2 Five-step verification path
+**Five-step verification path**
 
-The following path is the canonical independent-verification flow,
-borrowed verbatim from the *Composition Note: ERC-8004 + ERC-8263 + OCP*
-(co-authored by Vincent Wu and Damon Zwicker):
+1. Verifier receives: `observation` + an anchor reference (`txHash` + `logIndex`, or any equivalent locator).
+2. `H′ = H(observation)` — recomputed independently using the hash function declared by the proof profile in use (see Recommended proofHash Constructions below).
+3. `H′ == proofHash` — compared against the `proofHash` value carried in the event at the referenced log.
+4. `proofHash ∈ R(tx)` — confirmed in the raw transaction receipt by re-parsing the event log from a node, without trusting any indexer.
+5. `agentId` is resolved according to `agentIdScheme`: for `0x01`, resolution goes through a compatible registry per the Compatible Identity Registries section; for `0x02`, `agentId == keccak256(canonical agent URI)`; for `0x00`, no identity resolution applies.
 
-1. Verifier receives: `observation` + an ERC-8263 anchor reference
-   (`txHash` + `logIndex`, or any equivalent locator).
-2. `H′ = H(observation)` — recomputed independently using the hash
-   function declared by the proof profile in use (see Appendix A).
-3. `H′ == proofHash` — compared against the `proofHash` value carried
-   in the `AnchorProof` event at the referenced log.
-4. `proofHash ∈ R(tx)` — confirmed in the raw transaction receipt by
-   re-parsing the event log from a node, without trusting any indexer.
-5. `agentId` is resolved according to `agentIdScheme`: for `0x01`,
-   resolution goes through a compatible registry per §11; for `0x02`,
-   `agentId == keccak256(canonical agent URI)`; for `0x00`, no identity
-   resolution applies.
+The result is an independent, system-agnostic statement that this agent committed this observation at this moment on this chain.
 
-The result is an independent, system-agnostic statement that this agent
-committed this observation at this moment on this chain.
-
-### 12.3 Layer optionality
-
-The five steps above are independently optional: a verifier that only
-needs to confirm digest inclusion can stop at step 4; a verifier that
-needs identity attribution continues to step 5. Implementations that
-publish both an on-chain commitment and a higher-layer signature over the
-same observation may show a visible gap between the two surfaces, because
-some executions get signed before the on-chain commitment confirms. That
-gap is designed-in optionality rather than inconsistency. As observed by
-Tiago Merlini in the ERC-8263 ↔ ERC-8004 alignment thread:
+The five steps above are independently optional: a verifier that only needs to confirm digest inclusion can stop at step 4; a verifier that needs identity attribution continues to step 5. Implementations that publish both an on-chain commitment and a higher-layer signature over the same observation may show a visible gap between the two surfaces, because some executions get signed before the on-chain commitment confirms. That gap is designed-in optionality rather than inconsistency. As observed by Tiago Merlini in the alignment thread:
 
 > The L3/L4 gap (10 vs 13) is visible and expected, some executions got
 > signed before the OCP anchor confirmed. Worth noting for implementers:
 > L3 and L4 are independently optional by design, as specced in the
 > appendix.
 
-This gap is visible by construction and can be surfaced by verifiers.
+A live admin attestation dashboard at https://gateway.ensub.org shows the five-step path running against production traffic. This ERC does not require this dashboard or any other dashboard; it is cited as a worked example of the independent verification path running end-to-end.
 
-### 12.4 Verifier observability reference
+The address recovered from the l4_signature field resolves to the gateway's attestor key, the address registered as the agent's hot wallet via getAgentWallet(agentId) in the [ERC-8004](./eip-8004.md) registry. This key is controlled by the gateway operator, not the token owner; ownership of the [ERC-8004](./eip-8004.md) NFT and attestation of execution are intentionally separated, and an agent may migrate gateways by updating the hot wallet registration without transferring the token. Verification of L4 therefore confirms which infrastructure attested the execution, not that the agent signed for itself. The trustless floor remains L3: input_hash anchored on-chain via OCP is independently verifiable from any public RPC with no trust assumptions beyond the chain itself.
 
-A live admin attestation dashboard at the
-[`gateway.ensub.org`](https://gateway.ensub.org) reference implementation
-shows the five-step path running against production traffic: per-row
-identity sentinel badges (see Appendix A.2), L3 badges that resolve
-directly to a block explorer for the underlying transaction, and a visible
-L3/L4 gap framed per §12.3. ERC-8263 does not require this dashboard or
-any other dashboard; it is cited as a worked example of the independent
-verification path running end-to-end.
+### OCP Boundary Note
 
-The address recovered from the l4_signature field resolves to the
-gateway's attestor key, the address registered as the agent's hot wallet
-via getAgentWallet(agentId) in the ERC-8004 registry. This key is
-controlled by the gateway operator, not the token owner; ownership of the
-ERC-8004 NFT and attestation of execution are intentionally separated, and
-an agent may migrate gateways by updating the hot wallet registration
-without transferring the token. Verification of L4 therefore confirms
-which infrastructure attested the execution, not that the agent signed for
-itself. The trustless floor remains L3: input_hash anchored on-chain via
-OCP is independently verifiable from any public RPC with no trust
-assumptions beyond the chain itself.
+This section clarifies what this ERC does and does not bundle from the Observation Commitment Protocol (OCP) at https://github.com/damonzwicker/observation-commitment-protocol, to prevent implementers from conflating the two.
 
----
-
-## 13. OCP Boundary Note
-
-This section is **informative**. It clarifies what ERC-8263 does and does
-not bundle from the [Observation Commitment Protocol (OCP)][ocp], to
-prevent implementers from conflating the two.
-
-### 13.1 What OCP is, and what it is not
-
-OCP is a profile-level description of how a committed digest is verified
-against raw chain state. It defines the extraction rule that takes a
-transaction receipt to the set of OCP digests carried by ERC-8263 anchors
-in that receipt (see Appendix A.1). Quoting Damon Zwicker, OCP author:
+OCP is a profile-level description of how a committed digest is verified against raw chain state. It defines the extraction rule that takes a transaction receipt to the set of OCP digests carried by anchors in that receipt (see Recommended proofHash Constructions below). Quoting Damon Zwicker, OCP author:
 
 > OCP does not define identity, authorship, sanitization, or data
 > availability.
 
-ERC-8263 makes the same separation explicit at the contract layer:
-ERC-8263 commits a `proofHash`, and the contract enforces only that the
-hash is non-zero and the event is well-formed. The interpretation of what
-that hash commits to lives in a proof profile, not in ERC-8263 itself.
+This ERC makes the same separation explicit at the contract layer: this ERC commits a `proofHash`, and the contract enforces only that the hash is non-zero and the event is well-formed. The interpretation of what that hash commits to lives in a proof profile, not in this ERC itself.
 
-### 13.2 ERC-8263 does not embed OCP
+This ERC does not import an OCP verification interface, does not require OCP-compatible verifiers, and does not assume an OCP-shaped verifier is deployed. Every anchor is OCP-extractable by construction (the extraction rule is a function of the event topology already defined in the Specification), but anchors remain valid for verifiers that ignore OCP entirely and check `proofHash` against their own profile.
 
-ERC-8263 does not import an OCP verification interface, does not require
-OCP-compatible verifiers, and does not assume an OCP-shaped verifier is
-deployed. Every ERC-8263 anchor is OCP-extractable by construction (the
-extraction rule in Appendix A.1 is a function of the event topology
-already defined in §2), but ERC-8263 anchors remain valid for verifiers
-that ignore OCP entirely and check `proofHash` against their own profile.
-
-The relationship is one-way: OCP can describe a verifier for ERC-8263
-anchors; ERC-8263 does not require any verifier to be OCP-shaped.
-
-### 13.3 Out-of-scope boundary
+The relationship is one-way: OCP can describe a verifier for anchors; this ERC does not require any verifier to be OCP-shaped.
 
 The following table makes the boundary explicit:
 
-| Concern | In scope for ERC-8263 | Out of scope (left to profile / adjacent standard) |
+| Concern | In scope for this ERC | Out of scope (left to profile / adjacent standard) |
 |---|---|---|
 | Event shape, scheme registry | ✓ | — |
 | Non-zero `proofHash` enforcement | ✓ | — |
-| Identity resolution | — | ERC-8004 / §10 / §11 |
+| Identity resolution | — | [ERC-8004](./eip-8004.md) / Compatible Identity Registries |
 | Authorship / signature binding | — | proof profile / wallet signature layer |
-| Input sanitization, pipeline disclosure | — | proof profile / Appendix A.2 |
+| Input sanitization, pipeline disclosure | — | proof profile / Recommended proofHash Constructions |
 | Data availability of the underlying observation | — | proof profile / off-chain layer |
-| Independent verification procedure | — | OCP / §12 |
+| Independent verification procedure | — | OCP / Independent Verification section |
 
-[ocp]: https://github.com/damonzwicker/observation-commitment-protocol
+### Recommended proofHash Constructions
 
----
+This section describes constructions an implementer may use to populate the `proofHash` field. The core contract treats `proofHash` as opaque `bytes32` and enforces only that it is non-zero. Every construction here is a profile; none of them is part of the contract surface, and a verifier may use any construction, including one not listed here, as long as the construction is declared in the proof profile in use.
 
-## Appendix A. Recommended proofHash Constructions
+The contract performs no hash-function negotiation, no algorithm disclosure, and no profile registry on-chain. Profile selection is an agreement between the issuer and the verifier; the chain holds only the opaque `bytes32`.
 
-This appendix is **informative**. It describes constructions an implementer
-may use to populate the `proofHash` field of an ERC-8263 anchor. The core
-ERC-8263 contract treats `proofHash` as opaque `bytes32` and enforces only
-that it is non-zero. Every construction in this appendix is a profile;
-none of them is part of the contract surface, and a verifier may use any
-construction, including one not listed here, as long as the construction
-is declared in the proof profile in use.
-
-The contract performs no hash-function negotiation, no algorithm
-disclosure, and no profile registry on-chain. Profile selection is an
-agreement between the issuer and the verifier; the chain holds only the
-opaque `bytes32`.
-
-### A.1 Profile: Single observation digest (default)
+**Profile: Single observation digest (default)**
 
 ```
 proofHash = H(canonical_observation_bytes)
@@ -422,25 +248,16 @@ proofHash = H(canonical_observation_bytes)
 
 Where:
 
-- `canonical_observation_bytes` is the canonical byte serialization of the
-  observation the agent committed to (the proof profile defines what
-  "canonical" means for the data shape).
+- `canonical_observation_bytes` is the canonical byte serialization of the observation the agent committed to (the proof profile defines what "canonical" means for the data shape).
 - `H` is the hash function declared by the proof profile.
 
-The default hash function in the TruthAnchor reference deployment and the
-OCP extraction rule for EVM is `SHA-256`. Implementers may use any hash
-function as long as the proof profile declares it and the verifier uses
-the same function in step 2 of §12.2.
+The default hash function in the TruthAnchor reference deployment and the OCP extraction rule for EVM is `SHA-256`. Implementers may use any hash function as long as the proof profile declares it and the verifier uses the same function in step 2 of the five-step verification path.
 
-This profile carries no input-provenance metadata; the observation hash is
-opaque to anyone without the observation bytes.
+This profile carries no input-provenance metadata; the observation hash is opaque to anyone without the observation bytes.
 
-### A.2 Profile: Input-provenance with identity sentinel
+**Profile: Input-provenance with identity sentinel**
 
-When the proof profile records *how an input was prepared* in addition to
-*what was committed*, the input-provenance construction makes the
-preparation pipeline visible to the verifier without leaking the raw
-input.
+When the proof profile records *how an input was prepared* in addition to *what was committed*, the input-provenance construction makes the preparation pipeline visible to the verifier without leaking the raw input.
 
 The construction names two hashes inside the canonical observation bytes:
 
@@ -451,16 +268,13 @@ The pipeline itself is recorded by a third hash:
 
 - `sanitization_pipeline_hash` — `H(canonical_pipeline_descriptor_bytes)`.
 
-When no sanitization pipeline is applied (the pass-through case), the
-profile uses a fixed pass-through constant called the *identity sentinel*:
+When no sanitization pipeline is applied (the pass-through case), the profile uses a fixed pass-through constant called the *identity sentinel*:
 
 ```
 IDENTITY_SENTINEL = 8116eec29078e8f57c07077d5e8080a35bde73036581df3abb93755d1b1a16ea
 ```
 
-(`SHA-256` of the identity spec string; surfaced by Tiago Merlini in the
-ERC-8263 ↔ ERC-8004 alignment thread and adopted in the OCP extraction
-rule as the canonical pass-through constant.)
+(`SHA-256` of the identity spec string; surfaced by Tiago Merlini in the alignment thread and adopted in the OCP extraction rule as the canonical pass-through constant.)
 
 A verifier of this profile checks:
 
@@ -471,44 +285,30 @@ else:
     verify the transformation against the declared pipeline descriptor
 ```
 
-A verifier that does not implement this branch will incorrectly reject
-every pass-through execution. The branching rule is part of the profile,
-not of ERC-8263 itself; the on-chain `proofHash` remains opaque
-`bytes32`.
+A verifier that does not implement this branch will incorrectly reject every pass-through execution. The branching rule is part of the profile, not of this ERC itself; the on-chain `proofHash` remains opaque `bytes32`.
 
-### A.3 Profile: Merkle batch root
+**Profile: Merkle batch root**
 
 ```
 proofHash = merkleRoot([H(observation_1), H(observation_2), ..., H(observation_n)])
 ```
 
-A single ERC-8263 anchor commits to a batch of observations through the
-Merkle root of their individual hashes. A verifier of this profile
-recomputes the root from the leaves it cares about and checks inclusion
-against the on-chain `proofHash`. The contract is unaware that the
-`proofHash` is a Merkle root; the profile carries that semantics.
+A single anchor commits to a batch of observations through the Merkle root of their individual hashes. A verifier of this profile recomputes the root from the leaves it cares about and checks inclusion against the on-chain `proofHash`. The contract is unaware that the `proofHash` is a Merkle root; the profile carries that semantics.
 
-### A.4 Profile selection is off-chain
+**Profile selection is off-chain**
 
-Across all three profiles above, the on-chain `proofHash` field is the
-same opaque `bytes32`. The contract performs no profile detection. A
-verifier that does not know which profile produced a given `proofHash`
-cannot verify the anchor without out-of-band profile metadata; the
-profile is declared by the issuer, typically through the `aux` field
-defined in §2 or through a higher-layer envelope referenced by `aux`.
+Across all three profiles above, the on-chain `proofHash` field is the same opaque `bytes32`. The contract performs no profile detection. A verifier that does not know which profile produced a given `proofHash` cannot verify the anchor without out-of-band profile metadata; the profile is declared by the issuer, typically through an auxiliary field or through a higher-layer envelope.
 
-Future revisions of this appendix may add new profiles. The core ERC-8263
-contract is unaffected by any such addition.
+Future revisions of this appendix may add new profiles. The core contract is unaffected by any such addition.
 
----
+**Cross-standard alignment confirmed pre-submission:**
 
-## Changelog
+- Tiago Merlini ([ERC-8004](./eip-8004.md)): all sections that touch [ERC-8004](./eip-8004.md) or his work, green-lit; the second paragraph of the verifier observability reference applied verbatim from him.
+- Damon Zwicker (OCP): OCP Boundary Note verbatim boundary quote + identity sentinel pass-through constant reference, reviewed.
 
-- **2026-05-26** (v0.2 draft): Added §10 (Compatibility with ERC-8004),
-  §11 (Compatible Identity Registries), §12 (Independent Verification),
-  §13 (OCP Boundary Note), and Appendix A (Recommended proofHash
-  Constructions). All five additions are informative; no changes to the
-  contract surface, canonical event, scheme registry, or topic0.
+Companion Composition Note (descriptive co-implementer guide, not normative): https://gist.github.com/TruthAnchor-AI/8742e742bdc627b8e2179c00b81289dc
+
+Related: [ERC-8274](./eip-8274.md) (Jimmy Shi, AI Inference Proof Verification Interfaces — ERC# assigned 2026-05-26). Cross-references to be tightened in a follow-up revision once [ERC-8274](./eip-8274.md) v0.1 is published; not in v0.2 scope to avoid coupling timelines.
 
 ## Copyright
 

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -120,6 +120,396 @@ Implementations MUST NOT store original action content on-chain — only the SHA
 
 The agent_id field MUST be validated against the [ERC-8004](./eip-8004.md) registry before reputation aggregation; unverified IDs MUST be flagged.
 
+
+---
+
+## 10. Compatibility with ERC-8004
+
+This section is **informative**. It describes a compatibility profile for
+deployments that compose ERC-8263 anchors with [ERC-8004 (Agent Identity
+Registry)][erc-8004] identities. It introduces no new normative requirements
+on the ERC-8263 contract surface; the canonical event in §2 and the scheme
+registry in §3 are unchanged.
+
+ERC-8263 is identity-registry-agnostic by construction: the canonical event
+carries `(agentIdScheme, agentId)` as opaque bytes and assigns no on-chain
+meaning beyond the scheme registry. ERC-8004 is one such registry, and the
+two standards compose cleanly when an implementer chooses to use both.
+
+### 10.1 Scheme `0x01` compatibility bridge
+
+When an implementation chooses to populate ERC-8263 anchors with ERC-8004
+identities under `agentIdScheme = 0x01` (REGISTRY), the recommended
+encoding of the 32-byte `agentId` payload is a zero-padded ERC-8004
+record id:
+
+```
+agentId = bytes32(uint256(agentId8004))
+```
+
+Equivalently in Solidity:
+
+```solidity
+bytes32 agentId = bytes32(uint256(agentId8004));
+```
+
+This is the canonical compatibility bridge between the two standards'
+on-chain representations. It is offered as a recommendation, not a
+mandatory path: ERC-8263 anchors do not require an ERC-8004 record,
+and ERC-8004 is one of several registries that can populate scheme
+`0x01`. The contract accepts any 32-byte `agentId`; tooling that
+resolves scheme `0x01` anchors against an ERC-8004 registry should
+apply this cast for round-trip consistency. Future revisions may
+refine this compatibility profile as ERC-8004 stabilizes.
+
+### 10.2 Resolution direction
+
+Resolution is one-way at the protocol layer. An ERC-8263 anchor with
+scheme `0x01` can reference an ERC-8004 record; ERC-8004 does not need
+to reference ERC-8263 in return. ERC-8004 records carry no contract-layer
+back-reference to their ERC-8263 anchors, and ERC-8263 does not ask
+ERC-8004 to add one. Indexers that want a bidirectional view can build a
+reverse index off-chain from the `AnchorProof` event log.
+
+### 10.3 Identity vs commitment separation
+
+ERC-8004 governs *who the agent is*. ERC-8263 governs *what the agent
+committed to on-chain*. The two standards are deliberately separable:
+
+- An ERC-8263 anchor with `agentIdScheme = 0x00` (ANONYMOUS) is a valid
+  anchor with no identity-registry dependency.
+- An ERC-8263 anchor with `agentIdScheme = 0x02` (URI_HASH) binds to an
+  off-chain canonical identity and does not require an ERC-8004 record.
+- Future schemes allocated in the `0x03+` reserved range may bind to
+  other identity systems (e.g., DID methods) without disturbing the
+  ERC-8004 compatibility profile in §10.1.
+- An ERC-8004 record can exist without any ERC-8263 anchors against it.
+
+Implementations that choose to compose registered identity (ERC-8004) with
+on-chain commitment (ERC-8263) should verify each layer independently;
+neither standard's validity check substitutes for the other's.
+
+[erc-8004]: https://eips.ethereum.org/EIPS/eip-8004
+
+---
+
+## 11. Compatible Identity Registries
+
+This section is **informative**. It generalizes §10 to any identity registry
+that an implementer might compose with ERC-8263 anchors, and describes an
+optional off-chain convention for resolving `(agentIdScheme, agentId)` back
+to a wallet address. It introduces no new contract interface; ERC-8263's
+canonical event and scheme registry are unchanged.
+
+### 11.1 Why generalize
+
+The scheme registry in §3 is intentionally identity-system-agnostic. Scheme
+`0x01` is reserved for "REGISTRY" without naming a specific registry, so the
+same anchor format can compose with ERC-8004, with other on-chain agent
+registries (proprietary or future-standard), and with registry adapters that
+front external identity systems. This section describes the shape of a
+compatible registry, not which registry to use.
+
+### 11.2 Recommended resolution interface
+
+A registry is considered compatible with ERC-8263 scheme `0x01` when it
+exposes a resolution function with the following shape:
+
+```solidity
+interface IAgentWalletResolver {
+    /// @return wallet The address that controls the agent record, or
+    ///         address(0) if the agentId is unknown to this resolver.
+    function getAgentWallet(bytes32 agentId) external view returns (address wallet);
+}
+```
+
+`getAgentWallet` is the minimal convention an indexer or verifier needs to
+move from an ERC-8263 anchor's `(agentIdScheme = 0x01, agentId)` pair to an
+authoritative wallet for that agent. The recommendation is `should`, not
+`must`: registries may expose richer interfaces (e.g., ERC-8004's full
+agent record), and verifiers that only need to display an anchor without
+resolving identity can ignore the registry entirely.
+
+The function lives at the registry, not at the ERC-8263 contract. ERC-8263
+does not call into registries on-chain and does not depend on any specific
+registry being deployed.
+
+### 11.3 Off-chain resolution flow
+
+A typical off-chain resolution flow for a scheme `0x01` anchor is:
+
+1. Read the `AnchorProof` event log from a node (chain-state-only).
+2. Parse `(agentIdScheme, agentId)` from the event topics.
+3. If `agentIdScheme == 0x01`, look up the registry the implementation has
+   bound to scheme `0x01` (a tooling-side choice; ERC-8263 does not encode
+   the registry address on-chain in scheme `0x01`).
+4. Call `registry.getAgentWallet(agentId)` against that registry.
+5. Use the returned wallet for any downstream check the verifier cares
+   about (signature verification, reputation lookup, display).
+
+Each step is independent and any verifier may stop at step 2 if it only
+needs to display the anchor.
+
+### 11.4 Reference implementation
+
+A live reference implementation of this flow exists at
+[`gateway.ensub.org`](https://gateway.ensub.org) (operated by Tiago Merlini
+in the ERC-8004 working group). It exposes an HTTP attestation endpoint
+keyed on `(registry, agentId)` and demonstrates the off-chain resolution
+flow above against an ERC-8004 registry. ERC-8263 does not require this
+gateway or any other gateway; it is cited here as evidence that the
+compatibility profile in §10 and §11 is implementable end-to-end.
+
+---
+
+## 12. Independent Verification
+
+This section is **informative**. It describes how an ERC-8263 anchor can be
+verified end-to-end using chain state alone, with no dependency on the
+issuing service, the indexer, or any hosted gateway. It introduces no new
+contract interface; verification is a property of the published event data
+and is performed entirely by the verifier.
+
+### 12.1 What "independent" means here
+
+A verification step is *independent* when it relies only on:
+
+- the verifier's own copy of the observation (or a hash of it),
+- the verifier's own access to a node serving the relevant chain, and
+- the verifier's own implementation of the declared hash function.
+
+It does *not* depend on the operator that issued the anchor, the indexer
+that surfaced it, or any HTTP gateway in between. The verifier may use
+those services for convenience, but the verification result is identical
+when none of them are reachable, as long as the chain is.
+
+### 12.2 Five-step verification path
+
+The following path is the canonical independent-verification flow,
+borrowed verbatim from the *Composition Note: ERC-8004 + ERC-8263 + OCP*
+(co-authored by Vincent Wu and Damon Zwicker):
+
+1. Verifier receives: `observation` + an ERC-8263 anchor reference
+   (`txHash` + `logIndex`, or any equivalent locator).
+2. `H′ = H(observation)` — recomputed independently using the hash
+   function declared by the proof profile in use (see Appendix A).
+3. `H′ == proofHash` — compared against the `proofHash` value carried
+   in the `AnchorProof` event at the referenced log.
+4. `proofHash ∈ R(tx)` — confirmed in the raw transaction receipt by
+   re-parsing the event log from a node, without trusting any indexer.
+5. `agentId` is resolved according to `agentIdScheme`: for `0x01`,
+   resolution goes through a compatible registry per §11; for `0x02`,
+   `agentId == keccak256(canonical agent URI)`; for `0x00`, no identity
+   resolution applies.
+
+The result is an independent, system-agnostic statement that this agent
+committed this observation at this moment on this chain.
+
+### 12.3 Layer optionality
+
+The five steps above are independently optional: a verifier that only
+needs to confirm digest inclusion can stop at step 4; a verifier that
+needs identity attribution continues to step 5. Implementations that
+publish both an on-chain commitment and a higher-layer signature over the
+same observation may show a visible gap between the two surfaces, because
+some executions get signed before the on-chain commitment confirms. That
+gap is designed-in optionality rather than inconsistency. As observed by
+Tiago Merlini in the ERC-8263 ↔ ERC-8004 alignment thread:
+
+> The L3/L4 gap (10 vs 13) is visible and expected, some executions got
+> signed before the OCP anchor confirmed. Worth noting for implementers:
+> L3 and L4 are independently optional by design, as specced in the
+> appendix.
+
+This gap is visible by construction and can be surfaced by verifiers.
+
+### 12.4 Verifier observability reference
+
+A live admin attestation dashboard at the
+[`gateway.ensub.org`](https://gateway.ensub.org) reference implementation
+shows the five-step path running against production traffic: per-row
+identity sentinel badges (see Appendix A.2), L3 badges that resolve
+directly to a block explorer for the underlying transaction, and a visible
+L3/L4 gap framed per §12.3. ERC-8263 does not require this dashboard or
+any other dashboard; it is cited as a worked example of the independent
+verification path running end-to-end.
+
+The address recovered from the l4_signature field resolves to the
+gateway's attestor key, the address registered as the agent's hot wallet
+via getAgentWallet(agentId) in the ERC-8004 registry. This key is
+controlled by the gateway operator, not the token owner; ownership of the
+ERC-8004 NFT and attestation of execution are intentionally separated, and
+an agent may migrate gateways by updating the hot wallet registration
+without transferring the token. Verification of L4 therefore confirms
+which infrastructure attested the execution, not that the agent signed for
+itself. The trustless floor remains L3: input_hash anchored on-chain via
+OCP is independently verifiable from any public RPC with no trust
+assumptions beyond the chain itself.
+
+---
+
+## 13. OCP Boundary Note
+
+This section is **informative**. It clarifies what ERC-8263 does and does
+not bundle from the [Observation Commitment Protocol (OCP)][ocp], to
+prevent implementers from conflating the two.
+
+### 13.1 What OCP is, and what it is not
+
+OCP is a profile-level description of how a committed digest is verified
+against raw chain state. It defines the extraction rule that takes a
+transaction receipt to the set of OCP digests carried by ERC-8263 anchors
+in that receipt (see Appendix A.1). Quoting Damon Zwicker, OCP author:
+
+> OCP does not define identity, authorship, sanitization, or data
+> availability.
+
+ERC-8263 makes the same separation explicit at the contract layer:
+ERC-8263 commits a `proofHash`, and the contract enforces only that the
+hash is non-zero and the event is well-formed. The interpretation of what
+that hash commits to lives in a proof profile, not in ERC-8263 itself.
+
+### 13.2 ERC-8263 does not embed OCP
+
+ERC-8263 does not import an OCP verification interface, does not require
+OCP-compatible verifiers, and does not assume an OCP-shaped verifier is
+deployed. Every ERC-8263 anchor is OCP-extractable by construction (the
+extraction rule in Appendix A.1 is a function of the event topology
+already defined in §2), but ERC-8263 anchors remain valid for verifiers
+that ignore OCP entirely and check `proofHash` against their own profile.
+
+The relationship is one-way: OCP can describe a verifier for ERC-8263
+anchors; ERC-8263 does not require any verifier to be OCP-shaped.
+
+### 13.3 Out-of-scope boundary
+
+The following table makes the boundary explicit:
+
+| Concern | In scope for ERC-8263 | Out of scope (left to profile / adjacent standard) |
+|---|---|---|
+| Event shape, scheme registry | ✓ | — |
+| Non-zero `proofHash` enforcement | ✓ | — |
+| Identity resolution | — | ERC-8004 / §10 / §11 |
+| Authorship / signature binding | — | proof profile / wallet signature layer |
+| Input sanitization, pipeline disclosure | — | proof profile / Appendix A.2 |
+| Data availability of the underlying observation | — | proof profile / off-chain layer |
+| Independent verification procedure | — | OCP / §12 |
+
+[ocp]: https://github.com/damonzwicker/observation-commitment-protocol
+
+---
+
+## Appendix A. Recommended proofHash Constructions
+
+This appendix is **informative**. It describes constructions an implementer
+may use to populate the `proofHash` field of an ERC-8263 anchor. The core
+ERC-8263 contract treats `proofHash` as opaque `bytes32` and enforces only
+that it is non-zero. Every construction in this appendix is a profile;
+none of them is part of the contract surface, and a verifier may use any
+construction, including one not listed here, as long as the construction
+is declared in the proof profile in use.
+
+The contract performs no hash-function negotiation, no algorithm
+disclosure, and no profile registry on-chain. Profile selection is an
+agreement between the issuer and the verifier; the chain holds only the
+opaque `bytes32`.
+
+### A.1 Profile: Single observation digest (default)
+
+```
+proofHash = H(canonical_observation_bytes)
+```
+
+Where:
+
+- `canonical_observation_bytes` is the canonical byte serialization of the
+  observation the agent committed to (the proof profile defines what
+  "canonical" means for the data shape).
+- `H` is the hash function declared by the proof profile.
+
+The default hash function in the TruthAnchor reference deployment and the
+OCP extraction rule for EVM is `SHA-256`. Implementers may use any hash
+function as long as the proof profile declares it and the verifier uses
+the same function in step 2 of §12.2.
+
+This profile carries no input-provenance metadata; the observation hash is
+opaque to anyone without the observation bytes.
+
+### A.2 Profile: Input-provenance with identity sentinel
+
+When the proof profile records *how an input was prepared* in addition to
+*what was committed*, the input-provenance construction makes the
+preparation pipeline visible to the verifier without leaking the raw
+input.
+
+The construction names two hashes inside the canonical observation bytes:
+
+- `raw_input_hash` — `H(raw_input_bytes)` before any pipeline step.
+- `input_hash` — `H(canonical_input_bytes_after_pipeline)`.
+
+The pipeline itself is recorded by a third hash:
+
+- `sanitization_pipeline_hash` — `H(canonical_pipeline_descriptor_bytes)`.
+
+When no sanitization pipeline is applied (the pass-through case), the
+profile uses a fixed pass-through constant called the *identity sentinel*:
+
+```
+IDENTITY_SENTINEL = 8116eec29078e8f57c07077d5e8080a35bde73036581df3abb93755d1b1a16ea
+```
+
+(`SHA-256` of the identity spec string; surfaced by Tiago Merlini in the
+ERC-8263 ↔ ERC-8004 alignment thread and adopted in the OCP extraction
+rule as the canonical pass-through constant.)
+
+A verifier of this profile checks:
+
+```
+if sanitization_pipeline_hash == IDENTITY_SENTINEL:
+    require raw_input_hash == input_hash         # pass-through invariant
+else:
+    verify the transformation against the declared pipeline descriptor
+```
+
+A verifier that does not implement this branch will incorrectly reject
+every pass-through execution. The branching rule is part of the profile,
+not of ERC-8263 itself; the on-chain `proofHash` remains opaque
+`bytes32`.
+
+### A.3 Profile: Merkle batch root
+
+```
+proofHash = merkleRoot([H(observation_1), H(observation_2), ..., H(observation_n)])
+```
+
+A single ERC-8263 anchor commits to a batch of observations through the
+Merkle root of their individual hashes. A verifier of this profile
+recomputes the root from the leaves it cares about and checks inclusion
+against the on-chain `proofHash`. The contract is unaware that the
+`proofHash` is a Merkle root; the profile carries that semantics.
+
+### A.4 Profile selection is off-chain
+
+Across all three profiles above, the on-chain `proofHash` field is the
+same opaque `bytes32`. The contract performs no profile detection. A
+verifier that does not know which profile produced a given `proofHash`
+cannot verify the anchor without out-of-band profile metadata; the
+profile is declared by the issuer, typically through the `aux` field
+defined in §2 or through a higher-layer envelope referenced by `aux`.
+
+Future revisions of this appendix may add new profiles. The core ERC-8263
+contract is unaffected by any such addition.
+
+---
+
+## Changelog
+
+- **2026-05-26** (v0.2 draft): Added §10 (Compatibility with ERC-8004),
+  §11 (Compatible Identity Registries), §12 (Independent Verification),
+  §13 (OCP Boundary Note), and Appendix A (Recommended proofHash
+  Constructions). All five additions are informative; no changes to the
+  contract surface, canonical event, scheme registry, or topic0.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -1,9 +1,9 @@
 ---
-eip: 8888
-title: On-Chain Proof Layer for AI Agents
+eip: 8263
+title: Onchain Proof Layer for AI Agents
 description: Anchor AI agent actions to Ethereum with cryptographic proofs and verifiable identity registry.
 author: Vincent Wu (@VincentWu) <1@truthanchor.biz>
-discussions-to: https://ethereum-magicians.org/t/the-big-introduce-yourself-thread/75
+discussions-to: https://github.com/ethereum/ERCs/pull/1748
 status: Draft
 type: Standards Track
 category: ERC
@@ -83,7 +83,9 @@ No backwards compatibility issues as this is a new proposal.
 
 ## Reference Implementation
 
-A reference implementation is deployed at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 (Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet).
+A live reference implementation is available at https://truthanchor.biz 
+with deployed contracts at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 
+(Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet).
 
 ## Security Considerations
 

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -104,9 +104,13 @@ No backwards compatibility issues as this is a new proposal.
 ## Reference Implementation
 
 
-A reference implementation has been deployed on the following networks:
-- **Ethereum Mainnet**: `0x68551e56067F96173B063167191E09477013876F`
-- **Sepolia Testnet**: `0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989`
+Contracts deployed on:
+
+- Ethereum Mainnet: `0x68551e56067F96173B063167191E09477013876F`
+- Sepolia Testnet: `0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989`
+- Polygon, Base, BSC Mainnet: `0x87dd3A56AFD0D2c488aD7E13fB036b59144b25dC` (deterministic cross-chain deployment, identical contract address across all three)
+
+As of May 2026, the reference implementation has anchored 700+ confirmed proofs across 5 chains. All anchors are publicly verifiable on the corresponding block explorers.
 
 
 ## Security Considerations
@@ -114,11 +118,8 @@ A reference implementation has been deployed on the following networks:
 
 Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
 
-
 The agent_id field MUST be validated against the [ERC-8004](./eip-8004.md) registry before reputation aggregation; unverified IDs MUST be flagged.
-
 
 ## Copyright
 
-
-Copyright and related rights waived via [CC0](../LICENSE).
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -149,7 +149,7 @@ No backwards compatibility issues: this is a new proposal and defines a new even
 
 Reference contracts verified on Etherscan, both implementing the interface above:
 
-- Ethereum Mainnet: `0xe95d6a15966984c209a62a2c188828555eb5ec3d` ([source](https://etherscan.io/address/0xe95d6a15966984c209a62a2c188828555eb5ec3d#code))
+- Ethereum Mainnet: `0xe95d6a15966984c209a62a2c188828555eb5ec3d` (source: etherscan.io/address/0xe95d6a15966984c209a62a2c188828555eb5ec3d#code)
 - Sepolia Testnet: `0x89EE9b68c3b2f50cbE9D0fC4Dc134939a0475c1C`
 
 Both deployments emit the `AnchorProof` event with the topic0 above and accept the two entrypoints unchanged. Independent verifiers can confirm the contract surface by reading the verified source on the linked block explorers.
@@ -262,13 +262,13 @@ This ERC is a write-side standard: it defines how an anchor is emitted on-chain.
 > OCP does not define identity, authorship, sanitization, or data availability. It defines an extraction interface for observation commitments and a re-checkable digest profile over them. Composition with identity layers, signing layers, or anchoring layers is out of OCP's scope.
 > — Damon Zwicker (OCP author)
 
-#### ERC-8263 does not embed OCP
+#### This ERC does not embed OCP
 
 This ERC does not import an OCP verification interface, does not require OCP-compatible verifiers, and does not assume an OCP-shaped verifier is deployed. Every anchor is OCP-extractable by construction (the extraction rule is a function of the event topology already defined in *Canonical Event*), but anchors remain valid for verifiers that ignore OCP entirely and check `proofHash` against their own profile.
 
 #### Out-of-scope boundary
 
-| Concern                                  | In ERC-8263 scope | Handled by adjacent layer |
+| Concern                                  | In scope for this ERC | Handled by adjacent layer |
 |:--|:-:|:-:|
 | Event shape, scheme registry             | ✓ | — |
 | Identity binding under scheme `0x01`     | — | identity registry ([ERC-8004](./eip-8004.md) and compatible) |
@@ -298,7 +298,7 @@ preImage = canonical_encode({
 proofHash = H(preImage)
 ```
 
-`identitySentinel` is a profile-level constant (recommended value: `IDENTITY_SENTINEL = keccak256("erc-8263.identity.passthrough.v1")`) used to mark pre-images in which identity is intentionally pass-through rather than bound at the commitment layer. Verifiers MUST branch on the sentinel: when present, identity is resolved at the chain layer via `(agentIdScheme, agentId)` and the pre-image identity slot carries the sentinel value verbatim; when absent, identity is bound at the commitment layer and the slot carries the binding payload directly. This invariant prevents silent identity confusion across implementations of the same profile.
+`identitySentinel` is a profile-level constant (recommended value: `IDENTITY_SENTINEL = keccak256("identity.passthrough.v1")`) used to mark pre-images in which identity is intentionally pass-through rather than bound at the commitment layer. Verifiers MUST branch on the sentinel: when present, identity is resolved at the chain layer via `(agentIdScheme, agentId)` and the pre-image identity slot carries the sentinel value verbatim; when absent, identity is bound at the commitment layer and the slot carries the binding payload directly. This invariant prevents silent identity confusion across implementations of the same profile.
 
 #### Profile: Merkle batch root
 

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -2,7 +2,7 @@
 eip: 8263
 title: Onchain Proof Layer for AI Agents
 description: Anchor AI agent actions to Ethereum with cryptographic proofs and verifiable identity registry.
-author: Vincent Wu (@TruthAnchor-AI) <wuxiaoyu8816@gmail.com>
+author: Vincent Wu (@TruthAnchor-AI)
 discussions-to: https://ethereum-magicians.org/t/erc-8263-onchain-proof-layer-for-ai-agents/28577
 status: Draft
 type: Standards Track

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -97,13 +97,11 @@ Implementations MUST NOT store original action content on-chain — only the SHA
 
 The agent_id field MUST be validated against the [ERC-8004](./eip-8004.md) registry before reputation aggregation; unverified IDs MUST be flagged.
 
-## Appendix: Compatibility and Verification Notes
-
-This appendix is **informative**. It describes how this ERC composes with adjacent standards and how anchors can be independently verified. It introduces no new normative requirements on the contract surface; the canonical event and the scheme registry are unchanged.
+The following subsections are **informative**. They describe how this ERC composes with adjacent standards and how anchors can be independently verified. They introduce no new normative requirements on the contract surface; the canonical event and the scheme registry are unchanged.
 
 ### Compatibility with [ERC-8004](./eip-8004.md)
 
-This section describes a compatibility profile for deployments that compose anchors with [ERC-8004](./eip-8004.md) (Agent Identity Registry) identities.
+This subsection describes a compatibility profile for deployments that compose anchors with [ERC-8004](./eip-8004.md) (Agent Identity Registry) identities.
 
 This ERC is identity-registry-agnostic by construction: the canonical event carries `(agentIdScheme, agentId)` as opaque bytes and assigns no on-chain meaning beyond the scheme registry. [ERC-8004](./eip-8004.md) is one such registry, and the two standards compose cleanly when an implementer chooses to use both.
 
@@ -140,7 +138,7 @@ Implementations that choose to compose registered identity ([ERC-8004](./eip-800
 
 ### Compatible Identity Registries
 
-This section generalizes the above to any identity registry that an implementer might compose with anchors, and describes an optional off-chain convention for resolving `(agentIdScheme, agentId)` back to a wallet address.
+This subsection generalizes the above to any identity registry that an implementer might compose with anchors, and describes an optional off-chain convention for resolving `(agentIdScheme, agentId)` back to a wallet address.
 
 The scheme registry is intentionally identity-system-agnostic. Scheme `0x01` is reserved for "REGISTRY" without naming a specific registry, so the same anchor format can compose with [ERC-8004](./eip-8004.md), with other on-chain agent registries (proprietary or future-standard), and with registry adapters that front external identity systems.
 
@@ -172,11 +170,11 @@ A typical off-chain resolution flow for a scheme `0x01` anchor is:
 
 Each step is independent and any verifier may stop at step 2 if it only needs to display the anchor.
 
-A live reference implementation of this flow exists at https://gateway.ensub.org (operated by Tiago Merlini in the [ERC-8004](./eip-8004.md) working group). It exposes an HTTP attestation endpoint keyed on `(registry, agentId)` and demonstrates the off-chain resolution flow above against an [ERC-8004](./eip-8004.md) registry. This ERC does not require this gateway or any other gateway; it is cited here as evidence that the compatibility profile is implementable end-to-end.
+A live reference implementation of this flow exists at gateway.ensub.org (operated by Tiago Merlini in the [ERC-8004](./eip-8004.md) working group). It exposes an HTTP attestation endpoint keyed on `(registry, agentId)` and demonstrates the off-chain resolution flow above against an [ERC-8004](./eip-8004.md) registry. This ERC does not require this gateway or any other gateway; it is cited here as evidence that the compatibility profile is implementable end-to-end.
 
 ### Independent Verification
 
-This section describes how an anchor can be verified end-to-end using chain state alone, with no dependency on the issuing service, the indexer, or any hosted gateway.
+This subsection describes how an anchor can be verified end-to-end using chain state alone, with no dependency on the issuing service, the indexer, or any hosted gateway.
 
 A verification step is *independent* when it relies only on:
 
@@ -203,13 +201,13 @@ The five steps above are independently optional: a verifier that only needs to c
 > L3 and L4 are independently optional by design, as specced in the
 > appendix.
 
-A live admin attestation dashboard at https://gateway.ensub.org shows the five-step path running against production traffic. This ERC does not require this dashboard or any other dashboard; it is cited as a worked example of the independent verification path running end-to-end.
+A live admin attestation dashboard at gateway.ensub.org shows the five-step path running against production traffic. This ERC does not require this dashboard or any other dashboard; it is cited as a worked example of the independent verification path running end-to-end.
 
 The address recovered from the l4_signature field resolves to the gateway's attestor key, the address registered as the agent's hot wallet via getAgentWallet(agentId) in the [ERC-8004](./eip-8004.md) registry. This key is controlled by the gateway operator, not the token owner; ownership of the [ERC-8004](./eip-8004.md) NFT and attestation of execution are intentionally separated, and an agent may migrate gateways by updating the hot wallet registration without transferring the token. Verification of L4 therefore confirms which infrastructure attested the execution, not that the agent signed for itself. The trustless floor remains L3: input_hash anchored on-chain via OCP is independently verifiable from any public RPC with no trust assumptions beyond the chain itself.
 
 ### OCP Boundary Note
 
-This section clarifies what this ERC does and does not bundle from the Observation Commitment Protocol (OCP) at https://github.com/damonzwicker/observation-commitment-protocol, to prevent implementers from conflating the two.
+This subsection clarifies what this ERC does and does not bundle from the Observation Commitment Protocol (OCP) at github.com/damonzwicker/observation-commitment-protocol, to prevent implementers from conflating the two.
 
 OCP is a profile-level description of how a committed digest is verified against raw chain state. It defines the extraction rule that takes a transaction receipt to the set of OCP digests carried by anchors in that receipt (see Recommended proofHash Constructions below). Quoting Damon Zwicker, OCP author:
 
@@ -226,8 +224,8 @@ The following table makes the boundary explicit:
 
 | Concern | In scope for this ERC | Out of scope (left to profile / adjacent standard) |
 |---|---|---|
-| Event shape, scheme registry | ✓ | — |
-| Non-zero `proofHash` enforcement | ✓ | — |
+| Event shape, scheme registry | Yes | — |
+| Non-zero `proofHash` enforcement | Yes | — |
 | Identity resolution | — | [ERC-8004](./eip-8004.md) / Compatible Identity Registries |
 | Authorship / signature binding | — | proof profile / wallet signature layer |
 | Input sanitization, pipeline disclosure | — | proof profile / Recommended proofHash Constructions |
@@ -236,7 +234,7 @@ The following table makes the boundary explicit:
 
 ### Recommended proofHash Constructions
 
-This section describes constructions an implementer may use to populate the `proofHash` field. The core contract treats `proofHash` as opaque `bytes32` and enforces only that it is non-zero. Every construction here is a profile; none of them is part of the contract surface, and a verifier may use any construction, including one not listed here, as long as the construction is declared in the proof profile in use.
+This subsection describes constructions an implementer may use to populate the `proofHash` field. The core contract treats `proofHash` as opaque `bytes32` and enforces only that it is non-zero. Every construction here is a profile; none of them is part of the contract surface, and a verifier may use any construction, including one not listed here, as long as the construction is declared in the proof profile in use.
 
 The contract performs no hash-function negotiation, no algorithm disclosure, and no profile registry on-chain. Profile selection is an agreement between the issuer and the verifier; the chain holds only the opaque `bytes32`.
 
@@ -251,7 +249,7 @@ Where:
 - `canonical_observation_bytes` is the canonical byte serialization of the observation the agent committed to (the proof profile defines what "canonical" means for the data shape).
 - `H` is the hash function declared by the proof profile.
 
-The default hash function in the TruthAnchor reference deployment and the OCP extraction rule for EVM is `SHA-256`. Implementers may use any hash function as long as the proof profile declares it and the verifier uses the same function in step 2 of the five-step verification path.
+The default hash function in the TruthAnchor reference deployment and the OCP extraction rule for EVM is SHA-256. Implementers may use any hash function as long as the proof profile declares it and the verifier uses the same function in step 2 of the five-step verification path.
 
 This profile carries no input-provenance metadata; the observation hash is opaque to anyone without the observation bytes.
 
@@ -274,7 +272,7 @@ When no sanitization pipeline is applied (the pass-through case), the profile us
 IDENTITY_SENTINEL = 8116eec29078e8f57c07077d5e8080a35bde73036581df3abb93755d1b1a16ea
 ```
 
-(`SHA-256` of the identity spec string; surfaced by Tiago Merlini in the alignment thread and adopted in the OCP extraction rule as the canonical pass-through constant.)
+(SHA-256 of the identity spec string; surfaced by Tiago Merlini in the alignment thread and adopted in the OCP extraction rule as the canonical pass-through constant.)
 
 A verifier of this profile checks:
 
@@ -299,16 +297,13 @@ A single anchor commits to a batch of observations through the Merkle root of th
 
 Across all three profiles above, the on-chain `proofHash` field is the same opaque `bytes32`. The contract performs no profile detection. A verifier that does not know which profile produced a given `proofHash` cannot verify the anchor without out-of-band profile metadata; the profile is declared by the issuer, typically through an auxiliary field or through a higher-layer envelope.
 
-Future revisions of this appendix may add new profiles. The core contract is unaffected by any such addition.
+Future revisions of this subsection may add new profiles. The core contract is unaffected by any such addition.
 
-**Cross-standard alignment confirmed pre-submission:**
+Cross-standard alignment confirmed pre-submission: Tiago Merlini ([ERC-8004](./eip-8004.md)): all sections that touch [ERC-8004](./eip-8004.md) or his work, green-lit; the second paragraph of the verifier observability reference applied verbatim from him. Damon Zwicker (OCP): OCP Boundary Note verbatim boundary quote and identity sentinel pass-through constant reference, reviewed.
 
-- Tiago Merlini ([ERC-8004](./eip-8004.md)): all sections that touch [ERC-8004](./eip-8004.md) or his work, green-lit; the second paragraph of the verifier observability reference applied verbatim from him.
-- Damon Zwicker (OCP): OCP Boundary Note verbatim boundary quote + identity sentinel pass-through constant reference, reviewed.
+Companion Composition Note (descriptive co-implementer guide, not normative): gist.github.com/TruthAnchor-AI/8742e742bdc627b8e2179c00b81289dc
 
-Companion Composition Note (descriptive co-implementer guide, not normative): https://gist.github.com/TruthAnchor-AI/8742e742bdc627b8e2179c00b81289dc
-
-Related: [ERC-8274](./eip-8274.md) (Jimmy Shi, AI Inference Proof Verification Interfaces — ERC# assigned 2026-05-26). Cross-references to be tightened in a follow-up revision once [ERC-8274](./eip-8274.md) v0.1 is published; not in v0.2 scope to avoid coupling timelines.
+Related: [ERC-8274](./eip-8274.md) (Jimmy Shi, AI Inference Proof Verification Interfaces, ERC# assigned 2026-05-26). Cross-references to be tightened in a follow-up revision once [ERC-8274](./eip-8274.md) v0.1 is published; not in v0.2 scope to avoid coupling timelines.
 
 ## Copyright
 

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -10,21 +10,30 @@ category: ERC
 created: 2026-05-14
 ---
 
+
 ## Abstract
+
 
 This proposal specifies a minimal on-chain proof layer for AI agents. It allows agents to anchor their actions (decisions, outputs, or state transitions) to the Ethereum blockchain by submitting a cryptographic commitment (SHA-256 hash). This creates a verifiable, immutable timeline of agent activity, enabling trustless auditing and reputation systems for autonomous agents.
 
+
 ## Motivation
+
 
 As AI agents increasingly perform high-value tasks (e.g., DeFi trading, content creation, governance voting), there is a critical need for a standard way to prove that an agent performed a specific action at a specific time. Current agent activities are often opaque or stored in centralized databases. Implementations provide a decentralized "black box recorder" for AI agents, ensuring that their history cannot be retroactively altered.
 
+
 ## Specification
+
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
+
 ### Interface
 
+
 The protocol contract MUST implement the following interface:
+
 
 ```solidity
 interface IOnChainProof {
@@ -36,12 +45,14 @@ interface IOnChainProof {
      */
     event ProofAnchored(bytes32 indexed agentId, bytes32 indexed proofHash, uint256 timestamp);
 
+
     /**
      * @dev Anchors a single proof to the blockchain.
      * @param agentId The unique identifier of the AI agent.
      * @param proofHash The SHA-256 hash of the action/data.
      */
     function anchorProof(bytes32 agentId, bytes32 proofHash) external;
+
 
     /**
      * @dev Anchors multiple proofs in a single transaction to save gas.
@@ -52,9 +63,12 @@ interface IOnChainProof {
 }
 ```
 
+
 ### Data Schema
 
+
 The data being hashed SHOULD follow a structured JSON format to ensure interoperability:
+
 
 ```json
 {
@@ -71,26 +85,42 @@ The data being hashed SHOULD follow a structured JSON format to ensure interoper
 }
 ```
 
+
 ## Rationale
+
 
 ### SHA-256 vs Keccak256
 
+
 The use of SHA-256 is recommended for compatibility with off-chain AI systems and web standards, although Keccak256 is more common in Ethereum.
+
 
 ## Backwards Compatibility
 
+
 No backwards compatibility issues as this is a new proposal.
+
 
 ## Reference Implementation
 
-A reference implementation with deployed contracts at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 (Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet).
+
+A reference implementation has been deployed across multiple networks:
+- **Ethereum Mainnet, BSC, Polygon, Base**: `0x68551e56067F96173B063167191E09477013876F`
+- **Sepolia Testnet**: `0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989`
+
+As of May 2026, the protocol has successfully anchored over 300 verifiable agent action records across these production networks, demonstrating its scalability and cross-chain utility.
+
 
 ## Security Considerations
 
+
 Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
+
 
 The agent_id field MUST be validated against the [ERC-8004](./eip-8004.md) registry before reputation aggregation; unverified IDs MUST be flagged.
 
+
 ## Copyright
+
 
 Copyright and related rights waived via [CC0](../LICENSE).

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -12,7 +12,7 @@ created: 2026-05-14
 
 ## Abstract
 
-This proposal specifies a minimal on-chain proof layer for AI agents. It allows agents to anchor their actions (decisions, outputs, or state transitions) to the Ethereum blockchain by submitting a cryptographic commitment (SHA-256 hash). This creates a verifiable, immutable timeline of agent activity, enabling trustless auditing and reputation systems for autonomous agents.
+This proposal specifies a minimal on-chain proof layer for AI agents. It allows agents to anchor their actions (decisions, outputs, or state transitions) to the Ethereum blockchain by submitting a cryptographic commitment (typically a SHA-256 or Keccak-256 hash) together with an identity-scheme byte and a 32-byte agent identifier. This creates a verifiable, immutable timeline of agent activity, enabling trustless auditing and reputation systems for autonomous agents.
 
 ## Motivation
 
@@ -22,39 +22,97 @@ As AI agents increasingly perform high-value tasks (e.g., DeFi trading, content 
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-### Interface
+### Canonical Event
 
-The protocol contract MUST implement the following interface:
+The protocol contract MUST emit exactly one event for every successful anchor:
+
+```solidity
+event AnchorProof(
+    uint8           agentIdScheme,
+    bytes32 indexed agentId,
+    bytes32 indexed proofHash,
+    address indexed operator,
+    bytes           aux
+);
+```
+
+Event signature hash (topic0):
+`keccak256("AnchorProof(uint8,bytes32,bytes32,address,bytes)")`
+= `0x9fe832d83a52f83bd7d54181e4cc7ff8b4e227cc1d3a0144376894b5df6c23cc`.
+
+EVM caps indexed fields at three, so the topic layout is:
+
+| topic   | field        | rationale                                                    |
+|:-------:|:-------------|:-------------------------------------------------------------|
+| topic0  | event sig    | hash above                                                   |
+| topic1  | `agentId`    | per-agent audit trail (most common query)                    |
+| topic2  | `proofHash`  | "was this exact payload anchored?" lookup                    |
+| topic3  | `operator`   | transaction submitter (see *Canonical-form guards*; not an authorization claim) |
+
+`agentIdScheme` is deliberately not indexed: it lives in the data segment so indexers always decode it together with `agentId`. Decoupling them would let malformed clients produce ambiguous logs.
+
+Data decoding (for indexer authors): the non-indexed fields are ABI-encoded as the tuple `(uint8 agentIdScheme, bytes aux)`. In Solidity:
+`(uint8 scheme, bytes memory aux) = abi.decode(data, (uint8, bytes));`.
+The first 32-byte word is the padded `uint8`; the second is the offset to the `aux` bytes; the third onward holds aux length + contents.
+
+### AgentId Scheme Registry
+
+| `agentIdScheme` | name      | `agentId` derivation                                          |
+|:-:|:--|:--|
+| `0x00`  | ANONYMOUS | `bytes32(0)` (contract-enforced)                              |
+| `0x01`  | REGISTRY  | 32-byte registry record id ([ERC-8004](./eip-8004.md) or compatible) |
+| `0x02`  | URI_HASH  | `keccak256(canonical agent URI)`                              |
+| `0x03+` | reserved  | rejected at contract level (see *Canonical-form guards*)      |
+
+Higher-level conventions (e.g. `hf:owner/model`, `gh:owner/repo`, ENS handles) are URI shapes that resolve to scheme `0x02` via `keccak256` of the canonical URI string. They are not separate on-chain schemes — keeping the registry small avoids fragmentation while leaving room for future ERCs to register additional scheme bytes.
+
+### Entrypoints
+
+The protocol contract MUST implement the following two entrypoints:
 
 ```solidity
 interface IOnChainProof {
-    /**
-     * @dev Emitted when a new proof is anchored.
-     * @param agentId The unique identifier of the AI agent (e.g., an [ERC-8004](./eip-8004.md) ID).
-     * @param proofHash The SHA-256 hash of the action/data being anchored.
-     * @param timestamp The block timestamp when the proof was recorded.
-     */
-    event ProofAnchored(bytes32 indexed agentId, bytes32 indexed proofHash, uint256 timestamp);
+    /// @notice Minimal anchor: empty aux, lowest calldata cost.
+    function anchor(
+        uint8   agentIdScheme,
+        bytes32 agentId,
+        bytes32 proofHash
+    ) external;
 
-    /**
-     * @dev Anchors a single proof to the blockchain.
-     * @param agentId The unique identifier of the AI agent.
-     * @param proofHash The SHA-256 hash of the action/data.
-     */
-    function anchorProof(bytes32 agentId, bytes32 proofHash) external;
-
-    /**
-     * @dev Anchors multiple proofs in a single transaction to save gas.
-     * @param agentIds Array of agent identifiers.
-     * @param proofHashes Array of corresponding proof hashes.
-     */
-    function batchAnchor(bytes32[] calldata agentIds, bytes32[] calldata proofHashes) external;
+    /// @notice Extended anchor with opaque aux bytes for adjacent protocols.
+    function anchorWithAux(
+        uint8   agentIdScheme,
+        bytes32 agentId,
+        bytes32 proofHash,
+        bytes calldata aux
+    ) external;
 }
 ```
 
+`anchor` submits an anchor with empty `aux` and is the lowest-calldata path.
+
+`anchorWithAux` submits an anchor with optional `aux` bytes. **`aux` is explicitly non-normative.** It is an extension surface for adjacent protocols. Examples of (non-normative) uses: OCP digest commitments, session ids, parent-proof references. Indexers MUST treat `aux` as opaque bytes and MUST NOT derive proof semantics from it.
+
+Adjacent-protocol extraction is profile-defined. Adjacent protocols MAY define extraction conventions over `proofHash`, over `aux`, or over both — this ERC itself stays neutral and does not prescribe a mapping. A profile that treats `proofHash` as its own digest commits every anchor; a profile that treats `aux` (when present) as its carrier is opt-in. Both are valid composition shapes over the same event.
+
+### Canonical-Form Guards
+
+The contract MUST enforce these invariants at write time:
+
+| Field / Scheme       | Invariant                                  |
+|:--|:--|
+| `proofHash`          | `proofHash != bytes32(0)` (else revert)    |
+| scheme `0x00`        | `agentId == bytes32(0)` (else revert)      |
+| scheme `0x01`,`0x02` | `agentId != bytes32(0)` (else revert)      |
+| scheme `0x03+`       | revert (reserved)                          |
+
+Indexers can rely on these basic canonical-form invariants without re-validating them, but MUST NOT infer authorization, agent identity correctness, or payload validity from the event alone — those concerns belong to higher-layer verifier profiles.
+
+`proofHash` hashing: the contract does not constrain the hash algorithm or the canonicalization that produces `proofHash`. Profile-level rules apply at the commitment layer; the contract only requires that `proofHash` be a non-zero 32-byte value.
+
 ### Data Schema
 
-The data being hashed SHOULD follow a structured JSON format to ensure interoperability:
+The pre-image hashed into `proofHash` SHOULD follow a structured JSON format to ensure interoperability across implementations:
 
 ```json
 {
@@ -71,31 +129,36 @@ The data being hashed SHOULD follow a structured JSON format to ensure interoper
 }
 ```
 
+The contract itself is agnostic to this shape; the structure is a SHOULD at the application layer, not a contract-enforced invariant.
+
 ## Rationale
 
-### SHA-256 vs Keccak256
+### SHA-256 vs Keccak-256
 
-The use of SHA-256 is recommended for compatibility with off-chain AI systems and web standards, although Keccak256 is more common in Ethereum.
+SHA-256 is recommended for compatibility with off-chain AI systems and web standards, although Keccak-256 is more common in Ethereum. The contract treats `proofHash` as an opaque non-zero `bytes32`, so either algorithm (or a profile-defined construction) is acceptable; the algorithm is a profile decision, not a contract decision.
+
+### Single event, two entrypoints
+
+Both entrypoints emit the same `AnchorProof` event. Keeping a single canonical event means indexers and verifiers parse one topic0 across all anchors, regardless of whether `aux` was used. Splitting the event by entrypoint would fragment the indexer surface for no observable benefit at the commitment layer.
 
 ## Backwards Compatibility
 
-No backwards compatibility issues as this is a new proposal.
+No backwards compatibility issues: this is a new proposal and defines a new event signature (topic0 above) that does not collide with prior Ethereum events.
 
 ## Reference Implementation
 
-Contracts deployed on:
+Reference contracts verified on Etherscan, both implementing the interface above:
 
-- Ethereum Mainnet: `0x68551e56067F96173B063167191E09477013876F`
-- Sepolia Testnet: `0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989`
-- Polygon, Base, BSC Mainnet: `0x87dd3A56AFD0D2c488aD7E13fB036b59144b25dC` (deterministic cross-chain deployment, identical contract address across all three)
+- Ethereum Mainnet: `0xe95d6a15966984c209a62a2c188828555eb5ec3d` ([source](https://etherscan.io/address/0xe95d6a15966984c209a62a2c188828555eb5ec3d#code))
+- Sepolia Testnet: `0x89EE9b68c3b2f50cbE9D0fC4Dc134939a0475c1C`
 
-As of May 2026, the reference implementation has anchored 700+ confirmed proofs across 5 chains. All anchors are publicly verifiable on the corresponding block explorers.
+Both deployments emit the `AnchorProof` event with the topic0 above and accept the two entrypoints unchanged. Independent verifiers can confirm the contract surface by reading the verified source on the linked block explorers.
 
 ## Security Considerations
 
-Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
+Implementations MUST NOT store original action content on-chain — only the commitment hash. Storing plaintext leaks user data and exceeds practical gas limits.
 
-The agent_id field MUST be validated against the [ERC-8004](./eip-8004.md) registry before reputation aggregation; unverified IDs MUST be flagged.
+The `agentId` field MUST be validated against the chosen registry (e.g. [ERC-8004](./eip-8004.md) when `agentIdScheme = 0x01`) before reputation aggregation; unverified ids MUST be flagged.
 
 The following subsections are **informative**. They describe how this ERC composes with adjacent standards and how anchors can be independently verified. They introduce no new normative requirements on the contract surface; the canonical event and the scheme registry are unchanged.
 
@@ -105,36 +168,25 @@ This subsection describes a compatibility profile for deployments that compose a
 
 This ERC is identity-registry-agnostic by construction: the canonical event carries `(agentIdScheme, agentId)` as opaque bytes and assigns no on-chain meaning beyond the scheme registry. [ERC-8004](./eip-8004.md) is one such registry, and the two standards compose cleanly when an implementer chooses to use both.
 
-**Scheme `0x01` compatibility bridge**
+#### Scheme `0x01` compatibility bridge
 
 When an implementation chooses to populate anchors with [ERC-8004](./eip-8004.md) identities under `agentIdScheme = 0x01` (REGISTRY), the recommended encoding of the 32-byte `agentId` payload is a zero-padded [ERC-8004](./eip-8004.md) record id:
 
-```
-agentId = bytes32(uint256(agentId8004))
-```
-
-Equivalently in Solidity:
-
-```solidity
-bytes32 agentId = bytes32(uint256(agentId8004));
+```text
+agentId = bytes32(uint256(erc8004AgentId))
 ```
 
-This is the canonical compatibility bridge between the two standards' on-chain representations. It is offered as a recommendation, not a mandatory path: anchors do not require an [ERC-8004](./eip-8004.md) record, and [ERC-8004](./eip-8004.md) is one of several registries that can populate scheme `0x01`. The contract accepts any 32-byte `agentId`; tooling that resolves scheme `0x01` anchors against an [ERC-8004](./eip-8004.md) registry should apply this cast for round-trip consistency.
+This is a recommendation, not a mandate. Implementations remain free to use other 32-byte derivations under scheme `0x01`, provided they document the derivation in the operator's deployment notes so verifiers can reproduce the same value.
 
-**Resolution direction**
+#### Resolution direction
 
-Resolution is one-way at the protocol layer. An anchor with scheme `0x01` can reference an [ERC-8004](./eip-8004.md) record; [ERC-8004](./eip-8004.md) does not need to reference this ERC in return. Indexers that want a bidirectional view can build a reverse index off-chain from the event log.
+Resolution is one-way at the protocol layer. An anchor with scheme `0x01` can reference an [ERC-8004](./eip-8004.md) record; [ERC-8004](./eip-8004.md) does not need to reference this ERC in return. Indexers that want a bidirectional view can build a reverse index off-chain from the `AnchorProof` event log.
 
-**Identity vs commitment separation**
-
-[ERC-8004](./eip-8004.md) governs *who the agent is*. This ERC governs *what the agent committed to on-chain*. The two standards are deliberately separable:
+#### Identity vs commitment separation
 
 - An anchor with `agentIdScheme = 0x00` (ANONYMOUS) is a valid anchor with no identity-registry dependency.
 - An anchor with `agentIdScheme = 0x02` (URI_HASH) binds to an off-chain canonical identity and does not require an [ERC-8004](./eip-8004.md) record.
-- Future schemes allocated in the `0x03+` reserved range may bind to other identity systems (e.g., DID methods) without disturbing the [ERC-8004](./eip-8004.md) compatibility profile above.
-- An [ERC-8004](./eip-8004.md) record can exist without any anchors against it.
-
-Implementations that choose to compose registered identity ([ERC-8004](./eip-8004.md)) with on-chain commitment (this ERC) should verify each layer independently; neither standard's validity check substitutes for the other's.
+- The commitment carried in `proofHash` is independent of the identity scheme. The same `proofHash` can be re-anchored under a different `(agentIdScheme, agentId)` without breaking the commitment.
 
 ### Compatible Identity Registries
 
@@ -142,168 +194,121 @@ This subsection generalizes the above to any identity registry that an implement
 
 The scheme registry is intentionally identity-system-agnostic. Scheme `0x01` is reserved for "REGISTRY" without naming a specific registry, so the same anchor format can compose with [ERC-8004](./eip-8004.md), with other on-chain agent registries (proprietary or future-standard), and with registry adapters that front external identity systems.
 
-**Recommended resolution interface**
+#### Recommended resolution interface
 
-A registry is considered compatible with scheme `0x01` when it exposes a resolution function with the following shape:
+For an indexer or verifier to move from an anchor's `(agentIdScheme = 0x01, agentId)` pair to a wallet address, the underlying registry SHOULD expose a function with the following shape:
 
 ```solidity
 interface IAgentWalletResolver {
-    /// @return wallet The address that controls the agent record, or
-    ///         address(0) if the agentId is unknown to this resolver.
+    /// @notice Resolve a registry record id to its current wallet.
+    /// @param agentId The 32-byte agentId payload carried in the anchor.
+    /// @return wallet The current wallet address bound to that agentId,
+    ///                or address(0) if no binding exists.
     function getAgentWallet(bytes32 agentId) external view returns (address wallet);
 }
 ```
 
-`getAgentWallet` is the minimal convention an indexer or verifier needs to move from an anchor's `(agentIdScheme = 0x01, agentId)` pair to an authoritative wallet for that agent. The recommendation is `should`, not `must`: registries may expose richer interfaces (e.g., [ERC-8004](./eip-8004.md)'s full agent record), and verifiers that only need to display an anchor without resolving identity can ignore the registry entirely.
+`getAgentWallet` is the minimal convention an indexer or verifier needs to move from an anchor's `(agentIdScheme = 0x01, agentId)` pair to an authoritative wallet for that agent. The recommendation is SHOULD, not MUST: registries may expose richer interfaces (e.g., [ERC-8004](./eip-8004.md)'s full agent record), and verifiers that only need to display an anchor without resolving identity can ignore the registry entirely.
 
-The function lives at the registry, not at this ERC's contract. This ERC does not call into registries on-chain and does not depend on any specific registry being deployed.
-
-**Off-chain resolution flow**
+#### Off-chain resolution flow
 
 A typical off-chain resolution flow for a scheme `0x01` anchor is:
 
-1. Read the event log from a node (chain-state-only).
+1. Read the `AnchorProof` event log from a node (chain-state-only).
 2. Parse `(agentIdScheme, agentId)` from the event topics.
 3. If `agentIdScheme == 0x01`, look up the registry the implementation has bound to scheme `0x01` (a tooling-side choice; this ERC does not encode the registry address on-chain in scheme `0x01`).
-4. Call `registry.getAgentWallet(agentId)` against that registry.
-5. Use the returned wallet for any downstream check the verifier cares about (signature verification, reputation lookup, display).
+4. Call `getAgentWallet(agentId)` on that registry to obtain the current wallet.
 
 Each step is independent and any verifier may stop at step 2 if it only needs to display the anchor.
 
-A live reference implementation of this flow exists at gateway.ensub.org (operated by Tiago Merlini in the [ERC-8004](./eip-8004.md) working group). It exposes an HTTP attestation endpoint keyed on `(registry, agentId)` and demonstrates the off-chain resolution flow above against an [ERC-8004](./eip-8004.md) registry. This ERC does not require this gateway or any other gateway; it is cited here as evidence that the compatibility profile is implementable end-to-end.
+#### Reference implementation
+
+A public reference implementation of `IAgentWalletResolver` is operated at `gateway.ensub.org` as part of the [ERC-8004](./eip-8004.md) ecosystem and can be used as a model for additional registries.
 
 ### Independent Verification
 
 This subsection describes how an anchor can be verified end-to-end using chain state alone, with no dependency on the issuing service, the indexer, or any hosted gateway.
 
-A verification step is *independent* when it relies only on:
+#### What "independent" means here
 
-- the verifier's own copy of the observation (or a hash of it),
-- the verifier's own access to a node serving the relevant chain, and
-- the verifier's own implementation of the declared hash function.
+Independent verification means a verifier reproduces the assertion implicit in the anchor — "this `proofHash` was committed at this block for this `(agentIdScheme, agentId)`" — from chain state only.
 
 It does *not* depend on the operator that issued the anchor, the indexer that surfaced it, or any HTTP gateway in between.
 
-**Five-step verification path**
+#### Five-step verification path
 
 1. Verifier receives: `observation` + an anchor reference (`txHash` + `logIndex`, or any equivalent locator).
-2. `H′ = H(observation)` — recomputed independently using the hash function declared by the proof profile in use (see Recommended proofHash Constructions below).
-3. `H′ == proofHash` — compared against the `proofHash` value carried in the event at the referenced log.
-4. `proofHash ∈ R(tx)` — confirmed in the raw transaction receipt by re-parsing the event log from a node, without trusting any indexer.
-5. `agentId` is resolved according to `agentIdScheme`: for `0x01`, resolution goes through a compatible registry per the Compatible Identity Registries section; for `0x02`, `agentId == keccak256(canonical agent URI)`; for `0x00`, no identity resolution applies.
+2. Verifier computes `proofHash' = H(observation)` where `H` is the hash function declared by the profile (see *Recommended proofHash Constructions*).
+3. Verifier reads chain state directly (RPC, archive node, light client) to fetch the `AnchorProof` event at the referenced log.
+4. Verifier compares `proofHash'` with the `proofHash` recorded in the `AnchorProof` event at the referenced log.
+5. `agentId` is resolved according to `agentIdScheme`: for `0x01`, resolution goes through a compatible registry per *Compatible Identity Registries*; for `0x02`, `agentId == keccak256(canonical agent URI)`; for `0x00`, no identity resolution applies.
 
-The result is an independent, system-agnostic statement that this agent committed this observation at this moment on this chain.
+#### Layer optionality
 
-The five steps above are independently optional: a verifier that only needs to confirm digest inclusion can stop at step 4; a verifier that needs identity attribution continues to step 5. Implementations that publish both an on-chain commitment and a higher-layer signature over the same observation may show a visible gap between the two surfaces, because some executions get signed before the on-chain commitment confirms. That gap is designed-in optionality rather than inconsistency. As observed by Tiago Merlini in the alignment thread:
+Steps 3–5 are independent. A verifier that only cares about commitment integrity stops at step 4. A verifier that cares about identity continues to step 5. A verifier that cares about how the observation was produced may consult an adjacent observation-commitment standard (e.g. OCP); this ERC takes no dependency on whether such a verifier exists.
 
-> The L3/L4 gap (10 vs 13) is visible and expected, some executions got
-> signed before the OCP anchor confirmed. Worth noting for implementers:
-> L3 and L4 are independently optional by design, as specced in the
-> appendix.
+#### Verifier observability reference
 
-A live admin attestation dashboard at gateway.ensub.org shows the five-step path running against production traffic. This ERC does not require this dashboard or any other dashboard; it is cited as a worked example of the independent verification path running end-to-end.
+A live reference verifier and indexer for the resolution path described above is operated at `gateway.ensub.org`, and can be consulted as a worked example of the steps in this subsection.
 
-The address recovered from the l4_signature field resolves to the gateway's attestor key, the address registered as the agent's hot wallet via getAgentWallet(agentId) in the [ERC-8004](./eip-8004.md) registry. This key is controlled by the gateway operator, not the token owner; ownership of the [ERC-8004](./eip-8004.md) NFT and attestation of execution are intentionally separated, and an agent may migrate gateways by updating the hot wallet registration without transferring the token. Verification of L4 therefore confirms which infrastructure attested the execution, not that the agent signed for itself. The trustless floor remains L3: input_hash anchored on-chain via OCP is independently verifiable from any public RPC with no trust assumptions beyond the chain itself.
+> A subtle but important nuance for implementers: an [ERC-8004](./eip-8004.md) `agentId` denotes *ownership* of an agent record, not *attestation* of any specific anchor. A registry hot key can rotate; an anchor was emitted at a specific block. Verifiers that need attestation-strength binding should treat the anchor as the layer of truth and the registry as an L3 lookup that may be re-keyed without affecting the L4 chain-state record. The trustless floor of the verification path is the chain-state read in step 3; everything above it is a convenience layer.
 
 ### OCP Boundary Note
 
-This subsection clarifies what this ERC does and does not bundle from the Observation Commitment Protocol (OCP) at github.com/damonzwicker/observation-commitment-protocol, to prevent implementers from conflating the two.
+This ERC is a write-side standard: it defines how an anchor is emitted on-chain. The Observation Commitment Protocol (OCP) is a read-side standard: it defines how a verifier extracts and re-checks observation commitments. This subsection states the boundary so neither standard is presented as a precondition for the other.
 
-OCP is a profile-level description of how a committed digest is verified against raw chain state. It defines the extraction rule that takes a transaction receipt to the set of OCP digests carried by anchors in that receipt (see Recommended proofHash Constructions below). Quoting Damon Zwicker, OCP author:
+#### What OCP is, and what it is not
 
-> OCP does not define identity, authorship, sanitization, or data
-> availability.
+> OCP does not define identity, authorship, sanitization, or data availability. It defines an extraction interface for observation commitments and a re-checkable digest profile over them. Composition with identity layers, signing layers, or anchoring layers is out of OCP's scope.
+> — Damon Zwicker (OCP author)
 
-This ERC makes the same separation explicit at the contract layer: this ERC commits a `proofHash`, and the contract enforces only that the hash is non-zero and the event is well-formed. The interpretation of what that hash commits to lives in a proof profile, not in this ERC itself.
+#### ERC-8263 does not embed OCP
 
-This ERC does not import an OCP verification interface, does not require OCP-compatible verifiers, and does not assume an OCP-shaped verifier is deployed. Every anchor is OCP-extractable by construction (the extraction rule is a function of the event topology already defined in the Specification), but anchors remain valid for verifiers that ignore OCP entirely and check `proofHash` against their own profile.
+This ERC does not import an OCP verification interface, does not require OCP-compatible verifiers, and does not assume an OCP-shaped verifier is deployed. Every anchor is OCP-extractable by construction (the extraction rule is a function of the event topology already defined in *Canonical Event*), but anchors remain valid for verifiers that ignore OCP entirely and check `proofHash` against their own profile.
 
-The relationship is one-way: OCP can describe a verifier for anchors; this ERC does not require any verifier to be OCP-shaped.
+#### Out-of-scope boundary
 
-The following table makes the boundary explicit:
-
-| Concern | In scope for this ERC | Out of scope (left to profile / adjacent standard) |
-|---|---|---|
-| Event shape, scheme registry | Yes | — |
-| Non-zero `proofHash` enforcement | Yes | — |
-| Identity resolution | — | [ERC-8004](./eip-8004.md) / Compatible Identity Registries |
-| Authorship / signature binding | — | proof profile / wallet signature layer |
-| Input sanitization, pipeline disclosure | — | proof profile / Recommended proofHash Constructions |
-| Data availability of the underlying observation | — | proof profile / off-chain layer |
-| Independent verification procedure | — | OCP / Independent Verification section |
+| Concern                                  | In ERC-8263 scope | Handled by adjacent layer |
+|:--|:-:|:-:|
+| Event shape, scheme registry             | ✓ | — |
+| Identity binding under scheme `0x01`     | — | identity registry ([ERC-8004](./eip-8004.md) and compatible) |
+| Observation extraction & re-check digest | — | OCP |
+| Input-provenance / pre-image discipline  | — | profile (see *Recommended proofHash Constructions*) |
+| Output verification (zk, attested compute, etc.) | — | inference-verification layer (e.g. [ERC-8004](./eip-8004.md)-adjacent work) |
+| Data availability of the observation     | — | application choice (archival service, IPFS, off-chain log) |
 
 ### Recommended proofHash Constructions
 
-This subsection describes constructions an implementer may use to populate the `proofHash` field. The core contract treats `proofHash` as opaque `bytes32` and enforces only that it is non-zero. Every construction here is a profile; none of them is part of the contract surface, and a verifier may use any construction, including one not listed here, as long as the construction is declared in the proof profile in use.
+This appendix is **informative**. It catalogues recommended constructions for the `proofHash` field. The contract does not detect or enforce a profile; profile selection is an off-chain declaration carried by the issuer in `aux` (when present) or in a higher-layer envelope.
 
-The contract performs no hash-function negotiation, no algorithm disclosure, and no profile registry on-chain. Profile selection is an agreement between the issuer and the verifier; the chain holds only the opaque `bytes32`.
+#### Profile: Single observation digest (default)
 
-**Profile: Single observation digest (default)**
+The simplest profile: `proofHash = H(observation)` where `H` is a collision-resistant hash function (e.g. SHA-256 or Keccak-256) and `observation` is the canonical-form byte representation of the agent's action payload. A verifier with the observation recomputes `H(observation)` and checks equality against the `proofHash` in the `AnchorProof` event. This is the default extraction rule that OCP, when consulted, applies to anchors emitted by this ERC.
 
-```
-proofHash = H(canonical_observation_bytes)
-```
+#### Profile: Input-provenance with identity sentinel
 
-Where:
+For workloads where the verifier needs to bind the anchor not only to an observation but also to the input that produced it, the profile commits to a structured pre-image:
 
-- `canonical_observation_bytes` is the canonical byte serialization of the observation the agent committed to (the proof profile defines what "canonical" means for the data shape).
-- `H` is the hash function declared by the proof profile.
-
-The default hash function in the TruthAnchor reference deployment and the OCP extraction rule for EVM is SHA-256. Implementers may use any hash function as long as the proof profile declares it and the verifier uses the same function in step 2 of the five-step verification path.
-
-This profile carries no input-provenance metadata; the observation hash is opaque to anyone without the observation bytes.
-
-**Profile: Input-provenance with identity sentinel**
-
-When the proof profile records *how an input was prepared* in addition to *what was committed*, the input-provenance construction makes the preparation pipeline visible to the verifier without leaking the raw input.
-
-The construction names two hashes inside the canonical observation bytes:
-
-- `raw_input_hash` — `H(raw_input_bytes)` before any pipeline step.
-- `input_hash` — `H(canonical_input_bytes_after_pipeline)`.
-
-The pipeline itself is recorded by a third hash:
-
-- `sanitization_pipeline_hash` — `H(canonical_pipeline_descriptor_bytes)`.
-
-When no sanitization pipeline is applied (the pass-through case), the profile uses a fixed pass-through constant called the *identity sentinel*:
-
-```
-IDENTITY_SENTINEL = 8116eec29078e8f57c07077d5e8080a35bde73036581df3abb93755d1b1a16ea
+```text
+preImage = canonical_encode({
+  input:        H(input_bytes),
+  output:       H(output_bytes),
+  identity:     identitySentinel  // see below
+})
+proofHash = H(preImage)
 ```
 
-(SHA-256 of the identity spec string; surfaced by Tiago Merlini in the alignment thread and adopted in the OCP extraction rule as the canonical pass-through constant.)
+`identitySentinel` is a profile-level constant (recommended value: `IDENTITY_SENTINEL = keccak256("erc-8263.identity.passthrough.v1")`) used to mark pre-images in which identity is intentionally pass-through rather than bound at the commitment layer. Verifiers MUST branch on the sentinel: when present, identity is resolved at the chain layer via `(agentIdScheme, agentId)` and the pre-image identity slot carries the sentinel value verbatim; when absent, identity is bound at the commitment layer and the slot carries the binding payload directly. This invariant prevents silent identity confusion across implementations of the same profile.
 
-A verifier of this profile checks:
-
-```
-if sanitization_pipeline_hash == IDENTITY_SENTINEL:
-    require raw_input_hash == input_hash         # pass-through invariant
-else:
-    verify the transformation against the declared pipeline descriptor
-```
-
-A verifier that does not implement this branch will incorrectly reject every pass-through execution. The branching rule is part of the profile, not of this ERC itself; the on-chain `proofHash` remains opaque `bytes32`.
-
-**Profile: Merkle batch root**
-
-```
-proofHash = merkleRoot([H(observation_1), H(observation_2), ..., H(observation_n)])
-```
+#### Profile: Merkle batch root
 
 A single anchor commits to a batch of observations through the Merkle root of their individual hashes. A verifier of this profile recomputes the root from the leaves it cares about and checks inclusion against the on-chain `proofHash`. The contract is unaware that the `proofHash` is a Merkle root; the profile carries that semantics.
 
-**Profile selection is off-chain**
+#### Profile selection is off-chain
 
 Across all three profiles above, the on-chain `proofHash` field is the same opaque `bytes32`. The contract performs no profile detection. A verifier that does not know which profile produced a given `proofHash` cannot verify the anchor without out-of-band profile metadata; the profile is declared by the issuer, typically through an auxiliary field or through a higher-layer envelope.
 
 Future revisions of this subsection may add new profiles. The core contract is unaffected by any such addition.
-
-Cross-standard alignment confirmed pre-submission: Tiago Merlini ([ERC-8004](./eip-8004.md)): all sections that touch [ERC-8004](./eip-8004.md) or his work, green-lit; the second paragraph of the verifier observability reference applied verbatim from him. Damon Zwicker (OCP): OCP Boundary Note verbatim boundary quote and identity sentinel pass-through constant reference, reviewed.
-
-Companion Composition Note (descriptive co-implementer guide, not normative): gist.github.com/TruthAnchor-AI/8742e742bdc627b8e2179c00b81289dc
-
-Related: [ERC-8274](./eip-8274.md) (Jimmy Shi, AI Inference Proof Verification Interfaces, ERC# assigned 2026-05-26). Cross-references to be tightened in a follow-up revision once [ERC-8274](./eip-8274.md) v0.1 is published; not in v0.2 scope to avoid coupling timelines.
 
 ## Copyright
 

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -2,8 +2,8 @@
 eip: 8263
 title: Onchain Proof Layer for AI Agents
 description: Anchor AI agent actions to Ethereum with cryptographic proofs and verifiable identity registry.
-author: Vincent Wu (@VincentWu) <1@truthanchor.biz>
-discussions-to: https://ethereum-magicians.org/t/draft-erc-universal-ai-inference-verification-registry/28083
+author: Vincent Wu (@VincentWu) <wuxiaoyu8816@gmail.com>
+discussions-to: https://ethereum-magicians.org/t/erc-8263-on-chain-inference-attestation-registry-for-ai-agents/28577
 status: Draft
 type: Standards Track
 category: ERC
@@ -104,11 +104,9 @@ No backwards compatibility issues as this is a new proposal.
 ## Reference Implementation
 
 
-A reference implementation has been deployed across multiple networks:
-- **Ethereum Mainnet, BSC, Polygon, Base**: `0x68551e56067F96173B063167191E09477013876F`
+A reference implementation has been deployed on the following networks:
+- **Ethereum Mainnet**: `0x68551e56067F96173B063167191E09477013876F`
 - **Sepolia Testnet**: `0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989`
-
-As of May 2026, the protocol has successfully anchored over 300 verifiable agent action records across these production networks, demonstrating its scalability and cross-chain utility.
 
 
 ## Security Considerations

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -83,7 +83,7 @@ No backwards compatibility issues as this is a new proposal.
 
 ## Reference Implementation
 
-A live reference implementation with deployed contracts at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 (Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet) is available at https://truthanchor.biz.
+A live reference implementation with deployed contracts at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 (Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet).
 
 ## Security Considerations
 

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -3,7 +3,7 @@ eip: 8263
 title: Onchain Proof Layer for AI Agents
 description: Anchor AI agent actions to Ethereum with cryptographic proofs and verifiable identity registry.
 author: Vincent Wu (@VincentWu) <1@truthanchor.biz>
-discussions-to: https://github.com/ethereum/ERCs/pull/1748
+discussions-to: https://ethereum-magicians.org/t/erc-8263-onchain-proof-layer-for-ai-agents/23917
 status: Draft
 type: Standards Track
 category: ERC
@@ -83,9 +83,7 @@ No backwards compatibility issues as this is a new proposal.
 
 ## Reference Implementation
 
-A live reference implementation is available at https://truthanchor.biz 
-with deployed contracts at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 
-(Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet).
+A live reference implementation with deployed contracts at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 (Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet) is available at https://truthanchor.biz.
 
 ## Security Considerations
 

--- a/ERCS/erc-8263.md
+++ b/ERCS/erc-8263.md
@@ -3,7 +3,7 @@ eip: 8263
 title: Onchain Proof Layer for AI Agents
 description: Anchor AI agent actions to Ethereum with cryptographic proofs and verifiable identity registry.
 author: Vincent Wu (@VincentWu) <1@truthanchor.biz>
-discussions-to: https://ethereum-magicians.org/t/erc-8263-onchain-proof-layer-for-ai-agents/23917
+discussions-to: https://ethereum-magicians.org/t/draft-erc-universal-ai-inference-verification-registry/28083
 status: Draft
 type: Standards Track
 category: ERC
@@ -83,7 +83,7 @@ No backwards compatibility issues as this is a new proposal.
 
 ## Reference Implementation
 
-A live reference implementation with deployed contracts at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 (Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet).
+A reference implementation with deployed contracts at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 (Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet).
 
 ## Security Considerations
 

--- a/ERCS/erc-8888.md
+++ b/ERCS/erc-8888.md
@@ -10,84 +10,21 @@ category: ERC
 created: 2026-05-14
 ---
 
-
-
-
-
-
-
-
 ## Abstract
-
-
-
-
-
-
-
 
 This proposal specifies TruthAnchor, a minimal on-chain proof layer for AI agents. It allows agents to anchor their actions (decisions, outputs, or state transitions) to the Ethereum blockchain by submitting a cryptographic commitment (SHA-256 hash). This creates a verifiable, immutable timeline of agent activity, enabling trustless auditing and reputation systems for autonomous agents.
 
-
-
-
-
-
-
-
 ## Motivation
-
-
-
-
-
-
-
 
 As AI agents increasingly perform high-value tasks (e.g., DeFi trading, content creation, governance voting), there is a critical need for a standard way to prove that an agent performed a specific action at a specific time. Current agent activities are often opaque or stored in centralized databases. TruthAnchor provides a decentralized "black box recorder" for AI agents, ensuring that their history cannot be retroactively altered.
 
-
-
-
-
-
-
-
 ## Specification
-
-
-
-
-
-
-
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-
-
-
-
-
-
-
 ### Interface
 
-
-
-
-
-
-
-
 The TruthAnchor contract MUST implement the following interface:
-
-
-
-
-
-
-
 
 ```solidity
 interface ITruthAnchor {
@@ -99,99 +36,4 @@ interface ITruthAnchor {
      */
     event ProofAnchored(bytes32 indexed agentId, bytes32 indexed proofHash, uint256 timestamp);
 
-
-
-
-
-
-
-
     /**
-     * @dev Anchors a single proof to the blockchain.
-     * @param agentId The unique identifier of the AI agent.
-     * @param proofHash The SHA-256 hash of the action/data.
-     */
-    function anchorProof(bytes32 agentId, bytes32 proofHash) external;
-
-
-
-
-
-
-
-
-    /**
-     * @dev Anchors multiple proofs in a single transaction to save gas.
-     * @param agentIds Array of agent identifiers.
-     * @param proofHashes Array of corresponding proof hashes.
-     */
-    function batchAnchor(bytes32[] calldata agentIds, bytes32[] calldata proofHashes) external;
-}
-```
-
-
-
-
-
-
-
-
-### Data Schema
-
-
-
-
-
-
-
-
-The data being hashed SHOULD follow a structured JSON format to ensure interoperability:
-
-
-
-
-
-
-
-
-```json
-{
-  "version": "1.0",
-  "agent_id": "0x...",
-  "action_type": "trade",
-  "content": {
-    "pair": "ETH/USDC",
-    "amount": "1.5",
-    "tx_hash": "0x..."
-  },
-  "nonce": 12345,
-  "timestamp": 1715673600
-}
-```
-
-
-
-
-
-
-
-
-## Rationale
-
-
-
-
-
-
-
-
-### SHA-256 vs Keccak256
-
-## Security Considerations
-
-Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
-
-
-## Copyright
-
-Copyright and related rights waived via [CC0](../LICENSE).

--- a/ERCS/erc-8888.md
+++ b/ERCS/erc-8888.md
@@ -30,10 +30,63 @@ The TruthAnchor contract MUST implement the following interface:
 interface ITruthAnchor {
     /**
      * @dev Emitted when a new proof is anchored.
-     * @param agentId The unique identifier of the AI agent (e.g., an [ERC-8004](./erc-8004.md) ID).
+     * @param agentId The unique identifier of the AI agent (e.g., an [ERC-8004](./eip-8004.md) ID).
      * @param proofHash The SHA-256 hash of the action/data being anchored.
      * @param timestamp The block timestamp when the proof was recorded.
      */
     event ProofAnchored(bytes32 indexed agentId, bytes32 indexed proofHash, uint256 timestamp);
 
     /**
+     * @dev Anchors a single proof to the blockchain.
+     * @param agentId The unique identifier of the AI agent.
+     * @param proofHash The SHA-256 hash of the action/data.
+     */
+    function anchorProof(bytes32 agentId, bytes32 proofHash) external;
+
+    /**
+     * @dev Anchors multiple proofs in a single transaction to save gas.
+     * @param agentIds Array of agent identifiers.
+     * @param proofHashes Array of corresponding proof hashes.
+     */
+    function batchAnchor(bytes32[] calldata agentIds, bytes32[] calldata proofHashes) external;
+}
+```
+
+### Data Schema
+
+The data being hashed SHOULD follow a structured JSON format to ensure interoperability:
+
+```json
+{
+  "version": "1.0",
+  "agent_id": "0x...",
+  "action_type": "trade",
+  "content": {
+    "pair": "ETH/USDC",
+    "amount": "1.5",
+    "tx_hash": "0x..."
+  },
+  "nonce": 12345,
+  "timestamp": 1715673600
+}
+```
+
+## Rationale
+
+### SHA-256 vs Keccak256
+
+The use of SHA-256 is recommended for compatibility with off-chain AI systems and web standards, although Keccak256 is more common in Ethereum.
+
+## Backwards Compatibility
+
+No backwards compatibility issues as this is a new proposal.
+
+## Security Considerations
+
+Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
+
+The agent_id field MUST be validated against the ERC-8004 registry before reputation aggregation; unverified IDs MUST be flagged.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE).

--- a/ERCS/erc-8888.md
+++ b/ERCS/erc-8888.md
@@ -11,39 +11,59 @@ created: 2026-05-14
 ---
 
 
+
+
 ## Abstract
+
+
 
 
 This proposal specifies TruthAnchor, a minimal on-chain proof layer for AI agents. It allows agents to anchor their actions (decisions, outputs, or state transitions) to the Ethereum blockchain by submitting a cryptographic commitment (SHA-256 hash). This creates a verifiable, immutable timeline of agent activity, enabling trustless auditing and reputation systems for autonomous agents.
 
 
+
+
 ## Motivation
+
+
 
 
 As AI agents increasingly perform high-value tasks (e.g., DeFi trading, content creation, governance voting), there is a critical need for a standard way to prove that an agent performed a specific action at a specific time. Current agent activities are often opaque or stored in centralized databases. TruthAnchor provides a decentralized "black box recorder" for AI agents, ensuring that their history cannot be retroactively altered.
 
 
+
+
 ## Specification
+
+
 
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 
+
+
 ### Interface
 
 
+
+
 The TruthAnchor contract MUST implement the following interface:
+
+
 
 
 ```solidity
 interface ITruthAnchor {
     /**
      * @dev Emitted when a new proof is anchored.
-     * @param agentId The unique identifier of the AI agent (e.g., an ERC-8004 ID).
+     * @param agentId The unique identifier of the AI agent (e.g., an [ERC-8004](./erc-8004.md) ID).
      * @param proofHash The SHA-256 hash of the action/data being anchored.
      * @param timestamp The block timestamp when the proof was recorded.
      */
     event ProofAnchored(bytes32 indexed agentId, bytes32 indexed proofHash, uint256 timestamp);
+
+
 
 
     /**
@@ -52,6 +72,8 @@ interface ITruthAnchor {
      * @param proofHash The SHA-256 hash of the action/data.
      */
     function anchorProof(bytes32 agentId, bytes32 proofHash) external;
+
+
 
 
     /**
@@ -64,10 +86,16 @@ interface ITruthAnchor {
 ```
 
 
+
+
 ### Data Schema
 
 
+
+
 The data being hashed SHOULD follow a structured JSON format to ensure interoperability:
+
+
 
 
 ```json
@@ -86,52 +114,47 @@ The data being hashed SHOULD follow a structured JSON format to ensure interoper
 ```
 
 
+
+
 ## Rationale
+
+
 
 
 ### SHA-256 vs Keccak256
 While Keccak256 is native to the EVM, SHA-256 is chosen for the proof hash to maintain compatibility with off-chain AI systems and non-EVM environments where SHA-256 is the standard for data integrity.
 
 
+
+
 ### Minimal On-Chain Footprint
 Only the hash is stored on-chain to minimize gas costs. The actual action data is stored off-chain (e.g., IPFS, Arweave, or private storage).
+
+
 
 
 ### Informational Scoring
 The proposed reputation scoring based on these proofs is informational, not normative, to avoid coupling consensus-critical contract logic to subjective scoring.
 
 
+
+
 ## Backwards Compatibility
+
+
 
 
 Fully backwards-compatible. Existing anchors using truthanchor/v1 (hash-only, no agent identity) MAY remain valid; new anchors SHOULD use v2.
 
 
+
+
 ## Reference Implementation
+
+
 
 
 - Ethereum Mainnet contract: `0x68551e56067F96173B063167191E09477013876F`
 - Sepolia testnet contract: `0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989`
 - Multi-chain support: Polygon, Base, BNB Smart Chain
 - Open-source SDK (Python + Node.js): see project repository
-
-
-## Security Considerations
-
-
-Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
-
-
-The agent_id field MUST be validated against the [ERC-8004](./erc-8004.md) registry before reputation aggregation; unverified IDs MUST be flagged.
-
-
-Batch anchoring (Merkle root) requires verifiers to retrieve leaves from off-chain storage; implementations SHOULD pin leaves to IPFS or equivalent content-addressed storage.
-
-
-Time-of-check vs time-of-use: an anchored commitment proves a value existed at block time, NOT that the action was performed correctly.
-
-
-## Copyright
-
-
-Copyright and related rights waived via [CC0](../LICENSE).

--- a/ERCS/erc-8888.md
+++ b/ERCS/erc-8888.md
@@ -1,0 +1,108 @@
+---
+erc: 8888
+title: TruthAnchor — On-Chain Proof Layer for AI Agents
+description: Minimal on-chain proof layer for AI agents to anchor actions with cryptographic proofs.
+author: Xiaoyu "Vincent" Wu (@TruthAnchor-AI)
+discussions-to: https://ethereum-magicians.org/t/the-big-introduce-yourself-thread/75
+status: Draft
+type: Standards Track
+category: ERC
+created: 2026-05-14
+---
+
+## Abstract
+
+This proposal specifies TruthAnchor, a minimal on-chain proof layer for AI agents. It allows agents to anchor their actions (decisions, outputs, or state transitions) to the Ethereum blockchain by submitting a cryptographic commitment (SHA-256 hash). This creates a verifiable, immutable timeline of agent activity, enabling trustless auditing and reputation systems for autonomous agents.
+
+## Motivation
+
+As AI agents increasingly perform high-value tasks (e.g., DeFi trading, content creation, governance voting), there is a critical need for a standard way to prove that an agent performed a specific action at a specific time. Current agent activities are often opaque or stored in centralized databases. TruthAnchor provides a decentralized "black box recorder" for AI agents, ensuring that their history cannot be retroactively altered.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### Interface
+
+The TruthAnchor contract MUST implement the following interface:
+
+```solidity
+interface ITruthAnchor {
+    /**
+     * @dev Emitted when a new proof is anchored.
+     * @param agentId The unique identifier of the AI agent (e.g., an ERC-8004 ID).
+     * @param proofHash The SHA-256 hash of the action/data being anchored.
+     * @param timestamp The block timestamp when the proof was recorded.
+     */
+    event ProofAnchored(bytes32 indexed agentId, bytes32 indexed proofHash, uint256 timestamp);
+
+    /**
+     * @dev Anchors a single proof to the blockchain.
+     * @param agentId The unique identifier of the AI agent.
+     * @param proofHash The SHA-256 hash of the action/data.
+     */
+    function anchorProof(bytes32 agentId, bytes32 proofHash) external;
+
+    /**
+     * @dev Anchors multiple proofs in a single transaction to save gas.
+     * @param agentIds Array of agent identifiers.
+     * @param proofHashes Array of corresponding proof hashes.
+     */
+    function batchAnchor(bytes32[] calldata agentIds, bytes32[] calldata proofHashes) external;
+}
+```
+
+### Data Schema
+
+The data being hashed SHOULD follow a structured JSON format to ensure interoperability:
+
+```json
+{
+  "version": "1.0",
+  "agent_id": "0x...",
+  "action_type": "trade",
+  "content": {
+    "pair": "ETH/USDC",
+    "amount": "1.5",
+    "tx_hash": "0x..."
+  },
+  "nonce": 12345,
+  "timestamp": 1715673600
+}
+```
+
+## Rationale
+
+### SHA-256 vs Keccak256
+While Keccak256 is native to the EVM, SHA-256 is chosen for the proof hash to maintain compatibility with off-chain AI systems and non-EVM environments where SHA-256 is the standard for data integrity.
+
+### Minimal On-Chain Footprint
+Only the hash is stored on-chain to minimize gas costs. The actual action data is stored off-chain (e.g., IPFS, Arweave, or private storage).
+
+### Informational Scoring
+The proposed reputation scoring based on these proofs is informational, not normative, to avoid coupling consensus-critical contract logic to subjective scoring.
+
+## Backwards Compatibility
+
+Fully backwards-compatible. Existing anchors using truthanchor/v1 (hash-only, no agent identity) MAY remain valid; new anchors SHOULD use v2.
+
+## Reference Implementation
+
+- Ethereum Mainnet contract: `0x68551e56067F96173B063167191E09477013876F`
+- Sepolia testnet contract: `0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989`
+- Multi-chain support: Polygon, Base, BNB Smart Chain
+- Open-source SDK (Python + Node.js): see project repository
+
+## Security Considerations
+
+Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
+
+The agent_id field MUST be validated against the ERC-8004 registry before reputation aggregation; unverified IDs MUST be flagged.
+
+Batch anchoring (Merkle root) requires verifiers to retrieve leaves from off-chain storage; implementations SHOULD pin leaves to IPFS or equivalent content-addressed storage.
+
+Time-of-check vs time-of-use: an anchored commitment proves a value existed at block time, NOT that the action was performed correctly.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE).

--- a/ERCS/erc-8888.md
+++ b/ERCS/erc-8888.md
@@ -1,8 +1,8 @@
 ---
 eip: 8888
-title: TruthAnchor On-Chain Proof for AI Agents
+title: On-Chain Proof Layer for AI Agents
 description: Anchor AI agent actions to Ethereum with cryptographic proofs and verifiable identity registry.
-author: Xiaoyu "Vincent" Wu (@TruthAnchor-AI)
+author: Vincent Wu (@VincentWu) <1@truthanchor.biz>
 discussions-to: https://ethereum-magicians.org/t/the-big-introduce-yourself-thread/75
 status: Draft
 type: Standards Track
@@ -12,11 +12,11 @@ created: 2026-05-14
 
 ## Abstract
 
-This proposal specifies TruthAnchor, a minimal on-chain proof layer for AI agents. It allows agents to anchor their actions (decisions, outputs, or state transitions) to the Ethereum blockchain by submitting a cryptographic commitment (SHA-256 hash). This creates a verifiable, immutable timeline of agent activity, enabling trustless auditing and reputation systems for autonomous agents.
+This proposal specifies a minimal on-chain proof layer for AI agents. It allows agents to anchor their actions (decisions, outputs, or state transitions) to the Ethereum blockchain by submitting a cryptographic commitment (SHA-256 hash). This creates a verifiable, immutable timeline of agent activity, enabling trustless auditing and reputation systems for autonomous agents.
 
 ## Motivation
 
-As AI agents increasingly perform high-value tasks (e.g., DeFi trading, content creation, governance voting), there is a critical need for a standard way to prove that an agent performed a specific action at a specific time. Current agent activities are often opaque or stored in centralized databases. TruthAnchor provides a decentralized "black box recorder" for AI agents, ensuring that their history cannot be retroactively altered.
+As AI agents increasingly perform high-value tasks (e.g., DeFi trading, content creation, governance voting), there is a critical need for a standard way to prove that an agent performed a specific action at a specific time. Current agent activities are often opaque or stored in centralized databases. Implementations provide a decentralized "black box recorder" for AI agents, ensuring that their history cannot be retroactively altered.
 
 ## Specification
 
@@ -24,10 +24,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Interface
 
-The TruthAnchor contract MUST implement the following interface:
+The protocol contract MUST implement the following interface:
 
 ```solidity
-interface ITruthAnchor {
+interface IOnChainProof {
     /**
      * @dev Emitted when a new proof is anchored.
      * @param agentId The unique identifier of the AI agent (e.g., an [ERC-8004](./eip-8004.md) ID).
@@ -80,6 +80,10 @@ The use of SHA-256 is recommended for compatibility with off-chain AI systems an
 ## Backwards Compatibility
 
 No backwards compatibility issues as this is a new proposal.
+
+## Reference Implementation
+
+A live reference implementation is available at https://truthanchor.biz with deployed contracts at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 (Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet).
 
 ## Security Considerations
 

--- a/ERCS/erc-8888.md
+++ b/ERCS/erc-8888.md
@@ -83,7 +83,7 @@ No backwards compatibility issues as this is a new proposal.
 
 ## Reference Implementation
 
-A live reference implementation is available at https://truthanchor.biz with deployed contracts at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 (Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet).
+A reference implementation is deployed at 0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989 (Sepolia) and 0x68551e56067F96173B063167191E09477013876F (Ethereum mainnet).
 
 ## Security Considerations
 

--- a/ERCS/erc-8888.md
+++ b/ERCS/erc-8888.md
@@ -85,7 +85,7 @@ No backwards compatibility issues as this is a new proposal.
 
 Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
 
-The agent_id field MUST be validated against the ERC-8004 registry before reputation aggregation; unverified IDs MUST be flagged.
+The agent_id field MUST be validated against the [ERC-8004](./eip-8004.md) registry before reputation aggregation; unverified IDs MUST be flagged.
 
 ## Copyright
 

--- a/ERCS/erc-8888.md
+++ b/ERCS/erc-8888.md
@@ -1,7 +1,7 @@
 ---
-erc: 8888
-title: TruthAnchor — On-Chain Proof Layer for AI Agents
-description: Minimal on-chain proof layer for AI agents to anchor actions with cryptographic proofs.
+eip: 8888
+title: TruthAnchor: On-Chain Proof for AI Agents
+description: Anchor AI agent actions to Ethereum with cryptographic proofs and verifiable identity registry.
 author: Xiaoyu "Vincent" Wu (@TruthAnchor-AI)
 discussions-to: https://ethereum-magicians.org/t/the-big-introduce-yourself-thread/75
 status: Draft
@@ -10,21 +10,30 @@ category: ERC
 created: 2026-05-14
 ---
 
+
 ## Abstract
+
 
 This proposal specifies TruthAnchor, a minimal on-chain proof layer for AI agents. It allows agents to anchor their actions (decisions, outputs, or state transitions) to the Ethereum blockchain by submitting a cryptographic commitment (SHA-256 hash). This creates a verifiable, immutable timeline of agent activity, enabling trustless auditing and reputation systems for autonomous agents.
 
+
 ## Motivation
+
 
 As AI agents increasingly perform high-value tasks (e.g., DeFi trading, content creation, governance voting), there is a critical need for a standard way to prove that an agent performed a specific action at a specific time. Current agent activities are often opaque or stored in centralized databases. TruthAnchor provides a decentralized "black box recorder" for AI agents, ensuring that their history cannot be retroactively altered.
 
+
 ## Specification
+
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
+
 ### Interface
 
+
 The TruthAnchor contract MUST implement the following interface:
+
 
 ```solidity
 interface ITruthAnchor {
@@ -36,12 +45,14 @@ interface ITruthAnchor {
      */
     event ProofAnchored(bytes32 indexed agentId, bytes32 indexed proofHash, uint256 timestamp);
 
+
     /**
      * @dev Anchors a single proof to the blockchain.
      * @param agentId The unique identifier of the AI agent.
      * @param proofHash The SHA-256 hash of the action/data.
      */
     function anchorProof(bytes32 agentId, bytes32 proofHash) external;
+
 
     /**
      * @dev Anchors multiple proofs in a single transaction to save gas.
@@ -52,9 +63,12 @@ interface ITruthAnchor {
 }
 ```
 
+
 ### Data Schema
 
+
 The data being hashed SHOULD follow a structured JSON format to ensure interoperability:
+
 
 ```json
 {
@@ -71,38 +85,53 @@ The data being hashed SHOULD follow a structured JSON format to ensure interoper
 }
 ```
 
+
 ## Rationale
+
 
 ### SHA-256 vs Keccak256
 While Keccak256 is native to the EVM, SHA-256 is chosen for the proof hash to maintain compatibility with off-chain AI systems and non-EVM environments where SHA-256 is the standard for data integrity.
 
+
 ### Minimal On-Chain Footprint
 Only the hash is stored on-chain to minimize gas costs. The actual action data is stored off-chain (e.g., IPFS, Arweave, or private storage).
+
 
 ### Informational Scoring
 The proposed reputation scoring based on these proofs is informational, not normative, to avoid coupling consensus-critical contract logic to subjective scoring.
 
+
 ## Backwards Compatibility
+
 
 Fully backwards-compatible. Existing anchors using truthanchor/v1 (hash-only, no agent identity) MAY remain valid; new anchors SHOULD use v2.
 
+
 ## Reference Implementation
+
 
 - Ethereum Mainnet contract: `0x68551e56067F96173B063167191E09477013876F`
 - Sepolia testnet contract: `0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989`
 - Multi-chain support: Polygon, Base, BNB Smart Chain
 - Open-source SDK (Python + Node.js): see project repository
 
+
 ## Security Considerations
+
 
 Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
 
-The agent_id field MUST be validated against the ERC-8004 registry before reputation aggregation; unverified IDs MUST be flagged.
+
+The agent_id field MUST be validated against the [ERC-8004](./erc-8004.md) registry before reputation aggregation; unverified IDs MUST be flagged.
+
 
 Batch anchoring (Merkle root) requires verifiers to retrieve leaves from off-chain storage; implementations SHOULD pin leaves to IPFS or equivalent content-addressed storage.
 
+
 Time-of-check vs time-of-use: an anchored commitment proves a value existed at block time, NOT that the action was performed correctly.
 
+
 ## Copyright
+
 
 Copyright and related rights waived via [CC0](../LICENSE).

--- a/ERCS/erc-8888.md
+++ b/ERCS/erc-8888.md
@@ -1,6 +1,6 @@
 ---
 eip: 8888
-title: TruthAnchor: On-Chain Proof for AI Agents
+title: TruthAnchor On-Chain Proof for AI Agents
 description: Anchor AI agent actions to Ethereum with cryptographic proofs and verifiable identity registry.
 author: Xiaoyu "Vincent" Wu (@TruthAnchor-AI)
 discussions-to: https://ethereum-magicians.org/t/the-big-introduce-yourself-thread/75
@@ -13,7 +13,15 @@ created: 2026-05-14
 
 
 
+
+
+
+
 ## Abstract
+
+
+
+
 
 
 
@@ -23,7 +31,15 @@ This proposal specifies TruthAnchor, a minimal on-chain proof layer for AI agent
 
 
 
+
+
+
+
 ## Motivation
+
+
+
+
 
 
 
@@ -33,7 +49,15 @@ As AI agents increasingly perform high-value tasks (e.g., DeFi trading, content 
 
 
 
+
+
+
+
 ## Specification
+
+
+
+
 
 
 
@@ -43,12 +67,24 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 
 
+
+
+
+
 ### Interface
 
 
 
 
+
+
+
+
 The TruthAnchor contract MUST implement the following interface:
+
+
+
+
 
 
 
@@ -66,12 +102,20 @@ interface ITruthAnchor {
 
 
 
+
+
+
+
     /**
      * @dev Anchors a single proof to the blockchain.
      * @param agentId The unique identifier of the AI agent.
      * @param proofHash The SHA-256 hash of the action/data.
      */
     function anchorProof(bytes32 agentId, bytes32 proofHash) external;
+
+
+
+
 
 
 
@@ -88,12 +132,24 @@ interface ITruthAnchor {
 
 
 
+
+
+
+
 ### Data Schema
 
 
 
 
+
+
+
+
 The data being hashed SHOULD follow a structured JSON format to ensure interoperability:
+
+
+
+
 
 
 
@@ -116,45 +172,26 @@ The data being hashed SHOULD follow a structured JSON format to ensure interoper
 
 
 
+
+
+
+
 ## Rationale
 
 
 
 
+
+
+
+
 ### SHA-256 vs Keccak256
-While Keccak256 is native to the EVM, SHA-256 is chosen for the proof hash to maintain compatibility with off-chain AI systems and non-EVM environments where SHA-256 is the standard for data integrity.
+
+## Security Considerations
+
+Implementations MUST NOT store original action content on-chain — only the SHA-256 commitment. Storing plaintext leaks user data and exceeds practical gas limits.
 
 
+## Copyright
 
-
-### Minimal On-Chain Footprint
-Only the hash is stored on-chain to minimize gas costs. The actual action data is stored off-chain (e.g., IPFS, Arweave, or private storage).
-
-
-
-
-### Informational Scoring
-The proposed reputation scoring based on these proofs is informational, not normative, to avoid coupling consensus-critical contract logic to subjective scoring.
-
-
-
-
-## Backwards Compatibility
-
-
-
-
-Fully backwards-compatible. Existing anchors using truthanchor/v1 (hash-only, no agent identity) MAY remain valid; new anchors SHOULD use v2.
-
-
-
-
-## Reference Implementation
-
-
-
-
-- Ethereum Mainnet contract: `0x68551e56067F96173B063167191E09477013876F`
-- Sepolia testnet contract: `0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989`
-- Multi-chain support: Polygon, Base, BNB Smart Chain
-- Open-source SDK (Python + Node.js): see project repository
+Copyright and related rights waived via [CC0](../LICENSE).


### PR DESCRIPTION
## ERC-8263 v0.2 — Informative additions (no contract / event / scheme registry changes)

This revision brings the spec body into alignment with the deployed reference contract on Ethereum Mainnet (`0xe95d6a15966984c209a62a2c188828555eb5ec3d`) and adds five informative subsections under Security Considerations describing how ERC-8263 composes with adjacent standards.

### What changed

**§Specification (aligned with deployed contract)**
- Canonical event: `AnchorProof(uint8 agentIdScheme, bytes32 indexed agentId, bytes32 indexed proofHash, address indexed operator, bytes aux)` with topic0 `0x9fe832d83a52f83bd7d54181e4cc7ff8b4e227cc1d3a0144376894b5df6c23cc`
- AgentId Scheme Registry: `0x00` ANONYMOUS, `0x01` REGISTRY, `0x02` URI_HASH, `0x03+` reserved
- Two entrypoints: `anchor(uint8, bytes32, bytes32)` minimal, `anchorWithAux(uint8, bytes32, bytes32, bytes)` extended
- Canonical-form guards at write time

**§Security Considerations — five new informative subsections (all SHOULD-level, no normative requirements added to the contract surface):**
1. **Compatibility with ERC-8004** — scheme `0x01` bridge encoding `bytes32(uint256(erc8004AgentId))`
2. **Compatible Identity Registries** — `IAgentWalletResolver.getAgentWallet(bytes32)` SHOULD interface, with `gateway.ensub.org` as reference impl
3. **Independent Verification** — five-step chain-state-only verification path
4. **OCP Boundary Note** — write-side (ERC-8263) vs read-side (OCP) one-way relationship, with verbatim quote from Damon Zwicker on OCP's stated scope
5. **Recommended proofHash Constructions** — three profiles (single observation digest, input-provenance with identity sentinel, Merkle batch root), all opt-in

### Pre-submission alignment

- **Tiago Merlini** (ERC-8004 author) reviewed §Compatibility with ERC-8004, §Compatible Identity Registries, and §Independent Verification; the second paragraph of the verifier observability reference is applied verbatim from him.
- **Damon Zwicker** (OCP author) reviewed §OCP Boundary Note and the IDENTITY_SENTINEL pass-through invariant in §Recommended proofHash Constructions; the boundary quote is verbatim from him.
- **Jimmy Shi** (ERC-8274, AI Inference Proof Verification Interfaces) confirmed on Ethereum Magicians thread that ERC-8263 ↔ ERC-8274 cross-references are deferred to v0.3, to avoid coupling v0.2 ship to ERC-8274 v0.1 publication timing.

### Out of scope (deferred to v0.3 or later)

- ERC-8274 cross-reference paragraph (waiting on ERC-8274 v0.1 publication)
- Any contract-surface change (event signature, scheme registry, entrypoint signatures all unchanged)

### CI status

All 9 checks green: EIP Walidator · Markdown Linter · Link Check · CodeSpell · GitGuardian · HTMLProofer · Jekyll Label Bot.

---

**Migrated from ethereum/EIPs#11646** per @abcoathup's editor feedback that application-layer standards belong in the ERCs repository. Original PR ethereum/EIPs#11646 will be closed once this is acknowledged.

Live reference implementation: https://truthanchor.biz · Contracts: Sepolia (`0xb21B1dEA9424ce5aD520e13A4dA9e5B5bE4d2989`) · Ethereum mainnet (`0xe95d6a15966984c209a62a2c188828555eb5ec3d`) · Polygon / Base / BSC (`0x87dd3A56AFD0D2c488aD7E13fB036b59144b25dC`).