### PR TITLE
Update ERC-7766: Move to Withdrawn

### DIFF
--- a/ERCS/erc-7766.md
+++ b/ERCS/erc-7766.md
@@ -4,7 +4,8 @@ title: Signature Aggregation for ERC-4337
 description: An ERC-4337 improvement to aggregation of all UserOperation signatures in a bundle
 author: Vitalik Buterin (@vbuterin), Yoav Weiss (@yoavw), Dror Tirosh (@drortirosh), Shahaf Nacson (@shahafn), Alex Forshtat (@forshtat)
 discussions-to: https://ethereum-magicians.org/t/erc-7766-signature-aggregation-for-account-abstraction/21123
-status: Draft
+status: Withdrawn
+withdrawal-reason: No production adoption of aggregateable signature schemes in contemporary AA context. Alternative will be created for Native AA aggregation in the near future.
 type: Standards Track
 category: ERC
 created: 2024-09-01


### PR DESCRIPTION
No production adoption of aggregateable signature schemes in contemporary AA context. Alternative will be created for Native AA aggregation in the near future. This ERC is being withdrawn by the authors.