### PR TITLE
Update ERC-7730: Introduce 'alert' field for dangerous contracts being removed from the registry

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -115,6 +115,8 @@ The `metadata` section contains constants that can be trusted when the ERC-7730 
 
 In this example, the metadata section contains only the recipient information, in the form of a displayable name (`owner` key), contract displayable name (`contractName` key) and additional information (`info` key) that MAY be used by wallets to provide details about the recipient.
 
+The optional `alert` key can carry a security message that wallets MUST surface to users before allowing signing.
+
 Finally, the `display` section contains the definitions of how to format each field of targeted contract calls under the `formats` key. 
 
 In this example, the function being described is identified by its human-readable ABI fragment `transfer(address to,uint256 value)`. Wallets strip the parameter names to compute the type-only signature `transfer(address,uint256)`, hash it, and match the resulting selector `0xa9059cbb` against the calldata.
@@ -692,6 +694,58 @@ This snippet introduces an enumeration describing the displayable values of an i
 ```
 
 In this example, the `interestRateMode` field is formatted using the enumeration defined under `$.metadata.enums.interestRateMode`.
+
+### `Alert` section
+
+The `alert` key is an optional top-level field that communicates a security message about the contract or message targeted by this ERC-7730 file.
+
+It is intended to allow registry operators to publish revoked specifications for contracts that were previously added to the registry but are known to become compromised, malicious, or otherwise unsafe.
+This ensures that wallets show a prominent warning instead of silently falling back to blind signing.
+
+**`severity`**
+
+A required string, one of `"warning"` or `"critical"`:
+
+* `"warning"`: Something noteworthy that users should be aware of before proceeding. Wallets MUST display the `message` before the normal signing screen. Signing MAY proceed after acknowledgment.
+* `"critical"`: The contract is known to be compromised or malicious. Wallets MUST display the `message` prominently. Wallets SHOULD prevent signing by default and require an explicit "I understand the risk" acknowledgment step before allowing it.
+
+**`message`**
+
+A required plain-text string describing the nature of the alert. It MUST NOT exceed 500 characters. It MUST be rendered as plain text. No markup of any kind MUST be interpreted.
+
+A `message` SHOULD include enough context for a user to understand why the alert was issued. A `message` SHOULD NOT contain any links or reference any external resources.
+
+**Coexistence with `display`**
+
+An `alert` MAY coexist with a `display` section.
+
+For `"warning"` severity, wallets SHOULD still render field-level display after showing the alert, so users can see exactly what they are signing.
+
+For `"critical"` severity, the `display` section MAY be absent. Wallets SHOULD treat `"critical"` alerts as sufficient reason to show no further formatting.
+
+**Tombstone-only files**
+
+A valid ERC-7730 file MAY contain only `context` and `alert`, with no `metadata` or `display`. This is the canonical tombstone form for a known malicious contract.
+
+
+*Example — critical tombstone*
+
+```json
+{
+    "$schema": "./erc7730-v2.schema.json",
+    "context": {
+        "contract": {
+            "deployments": [
+                { "chainId": 1, "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3" }
+            ]
+        }
+    },
+    "alert": {
+        "severity": "critical",
+        "message": "This contract was compromised on 2025-03-01. Its owner signing keys are no longer under legitimate control. Do not sign any transactions targeting this address."
+    }
+}
+```
 
 ### `Display` section
 
@@ -1599,6 +1653,7 @@ More examples can be found in the asset folder.
 | [example-visibility-rules.json](../assets/eip-7730/example-visibility-rules.json) | Example of controlling the visibility of fields |
 | [example-account-execute.json](../assets/eip-7730/example-account-execute.json) | Example of EIP-4337 smart wallet execute function clear signing |
 | [example-userops-eip-712.json](../assets/eip-7730/example-userops-eip712.json) | Example of EIP-4337 User Operation clear signing |
+| [example-alert.json](../assets/eip-7730/example-alert.json) | Example of a tombstone alert for a known-compromised contract |
 
 
 ## Security Considerations

--- a/assets/erc-7730/erc7730-v2.schema.json
+++ b/assets/erc-7730/erc7730-v2.schema.json
@@ -33,6 +33,10 @@
             "$ref": "#/$metadata/main"
         },
 
+        "alert": {
+            "$ref": "#/$alert/main"
+        },
+
         "display": {
             "$ref": "#/$display/main"
         }
@@ -326,6 +330,31 @@
         }
     },
 
+    "$alert": {
+        "main": {
+            "title": "Alert Section",
+            "type": "object",
+            "description": "An optional security alert communicating that the targeted contract is known to be compromised, malicious, destructed or rendered inoperative. When present, wallets MUST display the message prominently instead of the normal signing screen.",
+
+            "properties": {
+                "severity": {
+                    "title": "Alert Severity",
+                    "type": "string",
+                    "description": "The severity of the alert: 'warning' means proceed with caution; wallets MUST show the message but MAY allow signing; 'critical' means the contract is known malicious or compromised; wallets SHOULD block signing or require explicit risk acknowledgment.",
+                    "enum": ["warning", "critical"]
+                },
+                "message": {
+                    "title": "Alert Message",
+                    "type": "string",
+                    "description": "A plain-text description of the alert. MUST NOT exceed 500 characters. Should include enough context for a user to understand the risk and recommended action.",
+                    "maxLength": 500
+                }
+            },
+            "required": ["severity", "message"],
+            "additionalProperties": false
+        }
+    },
+
     "$display": {
         "main": {
             "title": "Display Formatting Info Section",
@@ -356,7 +385,7 @@
                                 "pattern": "^\\s*[A-Za-z_][A-Za-z0-9_:]*\\s*\\(\\s*(?:[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*(?:,\\s*[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*)*)?\\)\\s*(?:\\s*[A-Za-z_][A-Za-z0-9_:]*\\s*\\(\\s*(?:[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*(?:,\\s*[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*)*)?\\)\\s*)*$"
                             }
                         ]
-                        
+
                     },
 
                     "additionalProperties": {
@@ -677,13 +706,13 @@
                 ],
                 "description": "Conditional display rules. Either 'ifNotIn' or 'mustMatch' must be defined, but not both."
                 }
-            ]    
+            ]
         },
         "mapReference": {
             "title": "Map Reference",
             "type": "object",
             "properties": {
-                "map": { 
+                "map": {
                     "type": "string",
                     "description": "The path to the referenced map."
                 },

--- a/assets/erc-7730/example-alert.json
+++ b/assets/erc-7730/example-alert.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "./erc7730-v2.schema.json",
+
+    "$comment": "Example of a tombstone ERC-7730 file for a known-compromised contract. No display formatting is provided; the alert is sufficient.",
+
+    "context": {
+        "contract": {
+            "deployments": [
+                { "chainId": 1, "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3" }
+            ]
+        }
+    },
+
+    "alert": {
+        "severity": "critical",
+        "message": "This contract was compromised on 2025-03-01. Its signing keys are no longer under legitimate control. Do not sign any transactions targeting this address."
+    }
+}


### PR DESCRIPTION
This is a relatively small change that allows the registry operator to mark a contract that was previously present in the registry as a hacked or newly malicious.

Without this feature, the contract can only have two possible states as far as ERC-7730 is concerned - the specification either exists or it doesn't.

Removing a contract from the registry forces the wallet to fall back to blind signing, however this may not be the best possible action if we know for sure the contract is in fact malicious - users are likely to continue issuing blind signatures for years until ERC-7730 is adopted universally.

These registry-level alerts are not a replacement for a proper security monitoring API, but I believe it is a safe and reasonable default fallback feature for wallets.