### PR TITLE
Update ERC-6123: Feature/erc 6123 position to int256

### DIFF
--- a/ERCS/erc-6123.md
+++ b/ERCS/erc-6123.md
@@ -81,9 +81,10 @@ The following methods specify a Smart Derivative Contract's trade initiation, tr
 A party can initiate a trade by providing the party address to trade with, trade data, trade position, payment amount for the trade and initial settlement data. Only registered counterparties are allowed to use that function.
 
 ```solidity
-function inceptTrade(address withParty, string memory tradeData, int position, int256 paymentAmount, string memory initialSettlementData) external returns (string memory);
+function inceptTrade(address withParty, string memory tradeData, int256 position, int256 paymentAmount, string memory initialSettlementData) external returns (string memory);
 ```
 
+The position can be negative (sell) or positive (buy). The paymentAmount can be negative or positive.
 The position and the paymentAmount are viewed from the incepter.
 The function will return a generated unique `tradeId`. The trade id will also be emitted by an event.
 
@@ -92,7 +93,7 @@ The function will return a generated unique `tradeId`. The trade id will also be
 A counterparty can confirm a trade by providing its trade specification data, which then gets matched against the data stored from `inceptTrade` call.
 
 ```solidity
-function confirmTrade(address withParty, string memory tradeData, int position, int256 paymentAmount, string memory initialSettlementData) external;
+function confirmTrade(address withParty, string memory tradeData, int256 position, int256 paymentAmount, string memory initialSettlementData) external;
 ```
 
 Here, the position and the paymentAmount is viewed from the confimer (opposite sign compared to the call to `inceptTrade`).
@@ -102,7 +103,7 @@ Here, the position and the paymentAmount is viewed from the confimer (opposite s
 The counterparty that called `inceptTrade` has the option to cancel the trade, e.g., in the case where the trade is not confirmed in a timely manner.
 
 ```solidity
-function cancelTrade(address withParty, string memory tradeData, int position, int256 paymentAmount, string memory initialSettlementData) external;
+function cancelTrade(address withParty, string memory tradeData, int256 position, int256 paymentAmount, string memory initialSettlementData) external;
 ```
 
 #### Trade Termination: `requestTermination`

--- a/assets/erc-6123/contracts/ISDCTrade.sol
+++ b/assets/erc-6123/contracts/ISDCTrade.sol
@@ -20,11 +20,11 @@ interface ISDCTrade {
      * @param withParty is the party the inceptor wants to trade with
      * @param tradeId is the trade ID (e.g. generated internally)
      * @param tradeData a description of the trade specification e.g. in xml format, suggested structure - see assets/eip-6123/doc/sample-tradedata-filestructure.xml
-     * @param position is the position the inceptor has in that trade
+     * @param position is the position the inceptor has in that trade, may be negative (sell) or positive (buy)
      * @param paymentAmount is the payment amount which can be positive or negative (viewed from the inceptor)
      * @param initialSettlementData the initial settlement data (e.g. initial market data at which trade was incepted)
      */
-    event TradeIncepted(address initiator, address withParty, string tradeId, string tradeData, int position, int256 paymentAmount, string initialSettlementData);
+    event TradeIncepted(address initiator, address withParty, string tradeId, string tradeData, int256 position, int256 paymentAmount, string initialSettlementData);
 
     /**
      * @dev Emitted when an incepted trade is confirmed by the opposite counterparty
@@ -92,12 +92,12 @@ interface ISDCTrade {
      * @dev emits a {TradeIncepted} event
      * @param withParty is the party the inceptor wants to trade with
      * @param tradeData a description of the trade specification e.g. in xml format, suggested structure - see assets/eip-6123/doc/sample-tradedata-filestructure.xml
-     * @param position is the position the inceptor has in that trade
+     * @param position is the position the inceptor has in that trade, may be negative (sell) or positive (buy)
      * @param paymentAmount is the payment amount which can be positive or negative (viewed from the inceptor)
      * @param initialSettlementData the initial settlement data (e.g. initial market data at which trade was incepted)
      * @return the tradeId uniquely determining this trade.
      */
-    function inceptTrade(address withParty, string memory tradeData, int position, int256 paymentAmount, string memory initialSettlementData) external returns (string memory);
+    function inceptTrade(address withParty, string memory tradeData, int256 position, int256 paymentAmount, string memory initialSettlementData) external returns (string memory);
 
     /**
      * @notice Performs a matching of provided trade data and settlement data of a previous trade inception
@@ -108,18 +108,18 @@ interface ISDCTrade {
      * @param paymentAmount is the payment amount which can be positive or negative (viewed from the confirmer, negative of the inceptor's view)
      * @param initialSettlementData the initial settlement data (e.g. initial market data at which trade was incepted)
      */
-     function confirmTrade(address withParty, string memory tradeData, int position, int256 paymentAmount, string memory initialSettlementData) external;
+     function confirmTrade(address withParty, string memory tradeData, int256 position, int256 paymentAmount, string memory initialSettlementData) external;
 
     /**
      * @notice Performs a matching of provided trade data and settlement data of a previous trade inception. Required to be called by inceptor.
      * @dev emits a {TradeCanceled} event if trade data match and msg.sender agrees with the party that incepted the trade.
      * @param withParty is the party the inceptor wants to trade with
      * @param tradeData a description of the trade specification e.g. in xml format, suggested structure - see assets/eip-6123/doc/sample-tradedata-filestructure.xml
-     * @param position is the position the inceptor has in that trade
+     * @param position is the position the inceptor has in that trade, may be negative (sell) or positive (buy)
      * @param paymentAmount is the payment amount which can be positive or negative (viewed from the inceptor)
      * @param initialSettlementData the initial settlement data (e.g. initial market data at which trade was incepted)
      */
-    function cancelTrade(address withParty, string memory tradeData, int position, int256 paymentAmount, string memory initialSettlementData) external;
+    function cancelTrade(address withParty, string memory tradeData, int256 position, int256 paymentAmount, string memory initialSettlementData) external;
 
     /// Trade termination
 

--- a/assets/erc-6123/contracts/SDCSingleTrade.sol
+++ b/assets/erc-6123/contracts/SDCSingleTrade.sol
@@ -133,7 +133,7 @@ abstract contract SDCSingleTrade is ISDCTrade {
      * emits a TradeIncepted
      * can be called only when TradeState = Incepted
      */
-    function inceptTrade(address _withParty, string memory _tradeData, int _position, int256 _paymentAmount, string memory _initialSettlementData) external override onlyCounterparty onlyWhenTradeInactive returns (string memory) {
+    function inceptTrade(address _withParty, string memory _tradeData, int256 _position, int256 _paymentAmount, string memory _initialSettlementData) external override onlyCounterparty onlyWhenTradeInactive returns (string memory) {
         require(msg.sender != _withParty, "Calling party cannot be the same as withParty");
         require(_position == 1 || _position == -1, "Position can only be +1 or -1");
         tradeState = TradeState.Incepted; // Set TradeState to Incepted
@@ -153,7 +153,7 @@ abstract contract SDCSingleTrade is ISDCTrade {
      * emits a TradeConfirmed
      * can be called only when TradeState = Incepted
      */
-    function confirmTrade(address _withParty, string memory _tradeData, int _position, int256 _paymentAmount, string memory _initialSettlementData) external override  onlyCounterparty onlyWhenTradeIncepted {
+    function confirmTrade(address _withParty, string memory _tradeData, int256 _position, int256 _paymentAmount, string memory _initialSettlementData) external override  onlyCounterparty onlyWhenTradeIncepted {
         address inceptingParty = msg.sender == party1 ? party2 : party1;
         uint256 transactionHash = uint256(keccak256(abi.encode(_withParty,msg.sender,_tradeData,-_position, -_paymentAmount,_initialSettlementData)));
         require(pendingRequests[transactionHash] == inceptingParty, "Confirmation fails due to inconsistent trade data or wrong party address");
@@ -171,7 +171,7 @@ abstract contract SDCSingleTrade is ISDCTrade {
       * emits a TradeConfirmed
       * can be called only when TradeState = Incepted
       */
-    function cancelTrade(address _withParty, string memory _tradeData, int _position, int256 _paymentAmount, string memory _initialSettlementData) external override  onlyCounterparty onlyWhenTradeIncepted {
+    function cancelTrade(address _withParty, string memory _tradeData, int256 _position, int256 _paymentAmount, string memory _initialSettlementData) external override  onlyCounterparty onlyWhenTradeIncepted {
         address inceptingParty = msg.sender;
         uint256 transactionHash = uint256(keccak256(abi.encode(msg.sender,_withParty,_tradeData,_position,_paymentAmount,_initialSettlementData)));
         require(pendingRequests[transactionHash] == inceptingParty, "Cancellation fails due to inconsistent trade data or wrong party address");

--- a/assets/erc-6123/package.json
+++ b/assets/erc-6123/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finmath.net/sdc",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Solidity Smart Derivative Contracts",
   "author": "Christian Fries, Peter Kohl-Landgraf, Alexandros Korpis",
   "license": "ISC",


### PR DESCRIPTION
- used int256 instead of int (which is an alias for int256).
- clarified sign convention for position and payment