### PR TITLE
Update ERC-8196: Move to Last Call

### DIFF
--- a/ERCS/erc-8196.md
+++ b/ERCS/erc-8196.md
@@ -179,7 +179,7 @@ Each audit entry MUST include `previousHash` for integrity. Implementations MAY 
 - Hash-chain audit provides tamper detection without full on-chain cost  
 - Verification gating allows flexibility while encouraging trust standards like ERC-8126
 
-This specification explores novel combinations of policy-bound signing, hash-chained auditing, and entropy commitments to enable verifiable agent autonomy under potentially hostile hosts, with open questions regarding gas-efficient audit roots, threshold-based containment mechanisms, and the enforcement of CROPS properties in high-value agent scenarios.
+This specification explores novel combinations of policy-bound signing, hash-chained auditing, and entropy commitments to enable verifiable agent autonomy under potentially hostile hosts, with open questions regarding gas-efficient audit roots, threshold-based containment mechanisms, and the enforcement of Censorship Resistant, Open Source, Private, and Secure (CROPS) properties in high-value agent scenarios.
 
 ## Backwards Compatibility
 

--- a/ERCS/erc-8196.md
+++ b/ERCS/erc-8196.md
@@ -4,15 +4,15 @@ title: AI Agent Authenticated Wallet
 description: Policy-bound transaction execution and verifiable credential delegation for autonomous AI agents
 author: Leigh Cronian (@cybercentry) <leigh.cronian@cybercentry.co.uk>, Chris Johnson <chris@virtuals.io>
 discussions-to: https://ethereum-magicians.org/t/erc-8196-ai-agent-authenticated-wallet/27987
-status: Review
+status: Last Call
+last-call-deadline: 2026-07-09
 type: Standards Track
 category: ERC
 created: 2026-03-14
-requires: 155, 191, 712, 4337, 8004, 8126
+requires: 155, 191, 712, 4337, 8126
 ---
 
 ## Abstract
-
 This ERC defines a standard interface for AI agent-authenticated wallets. These wallets execute transactions only when accompanied by verifiable cryptographic proof that the action complies with a specific policy defined by the asset owner.
 
 It serves as **Layer 3 (Execute)** in a modular trust stack designed for secure autonomous AI agents:
@@ -60,10 +60,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This ERC defines an on-chain smart contract interface (`IAIAgentAuthenticatedWallet`). Implementations are expected to be smart contracts (such as [ERC-4337](./eip-4337.md) account abstraction wallets or dedicated policy enforcement modules) that implement this interface.
 
-- Registration Check (ERC-8004): Implementations MUST verify that the agent is properly registered via ERC-8004 before registering or using any policy.
-- Verification Check (ERC-8126): Implementations MUST perform a verification check using ERC-8126 before executing any agent action. The policy’s `minVerificationScore` field MUST be enforced. Actions MUST be rejected if the agent’s current ERC-8126 score exceeds the `minVerificationScore` value set in the policy.
+- Verification Check (ERC-8126): Implementations MUST perform a verification check using ERC-8126 before executing any agent action. The policy’s `minVerificationScore` field MUST be enforced. Actions MUST be rejected if the agent’s current ERC-8126 score exceeds the `minVerificationScore` value set in the policy. The agent's ERC-8126 score MUST be looked up by the policy's `agentId` via `getLatestRiskScore`.
 
-Off-chain components (such as agent hosting services, wallet UIs, and relayers) SHOULD also perform the same registration and verification checks before submitting transactions or UserOperations.
+Off-chain components (such as agent hosting services, wallet UIs, and relayers) SHOULD also perform the same verification checks before submitting transactions or UserOperations.
 
 ### Agent Policy Structure
 
@@ -73,6 +72,7 @@ Policies MUST include the following fields:
 |------------------------|---------------|----------|-------------|
 | `policyId`             | `bytes32`     | Yes      | Unique policy identifier |
 | `agentAddress`         | `address`     | Yes      | Authorized AI agent address |
+| `agentId`              | `uint256`     | Yes      | ERC-8004 agent id; key for the ERC-8126 `getLatestRiskScore` lookup |
 | `ownerAddress`         | `address`     | Yes      | Asset owner / delegator |
 | `allowedActions`       | `string[]`    | Yes      | List of permitted actions (e.g. `["transfer", "swap"]`) |
 | `allowedContracts`     | `address[]`   | Yes      | Whitelist of target contracts |
@@ -128,6 +128,7 @@ Policies MUST include the following fields:
 
         function registerPolicy(
             address agent,
+            uint256 agentId,
             string[] calldata allowedActions,
             address[] calldata allowedContracts,
             address[] calldata blockedContracts,
@@ -161,7 +162,7 @@ Policies MUST include the following fields:
 
 ### Audit Trail (Hash-Chained)
 
-Each audit entry MUST include `previousHash` for integrity. Implementations MAY store entries off-chain (e.g. IPFS) with periodic on-chain Merkle roots posted to [ERC-8004](./eip-8004.md)'s Validation Registry.
+Each audit entry MUST include `previousHash` for integrity. Implementations MAY store entries off-chain (e.g. IPFS) with periodic Merkle roots anchored on-chain (for example, to ERC-8004's Validation Registry).
 
 ### Error Codes
 
@@ -169,7 +170,6 @@ Each audit entry MUST include `previousHash` for integrity. Implementations MAY 
     error ValueExceedsLimit(uint256 value, uint256 maxValue);
     error InvalidSignature(address recovered, address expected);
     error EntropyVerificationFailed(bytes32 commitment, bytes32 revealed);
-    error AgentNotRegistered(address agent);
     error PolicyViolation(bytes32 policyHash, string reason);
 
 ## Rationale
@@ -187,7 +187,6 @@ Compatible with ERC-4337 wallets and existing standards. No breaking changes.
 
 ## Security Considerations
 
-- Implementations should verify ERC-8004 registration before allowing any policy delegation.
 - Expiration checks and nonce uniqueness should be enforced to prevent replay attacks.
 - The hash-chained audit trail makes tampering detectable through broken hash links.
 - Host manipulation remains a probabilistic risk. For high-value agents, using multiple independent hosts is recommended to reduce this threat.

--- a/ERCS/erc-8196.md
+++ b/ERCS/erc-8196.md
@@ -5,7 +5,7 @@ description: Policy-bound transaction execution and verifiable credential delega
 author: Leigh Cronian (@cybercentry) <leigh.cronian@cybercentry.co.uk>, Chris Johnson <chris@virtuals.io>
 discussions-to: https://ethereum-magicians.org/t/erc-8196-ai-agent-authenticated-wallet/27987
 status: Last Call
-last-call-deadline: 2026-07-09
+last-call-deadline: 2026-07-14
 type: Standards Track
 category: ERC
 created: 2026-03-14


### PR DESCRIPTION
Update ERC-8196: Move to Last Call

Status: Review → Last Call.

last-call-deadline: 2026-07-14 (14 days).

Decouples ERC-8004 as a direct dependency (enforced transitively via ERC-8126); registerPolicy now takes agentId.