### PR TITLE
Update ERC-7730: Introduce schema semantic versioning

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -2,7 +2,7 @@
 eip: 7730
 title: Structured Data Clear Signing Format
 description: JSON format describing how to clear-sign smart contract calls and typed messages.
-author: Laurent Castillo (@lcastillo-ledger), Derek Rein (@arein), Pierre Aoun (@paoun-ledger), Arik Galansky (@arikg), Bartosz Rozwarski (@llbartekll), Kaan Uzdogan (@kuzdogan), Fredrik (@Fredrik0x)
+author: Laurent Castillo (@lcastillo-ledger), Derek Rein (@arein), Pierre Aoun (@paoun-ledger), Arik Galansky (@arikg), Bartosz Rozwarski (@llbartekll), Kaan Uzdogan (@kuzdogan), Fredrik (@Fredrik0x), Alex Forshtat (@forshtat)
 discussions-to: https://ethereum-magicians.org/t/eip-7730-proposal-for-a-clear-signing-standard-format-for-wallets/20403
 status: Draft
 type: Standards Track

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -154,7 +154,7 @@ Once a version is finalized, its file contents MUST NOT change. Any subsequent c
 
 Release-candidate files MAY be replaced or removed in the process of finalizing a version.
 
-Each schema file is published in two locations: alongside this ERC, under `assets/eip-7730/`, and mirrored into the descriptor registry that consumes these files.
+Each schema file is published in two locations: alongside this ERC, under assets/eip-7730/, and mirrored into the descriptor registry that consumes these files.
 
 The version of the specification used by a descriptor file is the version identified by its `$schema` key, as introduced in the [Simple example](#simple-example). Consumers MUST use this key to select which schema version and which validation and interpretation rules apply to a given descriptor.
 
@@ -166,8 +166,8 @@ To see the ERC text as it read for a specific released version, check out this r
 
 | Version      | Schema                                                                | Commit                                                         | Status            |
 |--------------|-----------------------------------------------------------------------|----------------------------------------------------------------|-------------------|
-| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json) | [`d42dfc9d`](https://github.com/ethereum/ERCs/commit/d42dfc9d) | Deprecated        |
-| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json) | [`a124a871`](https://github.com/ethereum/ERCs/commit/a124a871) | Active            |
+| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json) | `d42dfc9d`                                                     | Deprecated        |
+| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json) | `a124a871`                                                     | Active            |
 | `3.0.0-rc.1` | TBD                                                                   | TBD                                                            | Release Candidate |
 
 `1.0.0` and `2.0.0` are the two schema versions that were released prior to the introduction of this versioning scheme; they are renumbered here under semver with no change to their content or file names. Every version released from now on is added as a new row in this table, without altering the rows already present, and follows the `erc7730-v<MAJOR>.<MINOR>.<PATCH>[-rc.<N>].schema.json` file naming pattern described above.

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -15,7 +15,7 @@ requires: 155, 712
 
 This specification defines a JSON format carrying additional information required to correctly display structured data for human verification on wallet screens or for machine consumption e.g. by transaction simulation engines.
 
-The [ERC-7730](./erc-7730.md) specification enriches type data contained in the ABIs and schemas of structured messages (structures like the calldata of an EVM transaction, an [EIP-712](./eip-712.md) message or an [ERC-4337](./erc-4337.md) User Operation) with additional formatting information and dynamic value interpolation, enabling both human-readable display with contextual intent descriptions and machine-interpretable data processing. For instance, a solidity field containing an amount, encoded as an uint256, can be converted to the right magnitude and appended with the correct ticker for display, or parsed programmatically for transaction simulation. Fields containing encrypted values (such as FHE-encrypted amounts in confidential token standards like [ERC-7984](./erc-7984.md)) can also be annotated with decryption context, enabling wallets to either decrypt and display the plaintext value or present a meaningful fallback.
+The [ERC-7730](./eip-7730.md) specification enriches type data contained in the ABIs and schemas of structured messages (structures like the calldata of an EVM transaction, an [EIP-712](./eip-712.md) message or an [ERC-4337](./eip-4337.md) User Operation) with additional formatting information and dynamic value interpolation, enabling both human-readable display with contextual intent descriptions and machine-interpretable data processing. For instance, a solidity field containing an amount, encoded as an uint256, can be converted to the right magnitude and appended with the correct ticker for display, or parsed programmatically for transaction simulation. Fields containing encrypted values (such as FHE-encrypted amounts in confidential token standards like [ERC-7984](./eip-7984.md)) can also be annotated with decryption context, enabling wallets to either decrypt and display the plaintext value or present a meaningful fallback.
 
 Wallets and automated systems will use curated ERC-7730 files alongside the raw data to sign in order to construct appropriate interfaces for their respective use cases.
 
@@ -28,7 +28,7 @@ Properly validating a transaction on a hardware wallet's screen (also known as C
 - Function name or main message type is often a developer oriented name and does not translate to a clear intent for the user
 - Fields in the data to sign are tied to primitive types only, but those can be displayed in many different ways. For instance, integers can be displayed as percentages, dates, etc...
 - Some fields require additional metadata to be displayed correctly, for instance token amounts require knowledge of the decimals and the ticker, as well as where to find the token address itself to be correctly formatted.
-- Some values can be encrypted, such as encrypted amounts in confidential tokens following [ERC-7984](./erc-7984.md). These values cannot be directly interpreted, so additional context must be provided to enable wallets to decrypt and display them for users.
+- Some values can be encrypted, such as encrypted amounts in confidential tokens following [ERC-7984](./eip-7984.md). These values cannot be directly interpreted, so additional context must be provided to enable wallets to decrypt and display them for users.
 
 This specification intends to provide a simple, open standard format to provide wallets with the additional information required to properly format a structured data to sign for review by users.
 
@@ -181,9 +181,9 @@ To see the ERC text as it read for a specific released version, check out this r
 
 | Version      | Schema                                                                    | Commit ID  | Status     |
 |--------------|---------------------------------------------------------------------------|------------|------------|
-| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/erc-7730/erc7730-v1.schema.json)     | `d42dfc9d` | Deprecated |
-| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/erc-7730/erc7730-v2.schema.json)     | TBD        | Active     |
-| `3.0.0-next` | [`erc7730-v3.0.0-next.schema.json`](../assets/erc-7730/erc7730-v3.0.0-next.schema.json) | N/A | Draft |
+| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json)     | `d42dfc9d` | Deprecated |
+| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json)     | TBD        | Active     |
+| `3.0.0-next` | [`erc7730-v3.0.0-next.schema.json`](../assets/eip-7730/erc7730-v3.0.0-next.schema.json) | N/A | Draft |
 
 `1.0.0` and `2.0.0` are the two schema versions that were released prior to the introduction of this versioning scheme; they are renumbered here under semver with no change to their content or file names. Every version released from now on is added as a new row in this table, without altering the rows already present, and follows the `erc7730-v<MAJOR>.<MINOR>.<PATCH>[-rc.<N>].schema.json` file naming pattern described above.
 
@@ -210,7 +210,7 @@ Displaying structured data is often done by wallets to review its content before
 - The container structure does not necessarily follow the same type system as the structured data.
 - Wallets receive the full container structure and uses the signature scheme to generate a signature on the overall structure.
 
-![Structured Data and Container](../assets/erc-7730/structured-data.svg)
+![Structured Data and Container](../assets/eip-7730/structured-data.svg)
 
 Current specification covers EVM smart contract calldata:
 - Defined in Solidity
@@ -657,7 +657,7 @@ Maps references can be used anywhere a parameter with constant value would be us
 
 A wallet MUST replace a path to a map using the value matching the `keyPath` parameter. In case no values matches the wallet MUST consider the 7730 file invalid for the transaction. 
 
-An example can be found in [example-maps.json](../assets/erc-7730/example-maps.json) and [example-maps-pools.json](../assets/erc-7730/example-maps-pools.json).
+An example can be found in [example-maps.json](../assets/eip-7730/example-maps.json) and [example-maps-pools.json](../assets/eip-7730/example-maps-pools.json).
 
 *Examples*
 
@@ -1051,7 +1051,7 @@ Optional object containing formatter-specific parameters. Available parameters a
 
 When a formatter applies to an array, the parameters CAN also reference a path to an array. In that case, wallets should format each element of the array using the parameter value at the same index as the current element being formatted. Parameter arrays should be the same length as the formatted array else the wallet SHOULD raise an error.
 
-See [example-array-iteration.json](../assets/erc-7730/example-array-iteration.json) for examples on array iteration.
+See [example-array-iteration.json](../assets/eip-7730/example-array-iteration.json) for examples on array iteration.
 
 **`$id`** 
 
@@ -1132,7 +1132,7 @@ Recursive path references work by concatenating the paths of the parents *struct
 
 This recursivity allows structuring the ERC-7730 file itself, but is NOT RECOMMENDED. It is expected that resource limited wallets will only support very limited recursivity in the ERC-7730 file itself, so the initial intent of the spec is to "flatten" the list of fields to display using the *path* mechanics. 
 
-See [example-array-iteration.json](../assets/erc-7730/example-array-iteration.json) for examples on grouping and group iteration control.
+See [example-array-iteration.json](../assets/eip-7730/example-array-iteration.json) for examples on grouping and group iteration control.
 
 #### Slices in paths
 
@@ -1451,7 +1451,7 @@ Formats applicable to `address` solidity type.
 
 | **`raw`**       |                                                                                              |
 |-----------------|----------------------------------------------------------------------------------------------|
-| *Description*   | Display address as an [ERC-55](./erc-55.md) formatted string. Truncation is device dependent |
+| *Description*   | Display address as an [ERC-55](./eip-55.md) formatted string. Truncation is device dependent |
 | *Parameters*    | None                                                                                         |
 | *Examples*      | ---                                                                                          |
 | `0x5aAe...eAed` | Field Value 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed                                       |
@@ -1558,9 +1558,9 @@ Future versions of this specification may consider standardized internationaliza
 
 ### User Operations (ERC-4337)
 
-Clear signing [ERC-4337](./erc-4337.md) User Operations is supported using the `PackedUserOperation` EIP-712 signature format. See [example-userops-eip712.json](../assets/erc-7730/example-userops-eip712.json) for a reference implementation.
+Clear signing [ERC-4337](./eip-4337.md) User Operations is supported using the `PackedUserOperation` EIP-712 signature format. See [example-userops-eip-712.json](../assets/eip-7730/example-userops-eip712.json) for a reference implementation.
 
-The inner calldata typically contains an `execute` call to interact with other contracts. This can be clear signed using a separate ERC-7730 file - see [example-account-execute.json](../assets/erc-7730/example-account-execute.json). Since execute functions are implementation-specific, each smart wallet will need its own ERC-7730 file.
+The inner calldata typically contains an `execute` call to interact with other contracts. This can be clear signed using a separate ERC-7730 file - see [example-account-execute.json](../assets/eip-7730/example-account-execute.json). Since execute functions are implementation-specific, each smart wallet will need its own ERC-7730 file.
 
 Smart wallets commonly use a proxy pattern. Refer to the [Proxy support](#proxy-support) section for guidance. 
 
@@ -1637,7 +1637,7 @@ Wallets MAY:
 
 ### Extensibility to other structured data formats
 
-In the future, this specification could be extended to structured data like Meta Transaction in [ERC-2771](./erc-2771.md), User Operations in [ERC-4337](./erc-4337.md), and batch transaction payloads in [EIP-5792](./eip-5792.md).
+In the future, this specification could be extended to structured data like Meta Transaction in [ERC-2771](./eip-2771.md), User Operations in [ERC-4337](./eip-4337.md), and batch transaction payloads in [EIP-5792](./eip-5792.md).
 
 The `interpolatedIntent` field is particularly well-suited for [EIP-5792](./eip-5792.md) batch transactions, as it enables wallets to concatenate multiple operation descriptions into a single, natural language sentence. By joining individual `interpolatedIntent` strings with " and ", wallets can provide users with clear, readable summaries of complex multi-step operations like "Approve Uniswap Router to spend 1000 USDC and Swap 1000 USDC for at least 0.25 WETH". This significantly improves the user experience when reviewing batch transactions compared to displaying separate, disconnected operation descriptions. See the [Value Interpolation](#value-interpolation) section for detailed implementation guidance and examples.
 
@@ -1658,16 +1658,16 @@ More examples can be found in the asset folder.
 
 | File name | Description |
 | --- | ---|
-| [example-main.json](../assets/erc-7730/example-main.json) | Simple example of a basic ERC-7730 file |
-| [example-erc-20.json](../assets/erc-7730/example-erc20.json) | Simple example of defining an interface for ERC-20 contracts |
-| [example-include.json](../assets/erc-7730/example-include.json) | Example of including an interface into another ERC-7730 file |
-| [example-eip712.json](../assets/erc-7730/example-eip712.json) | Clear signing EIP-712 example |
-| [example-array-iteration.json](../assets/erc-7730/example-array-iteration.json) | Examples of various array iteration modes and field grouping features |
-| [example-maps.json](../assets/erc-7730/example-maps.json) | Example of maps of constants |
-| [example-maps-pools.json](../assets/erc-7730/example-maps-pools.json) | Example of maps of constants |
-| [example-visibility-rules.json](../assets/erc-7730/example-visibility-rules.json) | Example of controlling the visibility of fields |
-| [example-account-execute.json](../assets/erc-7730/example-account-execute.json) | Example of ERC-4337 smart wallet execute function clear signing |
-| [example-userops-eip712.json](../assets/erc-7730/example-userops-eip712.json) | Example of ERC-4337 User Operation clear signing |
+| [example-main.json](../assets/eip-7730/example-main.json) | Simple example of a basic ERC-7730 file |
+| [example-erc-20.json](../assets/eip-7730/example-erc20.json) | Simple example of defining an interface for ERC-20 contracts |
+| [example-include.json](../assets/eip-7730/example-include.json) | Example of including an interface into another ERC-7730 file |
+| [example-eip-712.json](../assets/eip-7730/example-eip712.json) | Clear signing EIP-712 example |
+| [example-array-iteration.json](../assets/eip-7730/example-array-iteration.json) | Examples of various array iteration modes and field grouping features |
+| [example-maps.json](../assets/eip-7730/example-maps.json) | Example of maps of constants |
+| [example-maps-pools.json](../assets/eip-7730/example-maps-pools.json) | Example of maps of constants |
+| [example-visibility-rules.json](../assets/eip-7730/example-visibility-rules.json) | Example of controlling the visibility of fields |
+| [example-account-execute.json](../assets/eip-7730/example-account-execute.json) | Example of ERC-4337 smart wallet execute function clear signing |
+| [example-userops-eip-712.json](../assets/eip-7730/example-userops-eip712.json) | Example of ERC-4337 User Operation clear signing |
 
 
 ## Security Considerations
@@ -1728,7 +1728,7 @@ These patterns are often used in conjunction. Supporting those patterns require 
 
 **Upgradeable proxy contracts**
 
-Upgradeable proxy contracts (such as Transparent Proxies or UUPS proxies as defined in [ERC-1822](./erc-1822.md)) use a fixed proxy address that delegates calls to a replaceable implementation contract. For these contracts, the ERC-7730 file SHOULD be bound to the *proxy* address, since this is the stable address users interact with.
+Upgradeable proxy contracts (such as Transparent Proxies or UUPS proxies as defined in [ERC-1822](./eip-1822.md)) use a fixed proxy address that delegates calls to a replaceable implementation contract. For these contracts, the ERC-7730 file SHOULD be bound to the *proxy* address, since this is the stable address users interact with.
 
 When an upgrade introduces breaking ABI changes (new functions, modified signatures, or removed functions), developers SHOULD update the ERC-7730 file in the registry accordingly. Since the old implementation is no longer callable after the upgrade, the previous ERC-7730 definitions can be safely replaced.
 

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -146,7 +146,7 @@ Consumers SHOULD NOT build against a release-candidate schema unless they specif
 Once the version is ready, it is finalized by dropping its `-rc.N` suffix (e.g. `3.0.0-rc.3` -> `3.0.0`).
 From that point on the version is immutable, and any schema change merged afterwards opens a new pre-release for the next version (e.g. `4.0.0-rc.1`).
 
-Descriptors MUST pin the exact commit ID of this ERC document that they were authored against; see [The `$commit` key](#the-commit-key).
+Descriptors MAY pin the exact commit ID of this ERC document that they were authored against in [the `$commit` key](#the-commit-key).
 
 #### Schema files and the `$schema` key
 
@@ -158,6 +158,8 @@ Release-candidate files MAY be replaced or removed in the process of finalizing 
 
 Each schema file is published in two locations: alongside this ERC under the "assets" folder, and mirrored into the descriptor registry that consumes these files.
 
+Since the schema and the spec text are always changed together in the same pull request, a finalized schema file implicitly stays in sync with the ERC text as it read at that time. To make this traceable without introducing a separate versioning scheme, a finalized schema file's top-level `$comment` key MUST record the date and the commit ID at which that version was finalized, pointing back to the exact revision of this document the schema corresponds to.
+
 The version of the specification used by a descriptor file is the version identified by its `$schema` key, as introduced in the [Simple example](#simple-example). Consumers MUST use this key to select which schema version and which validation and interpretation rules apply to a given descriptor.
 
 Outside of this section, this document's text always describes the current release candidate version of the schema only.
@@ -166,7 +168,7 @@ To see the ERC text as it read for a specific released version, check out this r
 
 #### The `$commit` key
 
-Descriptors MUST include a top-level `$commit` key, alongside `$schema`. Its value MUST exactly match the commit hash recorded in the [Released versions](#released-versions) table for the schema version referenced by `$schema`.
+Descriptors MAY include a top-level `$commit` key, alongside `$schema`.
 
 This binds a descriptor to an exact, independently verifiable point in this document's history, removing any remaining ambiguity beyond the schema validation.
 
@@ -189,8 +191,7 @@ This binds a descriptor to an exact, independently verifiable point in this docu
 
 `1.0.0` and `2.0.0` are the two schema versions that were released prior to the introduction of this versioning scheme; they are renumbered here under semver with no change to their content or file names. Every version released from now on is added as a new row in this table, without altering the rows already present, and follows the `erc7730-v<MAJOR>.<MINOR>.<PATCH>[-rc.<N>].schema.json` file naming pattern described above.
 
-The `Commit ID` column contains the acceptable [`$commit`](#the-commit-key) values for descriptors.
-Descriptors targeting a given final schema version MUST set `$commit` to the value recorded here for that version.
+The `Commit ID` column contains the acceptable [`$commit`](#the-commit-key) values for descriptors, and the value that a schema file's `$comment` key SHOULD record when finalizing that version.
 
 `1.0.0` is deprecated.
 

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -15,7 +15,7 @@ requires: 155, 712
 
 This specification defines a JSON format carrying additional information required to correctly display structured data for human verification on wallet screens or for machine consumption e.g. by transaction simulation engines.
 
-The [ERC-7730](./eip-7730.md) specification enriches type data contained in the ABIs and schemas of structured messages (structures like the calldata of an EVM transaction, an [EIP-712](./eip-712.md) message or an [EIP-4337](./eip-4337.md) User Operation) with additional formatting information and dynamic value interpolation, enabling both human-readable display with contextual intent descriptions and machine-interpretable data processing. For instance, a solidity field containing an amount, encoded as an uint256, can be converted to the right magnitude and appended with the correct ticker for display, or parsed programmatically for transaction simulation. Fields containing encrypted values (such as FHE-encrypted amounts in confidential token standards like [ERC-7984](./eip-7984.md)) can also be annotated with decryption context, enabling wallets to either decrypt and display the plaintext value or present a meaningful fallback.
+The [ERC-7730](./erc-7730.md) specification enriches type data contained in the ABIs and schemas of structured messages (structures like the calldata of an EVM transaction, an [EIP-712](./eip-712.md) message or an [ERC-4337](./erc-4337.md) User Operation) with additional formatting information and dynamic value interpolation, enabling both human-readable display with contextual intent descriptions and machine-interpretable data processing. For instance, a solidity field containing an amount, encoded as an uint256, can be converted to the right magnitude and appended with the correct ticker for display, or parsed programmatically for transaction simulation. Fields containing encrypted values (such as FHE-encrypted amounts in confidential token standards like [ERC-7984](./erc-7984.md)) can also be annotated with decryption context, enabling wallets to either decrypt and display the plaintext value or present a meaningful fallback.
 
 Wallets and automated systems will use curated ERC-7730 files alongside the raw data to sign in order to construct appropriate interfaces for their respective use cases.
 
@@ -28,7 +28,7 @@ Properly validating a transaction on a hardware wallet's screen (also known as C
 - Function name or main message type is often a developer oriented name and does not translate to a clear intent for the user
 - Fields in the data to sign are tied to primitive types only, but those can be displayed in many different ways. For instance, integers can be displayed as percentages, dates, etc...
 - Some fields require additional metadata to be displayed correctly, for instance token amounts require knowledge of the decimals and the ticker, as well as where to find the token address itself to be correctly formatted.
-- Some values can be encrypted, such as encrypted amounts in confidential tokens following [ERC-7984](./eip-7984.md). These values cannot be directly interpreted, so additional context must be provided to enable wallets to decrypt and display them for users.
+- Some values can be encrypted, such as encrypted amounts in confidential tokens following [ERC-7984](./erc-7984.md). These values cannot be directly interpreted, so additional context must be provided to enable wallets to decrypt and display them for users.
 
 This specification intends to provide a simple, open standard format to provide wallets with the additional information required to properly format a structured data to sign for review by users.
 
@@ -181,9 +181,9 @@ To see the ERC text as it read for a specific released version, check out this r
 
 | Version      | Schema                                                                    | Commit ID  | Status     |
 |--------------|---------------------------------------------------------------------------|------------|------------|
-| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json)     | `d42dfc9d` | Deprecated |
-| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json)     | TBD        | Active     |
-| `3.0.0-next` | [`erc7730-v3.0.0-next.schema.json`](../assets/eip-7730/erc7730-v3.0.0-next.schema.json) | N/A | Draft |
+| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/erc-7730/erc7730-v1.schema.json)     | `d42dfc9d` | Deprecated |
+| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/erc-7730/erc7730-v2.schema.json)     | TBD        | Active     |
+| `3.0.0-next` | [`erc7730-v3.0.0-next.schema.json`](../assets/erc-7730/erc7730-v3.0.0-next.schema.json) | N/A | Draft |
 
 `1.0.0` and `2.0.0` are the two schema versions that were released prior to the introduction of this versioning scheme; they are renumbered here under semver with no change to their content or file names. Every version released from now on is added as a new row in this table, without altering the rows already present, and follows the `erc7730-v<MAJOR>.<MINOR>.<PATCH>[-rc.<N>].schema.json` file naming pattern described above.
 
@@ -210,7 +210,7 @@ Displaying structured data is often done by wallets to review its content before
 - The container structure does not necessarily follow the same type system as the structured data.
 - Wallets receive the full container structure and uses the signature scheme to generate a signature on the overall structure.
 
-![Structured Data and Container](../assets/eip-7730/structured-data.svg)
+![Structured Data and Container](../assets/erc-7730/structured-data.svg)
 
 Current specification covers EVM smart contract calldata:
 - Defined in Solidity
@@ -657,7 +657,7 @@ Maps references can be used anywhere a parameter with constant value would be us
 
 A wallet MUST replace a path to a map using the value matching the `keyPath` parameter. In case no values matches the wallet MUST consider the 7730 file invalid for the transaction. 
 
-An example can be found in [example-maps.json](../assets/eip-7730/example-maps.json) and [example-maps-pools.json](../assets/eip-7730/example-maps-pools.json).
+An example can be found in [example-maps.json](../assets/erc-7730/example-maps.json) and [example-maps-pools.json](../assets/erc-7730/example-maps-pools.json).
 
 *Examples*
 
@@ -1051,7 +1051,7 @@ Optional object containing formatter-specific parameters. Available parameters a
 
 When a formatter applies to an array, the parameters CAN also reference a path to an array. In that case, wallets should format each element of the array using the parameter value at the same index as the current element being formatted. Parameter arrays should be the same length as the formatted array else the wallet SHOULD raise an error.
 
-See [example-array-iteration.json](../assets/eip-7730/example-array-iteration.json) for examples on array iteration.
+See [example-array-iteration.json](../assets/erc-7730/example-array-iteration.json) for examples on array iteration.
 
 **`$id`** 
 
@@ -1132,7 +1132,7 @@ Recursive path references work by concatenating the paths of the parents *struct
 
 This recursivity allows structuring the ERC-7730 file itself, but is NOT RECOMMENDED. It is expected that resource limited wallets will only support very limited recursivity in the ERC-7730 file itself, so the initial intent of the spec is to "flatten" the list of fields to display using the *path* mechanics. 
 
-See [example-array-iteration.json](../assets/eip-7730/example-array-iteration.json) for examples on grouping and group iteration control.
+See [example-array-iteration.json](../assets/erc-7730/example-array-iteration.json) for examples on grouping and group iteration control.
 
 #### Slices in paths
 
@@ -1451,14 +1451,14 @@ Formats applicable to `address` solidity type.
 
 | **`raw`**       |                                                                                              |
 |-----------------|----------------------------------------------------------------------------------------------|
-| *Description*   | Display address as an [EIP-55](./eip-55.md) formatted string. Truncation is device dependent |
+| *Description*   | Display address as an [ERC-55](./erc-55.md) formatted string. Truncation is device dependent |
 | *Parameters*    | None                                                                                         |
 | *Examples*      | ---                                                                                          |
 | `0x5aAe...eAed` | Field Value 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed                                       |
 
 | **`addressName`**       |                    |
 |-------------------------|--------------------|
-| *Description*           | Display address as a trusted name if a trusted source exists, an EIP-55 formatted address otherwise. See [next section](#address-types-and-sources) for a reference of trusted sources |
+| *Description*           | Display address as a trusted name if a trusted source exists, an ERC-55 formatted address otherwise. See [next section](#address-types-and-sources) for a reference of trusted sources |
 | *Parameters*            | --- |
 | `types`                 | An array of expected types of the address (see [next section](#address-types-and-sources)). If set, the wallet SHOULD check that the address matches one of the types provided |
 | `sources`               | An array of acceptable sources for names (see [next section](#address-types-and-sources)). If set, the wallet SHOULD restrict name lookup to relevant sources |
@@ -1556,11 +1556,11 @@ All display strings in ERC-7730 files—including intents, labels, field names, 
 
 Future versions of this specification may consider standardized internationalization support once the base standard achieves wider adoption and the ecosystem can better assess the need for multilingual support.
 
-### User Operations (EIP-4337)
+### User Operations (ERC-4337)
 
-Clear signing [EIP-4337](./eip-4337.md) User Operations is supported using the `PackedUserOperation` EIP-712 signature format. See [example-userops-eip-712.json](../assets/eip-7730/example-userops-eip712.json) for a reference implementation.
+Clear signing [ERC-4337](./erc-4337.md) User Operations is supported using the `PackedUserOperation` EIP-712 signature format. See [example-userops-eip712.json](../assets/erc-7730/example-userops-eip712.json) for a reference implementation.
 
-The inner calldata typically contains an `execute` call to interact with other contracts. This can be clear signed using a separate ERC-7730 file - see [example-account-execute.json](../assets/eip-7730/example-account-execute.json). Since execute functions are implementation-specific, each smart wallet will need its own ERC-7730 file.
+The inner calldata typically contains an `execute` call to interact with other contracts. This can be clear signed using a separate ERC-7730 file - see [example-account-execute.json](../assets/erc-7730/example-account-execute.json). Since execute functions are implementation-specific, each smart wallet will need its own ERC-7730 file.
 
 Smart wallets commonly use a proxy pattern. Refer to the [Proxy support](#proxy-support) section for guidance. 
 
@@ -1637,7 +1637,7 @@ Wallets MAY:
 
 ### Extensibility to other structured data formats
 
-In the future, this specification could be extended to structured data like Meta Transaction in [EIP-2771](./eip-2771.md), User Operations in [EIP-4337](./eip-4337.md), and batch transaction payloads in [EIP-5792](./eip-5792.md).
+In the future, this specification could be extended to structured data like Meta Transaction in [ERC-2771](./erc-2771.md), User Operations in [ERC-4337](./erc-4337.md), and batch transaction payloads in [EIP-5792](./eip-5792.md).
 
 The `interpolatedIntent` field is particularly well-suited for [EIP-5792](./eip-5792.md) batch transactions, as it enables wallets to concatenate multiple operation descriptions into a single, natural language sentence. By joining individual `interpolatedIntent` strings with " and ", wallets can provide users with clear, readable summaries of complex multi-step operations like "Approve Uniswap Router to spend 1000 USDC and Swap 1000 USDC for at least 0.25 WETH". This significantly improves the user experience when reviewing batch transactions compared to displaying separate, disconnected operation descriptions. See the [Value Interpolation](#value-interpolation) section for detailed implementation guidance and examples.
 
@@ -1658,16 +1658,16 @@ More examples can be found in the asset folder.
 
 | File name | Description |
 | --- | ---|
-| [example-main.json](../assets/eip-7730/example-main.json) | Simple example of a basic ERC-7730 file |
-| [example-erc-20.json](../assets/eip-7730/example-erc20.json) | Simple example of defining an interface for ERC-20 contracts |
-| [example-include.json](../assets/eip-7730/example-include.json) | Example of including an interface into another ERC-7730 file |
-| [example-eip-712.json](../assets/eip-7730/example-eip712.json) | Clear signing EIP-712 example |
-| [example-array-iteration.json](../assets/eip-7730/example-array-iteration.json) | Examples of various array iteration modes and field grouping features |
-| [example-maps.json](../assets/eip-7730/example-maps.json) | Example of maps of constants |
-| [example-maps-pools.json](../assets/eip-7730/example-maps-pools.json) | Example of maps of constants |
-| [example-visibility-rules.json](../assets/eip-7730/example-visibility-rules.json) | Example of controlling the visibility of fields |
-| [example-account-execute.json](../assets/eip-7730/example-account-execute.json) | Example of EIP-4337 smart wallet execute function clear signing |
-| [example-userops-eip-712.json](../assets/eip-7730/example-userops-eip712.json) | Example of EIP-4337 User Operation clear signing |
+| [example-main.json](../assets/erc-7730/example-main.json) | Simple example of a basic ERC-7730 file |
+| [example-erc-20.json](../assets/erc-7730/example-erc20.json) | Simple example of defining an interface for ERC-20 contracts |
+| [example-include.json](../assets/erc-7730/example-include.json) | Example of including an interface into another ERC-7730 file |
+| [example-eip712.json](../assets/erc-7730/example-eip712.json) | Clear signing EIP-712 example |
+| [example-array-iteration.json](../assets/erc-7730/example-array-iteration.json) | Examples of various array iteration modes and field grouping features |
+| [example-maps.json](../assets/erc-7730/example-maps.json) | Example of maps of constants |
+| [example-maps-pools.json](../assets/erc-7730/example-maps-pools.json) | Example of maps of constants |
+| [example-visibility-rules.json](../assets/erc-7730/example-visibility-rules.json) | Example of controlling the visibility of fields |
+| [example-account-execute.json](../assets/erc-7730/example-account-execute.json) | Example of ERC-4337 smart wallet execute function clear signing |
+| [example-userops-eip712.json](../assets/erc-7730/example-userops-eip712.json) | Example of ERC-4337 User Operation clear signing |
 
 
 ## Security Considerations
@@ -1728,7 +1728,7 @@ These patterns are often used in conjunction. Supporting those patterns require 
 
 **Upgradeable proxy contracts**
 
-Upgradeable proxy contracts (such as Transparent Proxies or UUPS proxies as defined in [EIP-1822](./eip-1822.md)) use a fixed proxy address that delegates calls to a replaceable implementation contract. For these contracts, the ERC-7730 file SHOULD be bound to the *proxy* address, since this is the stable address users interact with.
+Upgradeable proxy contracts (such as Transparent Proxies or UUPS proxies as defined in [ERC-1822](./erc-1822.md)) use a fixed proxy address that delegates calls to a replaceable implementation contract. For these contracts, the ERC-7730 file SHOULD be bound to the *proxy* address, since this is the stable address users interact with.
 
 When an upgrade introduces breaking ABI changes (new functions, modified signatures, or removed functions), developers SHOULD update the ERC-7730 file in the registry accordingly. Since the old implementation is no longer callable after the upgrade, the previous ERC-7730 definitions can be safely replaced.
 

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -139,25 +139,42 @@ This standard may deprecate a version of the schema explicitly. Wallets SHOULD m
 
 Schema versions follow Semantic Versioning with an optional `-rc.N` pre-release suffix.
 
+A merged pull request against this ERC that changes the schema produces a new release-candidate version of that schema.
+It must publish the corresponding `-rc.N+1` file, and a previously published `-rc.N` file for the same in-flight version MAY be replaced or dropped without notice as new candidates are produced.
+Consumers SHOULD NOT build against a release-candidate schema unless they specifically intend to track in-development, unstable changes.
+
+Once the version is ready, it is finalized by dropping its `-rc.N` suffix (e.g. `3.0.0-rc.3` -> `3.0.0`).
+From that point on the version is immutable, and any schema change merged afterwards opens a new pre-release for the next version (e.g. `4.0.0-rc.1`).
+
 #### Schema files and the `$schema` key
 
 Each released and finalized version, including the current pre-release one, is published as its own immutable file named `erc7730-v<VERSION>[-rc.<N>].schema.json`.
 
-Once a version is published, its file contents MUST NOT change. Any subsequent change, including error fixes, is published as a new version with a new file.
+Once a version is finalized, its file contents MUST NOT change. Any subsequent change, including error fixes, is published as a new version with a new file.
+
+Release-candidate files MAY be replaced or removed in the process of finalizing a version.
+
+Each schema file is published in two locations: alongside this ERC, under `assets/eip-7730/`, and mirrored into the descriptor registry that consumes these files.
 
 The version of the specification used by a descriptor file is the version identified by its `$schema` key, as introduced in the [Simple example](#simple-example). Consumers MUST use this key to select which schema version and which validation and interpretation rules apply to a given descriptor.
 
 Outside of this section, this document's text always describes the current release candidate version of the schema only.
 
+To see the ERC text as it read for a specific released version, check out this repository at the commit referenced for that version in the [Released versions](#released-versions) table below.
+
 #### Released versions
 
-| Version               | Schema                                                                |
-|-----------------------|-----------------------------------------------------------------------|
-| `1.0.0`               | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json) |
-| `2.0.0` (current)     | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json) |
-| `3.0.0-rc.1` (future) | TBD                                                                   |
+| Version      | Schema                                                                | Commit                                                         | Status            |
+|--------------|-----------------------------------------------------------------------|----------------------------------------------------------------|-------------------|
+| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json) | [`d42dfc9d`](https://github.com/ethereum/ERCs/commit/d42dfc9d) | Deprecated        |
+| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json) | [`a124a871`](https://github.com/ethereum/ERCs/commit/a124a871) | Active            |
+| `3.0.0-rc.1` | TBD                                                                   | TBD                                                            | Release Candidate |
 
 `1.0.0` and `2.0.0` are the two schema versions that were released prior to the introduction of this versioning scheme; they are renumbered here under semver with no change to their content or file names. Every version released from now on is added as a new row in this table, without altering the rows already present, and follows the `erc7730-v<MAJOR>.<MINOR>.<PATCH>[-rc.<N>].schema.json` file naming pattern described above.
+
+`1.0.0` is deprecated.
+
+New integrations SHOULD target the "Active" version.
 
 ### Common concepts
 

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -102,7 +102,7 @@ The following is an example of how to clear sign a `transfer` function call on a
 }
 ```
 
-The `$schema` key refers to the latest version of this specification json schema (version 1 at the time of writing).
+The `$schema` key identifies the exact schema version this descriptor was authored against, as detailed in [Versioning](#versioning).
 
 The `context` key is used to provide binding context information for this file. It can be seen as a set of *constraints* on the structured data being reviewed, indicating whether the ERC-7730 file is valid for this data. A wallet MUST ensure these constraints are met before ERC-7730 formatting information is applied to the data being signed. 
 
@@ -126,9 +126,38 @@ In this example, the `to` parameter and the `value` parameter SHOULD both be dis
 
 ### Versioning
 
-The version of the specification used by the 7730 file is specified by linking to the reference schema file under the `$schema` key.
+The descriptor schema is versioned as part of this standard.
 
-The current version of the specification is `2` at the time of writing. The reference schema for version `2` is [here](../assets/eip-7730/erc7730-v2.schema.json).
+This ERC will periodically release a new, immutable, explicitly numbered version that may be considered "Final" for all intents and purposes.
+
+Descriptors conforming to this versioned schema are produced and consumed by supporting software and hardware wallets.
+When encountering a descriptor of a yet unsupported version, the wallet MUST consider it invalid.
+
+This standard may deprecate a version of the schema explicitly. Wallets SHOULD maintain support for all non-deprecated versions of the schema declared in the [Released Version](#released-versions) section.
+
+#### Version numbers
+
+Schema versions follow Semantic Versioning with an optional `-rc.N` pre-release suffix.
+
+#### Schema files and the `$schema` key
+
+Each released and finalized version, including the current pre-release one, is published as its own immutable file named `erc7730-v<VERSION>[-rc.<N>].schema.json`.
+
+Once a version is published, its file contents MUST NOT change. Any subsequent change, including error fixes, is published as a new version with a new file.
+
+The version of the specification used by a descriptor file is the version identified by its `$schema` key, as introduced in the [Simple example](#simple-example). Consumers MUST use this key to select which schema version and which validation and interpretation rules apply to a given descriptor.
+
+Outside of this section, this document's text always describes the current release candidate version of the schema only.
+
+#### Released versions
+
+| Version               | Schema                                                                |
+|-----------------------|-----------------------------------------------------------------------|
+| `1.0.0`               | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json) |
+| `2.0.0` (current)     | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json) |
+| `3.0.0-rc.1` (future) | TBD                                                                   |
+
+`1.0.0` and `2.0.0` are the two schema versions that were released prior to the introduction of this versioning scheme; they are renumbered here under semver with no change to their content or file names. Every version released from now on is added as a new row in this table, without altering the rows already present, and follows the `erc7730-v<MAJOR>.<MINOR>.<PATCH>[-rc.<N>].schema.json` file naming pattern described above.
 
 ### Common concepts
 
@@ -1582,6 +1611,14 @@ The `interpolatedIntent` field is particularly well-suited for [EIP-5792](./eip-
 
 ### Common keywords
 The DeFi ecosystem has matured and has some repeating usecases with well defined terms for different actions. While this ERC does not define specific standards for DEX or Lending protocol intents, for the sake of easier user readibility, teams with similar products should align on similar terminology to describe actions and actors. We encourage the creation of another layer of standardization on top of ERC-7730 to be recommeneded and even enforced in clear signing registries for improved user security.
+
+## Backwards Compatibility
+
+The descriptor schema is versioned independently per [Versioning](#versioning).
+
+A major version increment is backward incompatible with descriptors and tooling built against the previous major version.
+
+Consumers MUST rely on the `$schema` key of a given descriptor to select the schema version and behavior to apply.
 
 ## Test Cases
 

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1558,7 +1558,7 @@ Future versions of this specification may consider standardized internationaliza
 
 ### User Operations (ERC-4337)
 
-Clear signing [ERC-4337](./eip-4337.md) User Operations is supported using the `PackedUserOperation` EIP-712 signature format. See [example-userops-eip-712.json](../assets/eip-7730/example-userops-eip712.json) for a reference implementation.
+Clear signing [ERC-4337](./eip-4337.md) User Operations is supported using the `PackedUserOperation` EIP-712 signature format. See [example-userops-EIP-712.json](../assets/eip-7730/example-userops-eip712.json) for a reference implementation.
 
 The inner calldata typically contains an `execute` call to interact with other contracts. This can be clear signed using a separate ERC-7730 file - see [example-account-execute.json](../assets/eip-7730/example-account-execute.json). Since execute functions are implementation-specific, each smart wallet will need its own ERC-7730 file.
 
@@ -1659,15 +1659,15 @@ More examples can be found in the asset folder.
 | File name | Description |
 | --- | ---|
 | [example-main.json](../assets/eip-7730/example-main.json) | Simple example of a basic ERC-7730 file |
-| [example-erc-20.json](../assets/eip-7730/example-erc20.json) | Simple example of defining an interface for ERC-20 contracts |
+| [example-ERC-20.json](../assets/eip-7730/example-erc20.json) | Simple example of defining an interface for ERC-20 contracts |
 | [example-include.json](../assets/eip-7730/example-include.json) | Example of including an interface into another ERC-7730 file |
-| [example-eip-712.json](../assets/eip-7730/example-eip712.json) | Clear signing EIP-712 example |
+| [example-EIP-712.json](../assets/eip-7730/example-eip712.json) | Clear signing EIP-712 example |
 | [example-array-iteration.json](../assets/eip-7730/example-array-iteration.json) | Examples of various array iteration modes and field grouping features |
 | [example-maps.json](../assets/eip-7730/example-maps.json) | Example of maps of constants |
 | [example-maps-pools.json](../assets/eip-7730/example-maps-pools.json) | Example of maps of constants |
 | [example-visibility-rules.json](../assets/eip-7730/example-visibility-rules.json) | Example of controlling the visibility of fields |
 | [example-account-execute.json](../assets/eip-7730/example-account-execute.json) | Example of ERC-4337 smart wallet execute function clear signing |
-| [example-userops-eip-712.json](../assets/eip-7730/example-userops-eip712.json) | Example of ERC-4337 User Operation clear signing |
+| [example-userops-EIP-712.json](../assets/eip-7730/example-userops-eip712.json) | Example of ERC-4337 User Operation clear signing |
 
 
 ## Security Considerations

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -154,7 +154,7 @@ Once a version is finalized, its file contents MUST NOT change. Any subsequent c
 
 Release-candidate files MAY be replaced or removed in the process of finalizing a version.
 
-Each schema file is published in two locations: alongside this ERC, under assets/eip-7730/, and mirrored into the descriptor registry that consumes these files.
+Each schema file is published in two locations: alongside this ERC under the "assets" folder, and mirrored into the descriptor registry that consumes these files.
 
 The version of the specification used by a descriptor file is the version identified by its `$schema` key, as introduced in the [Simple example](#simple-example). Consumers MUST use this key to select which schema version and which validation and interpretation rules apply to a given descriptor.
 

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -146,6 +146,8 @@ Consumers SHOULD NOT build against a release-candidate schema unless they specif
 Once the version is ready, it is finalized by dropping its `-rc.N` suffix (e.g. `3.0.0-rc.3` -> `3.0.0`).
 From that point on the version is immutable, and any schema change merged afterwards opens a new pre-release for the next version (e.g. `4.0.0-rc.1`).
 
+Descriptors MUST pin the exact commit ID of this ERC document that they were authored against; see [The `$commit` key](#the-commit-key).
+
 #### Schema files and the `$schema` key
 
 Each released and finalized version, including the current pre-release one, is published as its own immutable file named `erc7730-v<VERSION>[-rc.<N>].schema.json`.
@@ -162,15 +164,33 @@ Outside of this section, this document's text always describes the current relea
 
 To see the ERC text as it read for a specific released version, check out this repository at the commit referenced for that version in the [Released versions](#released-versions) table below.
 
+#### The `$commit` key
+
+Descriptors MUST include a top-level `$commit` key, alongside `$schema`. Its value MUST exactly match the commit hash recorded in the [Released versions](#released-versions) table for the schema version referenced by `$schema`.
+
+This binds a descriptor to an exact, independently verifiable point in this document's history, removing any remaining ambiguity beyond the schema validation.
+
+*Example*
+
+```json
+{
+    "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v3.0.0-rc.1.schema.json",
+    "$commit": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
+}
+```
+
 #### Released versions
 
-| Version      | Schema                                                                | Commit                                                         | Status            |
-|--------------|-----------------------------------------------------------------------|----------------------------------------------------------------|-------------------|
-| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json) | `d42dfc9d`                                                     | Deprecated        |
-| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json) | `a124a871`                                                     | Active            |
-| `3.0.0-rc.1` | TBD                                                                   | TBD                                                            | Release Candidate |
+| Version      | Schema                                                                | Commit ID  | Status            |
+|--------------|-----------------------------------------------------------------------|------------|-------------------|
+| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json) | `d42dfc9d` | Deprecated        |
+| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json) | `a124a871` | Active            |
+| `3.0.0-rc.1` | TBD                                                                   | TBD        | Release Candidate |
 
 `1.0.0` and `2.0.0` are the two schema versions that were released prior to the introduction of this versioning scheme; they are renumbered here under semver with no change to their content or file names. Every version released from now on is added as a new row in this table, without altering the rows already present, and follows the `erc7730-v<MAJOR>.<MINOR>.<PATCH>[-rc.<N>].schema.json` file naming pattern described above.
+
+The `Commit ID` column contains the acceptable [`$commit`](#the-commit-key) values for descriptors.
+Descriptors targeting a given final schema version MUST set `$commit` to the value recorded here for that version.
 
 `1.0.0` is deprecated.
 

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -138,46 +138,52 @@ This standard may deprecate a version of the schema explicitly. Wallets and tool
 
 #### Version numbers
 
-Schema versions follow Semantic Versioning with an optional `-rc.N` pre-release suffix.
+Schema versions follow Semantic Versioning with an optional pre-release suffix: `-next` for the in-development draft, `-rc.N` for release candidates.
 
 A MAJOR bump indicates a breaking schema change, a MINOR bump indicates a backward-compatible addition, and a PATCH bump indicates a non-breaking fix or editorial change.
 
-A merged pull request against this ERC that changes the schema produces a new release-candidate version of that schema.
-It must publish the corresponding `-rc.N+1` file, and a previously published `-rc.N` file for the same in-flight version MAY be replaced or dropped without notice as new candidates are produced.
-Consumers SHOULD NOT build against a release-candidate schema unless they specifically intend to track in-development, unstable changes.
+Schema changes merged between releases accumulate in a single mutable draft file, named `erc7730-v<VERSION>-next.schema.json` after the targeted version.
+Its `version` key names the version of the next major release with a `-next` suffix (e.g. `3.0.0-next`).
+The `-next` draft schema changes frequently and without notice, and consumers MUST NOT rely on its stability.
 
-Once the version is ready, it is finalized by dropping its `-rc.N` suffix (e.g. `3.0.0-rc.3` -> `3.0.0`).
-From that point on the version is immutable, and any schema change merged afterwards opens a new pre-release for the next version (e.g. `4.0.0-rc.1`).
+Publishing a release candidate is a deliberate step, separate from making any particular change to the schema definition, explicitly taken by the authors when the draft is judged ready for integration testing. The draft's content is snapshotted into an immutable `-rc.N` file with an incremented candidate number (e.g. `3.0.0-rc.1`).
+Release candidates give wallets and tooling fixed checkpoints to test against while the draft continues to evolve.
+Consumers SHOULD NOT build against a release-candidate schema unless they specifically intend to participate in the integration testing.
+
+Once the version is ready, it is finalized by publishing its content under the plain version number with no suffix (e.g. `3.0.0-rc.3` -> `3.0.0`) and removing that version's release-candidate files.
+From that point on the version is immutable, and the draft file is renamed to target the next version (e.g. `erc7730-v4.0.0-next.schema.json`).
 
 #### Schema files and the `$schema` key
 
-Each released and finalized version, including the current pre-release one, is published as its own immutable file named `erc7730-v<VERSION>[-rc.<N>].schema.json`.
+Each released version, release candidate or final, is published as its own file named `erc7730-v<VERSION>[-rc.<N>].schema.json`. The in-development draft is published as `erc7730-v<VERSION>-next.schema.json`.
 
-Once a version is finalized, its file contents MUST NOT change. Any subsequent change, including error fixes, is published as a new version with a new file.
+Exactly one schema file is mutable at any time: the `-next` draft.
 
-Release-candidate files MAY be replaced or removed in the process of finalizing a version.
+Every other schema file is immutable from the moment it is published, and its contents MUST NOT change. Any change to a finalized version, including error fixes, is published as a new version with a new file.
+
+Release-candidate files MUST be removed by the authors once their version is finalized. The finalized version's schema files MUST never be modified or removed.
 
 Each schema file is published in two locations: alongside this ERC under the "assets" folder, and mirrored into the descriptor registry that consumes these files.
 
 Each schema file's own top-level `version` key is the authoritative identifier of its version.
 
-The `erc7730-v<VERSION>[-rc.<N>].schema.json` file naming pattern is a convention for humans and tooling, not the source of truth, and consumers MUST NOT derive the version by parsing the file name.
+The `erc7730-v<VERSION>[-rc.<N>|-next].schema.json` file naming pattern is a convention for humans and tooling, not the source of truth, and consumers MUST NOT derive the version by parsing the file name.
 
 The schema and this ERC text are always changed together in the same pull request. A finalized schema file remains in sync with the ERC text as it read at the time of finalization.
 
 The version of the specification used by a descriptor file is the version identified by its `$schema` key, as introduced in the [Simple example](#simple-example). Consumers MUST use this key to select which schema version and which validation and interpretation rules apply to a given descriptor.
 
-Outside of this section, this document's text always describes the current release candidate version of the schema only.
+Outside of this section, this document's text always describes the current draft version of the schema only.
 
 To see the ERC text as it read for a specific released version, check out this repository at the commit referenced for that version in the [Released versions](#released-versions) table below.
 
 #### Released versions
 
-| Version      | Schema                                                                | Commit ID  | Status            |
-|--------------|-----------------------------------------------------------------------|------------|-------------------|
-| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json) | `d42dfc9d` | Deprecated        |
-| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json) | `a124a871` | Active            |
-| `3.0.0-rc.1` | TBD                                                                   | TBD        | Release Candidate |
+| Version      | Schema                                                                    | Commit ID  | Status     |
+|--------------|---------------------------------------------------------------------------|------------|------------|
+| `1.0.0`      | [`erc7730-v1.schema.json`](../assets/eip-7730/erc7730-v1.schema.json)     | `d42dfc9d` | Deprecated |
+| `2.0.0`      | [`erc7730-v2.schema.json`](../assets/eip-7730/erc7730-v2.schema.json)     | TBD        | Active     |
+| `3.0.0-next` | [`erc7730-v3.0.0-next.schema.json`](../assets/eip-7730/erc7730-v3.0.0-next.schema.json) | N/A | Draft |
 
 `1.0.0` and `2.0.0` are the two schema versions that were released prior to the introduction of this versioning scheme; they are renumbered here under semver with no change to their content or file names. Every version released from now on is added as a new row in this table, without altering the rows already present, and follows the `erc7730-v<MAJOR>.<MINOR>.<PATCH>[-rc.<N>].schema.json` file naming pattern described above.
 

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -131,13 +131,16 @@ The descriptor schema is versioned as part of this standard.
 This ERC will periodically release a new, immutable, explicitly numbered version that may be considered "Final" for all intents and purposes.
 
 Descriptors conforming to this versioned schema are produced and consumed by supporting software and hardware wallets.
-When encountering a descriptor of a yet unsupported version, the wallet MUST consider it invalid.
+A wallet MUST consider a descriptor invalid if the MAJOR version identified by its `$schema` key is not one the wallet implements, since a MAJOR version bump signals a breaking change to the schema.
+If the MAJOR version matches but the descriptor declares a MINOR or PATCH version newer than what the wallet implements, the wallet MUST continue processing the descriptor using its implementation for the appropriate MAJOR version, since MINOR versions are backward-compatible additions and PATCH versions are non-breaking fixes or editorial changes, per Semantic Versioning.
 
-This standard may deprecate a version of the schema explicitly. Wallets SHOULD maintain support for all non-deprecated versions of the schema declared in the [Released Version](#released-versions) section.
+This standard may deprecate a version of the schema explicitly. Wallets and tooling SHOULD maintain support for all non-deprecated versions of the schema declared in the [Released Version](#released-versions) section.
 
 #### Version numbers
 
 Schema versions follow Semantic Versioning with an optional `-rc.N` pre-release suffix.
+
+A MAJOR bump indicates a breaking schema change, a MINOR bump indicates a backward-compatible addition, and a PATCH bump indicates a non-breaking fix or editorial change.
 
 A merged pull request against this ERC that changes the schema produces a new release-candidate version of that schema.
 It must publish the corresponding `-rc.N+1` file, and a previously published `-rc.N` file for the same in-flight version MAY be replaced or dropped without notice as new candidates are produced.
@@ -145,8 +148,6 @@ Consumers SHOULD NOT build against a release-candidate schema unless they specif
 
 Once the version is ready, it is finalized by dropping its `-rc.N` suffix (e.g. `3.0.0-rc.3` -> `3.0.0`).
 From that point on the version is immutable, and any schema change merged afterwards opens a new pre-release for the next version (e.g. `4.0.0-rc.1`).
-
-Descriptors MAY pin the exact commit ID of this ERC document that they were authored against in [the `$commit` key](#the-commit-key).
 
 #### Schema files and the `$schema` key
 
@@ -158,28 +159,17 @@ Release-candidate files MAY be replaced or removed in the process of finalizing 
 
 Each schema file is published in two locations: alongside this ERC under the "assets" folder, and mirrored into the descriptor registry that consumes these files.
 
-Since the schema and the spec text are always changed together in the same pull request, a finalized schema file implicitly stays in sync with the ERC text as it read at that time. To make this traceable without introducing a separate versioning scheme, a finalized schema file's top-level `$comment` key MUST record the date and the commit ID at which that version was finalized, pointing back to the exact revision of this document the schema corresponds to.
+Each schema file's own top-level `version` key is the authoritative identifier of its version.
+
+The `erc7730-v<VERSION>[-rc.<N>].schema.json` file naming pattern is a convention for humans and tooling, not the source of truth, and consumers MUST NOT derive the version by parsing the file name.
+
+The schema and this ERC text are always changed together in the same pull request. A finalized schema file remains in sync with the ERC text as it read at the time of finalization.
 
 The version of the specification used by a descriptor file is the version identified by its `$schema` key, as introduced in the [Simple example](#simple-example). Consumers MUST use this key to select which schema version and which validation and interpretation rules apply to a given descriptor.
 
 Outside of this section, this document's text always describes the current release candidate version of the schema only.
 
 To see the ERC text as it read for a specific released version, check out this repository at the commit referenced for that version in the [Released versions](#released-versions) table below.
-
-#### The `$commit` key
-
-Descriptors MAY include a top-level `$commit` key, alongside `$schema`.
-
-This binds a descriptor to an exact, independently verifiable point in this document's history, removing any remaining ambiguity beyond the schema validation.
-
-*Example*
-
-```json
-{
-    "$schema": "https://eips.ethereum.org/assets/eip-7730/erc7730-v3.0.0-rc.1.schema.json",
-    "$commit": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
-}
-```
 
 #### Released versions
 
@@ -190,8 +180,6 @@ This binds a descriptor to an exact, independently verifiable point in this docu
 | `3.0.0-rc.1` | TBD                                                                   | TBD        | Release Candidate |
 
 `1.0.0` and `2.0.0` are the two schema versions that were released prior to the introduction of this versioning scheme; they are renumbered here under semver with no change to their content or file names. Every version released from now on is added as a new row in this table, without altering the rows already present, and follows the `erc7730-v<MAJOR>.<MINOR>.<PATCH>[-rc.<N>].schema.json` file naming pattern described above.
-
-The `Commit ID` column contains the acceptable [`$commit`](#the-commit-key) values for descriptors, and the value that a schema file's `$comment` key SHOULD record when finalizing that version.
 
 `1.0.0` is deprecated.
 

--- a/assets/erc-7730/erc7730-v1.schema.json
+++ b/assets/erc-7730/erc7730-v1.schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "version": "1.0.0",
     "type": "object",
     "description": "ERC7730 Clear Signing Specification Schema. Specification located at https://github.com/LedgerHQ/clear-signing-erc7730-registry/tree/master/specs",
 

--- a/assets/erc-7730/erc7730-v2.schema.json
+++ b/assets/erc-7730/erc7730-v2.schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "version": "2.0.0",
     "type": "object",
     "description": "ERC7730 Clear Signing Specification Schema. Specification located at https://github.com/LedgerHQ/clear-signing-erc7730-registry/tree/master/specs",
 

--- a/assets/erc-7730/erc7730-v3.0.0-next.schema.json
+++ b/assets/erc-7730/erc7730-v3.0.0-next.schema.json
@@ -1,0 +1,1128 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "version": "3.0.0-next",
+    "type": "object",
+    "description": "ERC7730 Clear Signing Specification Schema. Specification located at https://github.com/LedgerHQ/clear-signing-erc7730-registry/tree/master/specs",
+
+    "properties": {
+
+        "$schema": {
+            "title": "Schema",
+            "type": "string",
+            "format": "uri-reference",
+            "description": "The schema that the document should conform to. This should be the URL of a version of the clear signing JSON schemas available under https://github.com/LedgerHQ/clear-signing-erc7730-registry/tree/master/specs"
+        },
+
+        "$comment": {
+            "title": "Schema",
+            "type": "string",
+            "description": "An optional comment string that can be used to document the purpose of the file."
+        },
+
+        "includes": {
+            "title": "External includes",
+            "type": "string",
+            "format": "uri-reference",
+            "description": "An URL of another ERC 7730 file that should be merged into this one. Includes are merged into this file before analysis. This can be used to manage interfaces definitions without redundancy."
+        },
+
+        "context": {
+            "$ref": "#/$context/main"
+        },
+
+        "metadata": {
+            "$ref": "#/$metadata/main"
+        },
+
+        "display": {
+            "$ref": "#/$display/main"
+        }
+    },
+    "additionalProperties": false,
+
+    "$context" : {
+        "main" : {
+            "title": "Binding Context Section",
+            "type": "object",
+            "description": "The binding context is a set of constraints that are used to bind the ERC7730 file to a specific structured data being displayed. Currently, supported contexts include contract-specific constraints or EIP712 message specific constraints.",
+
+            "properties": {
+                "$id" : {
+                    "$ref": "#/$definitions/id"
+                }
+            },
+
+            "oneOf": [
+                {
+                    "$ref": "#/$context/contract"
+                },
+                {
+                    "$ref": "#/$context/EIP712"
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+
+        "contract": {
+            "type": "object",
+
+            "properties": {
+                "contract": {
+                    "title": "Contract Binding Context",
+                    "type": "object",
+                    "description": "The contract binding context is a set constraints that are used to bind the ERC7730 file to a specific smart contract.",
+
+                    "properties": {
+                        "abi": {
+                            "description": "[Deprecated] ABI definition bound to this file. Continue providing it for backward compatibility only; new specs should rely on display formats."
+                        },
+                        "deployments": {
+                            "$ref": "#/$context/deployments"
+                        },
+                        "factory": {
+                            "title": "Factory constraint",
+                            "type": "object",
+                            "description": "A factory constraint is used to check whether the target contract is deployed by a specified factory.",
+                            "properties": {
+                                "deployments": {
+                                    "$ref": "#/$context/deployments"
+                                },
+                                "deployEvent": {
+                                    "title": "Deploy Event signature",
+                                    "type": "string",
+                                    "description": "The event signature that is emitted by the factory when deploying a new contract."
+                                }
+                            },
+                            "required": [
+                                "deployments",
+                                "deployEvent"
+                            ],
+                            "additionalProperties": false
+                        }
+
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "contract"
+            ]
+        },
+
+        "EIP712": {
+            "type": "object",
+            "properties": {
+                "eip712" : {
+                    "title": "EIP 712 Binding",
+                    "type": "object",
+                    "description": "The EIP-712 binding context is a set of constraints that must be verified by the message being signed.",
+
+                    "properties" : {
+                        "schemas": {
+                            "description": "[Deprecated] Schema definition bound to this file. Continue providing it for backward compatibility only; new specs should rely on display formats."
+                        },
+                        "domain": {
+                            "title": "EIP 712 Domain Binding constraint",
+                            "type": "object",
+                            "description": "Each value of the domain constraint MUST match the corresponding eip 712 message domain value.",
+
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "version": {
+                                    "type": "string"
+                                },
+                                "chainId": {
+                                    "type": "integer",
+                                    "format": "eip155"
+                                },
+                                "verifyingContract": {
+                                    "type": "string",
+                                    "format": "eip55"
+                                }
+                            }
+                        },
+                        "domainSeparator": {
+                            "title": "Domain Separator constraint",
+                            "type": "string",
+                            "description": "The domain separator value that must be matched by the message. In hex string representation."
+                        },
+                        "deployments": {
+                            "description": "An array of deployments describing what the chainId and verifyingContract in the domain should match.",
+                            "$ref": "#/$context/deployments"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "eip712"
+            ]
+        },
+
+        "deployments": {
+            "title": "Deployments constraint",
+            "type": "array",
+            "description": "An array of deployments describing where the contract is deployed. The target contract (Tx to or factory) MUST match one of those deployments.",
+            "items": {
+                "properties": {
+                    "chainId": {
+                        "type": "integer",
+                        "format": "eip155"
+                    },
+                    "address": {
+                        "type": "string",
+                        "format": "eip55"
+                    }
+                }
+            }
+        }
+    },
+
+    "$metadata": {
+        "main": {
+            "title": "Metadata Section",
+            "type": "object",
+            "description": "The metadata section contains information about constant values relevant in the scope of the current contract / message (as matched by the `context` section)",
+
+            "properties": {
+
+                "owner": {
+                    "title": "Owner display name",
+                    "type": "string",
+                    "description": "The display name of the owner or target of the contract / message to be clear signed."
+                },
+
+                "contractName": {
+                    "title": "Contract Name",
+                    "type": "string",
+                    "description": "The name of the contract targeted by the transaction or message."
+                },
+
+                "info": {
+                    "$ref": "#/$metadata/info"
+                },
+
+                "token": {
+                    "$ref": "#/$metadata/token"
+                },
+
+                "constants": {
+                    "$ref": "#/$metadata/constants"
+                },
+
+                "enums": {
+                    "$ref": "#/$metadata/enums"
+                }
+            }
+
+        },
+
+        "info" : {
+            "title": "Main contract's owner detailed information",
+            "type": "object",
+            "description": "The owner info section contains detailed information about the owner or target of the contract / message to be clear signed.",
+
+            "properties": {
+                "deploymentDate": {
+                    "title": "Deployment date of the contract / message",
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "The date of deployment of the contract / message."
+                },
+                "url": {
+                    "title": "Owner URL",
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL with more info on the entity the user interacts with."
+                }
+            },
+            "required": [
+                "url"
+            ],
+            "additionalProperties": false
+        },
+
+        "token" : {
+            "title": "Token Description",
+            "type": "object",
+            "description": "A description of an ERC20 token exported by this format, that should be trusted. Not mandatory if the corresponding metadata can be fetched from the contract itself.",
+
+            "properties": {
+                "name": {
+                    "title": "Token Name",
+                    "type": "string"
+                },
+                "ticker": {
+                    "title": "Token Ticker",
+                    "type": "string",
+                    "description": "A short capitalized ticker for the token, that will be displayed in front of corresponding amounts."
+                },
+                "decimals": {
+                    "title": "Token Decimals",
+                    "type": "integer",
+                    "description": "The number of decimals of the token ticker, used to display amounts."
+                }
+            },
+            "required": [
+                "name",
+                "ticker",
+                "decimals"
+            ],
+            "additionalProperties": false
+
+        },
+
+        "constants": {
+            "title": "Constant values",
+            "type": "object",
+            "description": "A set of values that can be used in format parameters. Can be referenced with a path expression like $.metadata.constants.CONSTANT_NAME",
+            "additionalProperties": {
+                "type": ["string", "integer", "number", "boolean", "null"]
+            }
+        },
+
+        "enums" : {
+            "title": "Enums",
+            "type": "object",
+            "description": "A set of enums that are used to format fields replacing values with human readable strings.",
+
+            "additionalProperties": {
+                "title": "Enumeration",
+                "type": "object",
+                "description": "A set of values that will be used to replace a field value with a human readable string. Enumeration keys are the field values and enumeration values are the displayable strings",
+
+                "additionalProperties": {
+                    "type": "string"
+                }
+            }
+        },
+
+        "maps": {
+            "title": "Maps",
+            "type": "object",
+            "description": "A set of maps that are used to manage context dependant constants. Maps can be used in place of constants, and the correpsonding constant is based on the map key resolved value. Each key is a map name that can be used as a reference.",
+
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "$keyType": {
+                        "title": "Key Type",
+                        "type": "string",
+                        "description": "An informational representation of the expected key type."
+                    },
+                    "values": {
+                        "title": "Map Values",
+                        "type": "object",
+                        "description": "A set of values that can be used as constants based on the resolved key. Each key is a possible key value, and each value is the corresponding constant value.",
+
+                        "additionalProperties": {
+                            "type": ["string", "integer", "number", "boolean", "null"]
+                        }
+                    },
+                    "unresolvedProperties": false
+                }
+            }
+        }
+    },
+
+    "$display": {
+        "main": {
+            "title": "Display Formatting Info Section",
+            "type": "object",
+            "description": "The display section contains all the information needed to format the data in a human readable way. It contains the constants and formatters used to display the data contained in the bound structure.",
+
+            "properties": {
+
+                "definitions": {
+                    "type": "object",
+                    "title": "Common Formatter Definitions",
+                    "description": "A set of definitions that can be used to share formatting information between multiple messages / functions. The definitions can be referenced by the key name in an internal path.",
+                    "additionalProperties": {
+                        "$ref": "#/$format/field"
+                    }
+                },
+
+                "formats": {
+                    "title": "List of field formats",
+                    "description": "The list includes formatting info for each field of a structure. For contract bindings, entries are keyed by the full function signature with parameter names; for EIP712 bindings, entries are keyed by the string returned by EIP 712 encodeType on the primary type.",
+                    "type": "object",
+                    "propertyNames": {
+                        "anyOf": [
+                            {
+                                "pattern": "^[A-Za-z_][A-Za-z0-9_:]*\\(\\s*(?:(?:(?:(?:tuple)?\\s*\\((?:[^()]|\\([^()]*\\))*\\)|[A-Za-z0-9_:]+)(?:\\[[0-9]*\\])*(?:\\s+(?:memory|calldata|storage))?\\s+[A-Za-z_][A-Za-z0-9_]*)(?:\\s*,\\s*(?:(?:(?:tuple)?\\s*\\((?:[^()]|\\([^()]*\\))*\\)|[A-Za-z0-9_:]+)(?:\\[[0-9]*\\])*(?:\\s+(?:memory|calldata|storage))?\\s+[A-Za-z_][A-Za-z0-9_]*))*\\s*)?\\)$"
+                            },
+                            {
+                                "pattern": "^\\s*[A-Za-z_][A-Za-z0-9_:]*\\s*\\(\\s*(?:[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*(?:,\\s*[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*)*)?\\)\\s*(?:\\s*[A-Za-z_][A-Za-z0-9_:]*\\s*\\(\\s*(?:[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*(?:,\\s*[A-Za-z_][A-Za-z0-9_:]*(?:\\[\\])?\\s+[A-Za-z_][A-Za-z0-9_]*\\s*)*)?\\)\\s*)*$"
+                            }
+                        ]
+                        
+                    },
+
+                    "additionalProperties": {
+                        "title": "A structured data format specification",
+                        "description": "A structured data format specification contains formatting information of fields in a single type of message.",
+                        "type": "object",
+
+                        "properties": {
+                            "$id": {
+                                "$ref": "#/$definitions/id"
+                            },
+                            "intent": {
+                                "$ref": "#/$display/intent"
+                            },
+                            "interpolatedIntent": {
+                                "$ref": "#/$display/interpolatedIntent"
+                            },
+                            "fields": {
+                                "$ref": "#/$display/fields"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "required": [
+                "formats"
+            ],
+            "additionalProperties": false
+        },
+        "intent": {
+            "oneOf": [
+                {
+                    "title": "Simple intent message",
+                    "description": "A description of the intent of the structured data signing, that will be displayed to the user.",
+                    "type": "string"
+                },
+                {
+                    "title": "Complex intent message",
+                    "description": "A description of the intent of the structured data signing, that will be displayed to the user.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+
+            ]
+        },
+        "interpolatedIntent": {
+            "title": "Interpolated intent message",
+            "description": "An optional intent string with embedded field values using {path} interpolation syntax. This provides a dynamic, contextual description by embedding actual transaction/message values directly in the intent string. Wallets should prefer displaying interpolatedIntent when available and fall back to intent if interpolation fails. See the specification for detailed formatting behavior and security considerations.",
+            "type": "string"
+        },
+        "fields": {
+            "title": "Field Formats set",
+            "type": "array",
+            "description": "An array containing the ordered definitions of fields formats. See the specification for more details.",
+
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "#/$format/field"
+                    },
+                    {
+                        "$ref": "#/$display/fieldGroup"
+                    },
+                    {
+                        "$ref": "#/$display/reference"
+                    }
+                ]
+            },
+            "unevaluatedProperties": false
+        },
+        "fieldGroup": {
+            "title": "A group of field formats, allowing recursivity in the schema and control over grouping and iteration.",
+            "description": "A set of field formats used to group whole definitions for structures for instance. This allows nesting definitions of formats, but note that support for deep nesting will be device dependent.",
+            "type": "object",
+
+            "properties": {
+                "$id": {
+                    "$ref": "#/$definitions/id"
+                },
+                "path": {
+                    "$ref": "#/$format/path"
+                },
+                "label": {
+                    "title": "Group Label",
+                    "description": "The group label of the field group, that will be displayed to the user in front of the formatted field values.",
+                    "type": "string"
+                },
+                "iteration": {
+                    "title": "Group arrays iteration mode",
+                    "description": "Specifies how iteration over arrays in the group should be handled. Sequential mode displays elements grouped by array, ie arr_0[0] ... arr_0[N] arr_1[0] ... arr_1[M]. Bundled mode displays elements of the arrays grouped by index, ie arr_0[0] arr_1[0] arr_0[1] arr_1[1] ... arr_0[N] arr_1[N]. In bundled mode, all arrays MUST be of the same length.",
+                    "type": "string",
+                    "enum": [ "sequential", "bundled" ]
+                },
+                "fields": {
+                    "$ref": "#/$display/fields"
+                }
+            },
+            "required": [
+                "fields"
+            ],
+            "additionalProperties": false
+        },
+        "reference": {
+            "title": "Reference",
+            "description": "A reference to a shared definition that should be used as the field formatting definition. The value is the key in the display definitions section, as a path expression $.display.definitions.DEFINITION_NAME. It is used to share definitions between multiple messages / functions.",
+            "properties": {
+                "path": {
+                    "$ref": "#/$format/path"
+                },
+                "value": {
+                    "$ref": "#/$format/value"
+                },
+                "label": {
+                    "description": "This value overrides the label in the referenced definition if set.",
+                    "type": "string"
+                },
+                "$ref": {
+                    "description": "An internal definition that should be used as the field formatting definition. The value is the key in the display definitions section, as a path expression $.display.definitions.DEFINITION_NAME.",
+                    "type": "string"
+                },
+                "params": {
+                    "description": "Parameters override. These values takes precedence over the ones in the definition itself",
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
+                "separator": {
+                    "description": "Separator override for the referenced definition.",
+                    "type": "string"
+                },
+                "visible": {
+                    "description": "Visibility override for the referenced definition.",
+                    "$ref": "#/$format/rules"
+                },
+                "encryption": {
+                    "description": "Encryption override for the referenced definition.",
+                    "$ref": "#/$format/encryptionParameters"
+                }
+            },
+            "required": [ "$ref" ],
+            "allOf": [
+                {
+                    "not": { "required": [ "path", "value" ] }
+                }
+            ],
+            "additionalProperties": false
+        }
+    },
+
+    "$format": {
+        "path": {
+            "title": "Path",
+            "type": "string",
+            "description": "A path to the field in the structured data. The path is a JSON path expression that can be used to extract the field value from the structured data."
+        },
+        "value": {
+            "title": "Value",
+            "type": ["string", "integer", "number", "boolean"],
+            "description": "A literal value on which the format should be applied instead of looking up a field in the structured data."
+        },
+
+        "field": {
+            "title": "Field formatter",
+            "description": "A field formatter contains formatting information of a single field in a message.",
+            "type": "object",
+
+            "properties": {
+                "$id": {
+                    "$ref": "#/$definitions/id"
+                },
+                "path": {
+                    "$ref": "#/$format/path"
+                },
+                "value": {
+                    "$ref": "#/$format/value"
+                },
+                "visible": {
+                    "$ref": "#/$format/rules"
+                },
+                "label": {
+                    "title": "Field Label",
+                    "description": "The label of the field, that will be displayed to the user in front of the formatted field value.",
+                    "type": "string"
+                },
+                "format": {
+                    "title": "Field Format",
+                    "description": "The format of the field, that will be used to format the field value in a human readable way.",
+                    "type": "string",
+                    "$ref": "#/$format/names"
+                },
+                "separator": {
+                    "title": "Field Separator",
+                    "description": "An optional separator string that will be used to separate multiple values when the field is an array. A separator use the interpolated string format with one specific parameter {index} replaced by the index of the element in the array.",
+                    "type": "string"
+                },
+                "encryption": {
+                    "$ref": "#/$format/encryptionParameters",
+                    "description": "If present, the field value is encrypted. The format specifies how to display the decrypted value."
+                  }
+            },
+            "allOf" : [
+                {
+                    "not": { "required": [ "path", "value" ] }
+                },
+                {
+                    "if": { "properties": { "format": { "const": "addressName" } } },
+                    "then": {
+                        "properties": {
+                            "params": { "$ref": "#/$format/addressNameParameters" }
+                        }
+                    }
+                },
+                {
+                    "if": { "properties": { "format": { "const": "interoperableAddressName" } } },
+                    "then": {
+                        "properties": {
+                            "params": { "$ref": "#/$format/interoperableAddressNameParameters" }
+                        }
+                    }
+                },
+                {
+                    "if": { "properties": { "format": { "const": "calldata" } } },
+                    "then": {
+                        "properties": {
+                            "params": { "$ref": "#/$format/calldataParameters" }
+                        }
+                    }
+                },
+                {
+                    "if": { "properties": { "format": { "const": "tokenAmount" } } },
+                    "then": {
+                        "properties": {
+                            "params": { "$ref": "#/$format/tokenAmountParameters" }
+                        }
+                    }
+                },
+                {
+                    "if": { "properties": { "format": { "const": "tokenTicker" } } },
+                    "then": {
+                        "properties": {
+                            "params": { "$ref": "#/$format/tokenTickerParameters" }
+                        }
+                    }
+                },
+                {
+                    "if": { "properties": { "format": { "const": "nftName" } } },
+                    "then": {
+                        "properties": {
+                            "params": { "$ref": "#/$format/nftNameParameters" }
+                        }
+                    }
+                },
+                {
+                    "if": { "properties": { "format": { "const": "date" } } },
+                    "then": {
+                        "properties": {
+                            "params": { "$ref": "#/$format/dateParameters" }
+                        }
+                    }
+                },
+                {
+                    "if": { "properties": { "format": { "const": "unit" } } },
+                    "then": {
+                        "properties": {
+                            "params": { "$ref": "#/$format/unitParameters" }
+                        }
+                    }
+                },
+                {
+                    "if": { "properties": { "format": { "const": "enum" } } },
+                    "then": {
+                        "properties": {
+                            "params": { "$ref": "#/$format/enumParameters" }
+                        }
+                    }
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "rules": {
+            "title": "Display Rule",
+            "description": "Specifies when a field should be displayed based on its value or context. Defaults to 'always' if not specified.",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "enum": ["always", "never", "optional"],
+                    "description": "Simple display rule: 'always' means always display, 'never' means always skip display, 'optional' means display only if wallet can."
+                },
+                {
+                "type": "object",
+                "properties": {
+                    "ifNotIn": {
+                        "type": "array",
+                        "description": "Display the field only if its value is NOT in this list.",
+                        "items": {
+                            "type": ["string", "number", "boolean", "null"]
+                        },
+                        "minItems": 1
+                    },
+                    "mustMatch": {
+                        "type": "array",
+                        "description": "Always skip display, but value MUST match one of these values.",
+                        "items": {
+                            "type": ["string", "number", "boolean", "null"]
+                        },
+                        "minItems": 1
+                    }
+                },
+                "additionalProperties": false,
+                "allOf": [
+                    {
+                    "not": {
+                        "required": ["ifNotIn", "mustMatch"]
+                    }
+                    }
+                ],
+                "description": "Conditional display rules. Either 'ifNotIn' or 'mustMatch' must be defined, but not both."
+                }
+            ]    
+        },
+        "mapReference": {
+            "title": "Map Reference",
+            "type": "object",
+            "properties": {
+                "map": { 
+                    "type": "string",
+                    "description": "The path to the referenced map."
+                },
+                "keyPath": {
+                    "type": "string",
+                    "description": "The path to the key used to resolve a value using the referenced map."
+                }
+            }
+        },
+        "names": {
+            "anyOf": [
+                {
+                    "title": "Raw format",
+                    "const": "raw",
+                    "description": "The field should be displayed as the natural representation of the underlying structured data type."
+                },
+                {
+                    "title": "address format",
+                    "const": "addressName",
+                    "description": "The field should be displayed as a trusted name, or as a raw address if no names are found in trusted sources. List of trusted sources can be optionally specified in parameters."
+                },
+                {
+                    "title": "address format",
+                    "const": "tokenTicker",
+                    "description": "The field should be displayed as an ERC 20 token ticker, or as a raw address if no token definition are found."
+                },
+                {
+                    "title": "bytes format",
+                    "const": "calldata",
+                    "description": "The field is itself a calldata embedded in main call. Another ERC 7730 should be used to parse this field. If not available or not supported, the wallet MAY display a hash of the embedded calldata instead."
+
+                },
+                {
+                    "title": "integer format",
+                    "const": "amount",
+                    "description": "The field should be displayed as an amount in underlying currency, converted using the best magnitude / ticker available."
+                },
+                {
+                    "title": "integer format",
+                    "const": "tokenAmount",
+                    "description": "The field should be displayed as an amount, preceded by the ticker. The magnitude and ticker should be derived from the token or tokenPath parameter corresponding metadata."
+                },
+                {
+                    "title": "integer format",
+                    "const": "nftName",
+                    "description": "The field should be displayed as a single NFT names, or as a raw token Id if a specific name is not found. Collection is specified by the collection or collectionPath parameter."
+                },
+                {
+                    "title": "integer format",
+                    "const": "date",
+                    "description": "The field should be displayed as a date. Suggested RFC3339 representation. Parameter specifies the encoding of the date."
+                },
+                {
+                    "title": "integer format",
+                    "const": "duration",
+                    "description": "The field should be displayed as a duration in HH:MM:ss form. Value is interpreted as a number of seconds."
+                },
+                {
+                    "title": "integer format",
+                    "const": "unit",
+                    "description": "The field should be displayed as a percentage. Magnitude of the percentage encoding is specified as a parameter. Example: a value of 3000 with magnitude 4 is displayed as 0.3%."
+                },
+                {
+                    "title": "integer format",
+                    "const": "enum",
+                    "description": "The field should be displayed as a human readable string by converting the value using the enum referenced in parameters."
+                },
+                {
+                    "title": "integer format",
+                    "const": "chainId",
+                    "description": "The field should be displayed as a Blockchain explicit name, as defined in EIP-155, based on the chain id value."
+                },
+                {
+                    "title": "integer format",
+                    "const": "interoperableAddressName",
+                    "description": "The field should be displayed as a trusted name or as an EIP-7930 Interoperable Address human readable format. List of trusted sources can be optionally specified in parameters."
+                }
+            ]
+        },
+        "addressNameParameters" : {
+            "title": "Address Names Formatting Parameters",
+            "type": "object",
+            "properties": {
+                "types": {
+                    "title": "Address Type",
+                    "type": "array",
+                    "description": "The types of address to display. Restrict allowable sources of names and MAY lead to additional checks from wallets.",
+                    "items": {
+                        "type": "string",
+                        "enum": [ "wallet", "eoa", "contract", "token", "collection" ]
+                    }
+                },
+                "sources": {
+                    "title": "Trusted Sources",
+                    "description": "Trusted Sources for names, in order of preferences. Sources values are wallet manufacturer specific, example values are \"local\" or \"ens\". See specification for more details on sources values.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "senderAddress": {
+                    "title": "Sender Address",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "description": "An address equal to this value is interpreted as the sender referenced by `@.from`."
+                        },
+                        {
+                            "type": "array",
+                            "description": "An array of addresses, any of which are interpreted as the sender referenced by `@.from`.",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "calldataParameters" : {
+            "title": "Embedded Calldata Formatting Parameters",
+            "type": "object",
+            "properties": {
+                "callee": {
+                    "title": "Callee Address",
+                    "type": ["string", "object"],
+                    "anyOf": [
+                        { "type": "string" },
+                        { "$ref": "#/$format/mapReference" }
+                    ],
+                    "description": "The address of the contract being called by this embedded calldata."
+                },
+                "calleePath": {
+                    "title": "Callee Path",
+                    "type": "string",
+                    "description": "The path to the address of the contract being called by this embedded calldata."
+                },
+                "selector": {
+                    "title": "Called Selector (Optional)",
+                    "type": ["string", "object"],
+                    "anyOf": [
+                        { "type": "string" },
+                        { "$ref": "#/$format/mapReference" }
+                    ],
+                    "description": "The selector being called, if not contained in the calldata. Hex string representation."
+                },
+                "selectorPath": {
+                    "title": "Called Selector Path (Optional)",
+                    "type": "string",
+                    "description": "The path to the selector being called, if not contained in the calldata."
+                },
+                "amount": {
+                    "title": "Amount (Optional)",
+                    "type": ["integer", "object"],
+                    "anyOf": [
+                        { "type": "integer" },
+                        { "$ref": "#/$format/mapReference" }
+                    ],
+                    "description": "The associated amount in native currency, if the calldata can be associated with a container value."
+                },
+                "amountPath": {
+                    "title": "Amoun Path (Optional)",
+                    "type": "string",
+                    "description": "The path to the associated amount in native currency, if the calldata can be associated with a container value."
+                },
+                "spender": {
+                    "title": "Spender Path (Optional)",
+                    "type": ["string", "object"],
+                    "anyOf": [
+                        { "type": "string" },
+                        { "$ref": "#/$format/mapReference" }
+                    ],
+                    "description": "The associated spender, if the calldata can be associated with a container value."
+                },
+                "spenderPath": {
+                    "title": "Spender Path (Optional)",
+                    "type": "string",
+                    "description": "The path to the associated spender, if the calldata can be associated with a container value."
+                }
+            },
+            "anyOf": [
+                {"required": ["callee"]},
+                {"required": ["calleePath"]}
+            ],
+            "allOf": [
+                {"not": { "required": ["callee", "calleePath"] }},
+                {"not": { "required": ["selector", "selectorPath"] }},
+                {"not": { "required": ["amount", "amountPath"] }},
+                {"not": { "required": ["spender", "spenderPath"] }}
+            ],
+            "additionalProperties": false
+        },
+        "tokenAmountParameters": {
+            "title": "Token Amount Formatting Parameters",
+            "type": "object",
+            "properties": {
+                "token": {
+                    "title": "Token",
+                    "type": ["string", "object"],
+                    "anyOf": [
+                        { "type": "string" },
+                        { "$ref": "#/$format/mapReference" }
+                    ],
+                    "description": "The token address, or a path to a constant in the ERC 7730 file."
+                },
+                "tokenPath": {
+                    "title": "Token Path",
+                    "type": "string",
+                    "description": "The path to the token address in the structured data."
+                },
+                "nativeCurrencyAddress": {
+                    "title": "Native Currency Address",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "description": "An address equal to this value is interpreted as an amount in native currency rather than a token."
+                        },
+                        {
+                            "type": "array",
+                            "description": "An array of addresses, any of which are interpreted as an amount in native currency rather than a token.",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                "threshold": {
+                    "title": "Unlimited Threshold",
+                    "type": "string",
+                    "description": "The threshold above which the amount should be displayed using the message parameter rather than the real amount."
+                },
+                "message": {
+                    "title": "Unlimited Message",
+                    "type": "string",
+                    "description": "The message to display when the amount is above the threshold."
+                },
+                "chainId": {
+                    "title": "Chain ID",
+                    "type": ["integer", "object"],
+                    "anyOf": [
+                        { "type": "integer" },
+                        { "$ref": "#/$format/mapReference" }
+                    ],
+                    "description": "Optional. The chain on which the token is deployed (constant, or a map reference). When present, the wallet SHOULD resolve token metadata (ticker, decimals) for this chain. Useful for cross-chain swap clear signing where the same token address may refer to different chains."
+                },
+                "chainIdPath": {
+                    "title": "Chain ID Path",
+                    "type": "string",
+                    "description": "Optional. Path to the chain ID in the structured data. When present, the wallet SHOULD resolve token metadata for the chain at this path. Useful for cross-chain swap clear signing."
+                }
+            },
+            "allOf": [
+                { "not": { "required": ["token", "tokenPath"] } },
+                { "not": { "required": ["chainId", "chainIdPath"] } }
+            ],
+            "additionalProperties": false
+        },
+        "tokenTickerParameters": {
+            "title": "Token Ticker Formatting Parameters",
+            "type": "object",
+            "properties": {
+                "chainId": {
+                    "title": "Chain ID",
+                    "type": ["integer", "object"],
+                    "anyOf": [
+                        { "type": "integer" },
+                        { "$ref": "#/$format/mapReference" }
+                    ],
+                    "description": "Optional. The chain on which the token is deployed (constant, or a map reference). When present, the wallet SHOULD resolve the token ticker for this chain. Useful for cross-chain swap clear signing."
+                },
+                "chainIdPath": {
+                    "title": "Chain ID Path",
+                    "type": "string",
+                    "description": "Optional. Path to the chain ID in the structured data. When present, the wallet SHOULD resolve the token ticker for the chain at this path. Useful for cross-chain swap clear signing."
+                }
+            },
+            "allOf": [
+                { "not": { "required": ["chainId", "chainIdPath"] } }
+            ],
+            "additionalProperties": false
+        },
+        "nftNameParameters" : {
+            "title": "NFT Names Formatting Parameters",
+            "type": "object",
+            "properties": {
+                "collection": {
+                    "title": "Collection Address",
+                    "type": ["string", "object"],
+                    "anyOf": [
+                        { "type": "string" },
+                        { "$ref": "#/$format/mapReference" }
+                    ],
+                    "description": "The collection address, or a path to a constant in the ERC 7730 file."
+                },
+                "collectionPath": {
+                    "title": "Collection Path",
+                    "type": "string",
+                    "description": "The path to the collection in the structured data."
+                }
+            },
+            "anyOf": [
+                {"required": ["collection"]},
+                {"required": ["collectionPath"]}
+            ],
+            "not": {
+                "required": ["collection", "collectionPath"]
+            },
+            "additionalProperties": false
+        },
+        "dateParameters": {
+            "title": "Date Formatting Parameters",
+            "type": "object",
+            "properties": {
+                "encoding": {
+                    "title": "Date Encoding",
+                    "type": "string",
+                    "description": "The encoding of the date.",
+                    "enum": [
+                        "blockheight",
+                        "timestamp"
+                    ]
+                }
+            },
+            "required": [
+                "encoding"
+            ],
+            "additionalProperties": false
+        },
+
+        "unitParameters": {
+            "title": "Unit Formatting Parameters",
+            "type": "object",
+            "properties": {
+                "base": {
+                    "title": "Unit base symbol",
+                    "type": "string",
+                    "description": "The base symbol of the unit, displayed after the converted value. It can be an SI unit symbol or acceptable dimensionless symbols like % or bps."
+                },
+                "decimals": {
+                    "title": "Decimals",
+                    "type": "integer",
+                    "description": "The number of decimals of the value, used to convert to a float."
+                },
+                "prefix": {
+                    "title": "Prefix",
+                    "type": "boolean",
+                    "description": "Whether the value should be converted to a prefixed unit, like k, M, G, etc."
+                }
+            },
+            "required": [
+                "base"
+            ],
+            "additionalProperties": false
+        },
+
+        "enumParameters": {
+            "title": "Enum Formatting Parameters",
+            "type": "object",
+            "properties": {
+                "$ref": {
+                    "title": "Enum reference",
+                    "type": "string",
+                    "description": "The internal path to the enum definition used to convert this value."
+                }
+            },
+            "required": [
+                "$ref"
+            ],
+            "additionalProperties": false
+        },
+        "interoperableAddressNameParameters" : {
+            "title": "Interoperable Address Names Formatting Parameters",
+            "type": "object",
+            "properties": {
+                "types": {
+                    "title": "Address Type",
+                    "type": "array",
+                    "description": "The types of address to display. Restrict allowable sources of names and MAY lead to additional checks from wallets.",
+                    "items": {
+                        "type": "string",
+                        "enum": [ "wallet", "eoa", "contract", "token", "collection" ]
+                    }
+                },
+                "sources": {
+                    "title": "Trusted Sources",
+                    "description": "Trusted Sources for names, in order of preferences. Sources values are wallet manufacturer specific, example values are \"local\" or \"ens\". See specification for more details on sources values.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "senderAddress": {
+                    "title": "Sender Address",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "description": "An address equal to this value is interpreted as the sender referenced by `@.from`."
+                        },
+                        {
+                            "type": "array",
+                            "description": "An array of addresses, any of which are interpreted as the sender referenced by `@.from`.",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "encryptionParameters": {
+            "title": "Encrypted Value Parameters",
+            "type": "object",
+            "properties": {
+              "scheme": {
+                "type": "string",
+                "description": "The encryption scheme used to produce the handle."
+              },
+              "plaintextType": {
+                "type": "string",
+                "description": "Solidity type of the decrypted value (the handle does not encode this)."
+              },
+              "fallbackLabel": {
+                "type": "string",
+                "description": "Optional label to display when decryption is not possible. Defaults to \"[Encrypted]\"."
+              }
+            },
+            "required": ["scheme"],
+            "additionalProperties": false
+        }
+
+    },
+
+    "$definitions": {
+        "id": {
+            "title": "ID",
+            "type": "string",
+            "description": "An internal identifier that can be used either for clarity specifying what the element is or as a reference in device specific sections."
+        }
+    }
+}


### PR DESCRIPTION
The purpose of this PR is to introduce explicit versioning process for the descriptor schemas.

There has been two versions of a descriptor released so far, and there is a number of potential changes suggested to the upcoming version.

If not specified clearly and explicitly, version conflicts may create confusion among the implementers.

The proposed approach finalizes the 'v1' and 'v2' releases, introduces semantic versioning for descriptors, and announces the start of work on `3.0.0-rc.1`.

It does not look feasible to maintain the full text of the ERC versioned, so the text should reference the current working "release candidate" schema. We should use git tags to mark the state of the ERC document describing schemas for previous versions if we need those.
