### PR TITLE
Update ERC-7730: Introduce explicit extensibility process

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -115,6 +115,8 @@ The `metadata` section contains constants that can be trusted when the ERC-7730 
 
 In this example, the metadata section contains only the recipient information, in the form of a displayable name (`owner` key), contract displayable name (`contractName` key) and additional information (`info` key) that MAY be used by wallets to provide details about the recipient.
 
+The optional `requires` section allows a specification to declare which extension ERCs it depends on, and provide a `fallback` specification for wallets that do not support those extensions.
+
 Finally, the `display` section contains the definitions of how to format each field of targeted contract calls under the `formats` key. 
 
 In this example, the function being described is identified by its human-readable ABI fragment `transfer(address to,uint256 value)`. Wallets strip the parameter names to compute the type-only signature `transfer(address,uint256)`, hash it, and match the resulting selector `0xa9059cbb` against the calldata.
@@ -524,6 +526,51 @@ When the exact construction of the EIP-712 domain is not known (for instance, wh
 The previous snippet defines a context for a `Permit2` EIP-712 message (types have been omitted for readability).
 
 The `domain` key indicates that the message signed domain MUST contain a `name` key of value `Permit2`. The `deployments` key means that the domain must contain both `chainId` and `verifyingContract` keys and they MUST match one of the deployment options (here, on ETH mainnet and Arbitrum).
+
+#### Binding context extensibility
+
+A binding context extension may be defined by an extension ERC.
+
+When using an extension-defined context, it is declared by the literal key `"extension"` under `context`, whose value is an object with exactly one key, the compact extension ID written as the ERC number in camelCase without hyphens.
+
+Example of a valid extension ID: `erc4337`.
+
+Specifications using an extension binding context MUST declare the extension in `requires`.
+
+```json
+{
+  "requires": ["erc4337"],
+  "fallback": "./entrypoint-basic.json",
+  "context": {
+    "extension": {
+      "erc4337": {
+        "packedUserOperation": {
+          "deployments": [
+            {
+              "chainId": 1,
+              "address": "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+The schema and constraint semantics for the extension context are defined by the corresponding extension ERC.
+
+### The `requires` and `fallback` section
+
+The `requires` parameters contains an array of valid extension IDs that are required by this file.
+The specification MUST NOT use any extension feature that is not listed in the `requires` array, and is considered invalid otherwise.
+The specification MUST NOT include any extension ID that is not used.
+
+The specification MUST provide a `fallback` specification when the `requires` array is not empty.
+The `fallback` parameter contains a URL pointing to a specifcation file that MUST NOT use extensions other than the "context binding extension" used in the `context` section.
+The specification MUST NOT provide a `fallback` specification when the `requires` field is omitted or empty.
+
+The fallback resolution is not recursive and stops at the first encountered `fallback` specification.
 
 ### `Metadata` section
 
@@ -1465,6 +1512,25 @@ List of currently supported encryption schemes hints for fields
 | ------------- | --------------------------------- |
 | fhevm         | FHEVM full homomorphic encryption |
 
+### Extension protocol
+
+ERC-7730 is designed as an extensible protocol, and new "extension" ERCs can be created to expand the capabilities of the protocol.
+
+An extension ERC should include the string "ERC-7730 extension" in its title.
+
+The following aspects of ERC-7730 are explicitly extensible:
+
+| Extension point              | Mechanism                                               | Naming convention                                                |
+|------------------------------|---------------------------------------------------------|------------------------------------------------------------------|
+| Context binding types        | New keys inside `context.extension`                     | `ercXXXX/context/name` (e.g., `@.erc4337.userOperation`)         |
+| Container value sets (`@.*`) | Document new `@.*` path values for the new context type | `@.eipXXXX.parameter` (e.g., `@.erc4337.paymaster`)              |
+| Field format type names      | New value for the `format` field                        | `ercXXXX/field/name` (e.g., `erc3525/format/semiFungibleAmount`) |
+| Encryption scheme names      | New value for `encryption.scheme`                       | `ercXXXX/encryption/name` (e.g., `erc7984/encryption/fhevm-v2`)  |
+
+Extension ERCs MUST NOT express alterations to the core behavior of ERC-7730 as defined in this specification.
+
+Specifications using any extension formats or fields MUST declare the extensions used in `requires`.
+
 ## Rationale
 
 ### Human readability
@@ -1576,7 +1642,8 @@ Wallets MAY:
 
 ### Extensibility to other structured data formats
 
-In the future, this specification could be extended to structured data like Meta Transaction in [EIP-2771](./eip-2771.md), User Operations in [EIP-4337](./eip-4337.md), and batch transaction payloads in [EIP-5792](./eip-5792.md).
+This specification provides a formal extension mechanism (see [Extension protocol](#extension-protocol)) that allows other ERCs to extend ERC-7730 with new context binding types, format names, and encryption schemes without modifying the core specification.
+For example, clear signing of User Operations [EIP-4337](./eip-4337.md), Meta Transactions [EIP-2771](./eip-2771.md), or batch transaction payloads in [EIP-5792](./eip-5792.md) can each be addressed by creating a dedicated extension ERC and using the `context.extension` mechanism.
 
 The `interpolatedIntent` field is particularly well-suited for [EIP-5792](./eip-5792.md) batch transactions, as it enables wallets to concatenate multiple operation descriptions into a single, natural language sentence. By joining individual `interpolatedIntent` strings with " and ", wallets can provide users with clear, readable summaries of complex multi-step operations like "Approve Uniswap Router to spend 1000 USDC and Swap 1000 USDC for at least 0.25 WETH". This significantly improves the user experience when reviewing batch transactions compared to displaying separate, disconnected operation descriptions. See the [Value Interpolation](#value-interpolation) section for detailed implementation guidance and examples.
 
@@ -1599,6 +1666,7 @@ More examples can be found in the asset folder.
 | [example-visibility-rules.json](../assets/eip-7730/example-visibility-rules.json) | Example of controlling the visibility of fields |
 | [example-account-execute.json](../assets/eip-7730/example-account-execute.json) | Example of EIP-4337 smart wallet execute function clear signing |
 | [example-userops-eip-712.json](../assets/eip-7730/example-userops-eip712.json) | Example of EIP-4337 User Operation clear signing |
+| [example-extension-context.json](../assets/eip-7730/example-extension-context.json) | Example of an extension binding context with `requires` and `fallback` |
 
 
 ## Security Considerations

--- a/assets/erc-7730/erc7730-v2.schema.json
+++ b/assets/erc-7730/erc7730-v2.schema.json
@@ -33,10 +33,33 @@
             "$ref": "#/$metadata/main"
         },
 
+        "requires": {
+            "title": "Required Extensions",
+            "type": "array",
+            "description": "An optional list of extension IDs this file depends on (e.g. 'erc4337'). Every listed extension is required: wallets that do not support one MUST NOT apply this spec, and MUST follow the 'fallback' pointer instead. A spec with no 'requires' uses only core ERC-7730.",
+            "items": {
+                "type": "string",
+                "pattern": "^(erc[0-9]{0,6})$"
+            },
+            "uniqueItems": true
+        },
+
+        "fallback": {
+            "title": "Fallback spec",
+            "type": "string",
+            "format": "uri-reference",
+            "description": "URI reference to a core ERC-7730 file for the same inputs. REQUIRED when 'requires' is non-empty. The target MUST NOT itself require extensions. Wallets that cannot satisfy 'requires' MUST use this file instead."
+        },
+
         "display": {
             "$ref": "#/$display/main"
         }
     },
+    "if": {
+        "properties": { "requires": { "minItems": 1 } },
+        "required": ["requires"]
+    },
+    "then": { "required": ["fallback"] },
     "additionalProperties": false,
 
     "$context" : {
@@ -57,6 +80,9 @@
                 },
                 {
                     "$ref": "#/$context/EIP712"
+                },
+                {
+                    "$ref": "#/$context/extension"
                 }
             ],
             "unevaluatedProperties": false
@@ -174,6 +200,24 @@
                         "type": "string",
                         "format": "eip55"
                     }
+                }
+            }
+        },
+
+        "extension": {
+            "type": "object",
+            "description": "An extension binding context defined by an extension ERC. Must have exactly one key: the compact extension ID in camelCase without hyphens (e.g. 'erc4337'). The extension must be listed in the top-level 'requires' field. The schema and constraint semantics of the extension object are defined by the corresponding extension ERC.",
+            "required": ["extension"],
+            "properties": {
+                "extension": {
+                    "type": "object",
+                    "description": "An object with exactly one key: the compact extension ID (e.g. 'erc4337', 'erc7816').",
+                    "minProperties": 1,
+                    "maxProperties": 1,
+                    "patternProperties": {
+                        "^erc[0-9]{0,6}$": {}
+                    },
+                    "additionalProperties": false
                 }
             }
         }
@@ -760,6 +804,12 @@
                     "title": "integer format",
                     "const": "interoperableAddressName",
                     "description": "The field should be displayed as a trusted name or as an EIP-7930 Interoperable Address human readable format. List of trusted sources can be optionally specified in parameters."
+                },
+                {
+                    "title": "Extension format",
+                    "type": "string",
+                    "pattern": "^erc-[0-9]+/.+",
+                    "description": "A field format type defined by an extension ERC, following the naming convention 'erc-XXXX/name' (e.g. 'erc-7984/encryptedAmount'). The extension must be listed in the top-level 'requires' field."
                 }
             ]
         },

--- a/assets/erc-7730/example-extension-context.json
+++ b/assets/erc-7730/example-extension-context.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "./erc7730-v2.schema.json",
+
+    "$comment": "Hypothetical example of an ERC-7730 file using an extension binding context. The 'requires' field declares the dependency on ERC-4337; 'fallback' points to a core-only spec for wallets that do not support it.",
+
+    "requires": ["erc4337"],
+    "fallback": "./example-main.json",
+
+    "context": {
+        "extension": {
+            "erc4337": {
+                "packedUserOperation": {
+                    "deployments": [
+                        { "chainId": 1, "address": "0x0000000071727De22E5E9d8BAf0edAc6f37da032" }
+                    ]
+                }
+            }
+        }
+    },
+
+    "metadata": {
+        "owner": "Example Bundler",
+        "contractName": "EntryPoint v0.7"
+    },
+
+    "display": {
+        "formats": {
+            "handleOps((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature)[] ops,address beneficiary)": {
+                "intent": "Execute User Operations",
+                "fields": [
+                    {
+                        "path": "ops.[].sender",
+                        "label": "Sender",
+                        "format": "addressName"
+                    },
+                    {
+                        "path": "ops.[].callData",
+                        "label": "Call",
+                        "format": "calldata",
+                        "params": { "calleePath": "ops.[].sender" }
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
The existing text of ERC-7730 mentions that it can be extended later,  but provides no instructions about how this can be done.

From experience with ERC-1271 and ERC-5792, under-specifying the process for extending the standard may lead to a significant mess in the future, once different versions are implemented by different vendors to a varying degree of completeness.

This PR introduces the first step towards a formal process of creating and specifying a versioning feature for ERC-7730.
