### PR TITLE
Update ERC-1450: Move to Review

### DIFF
--- a/ERCS/erc-1450.md
+++ b/ERCS/erc-1450.md
@@ -4,7 +4,7 @@ title: RTA-Controlled Security Token
 description: Security tokens where the Registered Transfer Agent has exclusive control over transfers for regulatory compliance
 author: Howard Marks (@howardmarks) <howard@startengine.com>, Devender Gollapally (@devender-startengine) <devender@startengine.com>, Joe Mathews (@se-joe) <joe@startengine.com>, Jordan Jahja (@jordan-jahja) <jordan.jahja@startengine.com>, John Shiple (@johnshiple), David Zhang (@david-colab) <david@startengine.com>
 discussions-to: https://ethereum-magicians.org/t/erc-1450-rta-controlled-security-token-standard/26385
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2018-09-25


### PR DESCRIPTION
The specification is complete and the authors are formally requesting peer review per EIP-1.

- The specified interface matches the audited reference implementation ([v1.17.0](https://github.com/StartEngine/erc1450-reference), Halborn, December 2025) exactly, following the optionality clarifications merged in #1811.
- In production on Polygon mainnet behind 400+ securities — every deployed contract reports `version() = 1.17.0` on-chain.
- Active discussion: [Ethereum Magicians thread](https://ethereum-magicians.org/t/erc-1450-rta-controlled-security-token-standard/26385).
