### PR TITLE
Update ERC-8257: Add featuredImage manifest field and 1:1/16:9 aspect ratio guidance

### DIFF
--- a/ERCS/erc-8257.md
+++ b/ERCS/erc-8257.md
@@ -438,7 +438,8 @@ Any RFC 8785 conformant implementation MUST produce the same byte output for the
 | Field | Type | Description |
 | --- | --- | --- |
 | `version` | string | Semantic version (e.g., `"1.0.0"`). Consumers MAY interpret an absent `version` as `"1.0.0"` for display purposes, but MUST NOT insert a default into the manifest before JCS canonicalization; the manifest is hashed as served. |
-| `image` | string | Tool icon URL. MUST be at most 2,048 bytes (UTF-8 byte length) after URL normalization, matching the `metadataURI` cap so both URL fields are bounded by the same unit. Consumers are responsible for rendering this field safely; see [Rendering Manifest Content](#rendering-manifest-content). |
+| `image` | string | Tool icon URL. The image SHOULD have a 1:1 aspect ratio; discovery surfaces are expected to render it as a profile-picture-style avatar or thumbnail. MUST be at most 2,048 bytes (UTF-8 byte length) after URL normalization, matching the `metadataURI` cap so both URL fields are bounded by the same unit. Consumers are responsible for rendering this field safely; see [Rendering Manifest Content](#rendering-manifest-content). |
+| `featuredImage` | string | Featured image URL for hero, banner, or card placements in discovery surfaces. The image SHOULD have a 16:9 aspect ratio. Subject to the same constraints as `image`: at most 2,048 bytes (UTF-8 byte length) after URL normalization, and rendered under the rules in [Rendering Manifest Content](#rendering-manifest-content). |
 | `tags` | array | Discovery tags. Each tag MUST match `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` and be 1-32 Unicode code points; the array MUST contain at most 16 entries and MUST NOT contain duplicates (consumers MUST reject manifests with repeated tags). |
 | `pricing` | array | Payment options for tool invocation (see [Pricing](#3-pricing)) |
 | `access` | object | Preflight access-requirement hints for agents (see [Access](#4-access)) |
@@ -474,6 +475,8 @@ Extension authors MUST namespace their keys. The RECOMMENDED form is a reverse-D
     }
   },
   "version": "1.0.0",
+  "image": "https://tools.example.com/nft-price-oracle/icon.png",
+  "featuredImage": "https://tools.example.com/nft-price-oracle/featured.png",
   "tags": ["nft", "pricing", "oracle"],
   "creatorAddress": "0xabcdefabcdef1234567890abcdefabcdef123456"
 }
@@ -612,7 +615,7 @@ Each requirement object:
 | `kind` | string | 4-byte hex selector (e.g., `"0xabcd1234"`). MUST match `^0x[0-9a-f]{8}$` (lowercase hex digits, for JCS-canonical-byte determinism — see [Canonical Manifest Bytes](#canonical-manifest-bytes)). Corresponds to `AccessRequirement.kind` onchain. |
 | `data` | string | Hex-encoded ABI payload. MUST match `^0x([0-9a-f]{2})*$` (lowercase, even number of hex digits). Layout is determined by `kind`. Subject to the per-entry byte cap in [Manifest Parser Hardening](#manifest-parser-hardening). |
 | `label` | string | Human-readable hint (e.g., `"Hold any Chonk on Base"`). MUST be at most 256 bytes (UTF-8 byte length, matching the onchain `label` cap in [Predicate Introspection Hardening](#predicate-introspection-hardening) so that the same string survives both decode paths). |
-| `links` | object | *(Optional)* String-to-string map of related URLs. Each value MUST be an `https://…` URL at most 2,048 bytes long (UTF-8 byte length, matching the `image` and `metadataURI` caps); other schemes (`http:`, `data:`, `javascript:`, `file:`, raw onchain identifiers, etc.) MUST NOT be used. Consumers MUST reject manifests whose `links` map contains any non-HTTPS value or any value longer than the cap. Map keys are short opaque labels chosen by the manifest author (e.g., `buy`, `docs`, `predicate-source`); the same length cap applies to keys. |
+| `links` | object | *(Optional)* String-to-string map of related URLs. Each value MUST be an `https://…` URL at most 2,048 bytes long (UTF-8 byte length, matching the `image`, `featuredImage`, and `metadataURI` caps); other schemes (`http:`, `data:`, `javascript:`, `file:`, raw onchain identifiers, etc.) MUST NOT be used. Consumers MUST reject manifests whose `links` map contains any non-HTTPS value or any value longer than the cap. Map keys are short opaque labels chosen by the manifest author (e.g., `buy`, `docs`, `predicate-source`); the same length cap applies to keys. |
 
 Because the `access` block is part of the manifest, it is committed onchain via `manifestHash`. Changing access requirements in the manifest requires calling `updateToolMetadata` with the new hash.
 
@@ -814,7 +817,7 @@ Origin comparison follows [RFC 6454](https://www.rfc-editor.org/rfc/rfc6454): sa
 
 #### URL Normalization
 
-Because URLs have multiple equivalent representations, both registrants and consumers MUST reduce HTTPS URLs in this ERC to a canonical form before writing, reading, or comparing them. The rules split into two groups: a **general HTTPS-URL** group that applies to every URL field (notably `endpoint` and `image`), and a **well-known-path** group that applies additionally to `metadataURI`.
+Because URLs have multiple equivalent representations, both registrants and consumers MUST reduce HTTPS URLs in this ERC to a canonical form before writing, reading, or comparing them. The rules split into two groups: a **general HTTPS-URL** group that applies to every URL field (notably `endpoint`, `image`, and `featuredImage`), and a **well-known-path** group that applies additionally to `metadataURI`.
 
 **General HTTPS-URL normalization** (rules G1‑G3):
 
@@ -1054,13 +1057,13 @@ All `keccak256` values are 32-byte outputs shown as `0x`-prefixed lowercase hex.
 
 Semantic input: the "Free Tool" example in [§2 Tool Manifest](#example-manifest-free-tool).
 
-JCS canonical bytes (UTF-8, 632 bytes, whitespace-free on a single line in the wire representation; rendered here without wrapping):
+JCS canonical bytes (UTF-8, 768 bytes, whitespace-free on a single line in the wire representation; rendered here without wrapping):
 
 ```
-{"creatorAddress":"0xabcdefabcdef1234567890abcdefabcdef123456","description":"Returns estimated floor price for any NFT collection.","endpoint":"https://tools.example.com/nft-price-oracle","inputs":{"properties":{"chainId":{"type":"integer"},"collection":{"description":"Contract address","type":"string"}},"required":["collection","chainId"],"type":"object"},"name":"nft-price-oracle","outputs":{"properties":{"floorPriceEth":{"type":"string"},"updatedAt":{"format":"date-time","type":"string"}},"type":"object"},"tags":["nft","pricing","oracle"],"type":"https://ercs.ethereum.org/ERCS/erc-8257#tool-manifest-v1","version":"1.0.0"}
+{"creatorAddress":"0xabcdefabcdef1234567890abcdefabcdef123456","description":"Returns estimated floor price for any NFT collection.","endpoint":"https://tools.example.com/nft-price-oracle","featuredImage":"https://tools.example.com/nft-price-oracle/featured.png","image":"https://tools.example.com/nft-price-oracle/icon.png","inputs":{"properties":{"chainId":{"type":"integer"},"collection":{"description":"Contract address","type":"string"}},"required":["collection","chainId"],"type":"object"},"name":"nft-price-oracle","outputs":{"properties":{"floorPriceEth":{"type":"string"},"updatedAt":{"format":"date-time","type":"string"}},"type":"object"},"tags":["nft","pricing","oracle"],"type":"https://ercs.ethereum.org/ERCS/erc-8257#tool-manifest-v1","version":"1.0.0"}
 ```
 
-- `manifestHash` = `0x786620b1a5d903c2ac4eafe964364292ca4b6ed763a13b29423c03ccca905af0`
+- `manifestHash` = `0x9a0f34405d7907b4c0ceebd23f293d9a1aa31c38e81d5c197e415cb8c16fed5f`
 
 Matching `ToolConfig` (registered on `eip155:8453` at registry `0xaaaa…aaaa` as tool ID `1`):
 
@@ -1068,7 +1071,7 @@ Matching `ToolConfig` (registered on `eip155:8453` at registry `0xaaaa…aaaa` a
 ToolConfig {
     creator:         0xabcdefabcdef1234567890abcdefabcdef123456,
     metadataURI:     "https://tools.example.com/.well-known/ai-tool/nft-price-oracle.json",
-    manifestHash:    0x786620b1a5d903c2ac4eafe964364292ca4b6ed763a13b29423c03ccca905af0,
+    manifestHash:    0x9a0f34405d7907b4c0ceebd23f293d9a1aa31c38e81d5c197e415cb8c16fed5f,
     accessPredicate: 0x0000000000000000000000000000000000000000
 }
 ```
@@ -1286,7 +1289,7 @@ Creators SHOULD prefer predicates that explicitly advertise `IAccessPredicate` v
 
 ### Metadata URI Length Cap
 
-Implementations MUST reject `metadataURI` values longer than 2,048 bytes (UTF-8 byte length, not Unicode code-point count) at both `registerTool` and `updateToolMetadata`, reverting with `InvalidMetadataURI`. The cap exists because the URI is creator-controlled, written into permanent storage, and re-read by every offchain consumer that resolves the tool. Without a normative cap, a single registration of a multi-kilobyte URI imposes a perpetual gas cost on indexers and a per-request bandwidth cost on every wallet that re-resolves the tool. The 2,048-byte ceiling matches the `image` field's URL cap in [§2 Optional Fields](#optional-fields) and is comfortably above any realistic well-known path: `<origin>/.well-known/ai-tool/<slug>.json` with the maximum 64-character slug and a typical origin fits in well under 400 bytes. Implementations MAY choose a smaller cap; 2,048 bytes is the upper bound.
+Implementations MUST reject `metadataURI` values longer than 2,048 bytes (UTF-8 byte length, not Unicode code-point count) at both `registerTool` and `updateToolMetadata`, reverting with `InvalidMetadataURI`. The cap exists because the URI is creator-controlled, written into permanent storage, and re-read by every offchain consumer that resolves the tool. Without a normative cap, a single registration of a multi-kilobyte URI imposes a perpetual gas cost on indexers and a per-request bandwidth cost on every wallet that re-resolves the tool. The 2,048-byte ceiling matches the URL cap on the `image` and `featuredImage` fields in [§2 Optional Fields](#optional-fields) and is comfortably above any realistic well-known path: `<origin>/.well-known/ai-tool/<slug>.json` with the maximum 64-character slug and a typical origin fits in well under 400 bytes. Implementations MAY choose a smaller cap; 2,048 bytes is the upper bound.
 
 ### Front-Running Tool Registration
 
@@ -1383,10 +1386,10 @@ The following normative rules apply to common render paths:
 
 - **Text fields (`name`, `description`, `tags`).** Consumers MUST contextually encode these fields when rendering: HTML-escape for text nodes, attribute-escape for attributes, and JS-escape for script contexts. UIs that inject them into the DOM without encoding are vulnerable to stored XSS from a single malicious registration.
 - **Markdown rendering of `description`.** Consumers that render Markdown MUST disable raw-HTML passthrough or sandbox the rendered output. A compliant Markdown renderer strips `<script>`, `<iframe>`, event handlers, and `javascript:` URLs, or runs under a CSP that neutralizes these surfaces.
-- **`image` URIs.** Consumers MUST NOT accept `javascript:`, `file:`, `data:text/html`, or `vbscript:` URIs for a tool icon: these schemes enable script execution or local-filesystem exposure and have no legitimate icon use case. Consumers SHOULD NOT accept `http:` (man-in-the-middle (MITM) risk) or `blob:` (cross-context leakage risk) URIs; consumers that do accept either MUST apply the scheme-appropriate defenses in the Per-Scheme Rendering Guidance below.
+- **`image` and `featuredImage` URIs.** Consumers MUST NOT accept `javascript:`, `file:`, `data:text/html`, or `vbscript:` URIs for a tool image: these schemes enable script execution or local-filesystem exposure and have no legitimate image use case. Consumers SHOULD NOT accept `http:` (man-in-the-middle (MITM) risk) or `blob:` (cross-context leakage risk) URIs; consumers that do accept either MUST apply the scheme-appropriate defenses in the Per-Scheme Rendering Guidance below.
 - **`endpoint` and extension-namespaced URL fields as clickable links.** Consumers SHOULD NOT render `javascript:`, `file:`, or `blob:` schemes as links; `http:` links are permitted only with explicit user consent because of MITM risk; all external links SHOULD carry `rel="noopener noreferrer"` to prevent tab-nabbing.
 
-#### Non-Normative: Per-Scheme Rendering Guidance for `image`
+#### Non-Normative: Per-Scheme Rendering Guidance for `image` and `featuredImage`
 
 For any scheme consumers do accept, scheme-appropriate defenses should be layered on the normative rules above:
 


### PR DESCRIPTION
## Summary

  Adds collection-style image metadata to the Tool Manifest (§2 Optional Fields):

  - `image` (existing field): now RECOMMENDS a 1:1 aspect ratio, rendered as a profile-picture-style avatar/thumbnail in discovery surfaces.
  - `featuredImage` (new optional field): featured image URL for hero/banner/card placements, RECOMMENDS a 16:9 aspect ratio. Same 2,048-byte URL cap and rendering-safety rules as `image`.

  Field naming and semantics loosely follow established NFT metadata conventions (e.g., OpenSea's `featured_image` contract-level field), camelCased to match the manifest's existing convention.

  ## Consistency updates

  - §6 URL Normalization, the `links` cap cross-reference, the Metadata URI Length Cap rationale, and the Security Considerations rendering rules now cover `featuredImage` alongside `image`.
  - The Free Tool example manifest doubles as a pinned test vector, so its JCS canonical bytes (632 → 768) and `manifestHash` were recomputed. The reference pipeline was verified by reproducing the previous pinned hash before computing the new one:
  `0x9a0f34405d7907b4c0ceebd23f293d9a1aa31c38e81d5c197e415cb8c16fed5f`.

  Aspect ratios are SHOULD-level guidance, not MUST — consumers can't reasonably reject a manifest over pixel dimensions.