### PR TITLE
Update ERC-8180: rename message-ID field author → sender

### DIFF
--- a/ERCS/erc-8180.md
+++ b/ERCS/erc-8180.md
@@ -34,7 +34,7 @@ Three interfaces:
 Supporting definitions:
 
 - **`IERC_BAM_Decoder`**: on-chain contract interface for decoding message payloads (untrusted)
-- **Message ID**: `keccak256(abi.encodePacked(author, nonce, contentHash))`
+- **Message ID**: `keccak256(abi.encodePacked(sender, nonce, contentHash))`
 - **Message hash**: `keccak256(abi.encodePacked(sender, nonce, contents))` — standardized input to
   the domain-separated signed hash
 - **Signing domain**: `keccak256(abi.encodePacked("ERC-BAM.v1", chainId))`
@@ -118,7 +118,7 @@ consumption.
 | **Decoder**              | An untrusted on-chain contract that extracts messages and signature data from payloads. Implements `IERC_BAM_Decoder`.                     |
 | **Batch**                | A collection of messages packed into a blob segment or calldata payload. Encoding is decoder-specific.                                    |
 | **Message**              | A single message within a batch, containing a sender address, a per-sender nonce, and content bytes.                                      |
-| **Message ID**           | `keccak256(abi.encodePacked(author, nonce, contentHash))`. Unique per message.                                                            |
+| **Message ID**           | `keccak256(abi.encodePacked(sender, nonce, contentHash))`. Unique per message.                                                            |
 | **Message hash**         | `keccak256(abi.encodePacked(sender, nonce, contents))`. Standardized hash of a single message. Input to the domain-separated signed hash. |
 | **Content hash**         | Identifier for a batch: EIP-4844 versioned hash (blobs) or `keccak256(batchData)` (calldata).                                             |
 | **Signing domain**       | `keccak256(abi.encodePacked("ERC-BAM.v1", chainId))`. Domain separator for message signatures.                                             |
@@ -419,7 +419,7 @@ interface IERC_BAM_Exposer {
     event MessageExposed(
         bytes32 indexed contentHash,
         bytes32 indexed messageId,
-        address indexed author,
+        address indexed sender,
         address exposer,
         uint64 timestamp
     );
@@ -434,9 +434,9 @@ interface IERC_BAM_Exposer {
 #### Behavior
 
 1. When an implementation's expose function successfully verifies and records a message, it MUST
-   emit `MessageExposed` with the content hash, message ID, author, `msg.sender`, and
+   emit `MessageExposed` with the content hash, message ID, sender, `msg.sender`, and
    `uint64(block.timestamp)`.
-2. The `messageId` MUST be computed as `keccak256(abi.encodePacked(author, nonce, contentHash))`.
+2. The `messageId` MUST be computed as `keccak256(abi.encodePacked(sender, nonce, contentHash))`.
 3. Implementations MUST track exposed message IDs and revert with `AlreadyExposed` if a message is
    exposed twice.
 4. `isExposed` MUST return `true` if a `MessageExposed` event has been emitted for the given
@@ -466,18 +466,18 @@ interoperability surface: any exposer, regardless of proof mechanism, emits `Mes
 Message IDs MUST be computed as:
 
 ```
-messageId = keccak256(abi.encodePacked(author, nonce, contentHash))
+messageId = keccak256(abi.encodePacked(sender, nonce, contentHash))
 ```
 
 Where:
 
-- `author` is the message author's Ethereum address (`address`, 20 bytes)
-- `nonce` is a per-author monotonically increasing counter (`uint64`, 8 bytes)
+- `sender` is the message sender's Ethereum address (`address`, 20 bytes)
+- `nonce` is a per-sender monotonically increasing counter (`uint64`, 8 bytes)
 - `contentHash` is the batch identifier (`bytes32`, 32 bytes): versioned hash for blob batches,
   `keccak256(batchData)` for calldata batches
 
 The result is a globally unique, deterministic identifier per message. The nonce prevents collisions
-when an author publishes multiple messages in the same batch.
+when a sender publishes multiple messages in the same batch.
 
 ### Signing Domain and Message Hash Convention
 
@@ -487,7 +487,7 @@ Message hashes MUST be computed as:
 messageHash = keccak256(abi.encodePacked(sender, nonce, contents))
 ```
 
-Where `sender` is the message author's Ethereum address (`address`, 20 bytes), `nonce` is the
+Where `sender` is the message sender's Ethereum address (`address`, 20 bytes), `nonce` is the
 per-sender monotonically increasing counter (`uint64`, 8 bytes), and `contents` is the message content (`bytes`,
 variable length).
 
@@ -620,7 +620,7 @@ Exposure (by anyone, permissionless):
      → computes signedHash  = keccak256(abi.encodePacked(domain, messageHash))
      → verifies BLS signature against registered key via registry
      → verifies KZG proof against versioned hash
-     → emits MessageExposed(contentHash, messageId, author, exposer, timestamp)
+     → emits MessageExposed(contentHash, messageId, sender, exposer, timestamp)
 
 Query:
   3. exposer.isExposed(messageId) → true
@@ -753,8 +753,8 @@ registry standard.
 
 ### Message ID determinism
 
-`keccak256(abi.encodePacked(author, nonce, contentHash))` is deterministic and computable from the message data
-alone, requiring no on-chain state. The author address prevents cross-user collisions, the nonce
+`keccak256(abi.encodePacked(sender, nonce, contentHash))` is deterministic and computable from the message data
+alone, requiring no on-chain state. The sender address prevents cross-user collisions, the nonce
 prevents same-batch collisions, and the content hash binds the ID to a specific batch.
 
 ### Domain separator for signing
@@ -836,9 +836,9 @@ path (`registerCalldataBatch`) works on any EVM chain.
 
 ### Message ID
 
-| Author (address) | Nonce | Content Hash    | Expected Message ID                               |
+| Sender (address) | Nonce | Content Hash    | Expected Message ID                               |
 | ---------------- | ----- | --------------- | ------------------------------------------------- |
-| `0xABCD...0001`  | `0`   | `0x1234...5678` | `keccak256(abi.encodePacked(author, 0, hash))`    |
+| `0xABCD...0001`  | `0`   | `0x1234...5678` | `keccak256(abi.encodePacked(sender, 0, hash))`    |
 | `0xABCD...0001`  | `1`   | `0x1234...5678` | Different from nonce=0 (same batch, different ID) |
 
 ## Reference Implementation
@@ -994,7 +994,7 @@ unambiguous because `sender` (20 bytes) and `nonce` (8 bytes) are fixed-size, so
 `contents` field always begins at byte 28. No two distinct `(sender, nonce, contents)` tuples
 produce the same packed encoding.
 
-The message ID is `keccak256(abi.encodePacked(author, nonce, contentHash))`. All three fields are fixed-size (20 +
+The message ID is `keccak256(abi.encodePacked(sender, nonce, contentHash))`. All three fields are fixed-size (20 +
 8 + 32 bytes), so the encoding is trivially unambiguous.
 
 For an attacker to find two distinct inputs that produce the same hash for either formula requires a


### PR DESCRIPTION
## Summary

Naming-consistency fix on ERC-8180 (Blob Authenticated Messaging). The `Message` struct in `IERC_BAM_Decoder`, the message-hash formula, and most surrounding prose already use `sender` for the message-sender's address. Only the **message-ID formula**, the **`MessageExposed` event's third indexed topic**, and a handful of prose references still used `author`. This PR renames those to `sender`.

- Message ID formula: `keccak256(abi.encodePacked(author, …))` → `keccak256(abi.encodePacked(sender, …))`
- `MessageExposed` event: `address indexed author` → `address indexed sender`
- Test-case table column header and example formula
- Definitions list, prose references, Worked Example 4, Rationale, Security Considerations

### Why this is zero-risk

`abi.encodePacked` does not encode Solidity variable names — only the byte layout. The hashed bytes are identical before and after this rename, so:

- All previously computed message IDs remain valid
- All previously computed signatures remain valid
- The Test Cases table results are unchanged
- No deployed contract behavior changes

This eliminates a long-standing inconsistency between the `Message` struct field (`sender`) and the consumers of that field (formerly `author`).

### Preserved

- The frontmatter `author:` field (lists ERC authors — unrelated)
- The word "authorship" used as a concept ("per-message authorship verification") in §Behavior

## Sequencing

This is the first of a planned pair of amendments to ERC-8180. A follow-up PR (`contentTag` promotion — a breaking event-ABI change) will be opened against `master` once this naming fix lands, to keep the two diffs cleanly separated for review.

This ERC is in `Draft` status.