### PR TITLE
Add ERC: Persistent Identity Token

### DIFF
--- a/ERCS/erc-persistent-identity.md
+++ b/ERCS/erc-persistent-identity.md
@@ -3,7 +3,7 @@ eip: TBD
 title: Persistent Identity Token
 description: A standard for persistent, human-readable identity tokens mapped to EVM addresses with support for resolution, lifecycle management, URL records, and policy-controlled governance.
 author: Idon Liu (@nftprof)
-discussions-to: TBD
+discussions-to: https://ethereum-magicians.org/t/erc-persistent-identity-token-pip-on-chain-identity-with-bind-to-lock-model/28641
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-persistent-identity.md
+++ b/ERCS/erc-persistent-identity.md
@@ -1,0 +1,198 @@
+---
+eip: TBD
+title: Persistent Identity Token
+description: A standard for persistent, human-readable identity tokens mapped to EVM addresses with support for resolution, lifecycle management, URL records, and policy-controlled governance.
+author: Idon Liu (@nftprof)
+discussions-to: TBD
+status: Draft
+type: Standards Track
+category: ERC
+created: 2026-04-30
+requires: 721, 165
+---
+
+## Abstract
+
+This ERC defines a standard interface for **Persistent Identity Tokens** — ERC-721 tokens that represent human-readable, on-chain identities bound to EVM addresses. A Persistent Identity Token can represent a username, account identity, application handle, game identity, brand identity, or agent identity.
+
+The standard introduces three interface layers:
+
+1. **Identity Layer** (`IPersistentIdentity`) — name registration, address binding, URL records, and soulbound locking
+2. **Resolution Layer** (`IPersistentIdentityResolver`) — convenience functions for resolving names to addresses and identity records
+3. **Policy Layer** (`IPersistentIdentityPolicy`) — governance actions including pricing, renaming, unbinding, and namespace rules
+
+## Motivation
+
+Web2 usernames are platform-controlled database entries. They are not owned by users, cannot interoperate across applications, and are vulnerable to deletion, impersonation, recycling, and bot creation.
+
+Web3 addresses are user-owned but not human-readable. They are difficult to use as social or login identities. Existing on-chain naming services (e.g., ENS) provide name resolution but do not address identity persistence, lifecycle governance, login system compatibility, or economic spam resistance.
+
+This standard introduces a bridge between both models by defining persistent on-chain identity objects that:
+
+- Map human-readable names to EVM addresses
+- Become soulbound when bound (preventing unauthorized transfers of active identities)
+- Support governance-controlled unbinding for legitimate transfers
+- Store URL records on-chain for canonical forwarding
+- Enable applications to use on-chain identities as login credentials
+- Provide economic spam resistance through configurable pricing
+- Support namespace-specific policy rules without modifying the core identity interface
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+### Identity Layer (`IPersistentIdentity`)
+
+A compliant contract MUST implement `IPersistentIdentity` and MUST be an ERC-721 token.
+
+#### Name Registration
+
+- Each token MUST be associated with exactly one human-readable name string.
+- Each name string MUST map to at most one token ID.
+- Names MUST be unique within a namespace (contract instance).
+
+```solidity
+function nameRegistered(string calldata name) external view returns (bool);
+function tokenOfName(string calldata name) external view returns (uint256);
+function nameOf(uint256 tokenId) external view returns (string memory);
+```
+
+#### Address Binding
+
+- Token owners MAY bind their token to an EVM address.
+- The `bind` function MUST set the bound address to `msg.sender`.
+- Binding MUST lock the token, preventing transfers.
+- A bound token MUST NOT be transferable until explicitly unbound by the policy layer.
+
+```solidity
+function boundAddress(uint256 tokenId) external view returns (address);
+function isBound(uint256 tokenId) external view returns (bool);
+function bind(uint256 tokenId) external;
+```
+
+#### URL Record
+
+- Bound tokens MAY have an associated URL record.
+- The `setUrlRecord` function MUST require the token to be bound.
+- URL records MUST be clearable by the policy layer on unbind.
+
+```solidity
+function urlRecord(uint256 tokenId) external view returns (string memory);
+function setUrlRecord(uint256 tokenId, string calldata url) external;
+```
+
+#### Tier Classification
+
+- Tokens MAY have a tier classification (e.g., Reserved, Standard, Basic).
+- Tier determines tradability rules. Reserved tier tokens MAY be permanently non-transferable.
+
+```solidity
+function tierOf(uint256 tokenId) external view returns (Tier);
+```
+
+#### Transfer Restrictions
+
+- If a token is bound (`isBound` returns true), the `_update` function (ERC-721 transfer hook) MUST revert.
+- Reserved tier tokens MUST NOT be transferable unless explicitly unlocked by the contract owner.
+- When a token is successfully transferred, the bound address and URL record MUST be cleared.
+
+### Resolution Layer (`IPersistentIdentityResolver`)
+
+A compliant contract SHOULD implement `IPersistentIdentityResolver` for convenience.
+
+```solidity
+function resolveAddress(string calldata name) external view returns (address);
+function resolveUrl(string calldata name) external view returns (string memory);
+function resolveIdentity(string calldata name) external view returns (
+    uint256 tokenId, address owner, address boundAddr, bool bound, string memory url, uint8 tier
+);
+```
+
+### Policy Layer (`IPersistentIdentityPolicy`)
+
+A compliant contract MAY implement `IPersistentIdentityPolicy` for governance.
+
+- `unbind` MUST clear the bound address, URL record, and lock status.
+- `rename` MUST update the name-to-token and token-to-name mappings.
+- `purchaseMint` MUST verify `msg.value` matches the on-chain price and mint to `msg.sender`.
+
+### Events
+
+All state changes MUST emit the corresponding events defined in the interfaces.
+
+### Metadata
+
+Token metadata returned by `tokenURI` SHOULD follow the standard ERC-721 metadata JSON schema and SHOULD include:
+
+- `name`: The human-readable identity name
+- `description`: Identity description including tier
+- `image`: Visual representation of the identity
+- `attributes`: Array including at minimum `Name`, `Tier`, and `Score` (if applicable)
+
+Implementations MAY include additional classification metadata (e.g., AI-driven rarity signals, cultural significance indicators, domain availability data) as extended attributes.
+
+## Rationale
+
+### Separation of Identity and Policy
+
+The standard separates the identity layer from the policy layer. The identity layer defines the minimum interface for persistent identity objects. The policy layer is namespace-specific and may include pricing, reclaim rules, reserved names, moderator controls, transferability rules, and dispute resolution.
+
+This separation allows different applications and communities to adopt the same identity standard while applying their own governance models.
+
+### Bind-to-Lock Model
+
+Unlike traditional SBTs (ERC-5192) which are non-transferable from mint, Persistent Identity Tokens are transferable when unbound. This enables a secondary market for unclaimed identities while protecting active identities from unauthorized transfer.
+
+The bind-to-lock model provides:
+- Users can trade unbound names freely
+- Once bound, the identity cannot be sold from under the user
+- Governance-controlled unbinding provides a safety mechanism
+
+### Economic Spam Resistance
+
+By supporting on-chain pricing through the policy layer, namespace operators can introduce controlled economic friction. This provides natural bot resistance without relying solely on centralized moderation.
+
+### URL Record vs DNS
+
+On-chain URL records provide a censorship-resistant forwarding mechanism. Unlike traditional DNS forwarding, the identity record does not depend on a DNS registrar. Access layers (websites, wallets, apps, resolver APIs) read from the on-chain source of truth.
+
+## Backwards Compatibility
+
+This standard is compatible with:
+
+- **ERC-721**: Persistent Identity Tokens are valid ERC-721 tokens.
+- **ERC-165**: Implementations SHOULD register support for `IPersistentIdentity` via ERC-165.
+- **ERC-5192**: The bind-to-lock behavior is philosophically related but distinct. ERC-5192 defines permanently non-transferable tokens; this standard defines conditionally non-transferable tokens based on binding state.
+- **ENS**: This standard operates at the identity/username layer rather than the naming/DNS layer. Implementations MAY coexist with ENS.
+- **ERC-6551**: Token Bound Accounts are complementary. A Persistent Identity Token MAY have an associated TBA for agent execution or wallet capabilities.
+- **ERC-4337**: Account abstraction is compatible. Persistent Identity resolution can be used in smart account contexts.
+
+## Security Considerations
+
+Implementers should consider:
+
+- **Impersonation risk**: Names are first-come-first-serve within a namespace. Policy layers SHOULD implement reserved name lists and moderation capabilities.
+- **Premium name disputes**: Governance rename capability provides a mechanism for resolving trademark and IP disputes.
+- **Moderator abuse**: Unbind and rename capabilities should be restricted to clearly defined governance roles with transparent event logging.
+- **Private key compromise**: If a user's key is compromised, the bound identity cannot be transferred (protecting the identity), but the attacker could unbind if they have governance access.
+- **Resolver poisoning**: External resolvers should validate on-chain data directly rather than relying on cached intermediaries.
+- **Malicious URL forwarding**: Applications displaying URL records should warn users before redirecting to external URLs.
+- **Bot registration**: Economic pricing through the policy layer provides spam resistance. Implementations SHOULD enforce minimum pricing for all registrations.
+- **Namespace squatting**: Policy layers SHOULD implement mechanisms to prevent or mitigate squatting of culturally significant names.
+
+## Reference Implementation
+
+PEG ID at [id.peg.gg](https://id.peg.gg) is the first reference implementation of the Persistent Identity Protocol, deployed on Pentagon Chain (chain ID 3344) at `0xf97EB9f8293D1FD5587a809Eb74518c300738d07`.
+
+The reference implementation includes:
+- Full `IPersistentIdentity` compliance
+- Policy layer with role-based access (Owner, Moderator)
+- Three-tier classification system (Reserved/SBT, Standard, Basic)
+- On-chain pricing with AI-driven classification
+- URL forwarding with on-chain records
+- Login system integration with existing Web2 authentication
+- Metadata API with dynamic SVG generation
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/assets/erc-persistent-identity/IPersistentIdentity.sol
+++ b/assets/erc-persistent-identity/IPersistentIdentity.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IPersistentIdentity
+ * @notice Core interface for the Persistent Identity Protocol (PIP).
+ *
+ *  A Persistent Identity Token is an ERC-721 token that represents a
+ *  human-readable, on-chain identity bound to an EVM address. Once bound,
+ *  the token becomes soulbound (non-transferable) until explicitly unbound
+ *  by a governance action.
+ *
+ *  Key properties:
+ *    - Human-readable name mapped to a token ID
+ *    - Token ID mapped to a bound EVM address (spatial binding)
+ *    - Binding locks the token (soulbound behavior)
+ *    - Unbinding requires governance/moderator action
+ *    - Optional URL record per identity
+ *    - Lifecycle events for all state changes
+ */
+interface IPersistentIdentity {
+
+    // ─── Enums ────────────────────────────────────────────────────────
+
+    /// @notice Identity tier classification
+    enum Tier { Reserved, Standard, Basic }
+
+    // ─── Events ───────────────────────────────────────────────────────
+
+    /// @notice Emitted when a new identity is minted
+    event IdentityMinted(
+        uint256 indexed tokenId,
+        string name,
+        Tier tier,
+        address indexed to,
+        address boundAddress
+    );
+
+    /// @notice Emitted when an identity is bound to an address
+    event IdentityBound(
+        uint256 indexed tokenId,
+        address indexed boundAddress
+    );
+
+    /// @notice Emitted when an identity is unbound (unlocked for transfer)
+    event IdentityUnbound(uint256 indexed tokenId);
+
+    /// @notice Emitted when an identity name is changed by governance
+    event IdentityRenamed(
+        uint256 indexed tokenId,
+        string oldName,
+        string newName
+    );
+
+    /// @notice Emitted when a URL record is set
+    event UrlRecordSet(
+        uint256 indexed tokenId,
+        string url
+    );
+
+    // ─── Errors ───────────────────────────────────────────────────────
+
+    /// @notice The name is already registered
+    error NameAlreadyRegistered(string name);
+
+    /// @notice The name string is empty
+    error EmptyName();
+
+    /// @notice Caller is not the token owner
+    error NotTokenOwner();
+
+    /// @notice Token is bound and cannot be transferred
+    error IdentityBoundLocked();
+
+    /// @notice Identity must be bound before this action
+    error IdentityNotBound();
+
+    // ─── Name Resolution ──────────────────────────────────────────────
+
+    /// @notice Check if a name is registered
+    /// @param name The human-readable name
+    /// @return True if the name has been minted
+    function nameRegistered(string calldata name) external view returns (bool);
+
+    /// @notice Get the token ID for a registered name
+    /// @param name The human-readable name
+    /// @return tokenId The token ID (reverts if not registered)
+    function tokenOfName(string calldata name) external view returns (uint256);
+
+    /// @notice Get the name for a token ID
+    /// @param tokenId The token ID
+    /// @return name The human-readable name
+    function nameOf(uint256 tokenId) external view returns (string memory);
+
+    // ─── Address Binding ──────────────────────────────────────────────
+
+    /// @notice Get the bound address for a token
+    /// @param tokenId The token ID
+    /// @return The bound EVM address (zero address if unbound)
+    function boundAddress(uint256 tokenId) external view returns (address);
+
+    /// @notice Check if a token is bound (and therefore locked)
+    /// @param tokenId The token ID
+    /// @return True if the token is bound to an address
+    function isBound(uint256 tokenId) external view returns (bool);
+
+    /// @notice Bind the token to the caller's address
+    /// @dev MUST set the bound address to msg.sender
+    /// @dev MUST lock the token (prevent transfers)
+    /// @dev MUST emit IdentityBound
+    /// @param tokenId The token ID (caller must be owner)
+    function bind(uint256 tokenId) external;
+
+    // ─── URL Record ───────────────────────────────────────────────────
+
+    /// @notice Get the URL record for a token
+    /// @param tokenId The token ID
+    /// @return The URL string (empty if not set)
+    function urlRecord(uint256 tokenId) external view returns (string memory);
+
+    /// @notice Set the URL record for a bound token
+    /// @dev MUST require the token to be bound
+    /// @dev MUST require caller to be token owner
+    /// @dev MUST emit UrlRecordSet
+    /// @param tokenId The token ID
+    /// @param url The URL to set
+    function setUrlRecord(uint256 tokenId, string calldata url) external;
+
+    // ─── Identity Metadata ────────────────────────────────────────────
+
+    /// @notice Get the tier of a token
+    /// @param tokenId The token ID
+    /// @return The tier classification
+    function tierOf(uint256 tokenId) external view returns (Tier);
+
+    /// @notice Get the total number of identities minted
+    /// @return The count of minted tokens
+    function totalMinted() external view returns (uint256);
+}

--- a/assets/erc-persistent-identity/IPersistentIdentityPolicy.sol
+++ b/assets/erc-persistent-identity/IPersistentIdentityPolicy.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IPersistentIdentityPolicy
+ * @notice Policy interface for namespace governance in the Persistent Identity Protocol.
+ *
+ *  The policy layer is separate from the identity layer. Each namespace
+ *  operator defines their own rules for:
+ *    - Who can mint (open, whitelist, moderator-only)
+ *    - Pricing (free, fixed, AI-driven, auction)
+ *    - Reclaim/rename authority
+ *    - Unbinding authority
+ *    - Reserved names
+ *    - Transfer restrictions per tier
+ *
+ *  This interface defines the governance actions that a policy controller
+ *  can perform on the identity contract. Implementations MAY restrict
+ *  these actions to specific roles (e.g., Owner, Moderator).
+ */
+interface IPersistentIdentityPolicy {
+
+    // ─── Events ───────────────────────────────────────────────────────
+
+    /// @notice Emitted when a name's price is set on-chain
+    event NamePriceSet(string name, uint256 price);
+
+    /// @notice Emitted when a governance rename occurs
+    event GovernanceRename(uint256 indexed tokenId, string oldName, string newName, string reason);
+
+    // ─── Governance Actions ───────────────────────────────────────────
+
+    /// @notice Unbind an identity (governance action, unlocks for transfer)
+    /// @dev MUST clear bound address, URL record, and lock status
+    /// @dev MUST emit IdentityUnbound
+    /// @param tokenId The token ID to unbind
+    function unbind(uint256 tokenId) external;
+
+    /// @notice Rename an identity (governance action)
+    /// @dev MUST update name mappings
+    /// @dev MUST emit IdentityRenamed
+    /// @param tokenId The token ID to rename
+    /// @param newName The new name string
+    function rename(uint256 tokenId, string calldata newName) external;
+
+    /// @notice Set the on-chain price for a name
+    /// @dev MUST only be callable by authorized policy controller
+    /// @param name The name to price
+    /// @param priceInWei The price in native token wei
+    /// @param tier The tier classification
+    function setNamePrice(string calldata name, uint256 priceInWei, uint8 tier) external;
+
+    /// @notice Purchase and mint a name at the on-chain price
+    /// @dev MUST verify msg.value matches the set price
+    /// @dev MUST mint the token to msg.sender (unbound)
+    /// @dev MUST clear the price listing after purchase
+    /// @param name The name to purchase
+    /// @return tokenId The minted token ID
+    function purchaseMint(string calldata name) external payable returns (uint256 tokenId);
+
+    // ─── Policy Queries ───────────────────────────────────────────────
+
+    /// @notice Get the on-chain price for a name
+    /// @param name The name to query
+    /// @return The price in wei (0 = not listed)
+    function namePrice(string calldata name) external view returns (uint256);
+
+    /// @notice Get the treasury address where purchase funds are sent
+    /// @return The treasury address
+    function treasury() external view returns (address);
+}

--- a/assets/erc-persistent-identity/IPersistentIdentityResolver.sol
+++ b/assets/erc-persistent-identity/IPersistentIdentityResolver.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IPersistentIdentityResolver
+ * @notice Resolution interface for looking up identity data by name.
+ *
+ *  Provides convenience functions for resolving a human-readable name
+ *  to its associated on-chain data in a single call. Implementations
+ *  MAY be on the same contract as IPersistentIdentity or on a separate
+ *  resolver contract.
+ */
+interface IPersistentIdentityResolver {
+
+    /// @notice Resolve a name to its bound address
+    /// @param name The human-readable name
+    /// @return The bound EVM address (zero if unbound or not registered)
+    function resolveAddress(string calldata name) external view returns (address);
+
+    /// @notice Resolve a name to its URL record
+    /// @param name The human-readable name
+    /// @return The URL string (empty if not set or not registered)
+    function resolveUrl(string calldata name) external view returns (string memory);
+
+    /// @notice Resolve a name to its full identity record
+    /// @param name The human-readable name
+    /// @return tokenId The token ID
+    /// @return owner The current token owner
+    /// @return boundAddr The bound address
+    /// @return bound Whether the identity is bound
+    /// @return url The URL record
+    /// @return tier The tier classification
+    function resolveIdentity(string calldata name) external view returns (
+        uint256 tokenId,
+        address owner,
+        address boundAddr,
+        bool bound,
+        string memory url,
+        uint8 tier
+    );
+}


### PR DESCRIPTION
## Summary

This ERC proposes a standard interface for **Persistent Identity Tokens** — ERC-721 tokens that represent human-readable, on-chain identities bound to EVM addresses.

## Three Interface Layers

1. **Identity Layer** (`IPersistentIdentity`) — name registration, address binding, URL records, and soulbound locking
2. **Resolution Layer** (`IPersistentIdentityResolver`) — on-chain name-to-address and identity lookup
3. **Policy Layer** (`IPersistentIdentityPolicy`) — namespace governance (pricing, renaming, unbinding, reserved names)

## Core Mechanism: Bind-to-Lock

Tokens are freely tradable when unbound. When a user binds an identity to their address (`bind(tokenId)`), the token becomes soulbound — protecting active identities from unauthorized transfer while allowing a secondary market for unclaimed names.

## Key Differentiators from Existing Standards

- **vs ENS:** Identity/username layer (not DNS). No expiry. Lifecycle governance. Agent-compatible.
- **vs ERC-5192 (SBT):** Conditional soulbinding (bound=locked, unbound=tradable) vs permanent non-transferability.
- **vs Web2 usernames:** User-owned, on-chain, portable across applications.

## Reference Implementation

PEG ID — live on Pentagon Chain (chain ID 3344) at `0xf97EB9f8293D1FD5587a809Eb74518c300738d07` with 2,200+ identities minted.

## Protocol Repository

[persistent-identity-protocol](https://github.com/blockchainsuperheroes/persistent-identity-protocol) — published under CC0 1.0 Universal.

## Compatibility

ERC-721, ERC-165, ERC-5192, ERC-6551, ERC-4337, ENS.

## Files

- `ERCS/erc-persistent-identity.md` — Full ERC specification
- `assets/erc-persistent-identity/` — Solidity interfaces (IPersistentIdentity, IPersistentIdentityResolver, IPersistentIdentityPolicy)