### PR TITLE
Update ERC-1450: Move to Last Call

### DIFF
--- a/ERCS/erc-1450.md
+++ b/ERCS/erc-1450.md
@@ -4,7 +4,8 @@ title: RTA-Controlled Security Token
 description: Security tokens where the Registered Transfer Agent has exclusive control over transfers for regulatory compliance
 author: Howard Marks (@howardmarks) <howard@startengine.com>, Devender Gollapally (@devender-startengine) <devender@startengine.com>, Joe Mathews (@se-joe) <joe@startengine.com>, Jordan Jahja (@jordan-jahja) <jordan.jahja@startengine.com>, John Shiple (@johnshiple), David Zhang (@david-colab) <david@startengine.com>
 discussions-to: https://ethereum-magicians.org/t/erc-1450-rta-controlled-security-token-standard/26385
-status: Review
+status: Last Call
+last-call-deadline: 2026-07-14
 type: Standards Track
 category: ERC
 created: 2018-09-25


### PR DESCRIPTION
This PR moves ERC-1450 from **Review** to **Last Call**, with a `last-call-deadline` of **2026-07-14** (≥14 days out). It is a one-line frontmatter status change; no normative text is modified.

## Why the spec is ready to freeze

The normative core is settled, audited, and proven in production — and has been stable, unchanged, for ~6 months.

**Stability / track record**
- The reference implementation (`v1.17.0`, third-party audited by Halborn, Dec 2025) has run **unchanged on Polygon mainnet for ~6 months**. Zero contract changes since the v1.17.0 release; the deployed fleet has been untouched and healthy since December 2025.
- **Spec == reference == chain.** Calling `version()` on any live contract returns `1.17.0`, identical to the reference repo HEAD and to the deployed package version recorded for every active contract.
- **643 tests passing, 86.2% branch coverage**; the Halborn audit findings are 100% addressed (including the one critical), and a separate audit covers the post-audit single-fee-token redesign.

**Production scale (Polygon mainnet)**
- **410 securities** issued by **275 companies** deployed as ERC-1450 tokens, representing over **$705M in capital raised**.
- **259 securities** have live on-chain supply: **389M+ shares** held by **208,000+ holders** across **352,000+ cap-table positions**, minted in **3,892 on-chain operations** — with zero open failures.
- Every contract is verifiable on-chain via `version()`; the reference implementation is public at https://github.com/StartEngine/erc1450-reference.

**Specification diligence done in Review**
- #1811 closed the spec-vs-implementation optionality gap: document-management and structured-recovery components are now explicitly OPTIONAL, so the normative core exactly matches the audited deployment.
- A line-by-line read of the merged spec against the v1.17.0 implementation found no spec↔implementation conflicts in the normative core (ERC-20 restriction semantics, core RTA functions, interface IDs, the fee system, and the transfer-request lifecycle all match the deployed behavior).
- No normative changes are anticipated during the Last Call window.

Feedback from anyone building transfer-agent, RWA, or compliant-securities infrastructure is very welcome on the discussions-to thread: https://ethereum-magicians.org/t/erc-1450-rta-controlled-security-token-standard/26385
