### PR TITLE
Update ERC-8048: Add Agent Metadata Profile (ERC-721T)

### DIFF
--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2025-09-30
-requires: 165
+requires: 165, 7930, 8119
 ---
 
 ## Abstract
@@ -106,6 +106,43 @@ A biometric identity system using open source hardware to create universal proof
 - Key: `"biometric_hash"` → Value: `bytes(bytes32(identity_commitment))`
 - Key: `"verification_time"` → Value: `bytes(bytes32(timestamp))`
 - Key: `"device_proof"` → Value: `bytes(bytes32(device_attestation))`
+
+### Agent Metadata Profile (ERC-721G)
+
+This profile, nicknamed **ERC-721G**, defines a reserved set of this ERC's metadata keys for [ERC-721](./eip-721.md) tokens that represent, expose, control, or are associated with agents. It is a standard *use* of this ERC's existing key-value interface; it does **not** define a new Solidity interface, a new [ERC-165](./eip-165.md) interface ID, or new events. Consumers read and write these records through `metadata(uint256,string)` and rely on the `MetadataSet` event for change notifications, exactly as for any other key under this ERC.
+
+A contract implementing this profile MUST implement ERC-721 and this ERC. The profile reserves the following per-token keys (the agent example earlier in this section is the same pattern; this profile fixes the canonical key set):
+
+| Key | Meaning | Value (`bytes`) |
+| :--- | :--- | :--- |
+| `context` | Agent context for the token. | UTF-8 text. Markdown is RECOMMENDED; issuers MAY embed a fenced JSON block for machine-readable fields, as in the AI-agent example above. |
+| `endpoint[<type>]` | Endpoint URI for the named protocol `<type>`. | UTF-8 URI. For `endpoint[web]`, an `https` URI is RECOMMENDED. |
+| `address[<chain-id>]` | The agent's account on the chain identified by `<chain-id>`, where `<chain-id>` is the [ERC-7930](./eip-7930.md) Chain Identifier (see "Chain-keyed addresses" below). | The 20-byte EVM address (raw, not text). |
+
+#### Endpoint types
+
+Keys are case-sensitive (the value of `key` is compared as exact bytes). Endpoint types in this profile are therefore lowercase, consistent with the `endpoint[<type>]` convention defined earlier in this section: `endpoint[mcp]` and `endpoint[MCP]` are distinct keys, and only the lowercase spelling carries the meaning reserved here. Implementations MUST write the canonical lowercase spelling for the types this profile reserves.
+
+The canonical endpoint types are:
+
+- `mcp` — Model Context Protocol endpoint.
+- `a2a` — Agent-to-Agent endpoint.
+- `web` — general web endpoint (aligned with [ERC-8004](./eip-8004.md) `web` service usage; the value MAY be any URI, with `https` RECOMMENDED).
+- `x402` — payment-enabled endpoint.
+
+Additional endpoint types MAY be used without changing this profile, provided they use the `endpoint[<type>]` form. Standards that reserve new types SHOULD define their exact canonical (lowercase) spelling.
+
+#### Chain-keyed addresses
+
+In `address[<chain-id>]`, `<chain-id>` is the [ERC-7930](./eip-7930.md) **Chain Identifier** — an Interoperable Address with a zero-length address part — encoded as a lowercase `0x`-prefixed hex string. The stored value is a normal 20-byte EVM address, not an ERC-7930 interoperable address; ERC-7930 is used only to name the chain.
+
+For example, the Chain Identifier for Ethereum mainnet (chain ID `1`) is `0x00010000010100`, and for Base (chain ID `8453`, i.e. `0x2105`) is `0x000100000202210500`. The agent's mainnet account would be stored as:
+
+- Key: `"address[0x00010000010100]"` → Value: the 20 bytes of the EVM address.
+
+#### Marketplace compatibility
+
+`tokenURI(uint256)` remains the ERC-721 marketplace metadata mechanism and is unchanged by this profile. Contracts SHOULD keep `tokenURI` JSON compatible with existing marketplaces (`name`, `description`, `image`). Agent-aware clients SHOULD read the keys above from this ERC's records rather than from `tokenURI`, and SHOULD treat both endpoints and `context` as untrusted input. Transferring the token transfers ownership of the record, not any offchain server, key, balance, or memory the records may reference.
 
 ### Optional Metadata Hooks
 


### PR DESCRIPTION
Adds an optional **Agent Metadata Profile**, nicknamed **ERC-721T**, to ERC-8048. It reserves a canonical set of ERC-8048 metadata keys for ERC-721 tokens that represent, expose, control, or are associated with agents.

**Reserved keys (all lowercase, case-sensitive):**
- `context` — UTF-8 agent context (markdown; MAY embed a JSON block)
- `endpoint[mcp]` / `[a2a]` / `[web]` / `[x402]` — per-protocol endpoint URIs, extensible to new types via the `endpoint[<type>]` form
- `address[<chain-id>]` — a 20-byte EVM address, where `<chain-id>` is an ERC-7930 Chain Identifier (used only to name the chain; the stored value is a plain EVM address, not an interoperable address)

**Design:** the profile is a *standard use* of ERC-8048's existing `metadata(uint256,string)` interface and `MetadataSet` event. It defines **no** new Solidity interface, **no** new ERC-165 interface ID, and **no** new events, and it keeps the existing `context` / `endpoint[<type>]` key convention already shown in the ERC-8048 agent example. `tokenURI` is unchanged and remains the ERC-721 marketplace metadata mechanism.

**Backwards compatibility:** purely additive and optional. Existing ERC-721 wallets and marketplaces are unaffected.

Adds ERC-7930 and ERC-8119 to `requires` (both already linked in the document).
