### PR TITLE
Update ERC 7730: update json-schema to 2020-12

### DIFF
--- a/assets/erc-7730/erc7730-v2.schema.json
+++ b/assets/erc-7730/erc7730-v2.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "ERC7730 Clear Signing Specification Schema. Specification located at https://github.com/LedgerHQ/clear-signing-erc7730-registry/tree/master/specs",
 
@@ -562,9 +562,6 @@
             "allOf" : [
                 {
                     "not": { "required": [ "path", "value" ] }
-                },
-                {
-                    "not": { "required": [ "$ref" ] } 
                 },
                 {
                     "if": { "properties": { "format": { "const": "addressName" } } },

--- a/assets/erc-7730/erc7730-v2.schema.json
+++ b/assets/erc-7730/erc7730-v2.schema.json
@@ -564,6 +564,9 @@
                     "not": { "required": [ "path", "value" ] }
                 },
                 {
+                    "not": { "required": [ "$ref" ] } 
+                },
+                {
                     "if": { "properties": { "format": { "const": "addressName" } } },
                     "then": {
                         "properties": {


### PR DESCRIPTION
following work on adding a new erc7730 registry using the `assets/erc-7730/erc7730-v2.schema.json` in  https://github.com/ethereum/clear-signing-erc7730-registry/pull/2595

 ## TL;DR

The v2 schema declares **draft-07** (line 2), but `field` uses `unevaluatedProperties: false` (a draft-2019-09+ keyword) to reject stray keys. Draft-07 ignores that keyword, so `field` accepts an extra `$ref` and overlaps the `reference` branch → any bare `{ "path": ..., "$ref": ... }` field matches two `oneOf` branches and fails validation. Fix: either declare 2020-12, or add `{ "not": { "required": ["$ref"] } }` to `field`.

---

## Details

**Symptom.** In the https://github.com/ethereum/clear-signing-erc7730-registry repository, `check-jsonschema` rejects bare references like `{ "path": "amount", "$ref": "$.display.definitions.x" }` with *"valid under each of `#/$display/reference`, `#/$format/field`"* (matches 2 of the `fields[]` `oneOf` branches).

**Cause.** Dialect mismatch: `field`'s `unevaluatedProperties: false` (line ~640) is meant to reject unknown keys, but it only exists from draft 2019-09 — under the declared draft-07 it's silently ignored, so `field` tolerates `$ref` and overlaps `reference`. The same mismatch overlaps `field`/`fieldGroup` for `{ "path": ..., "fields": [...] }` groups (e.g. `registry/paraswap/calldata-AugustusSwapper-v6.2.json` currently fails too).

**Fix options:**

1. **Root cause:** set line 2 to `https://json-schema.org/draft/2020-12/schema` → activates the existing `unevaluatedProperties`, fixes both overlaps, keeps strictness. ⚠️ changes whole-file dialect (e.g. `$ref`-with-siblings, line 546) — needs full-registry re-validation.
2. **Targeted, draft-07-safe (applied):** add `{ "not": { "required": ["$ref"] } }` to `field`'s `allOf`. Verified green on the affected file + `kyberswap` / `erc721` / `okx` / `1inch` / `lido` / `threshold`; no regression. Doesn't cover the `fieldGroup` overlap (would need an analogous `{ "not": { "required": ["fields"] } }`).
3. **Permissive:** `oneOf` → `anyOf` (line 419) — one word, fixes both, but weakens validation.

**Recommendation:** option 1 long-term (the dialect is just mis-declared); option 2 short-term/low-risk.

Open to discussion