### PR TITLE
Update ERC-2770: Move to Withdrawn

### DIFF
--- a/ERCS/erc-2770.md
+++ b/ERCS/erc-2770.md
@@ -3,7 +3,8 @@ eip: 2770
 title: Meta-Transactions Forwarder Contract
 author: Alex Forshtat (@forshtat), Dror Tirosh (@drortirosh)
 discussions-to: https://ethereum-magicians.org/t/erc-2770-meta-transactions-forwarder-contract/5391
-status: Stagnant
+status: Withdrawn
+withdrawal-reason: Singleton implementation does not require standardization.
 type: Standards Track
 category: ERC
 created: 2020-07-01


### PR DESCRIPTION
Singleton implementation does not require standardization. This ERC is being withdrawn by the author.