### PR TITLE
Update ERC-8180: add registerBlobBatches atomic multi-batch entrypoint

### DIFF
--- a/ERCS/erc-8180.md
+++ b/ERCS/erc-8180.md
@@ -2,7 +2,7 @@
 eip: 8180
 title: Blob Authenticated Messaging
 description: Interfaces for authenticated messaging over EIP-4844 blobs with on-chain decoder discovery
-author: Vitalik Buterin (@vbuterin), Skeletor Spaceman (@skeletor-spaceman)
+author: Vitalik Buterin (@vbuterin), Skeletor Spaceman (@skeletor-spaceman), Orca (@0xrcinus)
 discussions-to: https://ethereum-magicians.org/t/erc-8180-blob-authenticated-messaging-bam/27868
 status: Draft
 type: Standards Track
@@ -94,9 +94,10 @@ described in RFC 2119 and RFC 8174.
 ### Architecture Overview
 
 ```
-[Blob/calldata] → registerBlobBatch/registerCalldataBatch (Core)
+[Blob/calldata] → registerBlobBatch / registerBlobBatches / registerCalldataBatch (Core)
                      ↓ emits BlobBatchRegistered(contentTag, decoder, registry) or
-                     ↓ CalldataBatchRegistered(contentTag, decoder, registry)
+                     ↓ CalldataBatchRegistered(contentTag, decoder, registry),
+                     ↓ one per registered batch
 [Indexer sees event] → decoder.decode(payload) → messages + signatureData
                      ↓
 [Client computes] → messageHash per message (standardized formula)
@@ -202,6 +203,28 @@ interface IERC_BAM_Core is IERC_BSS {
         address decoder,
         address signatureRegistry
     ) external returns (bytes32 contentHash);
+
+    /// @notice One entry in a `registerBlobBatches` batch call. Mirrors
+    ///         `registerBlobBatch`'s arguments one-to-one.
+    struct BlobBatchCall {
+        uint256 blobIndex;
+        uint16  startFE;
+        uint16  endFE;
+        bytes32 contentTag;
+        address decoder;
+        address signatureRegistry;
+    }
+
+    /// @notice Register multiple blob batches atomically in a single transaction.
+    /// @dev Each entry is processed with the same `BLOBHASH(blobIndex)` read and
+    ///      `declareBlobSegment` invariants as `registerBlobBatch`. Emits one
+    ///      `BlobBatchRegistered` event per entry. Reverts when `calls.length == 0`,
+    ///      and reverts the entire transaction if any entry's invariants fail.
+    /// @param calls            Array of `BlobBatchCall` entries to register.
+    /// @return versionedHashes The EIP-4844 versioned hash of each entry's blob, in order.
+    function registerBlobBatches(BlobBatchCall[] calldata calls)
+        external
+        returns (bytes32[] memory versionedHashes);
 }
 ```
 
@@ -246,6 +269,32 @@ interface IERC_BAM_Core is IERC_BSS {
     lets consumers issue an `eth_getLogs` filter keyed on `contentTag` against either BAM core
     event directly, at parity with ERC-8179's `BlobSegmentDeclared`. This is a breaking change
     relative to earlier drafts in which `decoder` occupied the third indexed slot.
+15. **`registerBlobBatches` semantics.** Implementations MUST iterate `calls` in order. For each
+    entry, implementations MUST invoke the same internal logic as `registerBlobBatch` — call
+    `declareBlobSegment(entry.blobIndex, entry.startFE, entry.endFE, entry.contentTag)` and emit
+    `BlobBatchRegistered` with the returned versioned hash, `msg.sender`, and the entry's
+    `contentTag`, `decoder`, and `signatureRegistry`. The returned `versionedHashes` array MUST
+    contain the per-entry versioned hash at the corresponding index.
+16. **`registerBlobBatches` empty-array revert.** Implementations MUST revert when `calls.length`
+    is zero. The recommended error is `EmptyBatchArray()`. This is defense-in-depth against
+    aggregator bugs that would otherwise produce a no-op transaction.
+17. **`registerBlobBatches` atomicity.** A revert produced by any per-entry call to
+    `declareBlobSegment` MUST revert the entire `registerBlobBatches` transaction. Implementations
+    MUST NOT swallow per-entry failures or emit partial events. This atomicity property is what
+    makes the entrypoint safe for use by aggregators that pack multiple per-tag batches into one
+    blob — either every per-tag event lands together, or none do.
+18. **`registerBlobBatches` `msg.sender` invariant.** Every `BlobBatchRegistered` event emitted by a
+    single `registerBlobBatches` call MUST name the same `submitter` (the EOA or contract that
+    invoked `registerBlobBatches`). Implementations MUST NOT use `delegatecall` or any external hop
+    that could alter `msg.sender` between entries. This preserves the producer-trust model that
+    every event in a packed transaction is endorsed by the same submitter.
+19. **`registerBlobBatches` conformance.** Implementations claiming conformance with this ERC MUST
+    implement `registerBlobBatches` per the interface. The function MAY revert with a
+    `NotImplemented`-style error in implementations that have not yet rolled out the multi-tag
+    path, but the selector MUST be present so callers can `staticcall`-probe support.
+    Producers that pack multiple per-tag batches in a single transaction MUST use
+    `registerBlobBatches` (no other entrypoint provides cross-entry atomicity); single-entry
+    callers MAY use either entrypoint with byte-identical event content.
 
 #### Relationship to ERC-8179
 
@@ -737,6 +786,30 @@ the two BAM events from each other and from any other anonymous event sharing th
 topics, which loses more discoverability than the extra indexed slot recovers, and is also
 rejected.
 
+### Atomic multi-batch registration (`registerBlobBatches`)
+
+An aggregator that packs batches for multiple protocols into one shared blob needs to register
+each per-tag batch. Without a multi-entry entrypoint, the options are one transaction per batch —
+which defeats the purpose of sharing the blob, since `BLOBHASH` only resolves within the blob's
+own transaction — or sequential single-entry calls within one transaction via an external
+multicall contract, which breaks the `msg.sender`-as-`submitter` attribution model.
+`registerBlobBatches` provides the missing shape: one transaction, one submitter, one
+`BlobBatchRegistered` event per entry, all-or-nothing.
+
+The entrypoint lives on `IERC_BAM_Core` itself rather than on an optional extension interface
+(the route [ERC-8179](./eip-8179.md) takes with `IERC_BSS_Batch`). BSS declarations are
+single-protocol affairs where batching is a convenience; BAM aggregation across tags is the
+expected steady state of the protocol, and producers need a single selector they can
+`staticcall`-probe on any compliant core. The conformance clause keeps the burden on minimal
+implementations to one stub: the selector MUST exist, but MAY revert `NotImplemented` until the
+multi-tag path is rolled out.
+
+No `registerCalldataBatches` is defined. Calldata batches do not share a scarce container — each
+`registerCalldataBatch` call carries its own payload, and no `BLOBHASH` context binds entries to
+the registering transaction. A producer that wants several calldata batches registered atomically
+can submit them in separate transactions with no correlation loss, and the cross-entry atomicity
+that motivates the blob-path entrypoint has no calldata equivalent need.
+
 ### Trust separation: decoder vs registry
 
 The original design bundled decoding and verification in a single "schema" contract. If a client
@@ -888,6 +961,9 @@ path (`registerCalldataBatch`) works on any EVM chain.
 | `registerBlobBatch(0, 0, 4096, tag, decoder, sigReg)`       | Non-null tag, full blob    | `contentTag` topic on `BlobSegmentDeclared` equals `contentTag` topic on `BlobBatchRegistered` |
 | `eth_getLogs` on `BlobBatchRegistered` filtered by `contentTag=tag` | Two batches registered with different tags | Returns only the matching batch; filtering by an unused tag returns zero logs |
 | `eth_getLogs` on `CalldataBatchRegistered` filtered by `contentTag=tag` | Two batches registered with different tags | Returns only the matching batch; filtering by an unused tag returns zero logs |
+| `registerBlobBatches([c1, c2])`                             | Two valid entries, same blob, disjoint FE ranges, different tags | Emits two `BlobSegmentDeclared` + two `BlobBatchRegistered` (same `submitter`), returns both versioned hashes in entry order |
+| `registerBlobBatches([])`                                   | Empty array               | Reverts `EmptyBatchArray()`                                                      |
+| `registerBlobBatches([c1, cBad])`                           | Second entry has invalid segment | Entire transaction reverts; no events emitted for any entry                |
 
 ### Decoder
 
@@ -982,6 +1058,8 @@ import {IERC_BAM_Core} from "./IERC_BAM_Core.sol";
 contract BlobAuthenticatedMessagingCore is IERC_BAM_Core {
     uint16 internal constant MAX_FIELD_ELEMENTS = 4096;
 
+    error EmptyBatchArray();
+
     /// @inheritdoc IERC_BSS
     function declareBlobSegment(
         uint256 blobIndex,
@@ -1029,6 +1107,26 @@ contract BlobAuthenticatedMessagingCore is IERC_BAM_Core {
         emit CalldataBatchRegistered(
             contentHash, msg.sender, contentTag, decoder, signatureRegistry
         );
+    }
+
+    /// @inheritdoc IERC_BAM_Core
+    function registerBlobBatches(BlobBatchCall[] calldata calls)
+        external
+        returns (bytes32[] memory versionedHashes)
+    {
+        if (calls.length == 0) revert EmptyBatchArray();
+
+        versionedHashes = new bytes32[](calls.length);
+        for (uint256 i = 0; i < calls.length; i++) {
+            BlobBatchCall calldata c = calls[i];
+            versionedHashes[i] = declareBlobSegment(
+                c.blobIndex, c.startFE, c.endFE, c.contentTag
+            );
+
+            emit BlobBatchRegistered(
+                versionedHashes[i], msg.sender, c.contentTag, c.decoder, c.signatureRegistry
+            );
+        }
     }
 }
 ```


### PR DESCRIPTION
## Summary

Adds an atomic multi-batch registration entrypoint to `IERC_BAM_Core`, plus Orca (@0xrcinus) to the author list. This is the third in the ERC-8180 amendment series (#1785 rename, #1793 contentTag promotion — both merged) and is purely **additive**: no existing event or function changes shape.

## Why

An aggregator that packs batches for multiple protocols into one shared blob must register each per-tag batch. Without a multi-entry entrypoint the options are:

- **One transaction per batch** — defeats the purpose of sharing the blob, since `BLOBHASH` only resolves within the blob-carrying transaction itself.
- **An external multicall contract** wrapping N `registerBlobBatch` calls — breaks the `msg.sender`-as-`submitter` attribution model (the submitter becomes the multicall contract, not the producer), which the `(chainId, contentTag, submitter)` trust tuple from #1793 depends on.

`registerBlobBatches` provides the missing shape: one transaction, one submitter, one `BlobBatchRegistered` event per entry, all-or-nothing.

## What changes

### Interface (`IERC_BAM_Core`)

```solidity
struct BlobBatchCall {
    uint256 blobIndex;
    uint16  startFE;
    uint16  endFE;
    bytes32 contentTag;
    address decoder;
    address signatureRegistry;
}

function registerBlobBatches(BlobBatchCall[] calldata calls)
    external returns (bytes32[] memory versionedHashes);
```

`BlobBatchCall` mirrors `registerBlobBatch`'s arguments one-to-one.

### Behavior (new normative clauses 15–19)

- **Semantics** — iterate `calls` in order; each entry invokes the same internal logic as `registerBlobBatch` (`declareBlobSegment` + `BlobBatchRegistered`); returned hashes are per-entry, in order.
- **Empty-array revert** — MUST revert on `calls.length == 0`; recommended error `EmptyBatchArray()`. Defense-in-depth against no-op aggregator bugs.
- **Atomicity** — any per-entry `declareBlobSegment` revert reverts the whole transaction. No partial events. This is what makes the entrypoint safe for multi-tag packing: either every per-tag event lands together, or none do.
- **`msg.sender` invariant** — every event in a single call MUST name the same `submitter`; no `delegatecall` or external hop between entries.
- **Conformance** — the selector MUST be present on compliant cores (callers can `staticcall`-probe support); it MAY revert `NotImplemented` where the multi-tag path is not yet rolled out. Producers packing multiple per-tag batches in one transaction MUST use this entrypoint; single-entry callers MAY use either, with byte-identical event content.

### Rationale (new subsection)

Documents two design choices reviewers will reasonably ask about:

- **Why on the core interface rather than an optional extension** (the route ERC-8179 takes with `IERC_BSS_Batch`): BSS declarations are single-protocol affairs where batching is a convenience; BAM aggregation across tags is the expected steady state, and producers need one probe-able selector on any compliant core. The conformance clause caps the cost to minimal implementations at a single stub.
- **Why no `registerCalldataBatches`**: calldata batches don't share a scarce container and carry no `BLOBHASH` binding to the registering transaction, so the cross-entry atomicity that motivates the blob-path entrypoint has no calldata equivalent need.

### Test Cases

Three new rows: two-entry success (two event pairs, same submitter, ordered return), empty-array revert, and whole-transaction revert when any entry fails.

### Minimal Core Implementation

Extended to implement the new function (the example contract claims `is IERC_BAM_Core`, so it must provide the selector to compile).

## Author addition

Adds **Orca (@0xrcinus)** to the `author:` frontmatter, reflecting the amendment series contributed to this ERC (#1785, #1793, and this PR).

## Compatibility

Purely additive. Existing `registerBlobBatch` / `registerCalldataBatch` callers and all event consumers are unaffected. The new clauses do not modify clauses 1–14.