### PR TITLE
Update ERC-8180: bind contentTag into message hash and ID; per-tag nonces

### DIFF
--- a/ERCS/erc-8180.md
+++ b/ERCS/erc-8180.md
@@ -34,9 +34,9 @@ Three interfaces:
 Supporting definitions:
 
 - **`IERC_BAM_Decoder`**: on-chain contract interface for decoding message payloads (untrusted)
-- **Message ID**: `keccak256(abi.encodePacked(sender, nonce, contentHash))`
-- **Message hash**: `keccak256(abi.encodePacked(sender, nonce, contents))` — standardized input to
-  the domain-separated signed hash
+- **Message ID**: `keccak256(abi.encodePacked(sender, contentTag, nonce, contentHash))`
+- **Message hash**: `keccak256(abi.encodePacked(sender, contentTag, nonce, contents))` —
+  standardized input to the domain-separated signed hash
 - **Signing domain**: `keccak256(abi.encodePacked("ERC-BAM.v1", chainId))`
 
 ## Motivation
@@ -118,9 +118,9 @@ consumption.
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | **Decoder**              | An untrusted on-chain contract that extracts messages and signature data from payloads. Implements `IERC_BAM_Decoder`.                     |
 | **Batch**                | A collection of messages packed into a blob segment or calldata payload. Encoding is decoder-specific.                                    |
-| **Message**              | A single message within a batch, containing a sender address, a per-sender nonce, and content bytes.                                      |
-| **Message ID**           | `keccak256(abi.encodePacked(sender, nonce, contentHash))`. Unique per message.                                                            |
-| **Message hash**         | `keccak256(abi.encodePacked(sender, nonce, contents))`. Standardized hash of a single message. Input to the domain-separated signed hash. |
+| **Message**              | A single message within a batch, containing a sender address, a per-`(sender, contentTag)` nonce, and content bytes.                      |
+| **Message ID**           | `keccak256(abi.encodePacked(sender, contentTag, nonce, contentHash))`. Unique per message and per `contentTag`. |
+| **Message hash**         | `keccak256(abi.encodePacked(sender, contentTag, nonce, contents))`. Standardized hash of a single message. Input to the domain-separated signed hash. |
 | **Content hash**         | Identifier for a batch: EIP-4844 versioned hash (blobs) or `keccak256(batchData)` (calldata).                                             |
 | **Signing domain**       | `keccak256(abi.encodePacked("ERC-BAM.v1", chainId))`. Domain separator for message signatures.                                             |
 | **Signature scheme**     | A cryptographic signing algorithm (ECDSA, BLS, STARK, etc.) identified by a 1-byte scheme ID.                                             |
@@ -244,8 +244,7 @@ interface IERC_BAM_Core is IERC_BSS {
 14. **Indexed-topic layout.** In both BAM core events, `contentTag` occupies the third indexed
     topic slot (`topic[3]`); `decoder` and `signatureRegistry` are unindexed event data. This layout
     lets consumers issue an `eth_getLogs` filter keyed on `contentTag` against either BAM core
-    event directly, at parity with ERC-8179's `BlobSegmentDeclared`. This is a breaking change
-    relative to earlier drafts in which `decoder` occupied the third indexed slot.
+    event directly, at parity with ERC-8179's `BlobSegmentDeclared`.
 
 #### Relationship to ERC-8179
 
@@ -255,13 +254,12 @@ and `BlobBatchRegistered`. BSS indexers tracking `BlobSegmentDeclared` events di
 boundaries. BAM indexers tracking `BlobBatchRegistered` events discover the batch, its `contentTag`,
 its decoder, and its signature registry.
 
-Because `contentTag` is now emitted as an indexed topic on both BAM core events, consumers that
+Because `contentTag` is emitted as an indexed topic on both BAM core events, consumers that
 want "every BAM batch for protocol X" issue a single `eth_getLogs` filter against
 `BlobBatchRegistered` or `CalldataBatchRegistered` keyed on the `contentTag` topic. No same-
-transaction log-index correlation against `BlobSegmentDeclared` is required. On shared blobs —
-one blob carrying multiple declared segments — this eliminates the pairing ambiguity that earlier
-drafts of this ERC exposed: each BAM batch now carries its own `contentTag` directly in the event
-log, independent of any other segment declared under the same versioned hash.
+transaction log-index correlation against `BlobSegmentDeclared` is required: even on shared blobs —
+one blob carrying multiple declared segments — each BAM batch carries its own `contentTag` directly
+in the event log, independent of any other segment declared under the same versioned hash.
 
 BAM contracts do not require a shared singleton deployment. Each BAM deployment functions as its own
 BSS instance. Indexers filter by event topic hash (globally indexed on Ethereum), not by contract
@@ -310,7 +308,10 @@ interface IERC_BAM_Decoder {
 #### Behavior
 
 1. `decode` MUST return all messages in the payload as an array of `Message` structs. Each message
-   contains the sender's Ethereum address, a per-sender monotonically increasing nonce, and the content bytes.
+   contains the sender's Ethereum address, a per-`(sender, contentTag)` monotonically increasing
+   nonce (see Nonce Semantics), and the content bytes. The decoder itself is `contentTag`-unaware:
+   it returns the nonce as encoded; the tag scoping is a property of the signing protocol, not the
+   payload encoding.
 2. `decode` MUST return an empty array and empty bytes for an empty payload.
 3. `decode` MUST return the raw signature data as opaque bytes. The format is scheme-specific: for
    BLS, this is the aggregated signature (96 bytes); for ECDSA, this is the concatenated individual
@@ -332,16 +333,25 @@ decompression implements the same function.
 
 ### Nonce Semantics
 
-Nonces MUST be per-sender monotonically increasing within the signing protocol. A decoder MAY return
-messages with non-sequential nonces. Clients SHOULD treat messages whose nonce does not exceed the
-last-accepted nonce for that sender as invalid.
+Nonces MUST be scoped per `(sender, contentTag)` pair and monotonically increasing within that
+scope. A sender publishing under two distinct `contentTag` values maintains two independent nonce
+sequences; neither sequence constrains the other. A decoder MAY return messages with
+non-sequential nonces. Clients SHOULD track the last-accepted nonce per `(sender, contentTag)` and
+treat messages whose nonce does not exceed it as invalid.
 
-If a decoder returns duplicate `(sender, nonce)` pairs, the resulting message IDs collide. Clients
-MUST de-duplicate by `messageId`.
+If a decoder returns duplicate `(sender, nonce)` pairs within the same batch (and therefore the
+same `contentTag`), the resulting message IDs collide. Clients MUST de-duplicate by `messageId`.
 
 Nonce correctness is enforced by the signing protocol: the signer includes the correct nonce in the
 signed hash. An incorrect nonce produces a different `messageHash`, causing signature verification to
 fail.
+
+Per-tag nonce scoping is only safe because `contentTag` is bound into `messageHash` (see Signing
+Domain and Message Hash Convention). If the signed hash did not bind the tag, the same signed
+`(sender, nonce, contents)` would verify in a batch registered under any `contentTag`, and
+independent per-tag acceptance windows would let an aggregator replay one signed message into
+every app. With the tag bound, a message signed for one `contentTag` fails verification under any
+other, and the per-tag sequences cannot be cross-contaminated.
 
 ### Signature Registry Interface (`IERC_BAM_SignatureRegistry`)
 
@@ -472,7 +482,10 @@ interface IERC_BAM_Exposer {
 1. When an implementation's expose function successfully verifies and records a message, it MUST
    emit `MessageExposed` with the content hash, message ID, sender, `msg.sender`, and
    `uint64(block.timestamp)`.
-2. The `messageId` MUST be computed as `keccak256(abi.encodePacked(sender, nonce, contentHash))`.
+2. The `messageId` MUST be computed as
+   `keccak256(abi.encodePacked(sender, contentTag, nonce, contentHash))`, where `contentTag` is the
+   value emitted in the `BlobBatchRegistered` / `CalldataBatchRegistered` event for the batch
+   containing the message.
 3. Implementations MUST track exposed message IDs and revert with `AlreadyExposed` if a message is
    exposed twice.
 4. `isExposed` MUST return `true` if a `MessageExposed` event has been emitted for the given
@@ -502,30 +515,43 @@ interoperability surface: any exposer, regardless of proof mechanism, emits `Mes
 Message IDs MUST be computed as:
 
 ```
-messageId = keccak256(abi.encodePacked(sender, nonce, contentHash))
+messageId = keccak256(abi.encodePacked(sender, contentTag, nonce, contentHash))
 ```
 
 Where:
 
 - `sender` is the message sender's Ethereum address (`address`, 20 bytes)
-- `nonce` is a per-sender monotonically increasing counter (`uint64`, 8 bytes)
+- `contentTag` is the protocol/content identifier for the batch (`bytes32`, 32 bytes), equal to the
+  value emitted in `BlobBatchRegistered.contentTag` / `CalldataBatchRegistered.contentTag` for the
+  batch containing the message
+- `nonce` is a per-`(sender, contentTag)` monotonically increasing counter (`uint64`, 8 bytes)
 - `contentHash` is the batch identifier (`bytes32`, 32 bytes): versioned hash for blob batches,
   `keccak256(batchData)` for calldata batches
 
-The result is a globally unique, deterministic identifier per message. The nonce prevents collisions
-when a sender publishes multiple messages in the same batch.
+The result is a globally unique, deterministic identifier per message. The sender prevents
+cross-user collisions; `contentTag` prevents cross-app collisions for the same `(sender, nonce)`
+posted to distinct apps; and the nonce prevents collisions when a sender publishes multiple
+messages in the same batch.
 
 ### Signing Domain and Message Hash Convention
 
 Message hashes MUST be computed as:
 
 ```
-messageHash = keccak256(abi.encodePacked(sender, nonce, contents))
+messageHash = keccak256(abi.encodePacked(sender, contentTag, nonce, contents))
 ```
 
-Where `sender` is the message sender's Ethereum address (`address`, 20 bytes), `nonce` is the
-per-sender monotonically increasing counter (`uint64`, 8 bytes), and `contents` is the message content (`bytes`,
-variable length).
+Where `sender` is the message sender's Ethereum address (`address`, 20 bytes), `contentTag` is the
+protocol/content identifier for the batch (`bytes32`, 32 bytes, equal to the value emitted in the
+batch-registration event), `nonce` is the per-`(sender, contentTag)` monotonically increasing
+counter (`uint64`, 8 bytes), and `contents` is the message content (`bytes`, variable length). The
+60 fixed-size bytes preceding `contents` make the `abi.encodePacked` encoding unambiguous despite
+the variable-length tail.
+
+Binding `contentTag` into `messageHash` ties a signed message to the specific app context the
+sender intended. An untrusted aggregator that lifts a signed `(sender, nonce, contents)` into a
+batch registered under a different `contentTag` produces a `messageHash` that differs from what the
+sender signed; the signature fails to verify and the message is rejected.
 
 Message signatures MUST use a domain separator to prevent cross-chain replay:
 
@@ -572,7 +598,7 @@ Client verification (by anyone):
   2. COMPUTE HASHES (client, standardized)
      - domain = keccak256(abi.encodePacked("ERC-BAM.v1", chainId))
      - for each message:
-         messageHash = keccak256(abi.encodePacked(sender, nonce, contents))
+         messageHash = keccak256(abi.encodePacked(sender, contentTag, nonce, contents))
          signedHash  = keccak256(abi.encodePacked(domain, messageHash))
 
   3. VERIFY (trusted registry)
@@ -605,7 +631,7 @@ Client verification:
 
   2. COMPUTE HASHES
      - domain = keccak256(abi.encodePacked("ERC-BAM.v1", chainId))
-     - messageHash = keccak256(abi.encodePacked(sender, nonce, contents))
+     - messageHash = keccak256(abi.encodePacked(sender, contentTag, nonce, contents))
      - signedHash  = keccak256(abi.encodePacked(domain, messageHash))
 
   3. VERIFY
@@ -655,7 +681,7 @@ Setup:
 Exposure (by anyone, permissionless):
   2. exposer.expose(params)  // implementation-specific function
      → decodes message via decoder
-     → computes messageHash = keccak256(abi.encodePacked(sender, nonce, contents))
+     → computes messageHash = keccak256(abi.encodePacked(sender, contentTag, nonce, contents))
      → computes signedHash  = keccak256(abi.encodePacked(domain, messageHash))
      → verifies BLS signature against registered key via registry
      → verifies KZG proof against versioned hash
@@ -749,10 +775,13 @@ decoder causes only false negatives (valid messages rejected), never false posit
 messages accepted). Registries are "mostly ~4 highly-audited instances" — one per signature scheme.
 The trust surface is narrow and auditable.
 
-The standardized `messageHash = keccak256(abi.encodePacked(sender, nonce, contents))` formula is the bridge: the
-client computes hashes from the decoder's (untrusted) output, then verifies them against the
+The standardized `messageHash = keccak256(abi.encodePacked(sender, contentTag, nonce, contents))`
+formula is the bridge: the client computes hashes from the decoder's (untrusted) output combined
+with the `contentTag` from the (trusted) batch-registration event, then verifies them against the
 registry's (trusted) verification. If the decoder lies, the hashes are wrong, and verification
-fails.
+fails. Binding `contentTag` into the hash extends the same property to the aggregator: a message
+signed for one `contentTag` cannot be re-routed into a batch registered under a different
+`contentTag` without producing a hash that fails verification.
 
 | Component | Trust     | Count | Risk of lying                                   |
 | --------- | --------- | ----- | ----------------------------------------------- |
@@ -847,17 +876,23 @@ registry standard.
 
 ### Message ID determinism
 
-`keccak256(abi.encodePacked(sender, nonce, contentHash))` is deterministic and computable from the message data
-alone, requiring no on-chain state. The sender address prevents cross-user collisions, the nonce
-prevents same-batch collisions, and the content hash binds the ID to a specific batch.
+`keccak256(abi.encodePacked(sender, contentTag, nonce, contentHash))` is deterministic and
+computable from the message data combined with the batch-registration event's `contentTag`,
+requiring no on-chain state. The sender address prevents cross-user collisions; the `contentTag`
+prevents cross-app collisions for the same `(sender, nonce)` posted to distinct apps; the nonce
+prevents same-batch collisions; and the content hash binds the ID to a specific batch.
 
 ### Domain separator for signing
 
 The `"ERC-BAM.v1"` prefix prevents signature reuse across protocols; `chainId` prevents cross-chain
-replay. For individual user self-publication with ECDSA, adopters may define an [EIP-712](./eip-712.md) TypedData
-struct matching the `messageHash` fields for improved wallet display. The core standard does not
-mandate EIP-712 because aggregated BLS signing (the primary blob path) uses headless signing where
-wallet display provides no benefit.
+replay. For individual user self-publication with ECDSA, adopters may define an
+[EIP-712](./eip-712.md) TypedData struct matching the `messageHash` fields
+(`sender, contentTag, nonce, contents`) for improved wallet display. Adopters that take this path
+MUST include `contentTag` in the typed-data struct so the EIP-712 digest binds to the same app
+context as the `messageHash` formula — omitting `contentTag` from the typed data while binding it
+in `messageHash` would leave the ECDSA path open to cross-app re-routing that the BLS path
+prevents. The core standard does not mandate EIP-712 because aggregated BLS signing (the primary
+blob path) uses headless signing where wallet display provides no benefit.
 
 ## Backwards Compatibility
 
@@ -935,10 +970,11 @@ path (`registerCalldataBatch`) works on any EVM chain.
 
 ### Message ID
 
-| Sender (address) | Nonce | Content Hash    | Expected Message ID                               |
-| ---------------- | ----- | --------------- | ------------------------------------------------- |
-| `0xABCD...0001`  | `0`   | `0x1234...5678` | `keccak256(abi.encodePacked(sender, 0, hash))`    |
-| `0xABCD...0001`  | `1`   | `0x1234...5678` | Different from nonce=0 (same batch, different ID) |
+| Sender (address) | Content Tag     | Nonce | Content Hash    | Expected Message ID                                                          |
+| ---------------- | --------------- | ----- | --------------- | ---------------------------------------------------------------------------- |
+| `0xABCD...0001`  | `0xAAAA...AAAA` | `0`   | `0x1234...5678` | `keccak256(abi.encodePacked(sender, contentTag, 0, hash))`                   |
+| `0xABCD...0001`  | `0xAAAA...AAAA` | `1`   | `0x1234...5678` | Different from nonce=0 (same batch and tag, different ID)                    |
+| `0xABCD...0001`  | `0xBBBB...BBBB` | `0`   | `0x1234...5678` | Different from `0xAAAA...AAAA`, nonce=0 (same sender/nonce, different tag)   |
 
 ## Reference Implementation
 
@@ -962,7 +998,8 @@ Deployed on Sepolia:
 | BlobAuthenticatedMessagingCore | `0x9C4b230066a6808D83F5FBa0c040E0Df2Fcc7314` |
 | SocialBlobsCore (legacy)       | `0x11a825a0774d0471292eab4706743bffcdd5d137` |
 | BLSRegistry                    | `0x15866bf5a8724f2aa9fe75e262d8f00ba2818e25` |
-| BLSExposer                     | `0x443029b4b96fbf2d8feba77d828a394d19615a48` |
+| BLSExposer                     | _redeploy pending_ — interface changed to bind `contentTag` |
+| SimpleBoolVerifier             | `0xdec5faa3e32d6296e53bae7e359e059b58a482f4` |
 
 `BlobAuthenticatedMessagingCore` is the reference implementation of the amended
 ERC and emits the indexed-`contentTag` event layout described in
@@ -1135,13 +1172,16 @@ chains. Implementations should use the domain separator when computing signed me
 
 ### Message hash and message ID collisions
 
-The message hash is `keccak256(abi.encodePacked(sender, nonce, contents))`. The `abi.encodePacked` encoding is
-unambiguous because `sender` (20 bytes) and `nonce` (8 bytes) are fixed-size, so the variable-length
-`contents` field always begins at byte 28. No two distinct `(sender, nonce, contents)` tuples
-produce the same packed encoding.
+The message hash is `keccak256(abi.encodePacked(sender, contentTag, nonce, contents))`. The
+`abi.encodePacked` encoding is unambiguous because `sender` (20 bytes), `contentTag` (`bytes32`, 32
+bytes) and `nonce` (8 bytes) are all fixed-size, so the variable-length `contents` field always
+begins at byte 60. No two distinct `(sender, contentTag, nonce, contents)` tuples produce the same
+packed encoding.
 
-The message ID is `keccak256(abi.encodePacked(sender, nonce, contentHash))`. All three fields are fixed-size (20 +
-8 + 32 bytes), so the encoding is trivially unambiguous.
+The message ID is `keccak256(abi.encodePacked(sender, contentTag, nonce, contentHash))`. All four
+fields are fixed-size (20 + 32 + 8 + 32 bytes), so the encoding is trivially unambiguous. Two
+messages with the same `(sender, nonce)` posted to distinct `contentTag` values produce distinct
+message IDs; the ID itself separates cross-app duplicates.
 
 For an attacker to find two distinct inputs that produce the same hash for either formula requires a
 collision attack on keccak256 (birthday bound ~2^128 security). Finding a second input that matches a


### PR DESCRIPTION
> [!NOTE]
> **Draft.** Opened for early visibility while #1798 (`registerBlobBatches`) is in review. Expect a small mechanical conflict with #1798 in the Worked Examples / Test Cases area; will rebase whichever lands second.

## Summary

Binds `contentTag` into the standardized message hash and message ID formulas, and scopes nonces per `(sender, contentTag)`:

```
messageHash = keccak256(abi.encodePacked(sender, contentTag, nonce, contents))
messageId   = keccak256(abi.encodePacked(sender, contentTag, nonce, contentHash))
```

This is a **breaking cryptographic change** to the signing protocol — signatures and IDs computed under the previous formulas do not verify or match under these. ERC-8180 is in `Draft` status and the known deployments are Sepolia-only.

## Why

### Anti-re-routing (hash binding)

With `contentTag` now an indexed routing key on both BAM core events (#1793), the registration layer says *which app* a batch belongs to — but the signature layer didn't. A signed `(sender, nonce, contents)` verified identically in a batch registered under **any** `contentTag`, so an untrusted aggregator could lift a message signed for app A into a batch registered for app B and it would verify cleanly. Binding the tag into `messageHash` closes this: re-routing produces a hash the sender never signed, and verification fails.

This extends the ERC's core trust argument from the decoder to the aggregator: a lying decoder produces wrong hashes that fail verification; now a re-routing aggregator does too.

### Cross-app identity (ID binding)

The same `(sender, nonce)` posted to two apps previously produced colliding message IDs only distinguished by batch. With `contentTag` in the ID, cross-app messages are distinct at the identifier level — consumers no longer disambiguate externally.

### Per-`(sender, contentTag)` nonces

Nonce scoping moves from per-sender to per-`(sender, contentTag)`: a sender publishing under two tags maintains two independent monotonic sequences, and clients track last-accepted nonce per `(sender, contentTag)`.

The two changes in this PR are **one atomic design change**, not two stacked ones: per-tag acceptance windows are only safe because the tag is bound into the signed hash. Without the binding, one signed message would verify under every tag, and per-tag windows would let an aggregator replay it into every app. The Nonce Semantics section now states this dependency explicitly.

## What changes

- **Abstract / Definitions** — both formulas updated; Message ID noted as unique per message *and per tag*.
- **Decoder behavior** — clarifies the decoder is `contentTag`-unaware (tag scoping is a signing-protocol property, not a payload-encoding property; the client supplies the tag from the trusted registration event).
- **Nonce Semantics** — rewritten for per-`(sender, contentTag)` scoping, with the replay-safety rationale.
- **Exposer behavior clause 2** — `messageId` formula updated; `contentTag` sourced from the registration event for the batch containing the message.
- **Message ID / Signing Domain conventions** — formulas, field list (now 60 fixed bytes before `contents`), the anti-re-routing rationale, and an explicit breaking-change flag.
- **Worked Examples 1, 2, 4** — `messageHash` computation lines updated.
- **Rationale** — trust separation (aggregator re-routing), message ID determinism (cross-app collisions), and the EIP-712 guidance: typed-data adopters MUST include `contentTag` in the struct, otherwise the ECDSA path stays open to the re-routing the BLS path now prevents.
- **Test Cases** — Message ID table gains a Content Tag column and a third row: same `(sender, nonce, contentHash)` under a different tag yields a different ID.
- **Security Considerations** — collision analysis updated (fixed-size prefix 28 → 60 bytes; four fixed fields in the ID).
- **Reference Implementation** — `BLSExposer` marked *redeploy pending* (its on-chain hash computation changes); `SimpleBoolVerifier` added to the Sepolia table. The core contract is unaffected — it emits events and computes no message hashes.

## What this PR does NOT change

- Event signatures and registration functions (unchanged from #1793 / #1798)
- The signing domain (`"ERC-BAM.v1"` — the domain separator formula is untouched)
- The decoder interface (`Message` struct still `(sender, nonce, contents)`; the tag comes from the event, not the payload)

## Breaking-change scope

Messages signed under the old formula fail verification under the new one and vice versa. For Draft-status with testnet-only deployments, a clean cut is proposed: no dual-verification window, no versioned formula negotiation. The `"ERC-BAM.v1"` domain string is retained since the protocol has no mainnet signatures to migrate.