### PR TITLE
Update ERC-1613: Move to Draft

### DIFF
--- a/ERCS/erc-1613.md
+++ b/ERCS/erc-1613.md
@@ -1,7 +1,7 @@
 ---
 eip: 1613
 title: Gas stations network
-description: A Gas Station Network allowing smart contracts to accept collect-calls, enabling gasless transactions by paying for gas.
+description: A decentralized network allowing smart contracts to accept and pay for relayed transactions, enabling gasless user experiences.
 author: Yoav Weiss (@yoavw), Dror Tirosh (@drortirosh), Alex Forshtat (@forshtat), Shahaf Nacson (@shahafn)
 discussions-to: https://github.com/yoav-tabookey/EIPs/issues/1
 status: Draft

--- a/ERCS/erc-1613.md
+++ b/ERCS/erc-1613.md
@@ -1,13 +1,13 @@
 ---
 eip: 1613
 title: Gas stations network
-author: Yoav Weiss <yoav@tabookey.com>, Dror Tirosh <dror@tabookey.com>, Alex Forshtat <alex@tabookey.com>
+description: A Gas Station Network allowing smart contracts to accept collect-calls, paying for incoming transactions to enable gasless user interactions.
+author: Yoav Weiss (@yoavw), Dror Tirosh (@drortirosh), Alex Forshtat (@forshtat), Shahaf Nacson (@shahafn)
 discussions-to: https://github.com/yoav-tabookey/EIPs/issues/1
-status: Stagnant
+status: Draft
 type: Standards Track
 category: ERC
 created: 2018-11-18
-requires: 1077
 ---
 
 ## Simple Summary
@@ -20,9 +20,9 @@ Require no network changes, and minimal contract changes.
 Communicating with dapps currently requires paying ETH for gas, which limits dapp adoption to ether users. 
 Therefore, contract owners may wish to pay for the gas to increase user acquisition, or let their users pay for gas with fiat money. 
 Alternatively, a 3rd party may wish to subsidize the gas costs of certain contracts. 
-Solutions such as described in [EIP-1077](./eip-1077.md) could allow transactions from addresses that hold no ETH.
+Solutions could allow transactions from addresses that hold no ETH.
 
-The gas stations network is an [EIP-1077](./eip-1077.md) compliant effort to solve the problem by creating an incentive for nodes to run gas stations, where gasless transactions can be "fueled up". 
+The gas stations network is an effort to solve the problem by creating an incentive for nodes to run gas stations, where gasless transactions can be "fueled up". 
 It abstracts the implementation details from both the dapp maintainer and the user, making it easy to convert existing dapps to accept "collect-calls".
 
 The network consists of a single public contract trusted by all participating dapp contracts, and a decentralized network of relay nodes (gas stations) incentivized to listen on non-ether interfaces such as web or whisper, 
@@ -196,9 +196,21 @@ Specifically we've considered the following types of attacks:
 * Denial-of-service and financial attacks against individual contracts.
 * Denial-of-service attacks against the entire network, either by attacking existing entities, or by introducing any number of malicious entities.
 
-#### Attacks and mitigations
+## Backwards Compatibility
 
-##### Attack: Relay attempts to censor a transaction by not signing it, or otherwise ignoring a user request.
+The gas stations network is implemented as smart contracts and external entities, and does not require any network changes.
+
+Dapps adding gas station network support remain backwards compatible with their existing apps/users. The added methods apply on top of the existing ones, so no changes are required for existing apps.
+
+## Reference Implementation
+
+A working implementation of the [**gas stations network**](https://github.com/tabookey-dev/tabookey-gasless) consists of `RelayHub`, `RelayRecipient`, `web3 hooks`, an implementation of a gas station inside `geth`, and sample dapps using the gas stations network.
+
+## Security Considerations
+
+### Attacks and mitigations
+
+#### Attack: Relay attempts to censor a transaction by not signing it, or otherwise ignoring a user request.
 Relay is expected to return the signed transaction to the sender, immediately. 
 Sender doesn't need to wait for the transaction to be mined, and knows immediately whether it's request has been served. 
 If a relay doesn't return a signed transaction within a couple of seconds, sender cancels the operation, drops the connection, and switches to another relay. 
@@ -206,12 +218,12 @@ It also marks Relay as unresponsive in its private storage to avoid using it in 
 
 Therefore, the maximal damage a relay can cause with such attack, is a one-time delay of a couple of seconds. After a while, senders will avoid it altogether.
 
-##### Attack: Relay attempts to censor a transaction by signing it, returning it to the sender, but never putting it on the blockchain.
+#### Attack: Relay attempts to censor a transaction by signing it, returning it to the sender, but never putting it on the blockchain.
 This attack will backfire and not censor the transaction. 
 The sender can submit the transaction signed by Relay to the blockchain as a raw transaction through any node, so the transaction does happen, 
 but Relay may be unaware and therefore be stuck with a bad nonce which will break its next transaction.
 
-##### Attack: Relay attempts to censor a transaction by signing it, but publishing a different transaction with the same nonce.
+#### Attack: Relay attempts to censor a transaction by signing it, but publishing a different transaction with the same nonce.
 Reusing the nonce is the only DoS performed by a Relay, that cannot be detected within a couple of seconds during the http request. 
 It will only be detected when the malicious transaction with the same nonce gets mined and triggers the `RelayHub.TransactionRelayed` event. 
 However, the attack will backfire and cost Relay its entire stake.
@@ -225,14 +237,14 @@ The sender then proceeds to select a new relay and send the original transaction
 The result of such attack is a delay of a few blocks in sending the transaction (until the attack is detected) but the relay gets removed and loses its entire stake. 
 Scaling such attack would be prohibitively expensive, and actually quite profitable for senders and honest relays.
 
-##### Attack: Relay attempts to censor a transaction by signing it, but using a nonce higher than it's current nonce.
+#### Attack: Relay attempts to censor a transaction by signing it, but using a nonce higher than it's current nonce.
 In this attack, the Relay did create and return a perfectly valid transaction, but it will not be mined until this Relay fills the gap in the nonce with 'missing' transactions.
 This may delay the relaying of some transactions indefinitely. In order to mitigate that, the sender includes a `max_nonce` parameter with it's signing request.
 It is suggested to be higher by 2-3 from current nonce, to allow the relay process several transactions.
 
 When the sender receives a transaction signed by a Relay he validates that the nonce used is valid, and if it is not, the client will ignore the given relay and use other relays to relay given transaction. Therefore, there will be no actual delay introduced by such attack.
 
-##### Attack: Dapp attempts to burn relays funds by implementing an inconsistent acceptRelayedCall() and using multiple sender addresses to generate expensive transactions, thus performing a DoS attack on relays and reducing their profitability.
+#### Attack: Dapp attempts to burn relays funds by implementing an inconsistent acceptRelayedCall() and using multiple sender addresses to generate expensive transactions, thus performing a DoS attack on relays and reducing their profitability.
 In this attack, a contract sets an inconsistent acceptRelayedCall (e.g. return zero for even blocks, nonzero for odd blocks), and uses it to exhaust relay resources through unpaid transactions. 
 Relays can easily detect it after the fact. 
 If a transaction goes unpaid, the relay knows that the recipient contract's acceptRelayedCall has acted inconsistently, because the relay has verified its view function before sending the transaction. 
@@ -249,7 +261,7 @@ The attack can be made even more impractical by setting RelayHub to require a st
 so that attackers will have to raise a vast amount of ETH in order to simultaneously create enough malicious contracts and attack relays. 
 This protection is probably an overkill, since the attack doesn't scale regardless.
 
-##### Attack: User attempts to rob dapps by registering its own relay and sending expensive transactions to dapps.
+#### Attack: User attempts to rob dapps by registering its own relay and sending expensive transactions to dapps.
 If a malicious sender repeatedly abuses a recipient by sending meaningless/reverted transactions and causing the recipient to pay a relay for nothing, 
 it is the recipient's responsibility to blacklist that sender and have its acceptRelayedCall function return nonzero for that sender. 
 Collect calls are generally not meant for anonymous senders unknown to the recipient. 
@@ -263,7 +275,7 @@ A variation of this method, for free dapps (that don't charge the user, and pref
 or to login with a Google/Facebook account, which limits the rate of the attack to the attacker's ability to open many Google/Facebook accounts. 
 Only a user that passed that process is given credit in RelayRecipient. The rate of such Sybil attack would be too low to cause any real damage.
 
-##### Attack: Attacker attempts to reduce network availability by registering many unreliable relays.
+#### Attack: Attacker attempts to reduce network availability by registering many unreliable relays.
 Registering a relay requires placing a stake in RelayHub, and the stake can only be withdrawn after the relay is unregistered and a long cooldown period has passed, e.g. a month.
 
 Each unreliable relay can only cause a couple of seconds delay to senders, once, and then it gets blacklisted by them, as described in the first attack above. 
@@ -271,10 +283,10 @@ After it caused this minor delay and got blacklisted, the attacker must wait a m
 Simultaneously bringing up a number of unreliable relays, large enough to cause a noticeable network delay, would be prohibitively expensive due to the required stake, 
 and even then, all those relays will get blacklisted within a short time.
 
-##### Attack: Attacker attempts to replay a relayed transaction.
+#### Attack: Attacker attempts to replay a relayed transaction.
 Transactions include a nonce. RelayHub maintains a nonce (counter) for each sender. Transactions with bad nonces get reverted by RelayHub. Each transaction can only be relayed once.
 
-##### Attack: User does not execute the raw transaction received from the Relayer, therefore blocking the execution of all further transactions signed by this relayer
+#### Attack: User does not execute the raw transaction received from the Relayer, therefore blocking the execution of all further transactions signed by this relayer
 The user doesn't really have to execute the raw transaction. It's enough that the user can. The relationship between relay and sender is mutual distrust. The process described above incentivizes the relay to execute the transaction, so the user doesn't need to wait for actual mining to know that the transaction has been executed.
 
 Once relay returns the signed transaction, which should happen immediately, the relay is incentivized to also execute it on chain, so that it can advance its nonce and serve the next transaction. The user can (but doesn't have to) also execute the transaction. To understand why the attack isn't viable, consider the four possible scenarios after the signed transaction was returned to the sender:
@@ -285,16 +297,6 @@ Once relay returns the signed transaction, which should happen immediately, the 
 4. None of them execute the transaction. In this case the transaction doesn't get executed, but the relay is stuck. It can't serve the next transaction with the next nonce, because its nonce hasn't been advanced on-chain. It also can't serve the next transaction with the current nonce, as this can be proven by the user, having two different transactions signed by the same relay, with the same nonce. The user could use this to take the relay's nonce. So the relay is stuck unless it executes the transaction.
 
 As this matrix shows, the relay is __always__ incentivized to execute the transaction, once it returned it to the user, in order to end up in #1 or #3, and avoid the risk of #4. It's just a way to commit the relay to do its work, without requiring the user to wait for on-chain confirmation.
-
-## Backwards Compatibility
-
-The gas stations network is implemented as smart contracts and external entities, and does not require any network changes.
-
-Dapps adding gas station network support remain backwards compatible with their existing apps/users. The added methods apply on top of the existing ones, so no changes are required for existing apps.
-
-## Implementation
-
-A working implementation of the [**gas stations network**](https://github.com/tabookey-dev/tabookey-gasless) is being developed by **TabooKey**. It consists of `RelayHub`, `RelayRecipient`, `web3 hooks`, an implementation of a gas station inside `geth`, and sample dapps using the gas stations network.
 
 ## Copyright
 Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-1613.md
+++ b/ERCS/erc-1613.md
@@ -3,7 +3,7 @@ eip: 1613
 title: Gas stations network
 description: A decentralized network allowing smart contracts to accept and pay for relayed transactions, enabling gasless user experiences.
 author: Yoav Weiss (@yoavw), Dror Tirosh (@drortirosh), Alex Forshtat (@forshtat), Shahaf Nacson (@shahafn)
-discussions-to: https://github.com/yoav-tabookey/EIPs/issues/1
+discussions-to: https://ethereum-magicians.org/t/erc-1613-gas-station-network/29051
 status: Draft
 type: Standards Track
 category: ERC

--- a/ERCS/erc-1613.md
+++ b/ERCS/erc-1613.md
@@ -1,7 +1,7 @@
 ---
 eip: 1613
 title: Gas stations network
-description: A Gas Station Network allowing smart contracts to accept collect-calls, paying for incoming transactions to enable gasless user interactions.
+description: A Gas Station Network allowing smart contracts to accept collect-calls, enabling gasless transactions by paying for gas.
 author: Yoav Weiss (@yoavw), Dror Tirosh (@drortirosh), Alex Forshtat (@forshtat), Shahaf Nacson (@shahafn)
 discussions-to: https://github.com/yoav-tabookey/EIPs/issues/1
 status: Draft
@@ -10,15 +10,14 @@ category: ERC
 created: 2018-11-18
 ---
 
-## Simple Summary
-Make smart contracts (e.g. dapps) accessible to non-ether users by allowing contracts to accept "[collect-calls](https://en.wikipedia.org/wiki/Collect_call)", paying for incoming calls. 
-Let contracts "listen" on publicly accessible channels (e.g. web URL or a whisper address). 
-Incentivize nodes to run "gas stations" to facilitate this. 
-Require no network changes, and minimal contract changes.
-
 ## Abstract
 Communicating with dapps currently requires paying ETH for gas, which limits dapp adoption to ether users. 
 Therefore, contract owners may wish to pay for the gas to increase user acquisition, or let their users pay for gas with fiat money. 
+
+The Gas Station Network (GSN) makes smart contracts accessible to non-ether users by allowing contracts to accept "collect-calls", paying for incoming calls. 
+It lets contracts "listen" on publicly accessible channels (e.g. web URL or a whisper address) and incentivizes nodes to run "gas stations" to facilitate this. 
+It requires no network changes and minimal contract changes.
+
 Alternatively, a 3rd party may wish to subsidize the gas costs of certain contracts. 
 Solutions could allow transactions from addresses that hold no ETH.
 
@@ -204,7 +203,7 @@ Dapps adding gas station network support remain backwards compatible with their 
 
 ## Reference Implementation
 
-A working implementation of the [**gas stations network**](https://github.com/tabookey-dev/tabookey-gasless) consists of `RelayHub`, `RelayRecipient`, `web3 hooks`, an implementation of a gas station inside `geth`, and sample dapps using the gas stations network.
+A working implementation of the gas stations network consists of `RelayHub`, `RelayRecipient`, `web3 hooks`, and sample dapps using the gas stations network.
 
 ## Security Considerations
 


### PR DESCRIPTION
I am withdrawing some old stagnant ERCs, but the GSN, while not in development for years, withdrawing it does not make sense to me either, as the standard is still actively used on some chains, including Polygon where it is used by, among others, the Polymarket:

https://polygonscan.com/address/0xd216153c06e857cd7f72665e0af1d7d82172f494

I think it will be more reasonable to just clean it up and move it to final. Does this make sense?