### PR TITLE
Update ERC-8048: Rename Agent Metadata Profile nickname to ERC-721T

### DIFF
--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -107,9 +107,9 @@ A biometric identity system using open source hardware to create universal proof
 - Key: `"verification_time"` → Value: `bytes(bytes32(timestamp))`
 - Key: `"device_proof"` → Value: `bytes(bytes32(device_attestation))`
 
-### Agent Metadata Profile (ERC-721G)
+### Agent Metadata Profile (ERC-721T)
 
-This profile, nicknamed **ERC-721G**, defines a reserved set of this ERC's metadata keys for [ERC-721](./eip-721.md) tokens that represent, expose, control, or are associated with agents. It is a standard *use* of this ERC's existing key-value interface; it does **not** define a new Solidity interface, a new [ERC-165](./eip-165.md) interface ID, or new events. Consumers read and write these records through `metadata(uint256,string)` and rely on the `MetadataSet` event for change notifications, exactly as for any other key under this ERC.
+This profile, nicknamed **ERC-721T**, defines a reserved set of this ERC's metadata keys for [ERC-721](./eip-721.md) tokens that represent, expose, control, or are associated with agents. It is a standard *use* of this ERC's existing key-value interface; it does **not** define a new Solidity interface, a new [ERC-165](./eip-165.md) interface ID, or new events. Consumers read and write these records through `metadata(uint256,string)` and rely on the `MetadataSet` event for change notifications, exactly as for any other key under this ERC.
 
 A contract implementing this profile MUST implement ERC-721 and this ERC. The profile reserves the following per-token keys (the agent example earlier in this section is the same pattern; this profile fixes the canonical key set):
 


### PR DESCRIPTION
Renames the Agent Metadata Profile nickname added to ERC-8048 in #1829 from **ERC-721G** to **ERC-721T**, because the `ERC-721G` nickname collides with an existing usage.

This is a nickname-only change: no normative content, keys, interface, or behavior is modified.
