### PR TITLE
Update ERC-1450: Mark document management and recovery workflow as optional extensions

### DIFF
--- a/ERCS/erc-1450.md
+++ b/ERCS/erc-1450.md
@@ -44,6 +44,15 @@ The following standards MAY be implemented for enhanced functionality but are NO
 - **[EIP-3668 (CCIP-Read)](./eip-3668.md)**: MAY be used for off-chain compliance pre-checks. Implementations choosing to support this MUST implement the `preCheckCompliance` and `preCheckComplianceCallback` functions as specified.
 - **[ERC-1820 (Registry)](./eip-1820.md)**: MAY be used for interface registration. Implementations can optionally register their interfaces in the ERC-1820 registry for improved discoverability.
 
+In addition to the optional standards above, the following interface components defined in this specification are OPTIONAL extensions. Implementations MAY omit them; implementations that provide them MUST follow the behavior specified for them (including emitting the specified events):
+
+- **Document management** (`setDocument`, `getDocument`, `removeDocument`, `getAllDocuments`)
+- **Structured recovery workflow** (`initiateRecovery`, `cancelRecovery`, `executeRecovery`, `getRecoveryDetails`, `hasPendingRecovery`) — the REQUIRED baseline for lost-wallet recovery and court-ordered transfers is `controllerTransfer`, which all implementations MUST provide
+- **KYC status view** (`isKYCVerified`)
+- **Gasless fee approval** (`requestTransferWithPermit`)
+- **Off-chain compliance pre-checks** (`preCheckCompliance`, `preCheckComplianceCallback`)
+- **Transfer request status view** (`getRequestStatus`) — implementations MAY instead expose equivalent request data through other read methods (e.g., a public storage mapping)
+
 ### ERC-1450
 ERC-1450 is an interface standard that defines a security token where only the Registered Transfer Agent (RTA) has authority to execute transfers, mints, and burns. The token represents securities issued by an owner (the issuer) and managed exclusively by an RTA.
 
@@ -757,8 +766,10 @@ interface IERC1450 is IERC20, IERC165 {
     }
 
     /**
-     * @notice Get current status of a transfer request
+     * @notice Get current status of a transfer request (OPTIONAL)
      * @param requestId The transfer request ID
+     * @dev OPTIONAL: Implementations MAY instead expose equivalent request data
+     *      through other read methods (e.g., a public storage mapping).
      * @return status Current RequestStatus
      * @return from Source address
      * @return to Destination address
@@ -942,10 +953,14 @@ interface IERC1450 is IERC20, IERC165 {
     function preCheckComplianceCallback(bytes calldata response, bytes calldata extraData)
         external pure returns (bool);
 
-    // ERC-1643 Document Management Interface
+    // ============ ERC-1643 Document Management Interface (OPTIONAL) ============
+    // Implementations MAY support on-chain anchoring of document references.
+    // RTAs already maintain authoritative books and records off-chain per their
+    // regulatory obligations; on-chain anchoring is an optional transparency
+    // enhancement, not a compliance requirement.
 
     /**
-     * @notice Set a document for the token (RTA only)
+     * @notice Set a document for the token (RTA only) (OPTIONAL)
      * @param _name Document name (unique identifier)
      * @param _uri Document location (IPFS hash or HTTPS URL)
      * @param _documentHash Hash of the document for verification
@@ -960,7 +975,7 @@ interface IERC1450 is IERC20, IERC165 {
      *      - "COURT_ORDER": Legal judgments
      *      - "RECOVERY_EVIDENCE": Lost wallet documentation
      *
-     *      MUST emit DocumentUpdated event.
+     *      Implementations providing this function MUST emit DocumentUpdated.
      */
     function setDocument(
         bytes32 _name,
@@ -969,7 +984,7 @@ interface IERC1450 is IERC20, IERC165 {
     ) external;
 
     /**
-     * @notice Get a specific document's details
+     * @notice Get a specific document's details (OPTIONAL)
      * @param _name Document name to retrieve
      * @return documentUri Document location
      * @return documentHash Document hash for verification
@@ -985,26 +1000,31 @@ interface IERC1450 is IERC20, IERC165 {
         );
 
     /**
-     * @notice Remove a document (RTA only)
+     * @notice Remove a document (RTA only) (OPTIONAL)
      * @param _name Document name to remove
      * @dev Part of ERC-1643 standard. Only callable by RTA.
-     *      MUST emit DocumentRemoved event.
+     *      Implementations providing this function MUST emit DocumentRemoved.
      */
     function removeDocument(bytes32 _name) external;
 
     /**
-     * @notice Get all document names
+     * @notice Get all document names (OPTIONAL)
      * @return Array of all document names that have been set
      * @dev Part of ERC-1643 standard. Publicly accessible.
      *      Allows discovery of all documents associated with the token.
      */
     function getAllDocuments() external view returns (bytes32[] memory);
 
-    // Recovery Mechanism for Lost/Compromised Wallets
-    // Uses ERC-1643 for document management and aligns with ERC-1644 for controller operations
+    // ============ Recovery Workflow for Lost/Compromised Wallets (OPTIONAL) ============
+    // Uses ERC-1643 for document management and aligns with ERC-1644 for controller operations.
+    // OPTIONAL: This structured, time-locked workflow is an extension. The REQUIRED
+    // baseline for recovery is controllerTransfer — the RTA verifies the investor's
+    // identity through its existing off-chain KYC records and executes the transfer.
+    // The structured workflow adds public evidence anchoring and a dispute window
+    // for deployments that want on-chain transparency of recovery operations.
 
     /**
-     * @notice Initiate recovery process for lost wallet (RTA only)
+     * @notice Initiate recovery process for lost wallet (RTA only) (OPTIONAL)
      * @param lostWallet Address that has lost access
      * @param newWallet Proposed replacement address
      * @param documentName Name/type of the supporting document (ERC-1643 compatible)
@@ -1022,7 +1042,8 @@ interface IERC1450 is IERC20, IERC165 {
      *      - uri: Link to encrypted document storage (never store PII on-chain)
      *      - documentHash: Cryptographic hash for document integrity
      *
-     *      MUST emit DocumentUpdated event per ERC-1643 when evidence is submitted
+     *      Implementations providing this function MUST emit DocumentUpdated
+     *      per ERC-1643 when evidence is submitted
      */
     function initiateRecovery(
         address lostWallet,
@@ -1033,7 +1054,7 @@ interface IERC1450 is IERC20, IERC165 {
     ) external returns (uint256 recoveryId);
 
     /**
-     * @notice Cancel a pending recovery request (RTA only)
+     * @notice Cancel a pending recovery request (RTA only) (OPTIONAL)
      * @param recoveryId The recovery request to cancel
      * @dev Can be called if:
      *      - Original wallet owner proves they still have access
@@ -1043,11 +1064,12 @@ interface IERC1450 is IERC20, IERC165 {
     function cancelRecovery(uint256 recoveryId) external;
 
     /**
-     * @notice Execute recovery after time lock expires (RTA only)
+     * @notice Execute recovery after time lock expires (RTA only) (OPTIONAL)
      * @param recoveryId The recovery request to execute
      * @dev Transfers all tokens from lost wallet to new wallet
      *      Can only be executed after time lock period (e.g., 30 days)
-     *      MUST emit ControllerTransfer event per ERC-1644
+     *      Implementations providing this function MUST emit ControllerTransfer
+     *      per ERC-1644
      */
     function executeRecovery(uint256 recoveryId) external;
 
@@ -1155,7 +1177,8 @@ interface IERC1450 is IERC20, IERC165 {
         bytes operatorData
     );
 
-    // ERC-1643 Standard Events (Document Management)
+    // ERC-1643 Standard Events (Document Management — OPTIONAL, required if
+    // the document management extension is implemented)
     event DocumentUpdated(
         bytes32 indexed _name,
         string _uri,
@@ -1167,13 +1190,8 @@ interface IERC1450 is IERC20, IERC165 {
         bytes32 _documentHash
     );
 
-    event DocumentUpdated(
-        bytes32 indexed _name,
-        string _uri,
-        bytes32 _documentHash
-    );
-
-    // Recovery-specific Events (extending standard events)
+    // Recovery-specific Events (OPTIONAL, required if the recovery workflow
+    // extension is implemented)
     event RecoveryInitiated(
         uint256 indexed recoveryId,
         address indexed lostWallet,
@@ -2472,7 +2490,7 @@ This standard implements this controller model on-chain, providing:
 | **Privacy** | ✅ No PII on-chain | ❌ Identity data on-chain | ⚠️ Implementation varies | ✅ No identity required |
 | **Gas Efficiency** | ✅ Single contract | ❌ Multiple contracts | ❌ Modular architecture | ✅ Minimal |
 | **Operational Complexity** | ✅ Simple RTA operations | ❌ Complex rule engine | ❌ Partition management | ✅ Simple transfers |
-| **Recovery Mechanism** | ✅ Built-in, time-locked | ⚠️ Implementation-dependent | ⚠️ Via controller operations | ❌ None |
+| **Recovery Mechanism** | ✅ Via controller transfer; optional time-locked workflow | ⚠️ Implementation-dependent | ⚠️ Via controller operations | ❌ None |
 | **Court Orders** | ✅ Native support | ⚠️ Via forced transfers | ✅ Controller operations | ❌ None |
 | **Transfer Restrictions** | ✅ RTA-gated only | ✅ Rule-based | ✅ Partition-based | ❌ None |
 | **Direct Transfers** | ❌ Disabled (by design) | ⚠️ If rules allow | ⚠️ If authorized | ✅ Always allowed |
@@ -2518,8 +2536,8 @@ ERC-1450 leverages established security token patterns for maximum interoperabil
 - Uses `operatorData` parameter to specify transfer type while maintaining standard interface
 
 **Document Management Integration:**
-- Implements full document management interface: `setDocument`, `getDocument`, `removeDocument`, `getAllDocuments`
-- All evidence stored as document URIs with cryptographic hashes
+- Defines an optional document management interface aligned with established security token patterns: `setDocument`, `getDocument`, `removeDocument`, `getAllDocuments`
+- When implemented, all evidence is stored as document URIs with cryptographic hashes
 - Never stores PII directly on-chain, only references
 - Emits standard `DocumentUpdated` and `DocumentRemoved` events for audit trails
 


### PR DESCRIPTION
This PR adds explicit OPTIONAL markers to interface components that were already optional in intent, so that the normative core of the specification exactly matches the audited reference implementation and the production deployment. **No functions are added or removed, and no signatures change.**

### What changed

- An explicit list of OPTIONAL interface extensions in the *Optional Dependencies* section: document management, the structured recovery workflow, `isKYCVerified`, `requestTransferWithPermit`, CCIP-Read pre-checks, and `getRequestStatus`.
- `(OPTIONAL)` markers on the document management functions and the recovery workflow actions, with conditional MUST language ("implementations providing this function MUST emit ..."). The specification already marked the recovery *views* (`getRecoveryDetails`, `hasPendingRecovery`) as OPTIONAL — marking the recovery *actions* resolves that internal inconsistency.
- Removed a duplicate `DocumentUpdated` event declaration (editing artifact; the interface declared it twice).
- Two Rationale lines aligned with the optionality.

### Why

The REQUIRED baseline for lost-wallet recovery and court-ordered transfers is `controllerTransfer`: the RTA verifies the investor's identity through its existing off-chain KYC records — which are the RTA's authoritative books and records under its regulatory obligations — and executes the transfer. The structured, time-locked workflow with on-chain evidence anchoring is a transparency enhancement that some deployments may want, not a compliance requirement, and the specification should say so.

This follows the principle that the normative core of a standard should be what production implementations actually do.

### Production conformance (verifiable on-chain)

The audited reference implementation (v1.17.0, Halborn December 2025) is live on Polygon mainnet behind 407 securities with 3,892 completed mints across 259 symbols. Sample contracts — mint history is visible on the token pages, and `version()` returns `1.17.0` on each:

| Symbol | ERC-1450 token | RTA multisig proxy | Completed mints |
|---|---|---|---|
| STGC | [`0x0030F99932d59F894EF0E5c7ac77f46bEFB0CDf3`](https://polygonscan.com/token/0x0030F99932d59F894EF0E5c7ac77f46bEFB0CDf3) | [`0x687D5D5aefbec2dde3Ab47bfD8B606C3a97179fB`](https://polygonscan.com/address/0x687D5D5aefbec2dde3Ab47bfD8B606C3a97179fB) | 317 |
| MODCBN | [`0xf7bEe5cB83EC3E73426b22703eF629fF93cDaB20`](https://polygonscan.com/token/0xf7bEe5cB83EC3E73426b22703eF629fF93cDaB20) | [`0x4B732E23548c86368fEc1155Af752CdF517530e3`](https://polygonscan.com/address/0x4B732E23548c86368fEc1155Af752CdF517530e3) | 128 |
| FANCB | [`0xBC995a568d933359c08E5F349AC6DfE5fc13e02f`](https://polygonscan.com/token/0xBC995a568d933359c08E5F349AC6DfE5fc13e02f) | [`0x1fD591aE6aA9099eff5c2489Cb871c0098D287A1`](https://polygonscan.com/address/0x1fD591aE6aA9099eff5c2489Cb871c0098D287A1) | 116 |

These contracts implement the full normative core as marked in this PR; the components marked OPTIONAL here are exactly the ones not present in the deployed, audited contracts. This change is part of preparing the specification for Review.
