### PR TITLE
Update ERC-1450: refresh version() example to 1.17.0

### DIFF
--- a/ERCS/erc-1450.md
+++ b/ERCS/erc-1450.md
@@ -419,7 +419,7 @@ interface IERC1450 is IERC20, IERC165 {
 
     /**
      * @notice Returns the contract implementation version
-     * @return string Semantic version string (e.g., "1.10.1")
+     * @return string Semantic version string (e.g., "1.17.0")
      * @dev Enables upgrade detection for UUPS-upgradeable contracts.
      *      Version SHOULD match the reference implementation package version.
      *      Useful for:
@@ -2700,7 +2700,7 @@ The reference implementation includes automatic version synchronization between 
 
 ```solidity
 // Query version from deployed contract
-string memory deployedVersion = token.version();  // Returns "1.10.1"
+string memory deployedVersion = token.version();  // Returns "1.17.0"
 
 // Compare with local artifacts to detect upgrades
 if (keccak256(bytes(deployedVersion)) != keccak256(bytes(localVersion))) {


### PR DESCRIPTION
Refreshes the version() NatSpec and the Contract Versioning example from the older example string (1.10.1) to 1.17.0, matching the current audited reference implementation. Comment/example-only — no normative, interface, or frontmatter changes.