### PR TITLE
Update ERC-7930: define "Chain Identifier" term for zero-length-address IAs

### DIFF
--- a/ERCS/erc-7930.md
+++ b/ERCS/erc-7930.md
@@ -57,6 +57,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 **Interoperable Address**
 : A binary payload which unambiguously identifies a _target address_ on a target chain. e.g. `0x00010000010114d8da6bf26964af9d7eed9e03e53415d37aa96045`
 
+**Chain Identifier**
+: An _Interoperable Address_ with a zero-length _Address_. It identifies a chain rather than a specific address on that chain. e.g. `0x000100022045296998a6f8e2a784db5d9f95e18fc23f70441a1039446801089879b08c7ef000` is a Chain Identifier for Solana mainnet.
+
 
 ### _Interoperable Address_ Definition
 
@@ -83,7 +86,7 @@ The components outlined above have the following meanings:
 : Variable length, binary representation of the [CAIP-350] chain reference. Serialization of the _ChainReference_ within a specific namespace MUST follow the algorithm defined in the namespace's [CAIP-350] profile. Chain profiles are maintained by the Chain-Agnostic Standards Alliance (CASA).
 
 **AddressLength**
-: 1-byte integer encoding the length of Address in bytes. Note that it MAY be zero, in which case the _Interoperable Address_ MUST NOT include an address. It MUST NOT be zero if the _ChainReferenceLength_ is also zero.
+: 1-byte integer encoding the length of Address in bytes. Note that it MAY be zero, in which case the _Interoperable Address_ is a _Chain Identifier_ and MUST NOT include an address. It MUST NOT be zero if the _ChainReferenceLength_ is also zero.
 
 **Address**
 : Variable length field containing the binary encoding of the characters of the serialized address. The serialization for a specific _ChainType_ MUST follow the rules of its corresponding [CAIP-350] profile.
@@ -179,7 +182,7 @@ These components produce the following _Interoperable Address_:
 ```
 ---  
 
-#### Example 4: Solana mainnet network, no address
+#### Example 4: Solana mainnet Chain Identifier
 
 **Components**
 


### PR DESCRIPTION
## Summary

- Adds a **Chain Identifier** term to the Terminology section, defined as an _Interoperable Address_ with a zero-length _Address_ (i.e. one that identifies a chain rather than a specific address on that chain).
- References the new term in the `AddressLength` field description.
- Renames Example 4's heading from "Solana mainnet network, no address" to "Solana mainnet Chain Identifier".

## Motivation

The spec already allows `AddressLength == 0` (with `ChainReferenceLength > 0`) and demonstrates it in Example 4, but the construct had no name. Giving it a name ("Chain Identifier") makes it easier to refer to in downstream specs and conversation, and mirrors the existing `Chain-specific Address` term.

This change is purely additive terminology — no wire-format or semantic changes.

## Test plan

- [ ] EIP linter passes
- [x] Rendered markdown reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)