### PR TITLE
Update ERC-8226: add reference implementation and refine spec

### DIFF
--- a/ERCS/erc-8226.md
+++ b/ERCS/erc-8226.md
@@ -27,7 +27,7 @@ An agent purchasing a tokenized fund unit on behalf of an investor must satisfy 
 1. The mandate granted to the agent must be legally traceable, time-bounded, and financially capped, analogous to a power of attorney in traditional finance.
 1. The asset contract must validate the mandate atomically at execution time, without relying on off-chain coordination.
 
-Regulated token standards such as [ERC-7943](./eip-7943.md) and [ERC-3643](./eip-3643.md) govern who may hold or transact a token, but neither defines an agent delegation model. Agent identity standards such as [ERC-8004](./eip-8004.md) provide agent discovery and trust signals but no mandate framework, and general-purpose agent authorization standards such as ERC-8118 do not address regulated assets. RAMS defines the delegation interface, the compliance provider model, and the integration pattern with regulated token contracts.
+Regulated token standards such as [ERC-7943](./eip-7943.md) and [ERC-3643](./eip-3643.md) govern who may hold or transact a token, but neither defines an agent delegation model. Agent identity standards such as [ERC-8004](./eip-8004.md) provide agent discovery and trust signals but no mandate framework, and general-purpose agent authorization standards do not address regulated assets. RAMS defines the delegation interface, the compliance provider model, and the integration pattern with regulated token contracts.
 
 The compliance responsibilities across the three layers are as follows:
 
@@ -503,7 +503,7 @@ RAMS introduces no changes to any existing standard.
 
 ## Reference Implementation
 
-A reference implementation and test suite are available in [`../assets/erc-8226/`](../assets/erc-8226/): the `IAgentMandate` registry, an `IComplianceProvider`, an `IAgentExecutor`, and an [ERC-7943](./eip-7943.md) asset integration.
+A reference implementation and test suite are available in the [assets directory](../assets/erc-8226/): the `IAgentMandate` registry, an `IComplianceProvider`, an `IAgentExecutor`, and an [ERC-7943](./eip-7943.md) asset integration.
 
 `IAgentExecutor` is an OPTIONAL, non-normative companion interface for the account-side enforcement venues (an [EIP-7702](./eip-7702.md) delegate or a standalone executor). The forwarding logic is never part of `IAgentMandate`.
 

--- a/ERCS/erc-8226.md
+++ b/ERCS/erc-8226.md
@@ -503,7 +503,7 @@ RAMS introduces no changes to any existing standard.
 
 ## Reference Implementation
 
-A reference implementation and test suite are available in the [assets directory](../assets/erc-8226/): the `IAgentMandate` registry, an `IComplianceProvider`, an `IAgentExecutor`, and an [ERC-7943](./eip-7943.md) asset integration.
+A reference implementation and test suite are [available](../assets/eip-8226/README.md): the `IAgentMandate` registry, an `IComplianceProvider`, an `IAgentExecutor`, and an [ERC-7943](./eip-7943.md) asset integration.
 
 `IAgentExecutor` is an OPTIONAL, non-normative companion interface for the account-side enforcement venues (an [EIP-7702](./eip-7702.md) delegate or a standalone executor). The forwarding logic is never part of `IAgentMandate`.
 

--- a/ERCS/erc-8226.md
+++ b/ERCS/erc-8226.md
@@ -8,26 +8,26 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2026-04-12
-requires: 165
+requires: 165, 712, 1271
 ---
 
 ## Abstract
 
-This standard defines a compliance delegation layer for AI agents operating on tokenized regulated assets. It specifies how a verified principal can delegate scoped, time-bounded, and financially capped authority to an on-chain agent, and how regulated token contracts verify mandate validity through a pre-transfer compliance hook before executing transfers.
+This standard defines a compliance delegation layer for AI agents operating on tokenized regulated assets. It specifies how a verified principal can delegate scoped, time-bounded, and financially capped authority to an on-chain agent, and how a regulated token verifies the mandate before an agent-initiated action.
 
-Regulated Agent Mandate Standard, or RAMS, is agnostic to the agent identity system, the token standard, and the token compliance framework. It is designed to work with any trustless agent identity system that maps wallet addresses to agent identifiers (such as [ERC-8004](./eip-8004.md)), any token standard ([ERC-20](./eip-20.md), [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md)), and any regulated token standard that implements a pre-transfer compliance check (such as [ERC-7943](./eip-7943.md) or [ERC-3643](./eip-3643.md)).
+Regulated Agent Mandate Standard, or RAMS, is agnostic to the agent identity system, the token standard, and the token compliance framework. It works with any agent identity system (such as [ERC-8004](./eip-8004.md)), any token standard ([ERC-20](./eip-20.md), [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md)), and any regulated token standard (such as [ERC-7943](./eip-7943.md) or [ERC-3643](./eip-3643.md)).
 
 ## Motivation
 
-The market for tokenized real-world assets is entering a phase of institutional adoption. Platforms operating under regulatory frameworks are beginning to support programmable, agent-driven portfolio management on regulated instruments. AI agents that can autonomously execute securities transactions are no longer theoretical — they are being built now, without a standard that makes their operation legally defensible.
+The market for tokenized real-world assets is entering a phase of institutional adoption. Platforms operating under regulatory frameworks are starting to support programmable, agent-driven portfolio management on regulated instruments. AI agents that can autonomously execute securities transactions are no longer theoretical; they are being built now, without a standard that makes their operation legally defensible.
 
 An agent purchasing a tokenized fund unit on behalf of an investor must satisfy three conditions that no existing standard addresses jointly:
 
 1. The principal on whose behalf the agent acts must be a verified, Know Your Customer (KYC)-cleared legal identity, not merely an Ethereum address.
 1. The mandate granted to the agent must be legally traceable, time-bounded, and financially capped, analogous to a power of attorney in traditional finance.
-1. The asset contract must verify mandate validity atomically at the point of transfer, without relying on off-chain coordination.
+1. The asset contract must validate the mandate atomically at execution time, without relying on off-chain coordination.
 
-Compliance frameworks such as [ERC-7943](./eip-7943.md) and investor eligibility standards such as [ERC-3643](./eip-3643.md) govern who may hold or transact a regulated token, but neither defines an agent delegation model. Trustless agent identity standards such as [ERC-8004](./eip-8004.md) provide agent discovery and trust signals but no mandate framework. RAMS defines the delegation interface, the compliance provider model, and the integration pattern with regulated token contracts.
+Regulated token standards such as [ERC-7943](./eip-7943.md) and [ERC-3643](./eip-3643.md) govern who may hold or transact a token, but neither defines an agent delegation model. Agent identity standards such as [ERC-8004](./eip-8004.md) provide agent discovery and trust signals but no mandate framework, and general-purpose agent authorization standards such as ERC-8118 do not address regulated assets. RAMS defines the delegation interface, the compliance provider model, and the integration pattern with regulated token contracts.
 
 The compliance responsibilities across the three layers are as follows:
 
@@ -41,25 +41,27 @@ The compliance responsibilities across the three layers are as follows:
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHOULD", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174). All implementations MUST implement [ERC-165](./eip-165.md).
 
-RAMS defines two interfaces that MUST be deployed as separate contracts:
+RAMS defines two interfaces. Implementations SHOULD deploy them as separate contracts so that an independent compliance operator and the registry operator can be governed separately; a single operator MAY combine them.
 
 | Interface | Role | Deployed by |
 |---|---|---|
 | `IComplianceProvider` | Verifies principal eligibility (identity + compliance) | Compliance operator or platform |
-| `IAgentMandate` | Mandate lifecycle, execution recording, freeze, principal resolution, and views | RAMS registry operator |
+| `IAgentMandate` | Mandate lifecycle, execution recording, freeze, and views | RAMS registry operator |
 
 RAMS-aware regulated token contracts consult the RAMS registry inside their existing pre-transfer compliance hook.
 
 ### `IComplianceProvider`
 
-`IComplianceProvider` is implemented by a third-party compliance operator or platform — for example, a KYC provider or an on-chain identity registry adapter — and deployed independently of the RAMS registry. Its address is supplied by the principal at mandate grant time via the `complianceProvider` field of `IAgentMandate.grantMandate`. A single `IComplianceProvider` instance MAY serve multiple mandates across multiple principals.
+`IComplianceProvider` is implemented by a third-party compliance operator or platform (for example, a KYC provider or an on-chain identity registry adapter), deployed independently of the RAMS registry. Its address is supplied by the principal at mandate grant time via the `complianceProvider` field of `IAgentMandate.grantMandate`. A single `IComplianceProvider` instance MAY serve multiple mandates across multiple principals.
 
-The compliance provider manages principal eligibility: granting, revoking, and checking whether a principal is eligible for a given scope. Identity verification is a subset of compliance checking. A compliance provider that declares a principal eligible has implicitly verified that the underlying identity is valid.
+The compliance provider manages principal eligibility: granting, revoking, and checking whether a principal is eligible.
 
-Implementations MUST return structured data sufficient for regulatory audit. A binary oracle is not conformant: reason codes and expiry timestamps are required for any credible compliance trail. The compliance provider MUST verify that `identityRef` resolves to a valid, unrevoked attestation at `checkPrincipal` invocation time and MUST return `eligible == false` if it does not.
+When used, `checkPrincipal` MUST return structured data sufficient for regulatory audit: a binary oracle is non-conformant, since reason codes and expiry timestamps are required for any credible compliance trail. It MUST verify that `identityRef` resolves to a valid, unrevoked attestation and return `eligible == false` if it does not.
+
+The provider is mandatory: `grantMandate` MUST revert if `complianceProvider` is `address(0)`.
 
 ```solidity
-interface IComplianceProvider {
+interface IComplianceProvider is IERC165 {
     enum ReasonCode {
         COMPLIANT,             // 0
         KYC_EXPIRED,           // 1
@@ -72,41 +74,37 @@ interface IComplianceProvider {
         OTHER                  // 8
     }
 
-    /// @notice Emitted when a principal is granted eligibility for a scope.
+    /// @notice Emitted when a principal is granted eligibility.
     event PrincipalGranted(
         address indexed principal,
-        bytes32 indexed scopeHash,
-        bytes32 identityRef
+        bytes32 indexed identityRef
     );
 
     /// @notice Emitted when a previously eligible principal is revoked.
     event PrincipalRevoked(
         address indexed principal,
-        bytes32 indexed scopeHash,
-        bytes32 identityRef,
+        bytes32 indexed identityRef,
         ReasonCode reason
     );
 
-    /// @notice Grants eligibility to a principal for a given scope.
+    /// @notice Grants eligibility to a principal.
     /// @param principal The on-chain address of the principal.
     /// @param identityRef An off-chain identity reference (e.g., keccak256 of a Decentralized Identifier (DID) or attestation ID).
-    /// @param scopeHash The keccak256 hash of the off-chain scope document.
-    function grantPrincipal(address principal, bytes32 identityRef, bytes32 scopeHash) external;
+    /// @param expiresAt Unix timestamp after which eligibility MUST be re-checked. 0 means no expiry.
+    function grantPrincipal(address principal, bytes32 identityRef, uint48 expiresAt) external;
 
-    /// @notice Revokes a principal's eligibility for a given scope.
+    /// @notice Revokes a principal's eligibility.
     /// @param principal The on-chain address of the principal.
-    /// @param scopeHash The keccak256 hash of the off-chain scope document.
     /// @param reason The reason for revocation.
-    function revokePrincipal(address principal, bytes32 scopeHash, ReasonCode reason) external;
+    function revokePrincipal(address principal, ReasonCode reason) external;
 
-    /// @notice Returns eligibility of a principal for a given scope.
+    /// @notice Returns eligibility of a principal.
     /// @param principal The on-chain address of the principal.
     /// @param identityRef An off-chain identity reference (e.g., keccak256 of a Decentralized Identifier (DID) or attestation ID).
-    /// @param scopeHash The keccak256 hash of the off-chain scope document.
-    /// @return eligible True if the principal is compliant for this scope.
+    /// @return eligible True if the principal is compliant.
     /// @return reason Reason code. MUST be COMPLIANT when eligible is true.
     /// @return expiresAt Unix timestamp after which this result MUST be re-checked. 0 means no expiry.
-    function checkPrincipal(address principal, bytes32 identityRef, bytes32 scopeHash)
+    function checkPrincipal(address principal, bytes32 identityRef)
         external view returns (bool eligible, ReasonCode reason, uint48 expiresAt);
 }
 ```
@@ -115,105 +113,130 @@ An `IComplianceProvider` implementation MAY delegate identity verification to on
 
 ### `IAgentMandate`
 
-`IAgentMandate` is implemented by the RAMS registry, a single contract deployed by a registry operator (e.g., a platform or a regulated entity acting as operator). Principals interact with this contract to grant, extend, and revoke mandates. Regulated token contracts interact with this contract inside their pre-transfer compliance hook to verify mandate validity and record executions.
+`IAgentMandate` is implemented by the RAMS registry, a single contract deployed by a registry operator (e.g., a platform or a regulated entity acting as operator). Principals interact with this contract to grant, extend, and revoke mandates. Any contract in the agent's execution path calls `canExecute` to verify the mandate and `recordExecution` to record use.
 
-Each mandate references an off-chain scope document (specified in [Scope Document](#scope-document)) via `scopeHash`. The scope document is a content-addressed JSON file that describes, in human-readable form, the actions delegated, asset classes, jurisdictions, and operational notes. The on-chain `MandateScopeParams` struct mirrors the enforceable subset of those fields.
+Mandate storage is keyed by `(agent, principal)`. Each `(agent, principal)` pair has at most one active mandate at any given time.
 
-Each `agentId` has at most one active mandate at any given time. This constraint is by design: in regulated markets, each agent-principal relationship requires segregated accounts and independent audit trails. An operator serving multiple principals deploys one agent wallet per principal, each with its own `agentId` and mandate. This mirrors the account segregation requirements common to regulated financial frameworks.
+A mandate authorizes the agent to act on a set of actions on a specific asset. Actions are identified by `bytes32` labels.
 
-Value limits in `MandateScopeParams` are denominated in the base unit of the token at `assetAddress`. If `assetAddress` is `address(0)` (asset-class mandate), limits are denominated in the smallest unit of the currency declared in the off-chain scope document. `uint128` accommodates any practical financial instrument value with 18-decimal precision (up to approximately 3.4 × 10^20 whole tokens). A value of `type(uint128).max` signals "no limit" for both `maxTransactionValue` and `maxCumulativeValue`. Implementations MUST revert if an incoming amount exceeds `type(uint128).max`.
+A value of `type(uint256).max` in `maxTransactionValue` or `maxCumulativeValue` signals "no limit."
 
-The `EnforcerTier` enum distinguishes platform-initiated from regulator-initiated enforcement. This distinction is legally material: in a regulatory dispute, the audit trail must identify both the enforcer address and the authority tier. Implementations MUST use an access control mechanism that enforces this distinction. Access control for `freezeAgent` and `unfreezeAgent` MUST be enforced by the implementation. Global freeze (`bytes32(0)`) MUST be restricted to `REGULATORY` tier enforcers. Jurisdiction-scoped freeze MAY be executed by either tier. The admin role governing enforcer permissions MUST NOT be the same address as any enforcer.
+Caps are denominated in the asset's transfer quantity: the token amount for [ERC-20](./eip-20.md) and [ERC-1155](./eip-1155.md), and a token count (1 per transfer) for [ERC-721](./eip-721.md). RAMS caps the quantity transferred, not specific token identifiers.
+
+Freezing MUST be restricted to authorized enforcer roles defined by the implementation's access control, and the enforcer address MUST be recorded in the `AgentFrozen` event. The admin role governing enforcer permissions MUST NOT be the same address as any enforcer.
 
 An approved operator MAY call `revokeMandate` and `extendMandate` on behalf of the principal.
 
-`recordExecution` MUST only be callable by the token at `onChainScope.assetAddress` (asset-specific mandates), or by a contract registered in the RAMS token registry, or by an address with enforcer privileges (asset-class mandates). Arbitrary callers MUST be rejected. `recordExecution` MUST revert if the amount exceeds `maxTransactionValue` (when not set to `type(uint128).max`), or if `cumulativeUsed + amount` exceeds `maxCumulativeValue` (when not set to `type(uint128).max`). `cumulativeUsed` MUST NOT reset on `extendMandate`. A cap reset requires explicit revocation and re-issuance.
+`recordExecution` MUST only be callable by an authorized recorder: the mandate's `asset`, the principal's account, or an address granted the recorder role by the implementation's access control. Arbitrary callers MUST be rejected. `recordExecution` MUST apply the same existence, validity-window, revocation, action, and freeze checks as `canExecute` and revert if any fail. `recordExecution` increments `cumulativeUsed` by `amount` and MUST revert if the amount exceeds `maxTransactionValue` or if `cumulativeUsed + amount` exceeds `maxCumulativeValue` (when either is not set to `type(uint256).max`). `cumulativeUsed` MUST NOT reset on `extendMandate`. A cap reset requires explicit revocation and re-issuance.
 
-`grantMandate` MUST revert if `signature` is empty and `msg.sender != principal`. If `signature` is non-empty, implementations MUST verify the signature against `principal`. `grantMandate` MUST revert if `identityRef` is non-zero and the designated `complianceProvider.checkPrincipal` returns `eligible == false`. `grantMandate` MUST revert if `agentId` already has an active mandate. `extendMandate` MUST revert if `newValidUntil` is less than or equal to the current `validUntil`. Implementations MUST NOT treat `identityRef != bytes32(0)` as proof of eligibility independent of `complianceProvider.checkPrincipal`.
+#### Signed lifecycle operations
 
-`isActive` and `isActiveForAmount` MUST behave as follows (Solidity pseudocode, illustrative):
+`grantMandate`, `revokeMandate`, `extendMandate`, and `setOperator` MAY be called directly by the principal (`msg.sender == principal`) or by any submitter providing a principal signature over an [EIP-712](./eip-712.md) typed message. Implementations MUST verify principal signatures using [EIP-1271](./eip-1271.md)-compatible verification. The reference path is `SignatureChecker.isValidSignatureNow(principal, digest, signature)`, which handles EOAs, contract wallets (multisigs, DAOs), and [EIP-7702](./eip-7702.md)-delegated accounts.
+
+The typed-data domain separator follows [EIP-712](./eip-712.md) with `name = "RAMS"`, `version = "1"`, current `chainId`, and `verifyingContract` set to the RAMS registry address. Implementations MUST track a nonce per principal (`nonces[principal]`) and include it in every signed operation. Implementations MUST revert if `block.timestamp > deadline` or if the recovered signer does not match `principal`.
+
+The normative [EIP-712](./eip-712.md) typehashes are:
 
 ```solidity
-function isActive(uint256 agentId, address principal) public view returns (bool) {
-    Mandate storage m = mandates[agentId][principal];
+bytes32 constant GRANT_MANDATE_TYPEHASH = keccak256(
+    "GrantMandate(address agent,uint48 validFrom,uint48 validUntil,"
+    "address principal,address complianceProvider,bytes32 identityRef,"
+    "address asset,uint256 maxTransactionValue,uint256 maxCumulativeValue,"
+    "bytes32 metadata,bytes32[] actions,uint256 nonce,uint256 deadline)"
+);
+
+bytes32 constant REVOKE_MANDATE_TYPEHASH = keccak256(
+    "RevokeMandate(address agent,address principal,uint256 nonce,uint256 deadline)"
+);
+
+bytes32 constant EXTEND_MANDATE_TYPEHASH = keccak256(
+    "ExtendMandate(address agent,address principal,uint48 newValidUntil,uint256 nonce,uint256 deadline)"
+);
+
+bytes32 constant SET_OPERATOR_TYPEHASH = keccak256(
+    "SetOperator(address principal,address operator,bool approved,uint256 nonce,uint256 deadline)"
+);
+```
+
+`grantMandate` MUST revert if the `(agent, principal)` pair already has an active mandate. `grantMandate` MUST revert if `complianceProvider` is `address(0)`, and MUST revert if `complianceProvider.checkPrincipal` returns `eligible == false`. `extendMandate` MUST revert if `newValidUntil` is less than or equal to the current `validUntil`.
+
+At `grantMandate` the implementation writes the signed `actions[]` array into the `actionEnabled` mapping keyed by `(agent, principal)`. It MUST first clear any actions enabled by a prior mandate for the pair, and the new mandate MUST start with `revoked` set to false and `cumulativeUsed` set to 0. Subsequent on-chain enforcement reads from this mapping in O(1).
+
+#### Authorization check
+
+`canExecute` MUST behave as follows (Solidity pseudocode, illustrative):
+
+```solidity
+function canExecute(
+    address agent,
+    address principal,
+    address asset,
+    bytes32 action,
+    uint256 amount
+) public view returns (bool) {
+    Mandate storage m = mandates[agent][principal];
 
     if (m.principal == address(0))                                              return false; // mandate does not exist
+    if (asset != m.asset)                                                       return false; // wrong asset
     if (block.timestamp < m.validFrom || block.timestamp > m.validUntil)        return false; // outside validity window
     if (m.revoked)                                                              return false;
-    if (isFrozen(agentId, m.onChainScope.jurisdictionHash))                     return false;
-    if (isFrozen(agentId, bytes32(0)))                                          return false; // global freeze
+    if (!actionEnabled[agent][principal][action])                               return false;
+    if (isFrozen(agent))                                                        return false;
 
-    if (m.complianceProvider != address(0)) {
-        (bool eligible, , ) = IComplianceProvider(m.complianceProvider)
-            .checkPrincipal(principal, m.identityRef, m.scopeHash);
-        if (!eligible)                                                          return false;
-    }
+    if (m.maxTransactionValue != type(uint256).max
+        && amount > m.maxTransactionValue)                                      return false;
 
-    if (m.onChainScope.maxCumulativeValue != type(uint128).max
-        && m.cumulativeUsed >= m.onChainScope.maxCumulativeValue)               return false; // cap exhausted
-
-    return true;
-}
-
-function isActiveForAmount(uint256 agentId, address principal, uint256 amount) public view returns (bool) {
-    if (!isActive(agentId, principal))                                          return false;
-
-    Mandate storage m = mandates[agentId][principal];
-
-    if (m.onChainScope.maxTransactionValue != type(uint128).max
-        && uint128(amount) > m.onChainScope.maxTransactionValue)                return false;
-
-    if (m.onChainScope.maxCumulativeValue != type(uint128).max
-        && m.cumulativeUsed + uint128(amount) > m.onChainScope.maxCumulativeValue) return false;
+    if (m.maxCumulativeValue != type(uint256).max
+        && m.cumulativeUsed + amount > m.maxCumulativeValue)                    return false;
 
     return true;
 }
 ```
 
+#### Interface
+
 ```solidity
 interface IAgentMandate is IERC165 {
 
-    struct MandateScopeParams {
-        uint128 maxTransactionValue;
-        uint128 maxCumulativeValue;
-        address assetAddress;
-        bytes32 jurisdictionHash;
-    }
-
     struct Mandate {
-        address            principal;
-        bytes32            identityRef;
-        bytes32            scopeHash;
-        address            complianceProvider;
-        MandateScopeParams onChainScope;
-        uint48             validFrom;
-        uint48             validUntil;
-        uint128            cumulativeUsed;
-        bool               revoked;
+        address agent;
+        uint48  validFrom;
+        uint48  validUntil;
+        address principal;
+        bool    revoked;
+        address complianceProvider;
+        bytes32 identityRef;
+        address asset;
+        uint256 maxTransactionValue;
+        uint256 maxCumulativeValue;
+        uint256 cumulativeUsed;
+        bytes32 metadata;
     }
 
-    enum EnforcerTier { PLATFORM, REGULATORY }
-
-    /// @notice Emitted when a mandate is granted to an agent.
+    /// @notice Emitted when a mandate is granted.
     event MandateGranted(
-        uint256 indexed agentId,
+        address indexed agent,
         address indexed principal,
-        address indexed complianceProvider,
-        bytes32 scopeHash,
+        address complianceProvider,
+        address asset,
         uint48 validFrom,
-        uint48 validUntil
+        uint48 validUntil,
+        bytes32 metadata
     );
+
+    /// @notice Emitted when an action is enabled on a mandate at grant time.
+    event ActionEnabled(address indexed agent, address indexed principal, bytes32 indexed action);
 
     /// @notice Emitted when a mandate is revoked.
     event MandateRevoked(
-        uint256 indexed agentId,
+        address indexed agent,
         address indexed principal,
-        address indexed revokedBy
+        address revokedBy
     );
 
     /// @notice Emitted when a mandate's validity is extended.
     event MandateExtended(
-        uint256 indexed agentId,
+        address indexed agent,
         address indexed principal,
         uint48 newValidUntil
     );
@@ -225,110 +248,153 @@ interface IAgentMandate is IERC165 {
         bool approved
     );
 
-    /// @notice Emitted when an agent executes a transfer recorded by a RAMS-aware token.
+    /// @notice Emitted when an agent executes an action recorded by a RAMS-aware token.
     event ExecutionRecorded(
-        uint256 indexed agentId,
+        address indexed agent,
         address indexed principal,
+        bytes32 indexed action,
         uint256 amount,
-        uint128 cumulativeUsed
+        uint256 cumulativeUsed
     );
 
-    /// @notice Emitted when an agent is frozen for a jurisdiction or globally.
-    /// @dev jurisdictionHash of bytes32(0) indicates a global freeze. Global freeze is REGULATORY tier only.
+    /// @notice Emitted when an agent is frozen. Freezing is restricted to authorized enforcer roles.
     event AgentFrozen(
-        uint256 indexed agentId,
-        bytes32 indexed jurisdictionHash,
-        address indexed enforcer,
-        EnforcerTier tier
+        address indexed agent,
+        address indexed enforcer
     );
 
     /// @notice Emitted when a freeze is lifted.
     event AgentUnfrozen(
-        uint256 indexed agentId,
-        bytes32 indexed jurisdictionHash,
+        address indexed agent,
         address indexed enforcer
     );
 
-    /// @notice Grants a mandate to the specified agent on behalf of a principal.
-    /// @param agentId The unique agent identifier.
-    /// @param principal The address of the principal granting the mandate.
-    /// @param identityRef Off-chain identity reference for the principal. MUST be non-zero for regulated asset mandates.
-    /// @param scopeHash keccak256 of the off-chain scope document stored on IPFS or equivalent.
-    /// @param onChainScope Structured on-chain scope parameters.
-    /// @param complianceProvider Address of an IComplianceProvider. May be address(0) to skip compliance checks.
+    /// @notice Parameters for grantMandate, bundled into a struct to avoid stack-too-deep.
+    /// @param agent The address of the agent receiving the mandate.
     /// @param validFrom Unix timestamp from which the mandate is active.
     /// @param validUntil Unix timestamp after which the mandate expires.
-    /// @param signature Optional signature by the principal. If empty, msg.sender MUST equal principal.
-    function grantMandate(
-        uint256 agentId,
+    /// @param principal The address of the principal granting the mandate.
+    /// @param complianceProvider Address of an IComplianceProvider. MUST be a non-zero address.
+    /// @param identityRef Off-chain identity reference for the principal.
+    /// @param asset Specific asset address.
+    /// @param maxTransactionValue Per-transaction value cap.
+    /// @param maxCumulativeValue Cumulative value cap over the mandate's lifetime.
+    /// @param metadata Optional 32-byte pointer to off-chain metadata (e.g., legal-text content hash).
+    /// @param actions Array of action labels.
+    /// @param deadline Signature expiry timestamp (replay protection).
+    struct GrantMandateParams {
+        address   agent;
+        uint48    validFrom;
+        uint48    validUntil;
+        address   principal;
+        address   complianceProvider;
+        bytes32   identityRef;
+        address   asset;
+        uint256   maxTransactionValue;
+        uint256   maxCumulativeValue;
+        bytes32   metadata;
+        bytes32[] actions;
+        uint256   deadline;
+    }
+
+    /// @notice Grants a mandate from a principal to an agent.
+    /// @dev If `signature` is empty, msg.sender MUST equal params.principal. Otherwise the signature is verified
+    ///      via SignatureChecker against the GrantMandate [EIP-712](./eip-712.md) digest.
+    /// @param params The mandate parameters.
+    /// @param signature Principal signature ([EIP-712](./eip-712.md), [EIP-1271](./eip-1271.md) supported).
+    function grantMandate(GrantMandateParams calldata params, bytes calldata signature) external;
+
+    /// @notice Revokes the active mandate for the given agent and principal.
+    /// @dev Callable by the principal directly or by anyone with a valid principal signature. An approved operator MAY also call this.
+    /// @param agent The agent address whose mandate is revoked.
+    /// @param principal The principal address whose mandate is revoked.
+    /// @param deadline Signature expiry timestamp.
+    /// @param signature Principal signature ([EIP-712](./eip-712.md), [EIP-1271](./eip-1271.md) supported).
+    function revokeMandate(
+        address agent,
         address principal,
-        bytes32 identityRef,
-        bytes32 scopeHash,
-        MandateScopeParams calldata onChainScope,
-        address complianceProvider,
-        uint48 validFrom,
-        uint48 validUntil,
+        uint256 deadline,
         bytes calldata signature
     ) external;
 
-    /// @notice Revokes the active mandate for the given agent and principal.
-    /// @dev Callable by the principal or an approved operator.
-    /// @param agentId The unique agent identifier.
-    /// @param principal The address of the principal whose mandate is revoked.
-    function revokeMandate(uint256 agentId, address principal) external;
-
     /// @notice Extends the validity of an existing mandate without resetting cumulativeUsed.
-    /// @dev Callable by the principal or an approved operator.
-    /// @param agentId The unique agent identifier.
-    /// @param principal The address of the principal whose mandate is extended.
+    /// @dev Callable by the principal directly or by anyone with a valid principal signature. An approved operator MAY also call this.
+    /// @param agent The agent address.
+    /// @param principal The principal address.
     /// @param newValidUntil New expiry timestamp. MUST be greater than the current validUntil.
-    function extendMandate(uint256 agentId, address principal, uint48 newValidUntil) external;
+    /// @param deadline Signature expiry timestamp.
+    /// @param signature Principal signature ([EIP-712](./eip-712.md), [EIP-1271](./eip-1271.md) supported).
+    function extendMandate(
+        address agent,
+        address principal,
+        uint48 newValidUntil,
+        uint256 deadline,
+        bytes calldata signature
+    ) external;
 
-    /// @notice Freezes an agent for a given jurisdiction, or globally if jurisdictionHash is bytes32(0).
-    /// @dev Global freeze is restricted to REGULATORY tier enforcers.
-    /// @param agentId The unique agent identifier.
-    /// @param jurisdictionHash keccak256 of the ISO 3166-1 alpha-2 jurisdiction code, or bytes32(0) for global.
-    function freezeAgent(uint256 agentId, bytes32 jurisdictionHash) external;
+    /// @notice Freezes an agent, halting all of its mandates. Restricted to authorized enforcer roles.
+    /// @param agent The agent address to freeze.
+    function freezeAgent(address agent) external;
 
-    /// @notice Lifts a freeze for a given agent and jurisdiction.
-    /// @param agentId The unique agent identifier.
-    /// @param jurisdictionHash The jurisdiction hash of the freeze to lift, or bytes32(0) for global.
-    function unfreezeAgent(uint256 agentId, bytes32 jurisdictionHash) external;
+    /// @notice Lifts a freeze on an agent.
+    /// @param agent The agent address to unfreeze.
+    function unfreezeAgent(address agent) external;
 
-    /// @notice Sets or revokes operator approval for msg.sender.
-    /// @param operator The address being approved or revoked.
+    /// @notice Sets or revokes operator approval for the principal.
+    /// @dev Callable by the principal directly or by anyone with a valid principal signature.
+    /// @param principal The principal granting/revoking operator status.
+    /// @param operator The operator address being approved or revoked.
     /// @param approved True to approve, false to revoke.
-    function setOperator(address operator, bool approved) external;
+    /// @param deadline Signature expiry timestamp.
+    /// @param signature Principal signature ([EIP-712](./eip-712.md), [EIP-1271](./eip-1271.md) supported).
+    function setOperator(
+        address principal,
+        address operator,
+        bool approved,
+        uint256 deadline,
+        bytes calldata signature
+    ) external;
 
-    /// @notice Records an agent-initiated execution. Called by RAMS-aware regulated tokens inside their pre-transfer hook.
-    /// @param agentId The unique agent identifier.
-    /// @param principal The principal on whose behalf the transfer is executed.
-    /// @param amount The transfer amount in the token's base unit.
-    function recordExecution(uint256 agentId, address principal, uint256 amount) external;
+    /// @notice Records an agent-initiated execution. Called by RAMS-aware regulated tokens.
+    /// @param agent The agent address.
+    /// @param principal The principal on whose behalf the action is executed.
+    /// @param action The action label being executed.
+    /// @param amount The amount in the asset's base unit.
+    function recordExecution(
+        address agent,
+        address principal,
+        bytes32 action,
+        uint256 amount
+    ) external;
 
-    /// @notice Returns the principal address of the sole active mandate for the given agent.
-    /// @param agentId The unique agent identifier.
-    /// @return The principal address.
-    function getActivePrincipal(uint256 agentId) external view returns (address);
-
-    /// @notice Returns true if the mandate for the given agent and principal is currently active.
-    /// @param agentId The unique agent identifier.
+    /// @notice Returns true if the agent can execute the action on the asset for the principal at the given amount.
+    /// @dev Bundles asset, existence, validity, freeze, action, and cap checks into one call.
+    /// @param agent The agent address.
     /// @param principal The principal address.
-    /// @return True if the mandate is active.
-    function isActive(uint256 agentId, address principal) external view returns (bool);
+    /// @param asset The asset the action targets; MUST equal the mandate's `asset`.
+    /// @param action The action label being checked.
+    /// @param amount The amount to check, in the asset's base unit.
+    /// @return True if the agent can execute the action at this amount.
+    function canExecute(
+        address agent,
+        address principal,
+        address asset,
+        bytes32 action,
+        uint256 amount
+    ) external view returns (bool);
 
-    /// @notice Returns true if the mandate is active and the given amount is within all defined limits.
-    /// @param agentId The unique agent identifier.
+    /// @notice Returns true if the action is enabled on the mandate.
+    /// @param agent The agent address.
     /// @param principal The principal address.
-    /// @param amount The transfer amount to check, in the token's base unit.
-    /// @return True if the mandate is active and the amount is within limits.
-    function isActiveForAmount(uint256 agentId, address principal, uint256 amount) external view returns (bool);
+    /// @param action The action label.
+    /// @return True if the action is enabled.
+    function isActionEnabled(address agent, address principal, bytes32 action) external view returns (bool);
 
     /// @notice Returns the full Mandate struct for the given agent and principal.
-    /// @param agentId The unique agent identifier.
+    /// @param agent The agent address.
     /// @param principal The principal address.
     /// @return The Mandate struct.
-    function getMandate(uint256 agentId, address principal) external view returns (Mandate memory);
+    function getMandate(address agent, address principal) external view returns (Mandate memory);
 
     /// @notice Returns true if the operator is approved for the given principal.
     /// @param principal The principal address.
@@ -336,24 +402,29 @@ interface IAgentMandate is IERC165 {
     /// @return True if approved.
     function isOperator(address principal, address operator) external view returns (bool);
 
-    /// @notice Returns true if the agent is frozen for the given jurisdiction.
-    /// @param agentId The unique agent identifier.
-    /// @param jurisdictionHash The jurisdiction hash, or bytes32(0) to check the global freeze.
+    /// @notice Returns true if the agent is frozen.
+    /// @param agent The agent address.
     /// @return True if frozen.
-    function isFrozen(uint256 agentId, bytes32 jurisdictionHash) external view returns (bool);
+    function isFrozen(address agent) external view returns (bool);
 
+    /// @notice Returns the current nonce for a principal (used in signed operations).
+    /// @param principal The principal address.
+    /// @return The current nonce value.
+    function nonces(address principal) external view returns (uint256);
+
+    /// @notice Returns the [EIP-712](./eip-712.md) domain separator.
+    /// @return The domain separator hash.
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
 }
 ```
 
 ### Integration with Regulated Token Contracts
 
-Regulated token contracts that implement a pre-transfer compliance hook (such as `canTransfer` in [ERC-7943](./eip-7943.md) or transfer restrictions in [ERC-3643](./eip-3643.md)) can integrate with RAMS to detect agent-initiated transfers and enforce mandate validity. Agents call standard transfer functions ([ERC-20](./eip-20.md) `transfer`/`transferFrom`, [ERC-721](./eip-721.md) `safeTransferFrom`, [ERC-1155](./eip-1155.md) `safeTransferFrom`/`safeBatchTransferFrom`), no token-side changes are needed. The pseudocode below uses [ERC-20](./eip-20.md) as an example; the same pattern applies to [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) tokens.
+A regulated token integrates RAMS inside its existing pre-transfer hook (e.g., `canTransfer` in [ERC-7943](./eip-7943.md), transfer restrictions in [ERC-3643](./eip-3643.md)). The principal is the holder (`from`) and the agent is the caller (`msg.sender`); a transfer with `msg.sender != from` is agent-initiated and MUST satisfy the `(msg.sender, from)` mandate. The example below uses [ERC-20](./eip-20.md); the same pattern applies to [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md).
 
-The token MUST be able to resolve a wallet address to an agent identifier. An agent registry (such as [ERC-8004](./eip-8004.md)) MAY provide this mapping via a `getAgentByWallet(sender)` lookup. Alternatively, RAMS implementations MAY maintain a separate `agentWallet => agentId` mapping populated at `grantMandate` time.
+RAMS mandate validity does NOT replace token-level allowance or operator approval. For an agent-initiated transfer to succeed, both the token-level authorization ([ERC-20](./eip-20.md) allowance, or [ERC-721](./eip-721.md)/[ERC-1155](./eip-1155.md) operator approval) and the RAMS mandate MUST pass. RAMS is an additional compliance layer, not a replacement for token ownership semantics.
 
-When the sender is identified as an agent, the token resolves the principal by calling `ramsRegistry.getActivePrincipal(agentId)` and then executes a dual compliance check: first, the token's own investor eligibility check on the principal; second, the RAMS mandate validity (agent authority from this principal for this scope). Both conditions MUST hold for the transfer to proceed. The token's compliance module is never bypassed. When an agent initiates a transfer, the token applies its investor eligibility checks to the principal address, not the agent wallet. RAMS adds a second compliance layer but does not replace or override the first. The token issuer retains full sovereignty over who may hold or transact their instrument.
-
-The asset address MUST also be verified: if `onChainScope.assetAddress` is not `address(0)`, it MUST equal `address(this)`. If this check fails, the transfer MUST be rejected.
+The `action` label is an opaque `bytes32` chosen by the integrating token. The token MAY use a function selector (as below), a keccak256 of a namespaced string, or any other 32-byte identifier consistent with the labels the principal authorized in the mandate.
 
 ```solidity
 // Pseudocode: canTransfer for RAMS-aware ERC-7943 tokens.
@@ -361,100 +432,70 @@ The asset address MUST also be verified: if `onChainScope.assetAddress` is not `
 function canTransfer(address from, address to, uint256 amount)
     public view returns (bool)
 {
-    uint256 agentId = agentRegistry.getAgentByWallet(from);
-
-    if (agentId != 0) {
-        address principal = ramsRegistry.getActivePrincipal(agentId);
-
-        require(canSend(principal), ERC7943CannotTransfer(principal, to, amount));
-        require(canReceive(to), ERC7943CannotTransfer(principal, to, amount));
-
-        if (!ramsRegistry.isActiveForAmount(agentId, principal, amount)) return false;
-
-        Mandate memory mandate = ramsRegistry.getMandate(agentId, principal);
-        if (mandate.onChainScope.assetAddress != address(0) &&
-            mandate.onChainScope.assetAddress != address(this)) return false;
-
-        return true;
-    }
-
     require(canSend(from), ERC7943CannotTransfer(from, to, amount));
     require(canReceive(to), ERC7943CannotTransfer(from, to, amount));
-    return true;
+
+    if (msg.sender == from) return true;
+    if (ramsRegistry.getMandate(msg.sender, from).principal == address(0)) return true; // plain allowance, no mandate
+
+    bytes32 action = bytes32(IERC20.transferFrom.selector);
+    return ramsRegistry.canExecute(msg.sender, from, address(this), action, amount);
 }
 ```
 
 ```solidity
-// Pseudocode: transfer recording RAMS execution.
+// Pseudocode: _update hook recording RAMS execution.
 
-function transfer(address to, uint256 amount) public returns (bool) {
-    require(canTransfer(msg.sender, to, amount), ERC7943CannotTransfer(msg.sender, to, amount));
+function _update(address from, address to, uint256 amount) internal override {
+    require(canTransfer(from, to, amount), ERC7943CannotTransfer(from, to, amount));
 
-    uint256 agentId = agentRegistry.getAgentByWallet(msg.sender);
-    if (agentId != 0) {
-        address principal = ramsRegistry.getActivePrincipal(agentId);
-        ramsRegistry.recordExecution(agentId, principal, amount);
-        emit AgentOperationDetected(agentId, principal, amount);
+    if (from != address(0) && msg.sender != from
+        && ramsRegistry.getMandate(msg.sender, from).principal != address(0)) {
+        bytes32 action = bytes32(IERC20.transferFrom.selector);
+        ramsRegistry.recordExecution(msg.sender, from, action, amount);
     }
 
-    return super.transfer(to, amount);
+    super._update(from, to, amount);
 }
 ```
 
-RAMS-aware tokens SHOULD emit the following event for every agent-initiated transfer:
+This example is permissive: a transfer with no `(msg.sender, from)` mandate falls through to normal allowance rules. A token MAY instead require a mandate for every non-holder transfer.
 
-```solidity
-event AgentOperationDetected(
-    uint256 indexed agentId,
-    address indexed principal,
-    uint256 amount
-);
-```
+The same `canExecute` and `recordExecution` calls apply from any of the three enforcement venues:
 
-### Scope Document
+1. **Token hook**: a RAMS-aware token gates transfers in its compliance hook (above).
+2. **[EIP-7702](./eip-7702.md) account**: the principal delegates their account to an `IAgentExecutor`; agent actions originate as the principal.
+3. **Executor**: the principal approves an `IAgentExecutor` contract; the agent acts only through it.
 
-The off-chain JSON referenced by `scopeHash` MUST be stored on IPFS or equivalent content-addressed storage. The `notes` field SHOULD describe in human-readable language: (a) the actions delegated, (b) operational limitations not captured by structured fields, and (c) the regulatory context.
-
-Implementations MUST verify `onChainScope` internal consistency at `grantMandate` time. Off-chain tooling and the `grantMandate` caller MUST verify that `onChainScope` values are consistent with the scope document referenced by `scopeHash` before submission. Discrepancies discovered post-grant MUST be resolved via revocation.
-
-```json
-{
-    "type": "urn:eip:RAMS:scope:v1",
-    "actions": ["agent.action.buy", "agent.action.sell", "agent.action.transfer"],
-    "assetClasses": ["Security Token", "Debt Token"],
-    "tokenAddress": "0x...",
-    "maxTransactionValue": "500000",
-    "maxCumulativeValue": "2000000",
-    "valueCurrency": "USD",
-    "jurisdictions": ["EU", "AE-DU", "CH"],
-    "complianceProviderRef": "eip155:1:0x...",
-    "notes": "Agent is authorized to execute secondary market purchases of tokenized real estate securities on behalf of the principal, up to the stated transaction and cumulative limits, within the listed jurisdictions. No leveraged or derivative transactions are authorized."
-}
-```
+All read the same mandate. The venue is the integrator's choice and is out of scope of the normative interface.
 
 ## Rationale
 
-RAMS is defined as a separate ERC rather than an extension of any specific agent identity or token compliance standard because mandate delegation is a distinct concern. Agent identity standards (such as [ERC-8004](./eip-8004.md)) handle discovery and trust signals. Token compliance frameworks (such as [ERC-7943](./eip-7943.md) or [ERC-3643](./eip-3643.md)) handle investor eligibility. RAMS handles the delegation of authority from a principal to an agent. Coupling RAMS to a specific identity or compliance standard would limit its applicability across the fragmented regulated token ecosystem.
+RAMS is a separate ERC rather than an extension of any agent identity or token compliance standard because mandate delegation is a distinct concern. Coupling it to a specific standard would limit its use across the fragmented regulated token ecosystem.
 
-A single `IComplianceProvider` interface is used rather than separate identity and compliance interfaces because identity verification is a logical subset of compliance checking. A compliance provider that declares a principal eligible has already verified that the underlying identity is valid and unrevoked. Splitting these into separate interfaces forces consumers to make two calls to answer one question, creates inconsistency risk, and doubles the integration surface. A single interface with granular `ReasonCode` values preserves diagnostic specificity without the architectural overhead.
+Mandate storage is keyed by `(agent, principal)` addresses, similar to [ERC-20](./eip-20.md) `allowance`.
 
-Freeze authority is kept within `IAgentMandate` rather than a separate registry because an enforcer does not exist independently of the mandates it can freeze. Extracting freeze into a separate contract creates an additional deployment, audit surface, and integration point for what is functionally an access control list. The `EnforcerTier` distinction (`PLATFORM` vs `REGULATORY`) is preserved in the events, which is where it matters for audit trails.
+A single `IComplianceProvider` interface is used rather than separate identity and compliance interfaces because identity verification is a logical subset of compliance checking. A compliance provider that declares a principal eligible has already verified that the underlying identity is valid and unrevoked.
 
-One active principal per `agentId` is enforced because in regulated markets every managed account must be segregated. A portfolio manager handling multiple clients operates distinct accounts, each with its own mandate, risk profile, and audit trail. The on-chain equivalent is one agent wallet per principal with its own `agentId`. This mirrors the account segregation requirements common to regulated financial frameworks. Multiple agent wallets are trivially deployable via `CREATE2`.
+Mandate scope is encoded fully on-chain and bound by the principal's [EIP-712](./eip-712.md) signature, eliminating drift between on-chain state and any off-chain document. Actions are signed as a `bytes32[]` array and written into a mapping at grant time for O(1) enforcement. The `metadata` field is non-normative and does not participate in enforcement.
 
-Agents use standard token functions ([ERC-20](./eip-20.md), [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md)) rather than agent-prefixed variants because requiring `agentTransfer(to, amount, principal)` on the token leads to interface duplication: every token operation an agent can perform (`transfer`, `transferFrom`, `safeTransferFrom`, `mint`, `burn`, `approve`) would require an `agent*` variant. This bloats the token interface, increases the audit surface, and forces every RAMS-aware token to implement a parallel function set. The principal is resolved from the RAMS registry via `getActivePrincipal(agentId)` inside the token's existing pre-transfer compliance hook, requiring no new functions on the token.
+All signed lifecycle operations include a nonce and deadline; [EIP-1271](./eip-1271.md) verification allows smart-wallet principals (multisigs, DAOs).
 
-The pre-transfer hook executes a dual compliance check because a RAMS-aware token must first apply its own investor eligibility checks to the principal and then verify the RAMS mandate. These are two different questions answered by two different layers: the token issuer defines who may hold or transact their instrument, and RAMS defines who may delegate to an agent and under what constraints. Both conditions must hold, preserving full issuer sovereignty.
+`canExecute` bundles every runtime check into one call so the integrator cannot accidentally skip one.
 
-Value limits are denominated in token base units rather than fiat because denominating in fiat requires an on-chain FX oracle, introducing price manipulation risk and liveness dependency. Limits in token base units are deterministic and oracle-free. The off-chain scope document may include `valueCurrency` for readability; this field has no enforcement role on-chain.
+Freeze authority is kept within `IAgentMandate` rather than a separate registry because an enforcer does not exist independently of the mandates it can freeze. Enforcer authority is governed by the implementation's access-control roles, not by a hardcoded tier.
 
-`cumulativeUsed` does not reset on `extendMandate` because a mandate represents a single delegation agreement. Extending validity does not constitute a new agreement. A cap reset requires explicit revocation and re-issuance, preserving audit trail integrity.
+Enforcement is venue-agnostic: RAMS standardizes the mandate, not how it is enforced. Any contract in the agent's path applies it by calling `canExecute`, so the same mandate is honored whether the gate is a token hook, an account, or an executor.
 
-Jurisdiction-scoped freeze is supported because a regulatory action in one jurisdiction must not prevent an agent from operating in others. Global freeze (`bytes32(0)`) is reserved for `REGULATORY` enforcers only, reflecting the exceptional nature of a full regulatory halt.
+Agents use standard token functions ([ERC-20](./eip-20.md), [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md)) rather than agent-prefixed variants because that would require interface duplication. The token's existing compliance hook validates mandates via `canExecute`, requiring no new functions on the token.
 
-Operator permissions are explicitly scoped so that delegation of authority remains auditable. An operator can revoke or extend a mandate (defensive actions) but cannot grant new mandates (offensive actions that create new legal obligations). This asymmetry reflects the fiduciary principle that a delegate should be able to limit or terminate authority but not expand it without the principal's direct authorization.
+Value limits are denominated in token base units rather than fiat to stay deterministic and oracle-free.
 
-RAMS defines its own `IComplianceProvider` interface that is agnostic to the identity verification backend. An implementation MAY use an [ERC-3643](./eip-3643.md)-compatible registry, an [ERC-7943](./eip-7943.md) compliance module, or any other on-chain identity source as the data backend for principal eligibility checks. There is no dependency on any specific token compliance or identity standard.
+`cumulativeUsed` does not reset on `extendMandate` because a mandate represents a single delegation agreement; a cap reset requires explicit revocation and re-issuance.
+
+Freezing is reserved for authorized enforcer roles, reflecting the exceptional nature of a halt.
+
+Operator permissions are explicitly scoped so that delegation remains auditable: an operator can revoke or extend a mandate but cannot grant new ones.
 
 ## Backwards Compatibility
 
@@ -462,21 +503,36 @@ RAMS introduces no changes to any existing standard.
 
 ## Reference Implementation
 
-<!-- TODO: reference implementation -->
+A reference implementation and test suite are available in [`../assets/erc-8226/`](../assets/erc-8226/): the `IAgentMandate` registry, an `IComplianceProvider`, an `IAgentExecutor`, and an [ERC-7943](./eip-7943.md) asset integration.
+
+`IAgentExecutor` is an OPTIONAL, non-normative companion interface for the account-side enforcement venues (an [EIP-7702](./eip-7702.md) delegate or a standalone executor). The forwarding logic is never part of `IAgentMandate`.
+
+```solidity
+interface IAgentExecutor {
+    /// @dev msg.sender is the agent; the implementer is bound to a principal.
+    ///      action = bytes4(data), amount read from data, so gated values match the real call.
+    ///      Calls canExecute and reverts if false, records the execution, then forwards the call.
+    function execute(address target, bytes calldata data) external returns (bytes memory);
+}
+```
+
+The executor maintains a mapping from each supported action selector to the position of its amount argument; on `execute`, it reads the gated amount from that position in the forwarded calldata, so the gated value is always the value that executes. Actions with no value argument gate at amount 0. RAMS gates a registered set of action signatures, not arbitrary calldata.
 
 ## Security Considerations
 
-`identityRef` is a reference, not proof. Eligibility comes from `complianceProvider.checkPrincipal`, not from a non-zero `identityRef` value. If an agent wallet address is also a standard investor address, the pre-transfer agent-detection logic could misidentify it. Agent identity registries should require proof of key control for agent wallet registration and emit a distinct event when an address is registered as an agent wallet.
+`identityRef` is a reference, not proof of eligibility. Grant-time eligibility comes from `checkPrincipal`; runtime eligibility always comes from the token's own check. If an agent wallet is also a standard investor address, the agent-detection logic could misidentify it; agent identity registries should require proof of key control and emit a distinct event when registering an agent wallet.
 
-If `recordExecution` were callable by arbitrary addresses, an attacker could advance `cumulativeUsed` to exhaust the cap and deny service to the legitimate agent. The caller restriction specified in the Specification closes this attack surface. Callers can use `isActiveForAmount` for pre-transaction checks or rely on `recordExecution`'s revert behavior for atomic enforcement.
+If `recordExecution` were callable by arbitrary addresses, an attacker could advance `cumulativeUsed` to exhaust the cap and deny service to the legitimate agent. The caller restriction specified in the Specification closes this attack surface. Callers can use `canExecute` for pre-transaction checks or rely on `recordExecution`'s revert behavior for atomic enforcement.
 
-A compromised compliance provider can declare non-compliant principals as eligible. Principals should only use compliance providers with audited, time-locked upgrade mechanisms. The `REGULATORY` enforcer tier operates independently of compliance provider state, so a captured provider cannot prevent a regulator from halting an agent. If a compliance provider contract becomes non-responsive, all mandates referencing that provider become inoperative because `isActive` calls `complianceProvider.checkPrincipal`, which will revert. This constitutes a systemic denial-of-service risk. Principals should select compliance providers with documented uptime Service Level Agreements (SLAs) and audited fallback mechanisms. Implementations may define a grace period after which a mandate with an unresponsive provider is auto-revoked rather than permanently blocked, provided the revocation is logged for audit.
+A compromised compliance provider can approve an ineligible principal at grant time. This is bounded: compliance is checked at grant, not on the execution path, so a provider going offline cannot brick active mandates; the token's own eligibility check (`canSend`) still runs on every transfer; and an enforcer can freeze the agent independently of provider state. Principals should select compliance providers with audited, time-locked upgrade mechanisms.
 
 A transaction can fail at two distinct compliance layers: the token's investor eligibility check on the principal, or the RAMS mandate validity check on the agent. Frontends and autonomous agents should pre-verify both layers before submitting a transaction to enable clear diagnostic reporting.
 
-On-chain contracts cannot read or verify the content of an off-chain IPFS document. If `onChainScope` and the off-chain scope document drift, audit and enforcement diverge. The consistency requirements specified in the Scope Document section close this gap, and post-grant discrepancies are resolved via revocation.
+A window exists between a `PrincipalRevoked` event from the compliance provider and enforcement of a freeze on the RAMS registry. High-sensitivity protocols should use an automated freeze relay that monitors `PrincipalRevoked` events and calls `freezeAgent` immediately. The admin role MUST NOT be the same address as any enforcer, preventing self-escalation.
 
-A window exists between a `PrincipalRevoked` event from the compliance provider and enforcement of a freeze on the RAMS registry. High-sensitivity protocols should use an automated freeze relay that monitors `PrincipalRevoked` events and calls `freezeAgent` immediately. A `PLATFORM` enforcer that can execute global freezes is non-conformant per the Specification. The admin-versus-enforcer role separation specified in the Specification prevents self-escalation; without it, a single compromised key could both grant enforcer privileges and execute global freezes.
+An `IAgentExecutor` reads the gated amount from a registered per-action position. That registry is a trusted surface: a wrong position silently mis-gates caps, so the role that maintains it needs the same care as the enforcer role.
+
+The `metadata` field is non-normative: implementations and integrators MUST NOT rely on it for enforcement decisions, since its content (e.g., off-chain legal text) is not verifiable on-chain. It is provided as an opaque pointer for human-readable context and audit purposes only.
 
 ## Copyright
 

--- a/assets/erc-8226/.gitignore
+++ b/assets/erc-8226/.gitignore
@@ -1,0 +1,5 @@
+.gitmodules
+foundry.lock
+out/
+cache/
+lib/

--- a/assets/erc-8226/README.md
+++ b/assets/erc-8226/README.md
@@ -1,0 +1,24 @@
+# ERC-8226: Regulated Agent Mandate (RAMS) reference implementation
+
+Reference implementation for [ERC-8226](../../ERCS/erc-8226.md). Under development.
+
+## Layout
+
+| Path | Contents |
+|---|---|
+| `contracts/interfaces/IAgentMandate.sol` | Mandate lifecycle, recording, freeze, and view interface |
+| `contracts/interfaces/IComplianceProvider.sol` | Principal eligibility interface |
+| `contracts/interfaces/IAgentExecutor.sol` | Optional account-side executor interface |
+| `contracts/AgentMandate.sol` | RAMS registry (reference implementation) |
+| `contracts/ComplianceProvider.sol` | Reference compliance provider |
+| `contracts/AgentExecutor.sol` | Reference executor (optional venue) |
+| `contracts/regulated-asset-mock/IERC7943.sol` | ERC-7943 interface (vendored, used by the tests) |
+| `contracts/regulated-asset-mock/uRWA20.sol` | ERC-7943 uRWA-20 regulated asset (vendored, used by the tests) |
+| `test/` | Foundry tests |
+
+## Build
+
+```sh
+forge build
+forge test
+```

--- a/assets/erc-8226/README.md
+++ b/assets/erc-8226/README.md
@@ -1,6 +1,6 @@
 # ERC-8226: Regulated Agent Mandate (RAMS) reference implementation
 
-Reference implementation for [ERC-8226](../../ERCS/erc-8226.md). Under development.
+Reference implementation for ERC-8226. Under development.
 
 ## Layout
 

--- a/assets/erc-8226/contracts/AgentExecutor.sol
+++ b/assets/erc-8226/contracts/AgentExecutor.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {IAgentExecutor} from "./interfaces/IAgentExecutor.sol";
+import {IAgentMandate} from "./interfaces/IAgentMandate.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title AgentExecutor
+/// @notice Reference IAgentExecutor bound to one principal. An agent calls execute; the executor reads the
+///         gated amount from the forwarded calldata, gates it against the mandate, records it, then forwards.
+contract AgentExecutor is IAgentExecutor, Ownable, ReentrancyGuard {
+    /// @param supported Whether this selector may be executed.
+    /// @param hasAmount False for value-less actions (gate at amount 0).
+    /// @param amountIndex Index of the uint256 amount argument.
+    struct ActionSpec {
+        bool supported;
+        bool hasAmount;
+        uint8 amountIndex;
+    }
+
+    IAgentMandate public immutable rams;
+    address public immutable principal;
+
+    mapping(bytes4 selector => ActionSpec) public actions;
+
+    error UnsupportedAction(bytes4 selector);
+    error InvalidData();
+    error CannotExecute(address agent, address target, bytes4 selector, uint256 amount);
+    error CallFailed(bytes returnData);
+
+    constructor(IAgentMandate _rams, address _principal, address owner_) Ownable(owner_) {
+        rams = _rams;
+        principal = _principal;
+    }
+
+    /// @notice Sets how an action's amount is read. A wrong amountIndex mis-gates the cap, so treat this
+    ///         like the enforcer role.
+    function setAction(bytes4 selector, bool supported, bool hasAmount, uint8 amountIndex) external onlyOwner {
+        actions[selector] = ActionSpec({supported: supported, hasAmount: hasAmount, amountIndex: amountIndex});
+    }
+
+    /// @inheritdoc IAgentExecutor
+    function execute(address target, bytes calldata data) external nonReentrant returns (bytes memory) {
+        if (data.length < 4) revert InvalidData();
+
+        address agent = msg.sender;
+        bytes4 selector = bytes4(data[:4]);
+        ActionSpec memory spec = actions[selector];
+        if (!spec.supported) revert UnsupportedAction(selector);
+
+        uint256 amount = spec.hasAmount ? _amountArg(data, spec.amountIndex) : 0;
+        bytes32 action = bytes32(selector);
+
+        if (!rams.canExecute(agent, principal, target, action, amount)) {
+            revert CannotExecute(agent, target, selector, amount);
+        }
+
+        rams.recordExecution(agent, principal, action, amount);
+
+        (bool ok, bytes memory ret) = target.call(data);
+        if (!ok) revert CallFailed(ret);
+        return ret;
+    }
+
+    /// @dev A uint256 argument sits at 4 + 32*index in calldata, so this reads the amount by index.
+    function _amountArg(bytes calldata data, uint8 index) internal pure returns (uint256) {
+        uint256 offset = 4 + uint256(index) * 32;
+        if (data.length < offset + 32) revert InvalidData();
+        return uint256(bytes32(data[offset:offset + 32]));
+    }
+}

--- a/assets/erc-8226/contracts/AgentMandate.sol
+++ b/assets/erc-8226/contracts/AgentMandate.sol
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {IAgentMandate} from "./interfaces/IAgentMandate.sol";
+import {IComplianceProvider} from "./interfaces/IComplianceProvider.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/// @title AgentMandate
+/// @notice Reference RAMS registry. Holds one mandate per (agent, principal), gates agent actions via
+///         canExecute, records use via recordExecution, and supports role-based freeze.
+contract AgentMandate is IAgentMandate, AccessControl, EIP712 {
+    bytes32 public constant ENFORCER_ROLE = keccak256("ENFORCER_ROLE");
+    bytes32 public constant RECORDER_ROLE = keccak256("RECORDER_ROLE");
+
+    bytes32 private constant GRANT_MANDATE_TYPEHASH = keccak256(
+        "GrantMandate(address agent,uint48 validFrom,uint48 validUntil,"
+        "address principal,address complianceProvider,bytes32 identityRef,"
+        "address asset,uint256 maxTransactionValue,uint256 maxCumulativeValue,"
+        "bytes32 metadata,bytes32[] actions,uint256 nonce,uint256 deadline)"
+    );
+    bytes32 private constant REVOKE_MANDATE_TYPEHASH =
+        keccak256("RevokeMandate(address agent,address principal,uint256 nonce,uint256 deadline)");
+    bytes32 private constant EXTEND_MANDATE_TYPEHASH =
+        keccak256("ExtendMandate(address agent,address principal,uint48 newValidUntil,uint256 nonce,uint256 deadline)");
+    bytes32 private constant SET_OPERATOR_TYPEHASH =
+        keccak256("SetOperator(address principal,address operator,bool approved,uint256 nonce,uint256 deadline)");
+
+    mapping(address agent => mapping(address principal => Mandate)) private _mandates;
+    mapping(address agent => mapping(address principal => mapping(bytes32 action => bool))) private _actionEnabled;
+    mapping(address agent => mapping(address principal => bytes32[])) private _enabledList;
+    mapping(address principal => mapping(address operator => bool)) private _operatorApproved;
+    mapping(address agent => bool) private _frozen;
+    mapping(address principal => uint256) public nonces;
+
+    error ZeroComplianceProvider();
+    error MandateAlreadyActive();
+    error NoActiveMandate();
+    error PrincipalNotEligible();
+    error InvalidExpiry();
+    error NotPrincipal();
+    error NotAuthorized();
+    error SignatureExpired();
+    error InvalidSignature();
+    error UnauthorizedRecorder();
+    error NotExecutable();
+    error ExceedsTransactionCap();
+    error ExceedsCumulativeCap();
+    error AdminEnforcerOverlap();
+
+    constructor(address admin) EIP712("RAMS", "1") {
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    }
+
+    /// @inheritdoc IAgentMandate
+    function grantMandate(GrantMandateParams calldata p, bytes calldata signature) external {
+        if (p.complianceProvider == address(0)) revert ZeroComplianceProvider();
+        if (p.validUntil <= block.timestamp || p.validUntil <= p.validFrom) revert InvalidExpiry();
+
+        Mandate storage existing = _mandates[p.agent][p.principal];
+        if (existing.principal != address(0) && !existing.revoked && block.timestamp <= existing.validUntil) {
+            revert MandateAlreadyActive();
+        }
+
+        _authPrincipal(p.principal, _grantStructHash(p), p.deadline, signature);
+
+        (bool eligible,,) = IComplianceProvider(p.complianceProvider).checkPrincipal(p.principal, p.identityRef);
+        if (!eligible) revert PrincipalNotEligible();
+
+        _clearActions(p.agent, p.principal);
+
+        _mandates[p.agent][p.principal] = Mandate({
+            agent: p.agent,
+            validFrom: p.validFrom,
+            validUntil: p.validUntil,
+            principal: p.principal,
+            revoked: false,
+            complianceProvider: p.complianceProvider,
+            identityRef: p.identityRef,
+            asset: p.asset,
+            maxTransactionValue: p.maxTransactionValue,
+            maxCumulativeValue: p.maxCumulativeValue,
+            cumulativeUsed: 0,
+            metadata: p.metadata
+        });
+
+        emit MandateGranted(p.agent, p.principal, p.complianceProvider, p.asset, p.validFrom, p.validUntil, p.metadata);
+
+        for (uint256 i = 0; i < p.actions.length; i++) {
+            _actionEnabled[p.agent][p.principal][p.actions[i]] = true;
+            _enabledList[p.agent][p.principal].push(p.actions[i]);
+            emit ActionEnabled(p.agent, p.principal, p.actions[i]);
+        }
+    }
+
+    /// @inheritdoc IAgentMandate
+    function revokeMandate(address agent, address principal, uint256 deadline, bytes calldata signature) external {
+        Mandate storage m = _mandates[agent][principal];
+        if (m.principal == address(0) || m.revoked) revert NoActiveMandate();
+
+        bytes32 structHash =
+            keccak256(abi.encode(REVOKE_MANDATE_TYPEHASH, agent, principal, nonces[principal], deadline));
+        _authOperator(principal, structHash, deadline, signature);
+
+        m.revoked = true;
+        emit MandateRevoked(agent, principal, msg.sender);
+    }
+
+    /// @inheritdoc IAgentMandate
+    function extendMandate(
+        address agent,
+        address principal,
+        uint48 newValidUntil,
+        uint256 deadline,
+        bytes calldata signature
+    ) external {
+        Mandate storage m = _mandates[agent][principal];
+        if (m.principal == address(0) || m.revoked || block.timestamp > m.validUntil) revert NoActiveMandate();
+        if (newValidUntil <= m.validUntil) revert InvalidExpiry();
+
+        bytes32 structHash = keccak256(
+            abi.encode(EXTEND_MANDATE_TYPEHASH, agent, principal, newValidUntil, nonces[principal], deadline)
+        );
+        _authOperator(principal, structHash, deadline, signature);
+
+        m.validUntil = newValidUntil;
+        emit MandateExtended(agent, principal, newValidUntil);
+    }
+
+    /// @inheritdoc IAgentMandate
+    function setOperator(address principal, address operator, bool approved, uint256 deadline, bytes calldata signature)
+        external
+    {
+        bytes32 structHash =
+            keccak256(abi.encode(SET_OPERATOR_TYPEHASH, principal, operator, approved, nonces[principal], deadline));
+        _authPrincipal(principal, structHash, deadline, signature);
+
+        _operatorApproved[principal][operator] = approved;
+        emit OperatorSet(principal, operator, approved);
+    }
+
+    /// @inheritdoc IAgentMandate
+    function freezeAgent(address agent) external onlyRole(ENFORCER_ROLE) {
+        _frozen[agent] = true;
+        emit AgentFrozen(agent, msg.sender);
+    }
+
+    /// @inheritdoc IAgentMandate
+    function unfreezeAgent(address agent) external onlyRole(ENFORCER_ROLE) {
+        _frozen[agent] = false;
+        emit AgentUnfrozen(agent, msg.sender);
+    }
+
+    /// @inheritdoc IAgentMandate
+    function recordExecution(address agent, address principal, bytes32 action, uint256 amount) external {
+        Mandate storage m = _mandates[agent][principal];
+        if (msg.sender != m.asset && msg.sender != principal && !hasRole(RECORDER_ROLE, msg.sender)) {
+            revert UnauthorizedRecorder();
+        }
+        if (!_mandateAllows(m, agent, principal, action)) revert NotExecutable();
+        if (m.maxTransactionValue != type(uint256).max && amount > m.maxTransactionValue) {
+            revert ExceedsTransactionCap();
+        }
+        uint256 used = m.cumulativeUsed + amount;
+        if (m.maxCumulativeValue != type(uint256).max && used > m.maxCumulativeValue) {
+            revert ExceedsCumulativeCap();
+        }
+        m.cumulativeUsed = used;
+        emit ExecutionRecorded(agent, principal, action, amount, used);
+    }
+
+    /// @inheritdoc IAgentMandate
+    function canExecute(address agent, address principal, address asset, bytes32 action, uint256 amount)
+        external
+        view
+        returns (bool)
+    {
+        Mandate storage m = _mandates[agent][principal];
+
+        if (asset != m.asset) return false;
+        if (!_mandateAllows(m, agent, principal, action)) return false;
+        if (m.maxTransactionValue != type(uint256).max && amount > m.maxTransactionValue) return false;
+        if (m.maxCumulativeValue != type(uint256).max && m.cumulativeUsed + amount > m.maxCumulativeValue) {
+            return false;
+        }
+        return true;
+    }
+
+    /// @inheritdoc IAgentMandate
+    function isActionEnabled(address agent, address principal, bytes32 action) external view returns (bool) {
+        return _actionEnabled[agent][principal][action];
+    }
+
+    /// @inheritdoc IAgentMandate
+    function getMandate(address agent, address principal) external view returns (Mandate memory) {
+        return _mandates[agent][principal];
+    }
+
+    /// @inheritdoc IAgentMandate
+    function isOperator(address principal, address operator) external view returns (bool) {
+        return _operatorApproved[principal][operator];
+    }
+
+    /// @inheritdoc IAgentMandate
+    function isFrozen(address agent) external view returns (bool) {
+        return _frozen[agent];
+    }
+
+    /// @inheritdoc IAgentMandate
+    function DOMAIN_SEPARATOR() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(AccessControl, IERC165) returns (bool) {
+        return interfaceId == type(IAgentMandate).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /// @dev Keeps the admin role and the enforcer role on disjoint accounts, preventing self-escalation.
+    function _grantRole(bytes32 role, address account) internal override returns (bool) {
+        if (role == ENFORCER_ROLE && hasRole(DEFAULT_ADMIN_ROLE, account)) revert AdminEnforcerOverlap();
+        if (role == DEFAULT_ADMIN_ROLE && hasRole(ENFORCER_ROLE, account)) revert AdminEnforcerOverlap();
+        return super._grantRole(role, account);
+    }
+
+    /// @dev Principal-only: direct call by the principal, or a valid principal signature.
+    function _authPrincipal(address principal, bytes32 structHash, uint256 deadline, bytes calldata signature) private {
+        if (signature.length == 0) {
+            if (msg.sender != principal) revert NotPrincipal();
+        } else {
+            _verifySignature(principal, structHash, deadline, signature);
+        }
+    }
+
+    /// @dev Operator-allowed: principal, an approved operator, or a valid principal signature.
+    function _authOperator(address principal, bytes32 structHash, uint256 deadline, bytes calldata signature) private {
+        if (signature.length == 0) {
+            if (msg.sender != principal && !_operatorApproved[principal][msg.sender]) revert NotAuthorized();
+        } else {
+            _verifySignature(principal, structHash, deadline, signature);
+        }
+    }
+
+    function _verifySignature(address principal, bytes32 structHash, uint256 deadline, bytes calldata signature)
+        private
+    {
+        if (block.timestamp > deadline) revert SignatureExpired();
+        bytes32 digest = _hashTypedDataV4(structHash);
+        if (!SignatureChecker.isValidSignatureNow(principal, digest, signature)) revert InvalidSignature();
+        unchecked {
+            nonces[principal]++;
+        }
+    }
+
+    /// @dev Isolated so the 14-field encode has its own stack frame (avoids stack-too-deep without via-IR).
+    function _grantStructHash(GrantMandateParams calldata p) private view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                GRANT_MANDATE_TYPEHASH,
+                p.agent,
+                p.validFrom,
+                p.validUntil,
+                p.principal,
+                p.complianceProvider,
+                p.identityRef,
+                p.asset,
+                p.maxTransactionValue,
+                p.maxCumulativeValue,
+                p.metadata,
+                keccak256(abi.encodePacked(p.actions)),
+                nonces[p.principal],
+                p.deadline
+            )
+        );
+    }
+
+    /// @dev Shared gate for canExecute and recordExecution (existence, validity window, revoked, action,
+    ///      freeze) so the read check and the state mutation cannot drift. Caps are checked by the callers.
+    function _mandateAllows(Mandate storage m, address agent, address principal, bytes32 action)
+        private
+        view
+        returns (bool)
+    {
+        if (m.principal == address(0)) return false;
+        if (block.timestamp < m.validFrom || block.timestamp > m.validUntil) return false;
+        if (m.revoked) return false;
+        if (!_actionEnabled[agent][principal][action]) return false;
+        if (_frozen[agent]) return false;
+        return true;
+    }
+
+    function _clearActions(address agent, address principal) private {
+        bytes32[] storage prev = _enabledList[agent][principal];
+        for (uint256 i = 0; i < prev.length; i++) {
+            _actionEnabled[agent][principal][prev[i]] = false;
+        }
+        delete _enabledList[agent][principal];
+    }
+}

--- a/assets/erc-8226/contracts/ComplianceProvider.sol
+++ b/assets/erc-8226/contracts/ComplianceProvider.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {IComplianceProvider} from "./interfaces/IComplianceProvider.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title ComplianceProvider
+/// @notice Reference implementation of IComplianceProvider. The owner is the compliance operator
+///         who grants and revokes principal eligibility.
+contract ComplianceProvider is IComplianceProvider, ERC165, Ownable {
+    struct Record {
+        bytes32 identityRef;
+        uint48 expiresAt;
+        bool revoked;
+        ReasonCode reason;
+    }
+
+    mapping(address principal => Record) private _records;
+
+    error ZeroIdentityRef();
+    error NotActive(address principal);
+
+    constructor(address operator) Ownable(operator) {}
+
+    /// @inheritdoc IComplianceProvider
+    function grantPrincipal(address principal, bytes32 identityRef, uint48 expiresAt) external onlyOwner {
+        if (identityRef == bytes32(0)) revert ZeroIdentityRef();
+        _records[principal] =
+            Record({identityRef: identityRef, expiresAt: expiresAt, revoked: false, reason: ReasonCode.COMPLIANT});
+        emit PrincipalGranted(principal, identityRef);
+    }
+
+    /// @inheritdoc IComplianceProvider
+    function revokePrincipal(address principal, ReasonCode reason) external onlyOwner {
+        Record storage r = _records[principal];
+        if (r.identityRef == bytes32(0) || r.revoked) revert NotActive(principal);
+        r.revoked = true;
+        r.reason = reason;
+        emit PrincipalRevoked(principal, r.identityRef, reason);
+    }
+
+    /// @inheritdoc IComplianceProvider
+    function checkPrincipal(address principal, bytes32 identityRef)
+        external
+        view
+        returns (bool eligible, ReasonCode reason, uint48 expiresAt)
+    {
+        Record memory r = _records[principal];
+
+        if (r.identityRef == bytes32(0)) return (false, ReasonCode.IDENTITY_NOT_FOUND, 0);
+        if (r.revoked) return (false, r.reason, 0);
+        if (r.identityRef != identityRef) return (false, ReasonCode.IDENTITY_NOT_FOUND, 0);
+        if (r.expiresAt != 0 && block.timestamp > r.expiresAt) {
+            return (false, ReasonCode.KYC_EXPIRED, r.expiresAt);
+        }
+        return (true, ReasonCode.COMPLIANT, r.expiresAt);
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(bytes4 interfaceId) public view override(ERC165, IERC165) returns (bool) {
+        return interfaceId == type(IComplianceProvider).interfaceId || super.supportsInterface(interfaceId);
+    }
+}

--- a/assets/erc-8226/contracts/interfaces/IAgentExecutor.sol
+++ b/assets/erc-8226/contracts/interfaces/IAgentExecutor.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+/// @notice OPTIONAL, non-normative companion interface for the account-side enforcement venues
+///         (an EIP-7702 delegate or a standalone executor). The forwarding logic is never part of IAgentMandate.
+interface IAgentExecutor {
+    /// @dev msg.sender is the agent; the implementer is bound to a principal. The action label is the
+    ///      selector bytes4(data); the gated amount is read from `data` at a registered per-action position,
+    ///      not supplied by the caller, so gated values match the real call. Calls canExecute and reverts if
+    ///      false, records the execution, then forwards the call.
+    function execute(address target, bytes calldata data) external returns (bytes memory);
+}

--- a/assets/erc-8226/contracts/interfaces/IAgentMandate.sol
+++ b/assets/erc-8226/contracts/interfaces/IAgentMandate.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface IAgentMandate is IERC165 {
+    struct Mandate {
+        address agent;
+        uint48 validFrom;
+        uint48 validUntil;
+        address principal;
+        bool revoked;
+        address complianceProvider;
+        bytes32 identityRef;
+        address asset;
+        uint256 maxTransactionValue;
+        uint256 maxCumulativeValue;
+        uint256 cumulativeUsed;
+        bytes32 metadata;
+    }
+
+    /// @notice Parameters for grantMandate, bundled into a struct to avoid stack-too-deep.
+    /// @param agent The address of the agent receiving the mandate.
+    /// @param validFrom Unix timestamp from which the mandate is active.
+    /// @param validUntil Unix timestamp after which the mandate expires.
+    /// @param principal The address of the principal granting the mandate.
+    /// @param complianceProvider Address of an IComplianceProvider. MUST be a non-zero address.
+    /// @param identityRef Off-chain identity reference for the principal.
+    /// @param asset Specific asset address.
+    /// @param maxTransactionValue Per-transaction value cap.
+    /// @param maxCumulativeValue Cumulative value cap over the mandate's lifetime.
+    /// @param metadata Optional 32-byte pointer to off-chain metadata (e.g., legal-text content hash).
+    /// @param actions Array of action labels.
+    /// @param deadline Signature expiry timestamp (replay protection).
+    struct GrantMandateParams {
+        address agent;
+        uint48 validFrom;
+        uint48 validUntil;
+        address principal;
+        address complianceProvider;
+        bytes32 identityRef;
+        address asset;
+        uint256 maxTransactionValue;
+        uint256 maxCumulativeValue;
+        bytes32 metadata;
+        bytes32[] actions;
+        uint256 deadline;
+    }
+
+    /// @notice Emitted when a mandate is granted.
+    event MandateGranted(
+        address indexed agent,
+        address indexed principal,
+        address complianceProvider,
+        address asset,
+        uint48 validFrom,
+        uint48 validUntil,
+        bytes32 metadata
+    );
+
+    /// @notice Emitted when an action is enabled on a mandate at grant time.
+    event ActionEnabled(address indexed agent, address indexed principal, bytes32 indexed action);
+
+    /// @notice Emitted when a mandate is revoked.
+    event MandateRevoked(address indexed agent, address indexed principal, address revokedBy);
+
+    /// @notice Emitted when a mandate's validity is extended.
+    event MandateExtended(address indexed agent, address indexed principal, uint48 newValidUntil);
+
+    /// @notice Emitted when an operator approval is set or revoked.
+    event OperatorSet(address indexed principal, address indexed operator, bool approved);
+
+    /// @notice Emitted when an agent executes an action recorded by a RAMS-aware token.
+    event ExecutionRecorded(
+        address indexed agent, address indexed principal, bytes32 indexed action, uint256 amount, uint256 cumulativeUsed
+    );
+
+    /// @notice Emitted when an agent is frozen. Freezing is restricted to authorized enforcer roles.
+    event AgentFrozen(address indexed agent, address indexed enforcer);
+
+    /// @notice Emitted when a freeze is lifted.
+    event AgentUnfrozen(address indexed agent, address indexed enforcer);
+
+    /// @notice Grants a mandate from a principal to an agent.
+    /// @dev If `signature` is empty, msg.sender MUST equal params.principal. Otherwise the signature is verified
+    ///      via SignatureChecker against the GrantMandate EIP-712 digest.
+    /// @param params The mandate parameters.
+    /// @param signature Principal signature (EIP-712, EIP-1271 supported).
+    function grantMandate(GrantMandateParams calldata params, bytes calldata signature) external;
+
+    /// @notice Revokes the active mandate for the given agent and principal.
+    /// @dev Callable by the principal directly or by anyone with a valid principal signature. An approved operator MAY also call this.
+    /// @param agent The agent address whose mandate is revoked.
+    /// @param principal The principal address whose mandate is revoked.
+    /// @param deadline Signature expiry timestamp.
+    /// @param signature Principal signature (EIP-712, EIP-1271 supported).
+    function revokeMandate(address agent, address principal, uint256 deadline, bytes calldata signature) external;
+
+    /// @notice Extends the validity of an existing mandate without resetting cumulativeUsed.
+    /// @dev Callable by the principal directly or by anyone with a valid principal signature. An approved operator MAY also call this.
+    /// @param agent The agent address.
+    /// @param principal The principal address.
+    /// @param newValidUntil New expiry timestamp. MUST be greater than the current validUntil.
+    /// @param deadline Signature expiry timestamp.
+    /// @param signature Principal signature (EIP-712, EIP-1271 supported).
+    function extendMandate(
+        address agent,
+        address principal,
+        uint48 newValidUntil,
+        uint256 deadline,
+        bytes calldata signature
+    ) external;
+
+    /// @notice Freezes an agent, halting all of its mandates. Restricted to authorized enforcer roles.
+    /// @param agent The agent address to freeze.
+    function freezeAgent(address agent) external;
+
+    /// @notice Lifts a freeze on an agent.
+    /// @param agent The agent address to unfreeze.
+    function unfreezeAgent(address agent) external;
+
+    /// @notice Sets or revokes operator approval for the principal.
+    /// @dev Callable by the principal directly or by anyone with a valid principal signature.
+    /// @param principal The principal granting/revoking operator status.
+    /// @param operator The operator address being approved or revoked.
+    /// @param approved True to approve, false to revoke.
+    /// @param deadline Signature expiry timestamp.
+    /// @param signature Principal signature (EIP-712, EIP-1271 supported).
+    function setOperator(address principal, address operator, bool approved, uint256 deadline, bytes calldata signature)
+        external;
+
+    /// @notice Records an agent-initiated execution. Called by RAMS-aware regulated tokens.
+    /// @param agent The agent address.
+    /// @param principal The principal on whose behalf the action is executed.
+    /// @param action The action label being executed.
+    /// @param amount The amount in the asset's base unit.
+    function recordExecution(address agent, address principal, bytes32 action, uint256 amount) external;
+
+    /// @notice Returns true if the agent can execute the action on the asset for the principal at the given amount.
+    /// @dev Bundles asset, existence, validity, freeze, action, and cap checks into one call.
+    /// @param agent The agent address.
+    /// @param principal The principal address.
+    /// @param asset The asset the action targets; MUST equal the mandate's `asset`.
+    /// @param action The action label being checked.
+    /// @param amount The amount to check, in the asset's base unit.
+    /// @return True if the agent can execute the action at this amount.
+    function canExecute(address agent, address principal, address asset, bytes32 action, uint256 amount)
+        external
+        view
+        returns (bool);
+
+    /// @notice Returns true if the action is enabled on the mandate.
+    /// @param agent The agent address.
+    /// @param principal The principal address.
+    /// @param action The action label.
+    /// @return True if the action is enabled.
+    function isActionEnabled(address agent, address principal, bytes32 action) external view returns (bool);
+
+    /// @notice Returns the full Mandate struct for the given agent and principal.
+    /// @param agent The agent address.
+    /// @param principal The principal address.
+    /// @return The Mandate struct.
+    function getMandate(address agent, address principal) external view returns (Mandate memory);
+
+    /// @notice Returns true if the operator is approved for the given principal.
+    /// @param principal The principal address.
+    /// @param operator The operator address.
+    /// @return True if approved.
+    function isOperator(address principal, address operator) external view returns (bool);
+
+    /// @notice Returns true if the agent is frozen.
+    /// @param agent The agent address.
+    /// @return True if frozen.
+    function isFrozen(address agent) external view returns (bool);
+
+    /// @notice Returns the current nonce for a principal (used in signed operations).
+    /// @param principal The principal address.
+    /// @return The current nonce value.
+    function nonces(address principal) external view returns (uint256);
+
+    /// @notice Returns the EIP-712 domain separator.
+    /// @return The domain separator hash.
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}

--- a/assets/erc-8226/contracts/interfaces/IComplianceProvider.sol
+++ b/assets/erc-8226/contracts/interfaces/IComplianceProvider.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface IComplianceProvider is IERC165 {
+    enum ReasonCode {
+        COMPLIANT, // 0
+        KYC_EXPIRED, // 1
+        AML_FLAG, // 2
+        NOT_ACCREDITED, // 3
+        NOT_QUALIFIED, // 4
+        JURISDICTION_BLOCKED, // 5
+        IDENTITY_NOT_FOUND, // 6
+        ATTESTATION_REVOKED, // 7
+        OTHER // 8
+    }
+
+    /// @notice Emitted when a principal is granted eligibility.
+    event PrincipalGranted(address indexed principal, bytes32 indexed identityRef);
+
+    /// @notice Emitted when a previously eligible principal is revoked.
+    event PrincipalRevoked(address indexed principal, bytes32 indexed identityRef, ReasonCode reason);
+
+    /// @notice Grants eligibility to a principal.
+    /// @param principal The on-chain address of the principal.
+    /// @param identityRef An off-chain identity reference (e.g., keccak256 of a Decentralized Identifier (DID) or attestation ID).
+    /// @param expiresAt Unix timestamp after which eligibility MUST be re-checked. 0 means no expiry.
+    function grantPrincipal(address principal, bytes32 identityRef, uint48 expiresAt) external;
+
+    /// @notice Revokes a principal's eligibility.
+    /// @param principal The on-chain address of the principal.
+    /// @param reason The reason for revocation.
+    function revokePrincipal(address principal, ReasonCode reason) external;
+
+    /// @notice Returns eligibility of a principal.
+    /// @param principal The on-chain address of the principal.
+    /// @param identityRef An off-chain identity reference (e.g., keccak256 of a Decentralized Identifier (DID) or attestation ID).
+    /// @return eligible True if the principal is compliant.
+    /// @return reason Reason code. MUST be COMPLIANT when eligible is true.
+    /// @return expiresAt Unix timestamp after which this result MUST be re-checked. 0 means no expiry.
+    function checkPrincipal(address principal, bytes32 identityRef)
+        external
+        view
+        returns (bool eligible, ReasonCode reason, uint48 expiresAt);
+}

--- a/assets/erc-8226/contracts/regulated-asset-mock/IERC7943.sol
+++ b/assets/erc-8226/contracts/regulated-asset-mock/IERC7943.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/// @notice Interface for ERC-20 based implementations.
+interface IERC7943Fungible is IERC165 {
+    /// @notice Emitted when tokens are taken from one address and transferred to another.
+    /// @param from The address from which tokens were taken.
+    /// @param to The address to which seized tokens were transferred.
+    /// @param amount The amount seized.
+    event ForcedTransfer(address indexed from, address indexed to, uint256 amount);
+
+    /// @notice Emitted when `setFrozenTokens` is called, changing the frozen `amount` of tokens for `account`.
+    /// @param account The address of the account whose tokens are being frozen.
+    /// @param amount The amount of tokens frozen after the change.
+    event Frozen(address indexed account, uint256 amount);
+
+    /// @notice Error reverted when an account is not allowed to send tokens.
+    /// @param account The address of the account which is not allowed to send.
+    error ERC7943CannotSend(address account);
+
+    /// @notice Error reverted when an account is not allowed to receive tokens.
+    /// @param account The address of the account which is not allowed to receive.
+    error ERC7943CannotReceive(address account);
+
+    /// @notice Error reverted when a transfer is not allowed according to internal rules.
+    /// @param from The address from which tokens are being sent.
+    /// @param to The address to which tokens are being sent.
+    /// @param amount The amount sent.
+    error ERC7943CannotTransfer(address from, address to, uint256 amount);
+
+    /// @notice Error reverted when a transfer is attempted from `account` with an `amount` less than or equal to its balance, but greater than its unfrozen balance.
+    /// @param account The address holding the tokens.
+    /// @param amount The amount being transferred.
+    /// @param unfrozen The amount of tokens that are unfrozen and available to transfer.
+    error ERC7943InsufficientUnfrozenBalance(address account, uint256 amount, uint256 unfrozen);
+
+    /// @notice Takes tokens from one address and transfers them to another.
+    /// @dev Requires specific authorization. Used for regulatory compliance or recovery scenarios.
+    /// @param from The address from which `amount` is taken.
+    /// @param to The address that receives `amount`.
+    /// @param amount The amount to force transfer.
+    /// @return result True if the transfer executed correctly. Reverts on failure.
+    function forcedTransfer(address from, address to, uint256 amount) external returns (bool result);
+
+    /// @notice Changes the frozen status of `amount` tokens belonging to `account`.
+    /// This overwrites the current value, similar to an `approve` function.
+    /// @dev Requires specific authorization. Frozen tokens cannot be transferred by the account.
+    /// @param account The address of the account whose tokens are to be frozen.
+    /// @param amount The amount of tokens to freeze. It can be greater than account balance.
+    /// @return result True if the freezing executed correctly. Reverts on failure.
+    function setFrozenTokens(address account, uint256 amount) external returns (bool result);
+
+    /// @notice Checks if a specific account is allowed to send tokens according to token rules.
+    /// @dev This is often used for allowlist/KYC/KYB/AML checks.
+    /// @param account The address to check.
+    /// @return allowed True if the account is allowed to send, false otherwise.
+    function canSend(address account) external view returns (bool allowed);
+
+    /// @notice Checks if a specific account is allowed to receive tokens according to token rules.
+    /// @dev This is often used for allowlist/KYC/KYB/AML checks.
+    /// @param account The address to check.
+    /// @return allowed True if the account is allowed to receive, false otherwise.
+    function canReceive(address account) external view returns (bool allowed);
+
+    /// @notice Checks the frozen status/amount.
+    /// @param account The address of the account.
+    /// @dev It could return an amount higher than the account's balance.
+    /// @return amount The amount of tokens currently frozen for `account`.
+    function getFrozenTokens(address account) external view returns (uint256 amount);
+
+    /// @notice Checks if a transfer is currently possible according to token rules. It enforces validations on the frozen tokens.
+    /// @dev This can involve checks like allowlists, blocklists, transfer limits and other policy-defined restrictions.
+    /// @param from The address sending tokens.
+    /// @param to The address receiving tokens.
+    /// @param amount The amount being transferred.
+    /// @return allowed True if the transfer is allowed, false otherwise.
+    function canTransfer(address from, address to, uint256 amount) external view returns (bool allowed);
+}
+
+/// @notice Interface for ERC-721 based implementations.
+interface IERC7943NonFungible is IERC165 {
+    /// @notice Emitted when `tokenId` is taken from one address and transferred to another.
+    /// @param from The address from which `tokenId` is taken.
+    /// @param to The address to which seized `tokenId` is transferred.
+    /// @param tokenId The ID of the token being transferred.
+    event ForcedTransfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    /// @notice Emitted when `setFrozenTokens` is called, changing the frozen status of `tokenId` for `account`.
+    /// @param account The address of the account whose `tokenId` is subjected to freeze/unfreeze.
+    /// @param tokenId The ID of the token subjected to freeze/unfreeze.
+    /// @param frozenStatus Whether `tokenId` has been frozen or unfrozen.
+    event Frozen(address indexed account, uint256 indexed tokenId, bool indexed frozenStatus);
+
+    /// @notice Error reverted when an account is not allowed to send tokens.
+    /// @param account The address of the account which is not allowed to send.
+    error ERC7943CannotSend(address account);
+
+    /// @notice Error reverted when an account is not allowed to receive tokens.
+    /// @param account The address of the account which is not allowed to receive.
+    error ERC7943CannotReceive(address account);
+
+    /// @notice Error reverted when a transfer is not allowed according to internal rules.
+    /// @param from The address from which tokens are being sent.
+    /// @param to The address to which tokens are being sent.
+    /// @param tokenId The id of the token being sent.
+    error ERC7943CannotTransfer(address from, address to, uint256 tokenId);
+
+    /// @notice Error reverted when a transfer is attempted from `account` with a `tokenId` which has been previously frozen.
+    /// @param account The address holding the token with `tokenId`.
+    /// @param tokenId The ID of the token being frozen and unavailable to be transferred.
+    error ERC7943InsufficientUnfrozenBalance(address account, uint256 tokenId);
+
+    /// @notice Takes `tokenId` from one address and transfers it to another.
+    /// @dev Requires specific authorization. Used for regulatory compliance or recovery scenarios.
+    /// @param from The address from which `tokenId` is taken.
+    /// @param to The address that receives `tokenId`.
+    /// @param tokenId The ID of the token being transferred.
+    /// @return result True if the transfer executed correctly. Reverts on failure.
+    function forcedTransfer(address from, address to, uint256 tokenId) external returns (bool result);
+
+    /// @notice Changes the frozen status of `tokenId` belonging to an `account`.
+    /// This overwrites the current value, similar to an `approve` function.
+    /// @dev Requires specific authorization. Frozen tokens cannot be transferred by the account.
+    /// @param account The address of the account whose tokens are to be frozen.
+    /// @param tokenId The ID of the token to freeze.
+    /// @param frozenStatus Whether `tokenId` is being frozen or not.
+    /// @return result True if the freezing executed correctly. Reverts on failure.
+    function setFrozenTokens(address account, uint256 tokenId, bool frozenStatus) external returns (bool result);
+
+    /// @notice Checks if a specific account is allowed to send tokens according to token rules.
+    /// @dev This is often used for allowlist/KYC/KYB/AML checks.
+    /// @param account The address to check.
+    /// @return allowed True if the account is allowed to send, false otherwise.
+    function canSend(address account) external view returns (bool allowed);
+
+    /// @notice Checks if a specific account is allowed to receive tokens according to token rules.
+    /// @dev This is often used for allowlist/KYC/KYB/AML checks.
+    /// @param account The address to check.
+    /// @return allowed True if the account is allowed to receive, false otherwise.
+    function canReceive(address account) external view returns (bool allowed);
+
+    /// @notice Checks the frozen status of a specific `tokenId`.
+    /// @dev It could return true even if account does not hold the token.
+    /// @param account The address of the account.
+    /// @param tokenId The ID of the token.
+    /// @return frozenStatus Whether `tokenId` is currently frozen for `account`.
+    function getFrozenTokens(address account, uint256 tokenId) external view returns (bool frozenStatus);
+
+    /// @notice Checks if a transfer is currently possible according to token rules. It enforces validations on the frozen tokens.
+    /// @dev This can involve checks like allowlists, blocklists, transfer limits and other policy-defined restrictions.
+    /// @param from The address sending tokens.
+    /// @param to The address receiving tokens.
+    /// @param tokenId The ID of the token being transferred.
+    /// @return allowed True if the transfer is allowed, false otherwise.
+    function canTransfer(address from, address to, uint256 tokenId) external view returns (bool allowed);
+}
+
+/// @notice Interface for ERC-1155 based implementations.
+interface IERC7943MultiToken is IERC165 {
+    /// @notice Emitted when tokens are taken from one address and transferred to another.
+    /// @param from The address from which tokens were taken.
+    /// @param to The address to which seized tokens were transferred.
+    /// @param tokenId The ID of the token being transferred.
+    /// @param amount The amount seized.
+    event ForcedTransfer(address indexed from, address indexed to, uint256 indexed tokenId, uint256 amount);
+
+    /// @notice Emitted when `setFrozenTokens` is called, changing the frozen `amount` of `tokenId` tokens for `account`.
+    /// @param account The address of the account whose tokens are being frozen.
+    /// @param tokenId The ID of the token being frozen.
+    /// @param amount The amount of tokens frozen after the change.
+    event Frozen(address indexed account, uint256 indexed tokenId, uint256 amount);
+
+    /// @notice Error reverted when an account is not allowed to send tokens.
+    /// @param account The address of the account which is not allowed to send.
+    error ERC7943CannotSend(address account);
+
+    /// @notice Error reverted when an account is not allowed to receive tokens.
+    /// @param account The address of the account which is not allowed to receive.
+    error ERC7943CannotReceive(address account);
+
+    /// @notice Error reverted when a transfer is not allowed according to internal rules.
+    /// @param from The address from which tokens are being sent.
+    /// @param to The address to which tokens are being sent.
+    /// @param tokenId The id of the token being sent.
+    /// @param amount The amount sent.
+    error ERC7943CannotTransfer(address from, address to, uint256 tokenId, uint256 amount);
+
+    /// @notice Error reverted when a transfer is attempted from `account` with an `amount` of `tokenId` less than or equal to its balance, but greater than its unfrozen balance.
+    /// @param account The address holding the `amount` of `tokenId` tokens.
+    /// @param tokenId The ID of the token being transferred.
+    /// @param amount The amount of `tokenId` tokens being transferred.
+    /// @param unfrozen The amount of tokens that are unfrozen and available to transfer.
+    error ERC7943InsufficientUnfrozenBalance(address account, uint256 tokenId, uint256 amount, uint256 unfrozen);
+
+    /// @notice Takes tokens from one address and transfers them to another.
+    /// @dev Requires specific authorization. Used for regulatory compliance or recovery scenarios.
+    /// @param from The address from which `amount` is taken.
+    /// @param to The address that receives `amount`.
+    /// @param tokenId The ID of the token being transferred.
+    /// @param amount The amount to force transfer.
+    /// @return result True if the transfer executed correctly. Reverts on failure.
+    function forcedTransfer(address from, address to, uint256 tokenId, uint256 amount) external returns (bool result);
+
+    /// @notice Changes the frozen status of `amount` of `tokenId` tokens belonging to an `account`.
+    /// This overwrites the current value, similar to an `approve` function.
+    /// @dev Requires specific authorization. Frozen tokens cannot be transferred by the account.
+    /// @param account The address of the account whose tokens are to be frozen.
+    /// @param tokenId The ID of the token to freeze.
+    /// @param amount The amount of tokens to freeze. It can be greater than account balance.
+    /// @return result True if the freezing executed correctly. Reverts on failure.
+    function setFrozenTokens(address account, uint256 tokenId, uint256 amount) external returns (bool result);
+
+    /// @notice Checks if a specific account is allowed to send tokens according to token rules.
+    /// @dev This is often used for allowlist/KYC/KYB/AML checks.
+    /// @param account The address to check.
+    /// @return allowed True if the account is allowed to send, false otherwise.
+    function canSend(address account) external view returns (bool allowed);
+
+    /// @notice Checks if a specific account is allowed to receive tokens according to token rules.
+    /// @dev This is often used for allowlist/KYC/KYB/AML checks.
+    /// @param account The address to check.
+    /// @return allowed True if the account is allowed to receive, false otherwise.
+    function canReceive(address account) external view returns (bool allowed);
+
+    /// @notice Checks the frozen status/amount of a specific `tokenId`.
+    /// @dev It could return an amount higher than the account's balance.
+    /// @param account The address of the account.
+    /// @param tokenId The ID of the token.
+    /// @return amount The amount of `tokenId` tokens currently frozen for `account`.
+    function getFrozenTokens(address account, uint256 tokenId) external view returns (uint256 amount);
+
+    /// @notice Checks if a transfer is currently possible according to token rules. It enforces validations on the frozen tokens.
+    /// @dev This can involve checks like allowlists, blocklists, transfer limits and other policy-defined restrictions.
+    /// @param from The address sending tokens.
+    /// @param to The address receiving tokens.
+    /// @param tokenId The ID of the token being transferred.
+    /// @param amount The amount being transferred.
+    /// @return allowed True if the transfer is allowed, false otherwise.
+    function canTransfer(address from, address to, uint256 tokenId, uint256 amount) external view returns (bool allowed);
+}

--- a/assets/erc-8226/contracts/regulated-asset-mock/uRWA20.sol
+++ b/assets/erc-8226/contracts/regulated-asset-mock/uRWA20.sol
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {IERC7943Fungible} from "./IERC7943.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {AccessControlEnumerable} from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
+
+/// @title uRWA-20 Token Contract
+/// @notice An ERC-20 token implementation adhering to the IERC-7943 interface for Real World Assets.
+/// @dev Combines standard ERC-20 functionality with RWA-specific features like whitelisting,
+/// controlled minting/burning, asset forced transfers, and freezing. Managed via AccessControl.
+contract uRWA20 is Context, ERC20, AccessControlEnumerable, IERC7943Fungible {
+    /// @notice Role identifiers.
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+    bytes32 public constant FREEZING_ROLE = keccak256("FREEZING_ROLE");
+    bytes32 public constant WHITELIST_ROLE = keccak256("WHITELIST_ROLE");
+    bytes32 public constant FORCE_TRANSFER_ROLE = keccak256("FORCE_TRANSFER_ROLE");
+
+    /// @notice Mapping storing the send whitelist status for each account address.
+    /// @dev True indicates the account is allowed to send tokens, false otherwise.
+    mapping(address account => bool allowed) internal _sendWhitelist;
+
+    /// @notice Mapping storing the receive whitelist status for each account address.
+    /// @dev True indicates the account is allowed to receive tokens, false otherwise.
+    mapping(address account => bool allowed) internal _receiveWhitelist;
+
+    /// @notice Mapping storing the freezing status of assets for each account address.
+    /// @dev It gives the amount of ERC-20 tokens frozen in `account` wallet.
+    mapping(address account => uint256 amount) internal _frozenTokens;
+
+    /// @notice Emitted when an account's send whitelist status is changed.
+    /// @param account The address whose status was changed.
+    /// @param status The new whitelist status (true = whitelisted, false = not whitelisted).
+    event SendWhitelisted(address indexed account, bool status);
+
+    /// @notice Emitted when an account's receive whitelist status is changed.
+    /// @param account The address whose status was changed.
+    /// @param status The new whitelist status (true = whitelisted, false = not whitelisted).
+    event ReceiveWhitelisted(address indexed account, bool status);
+
+    /// @notice Contract constructor.
+    /// @dev Initializes the ERC-20 token with name and symbol, and grants all roles
+    /// (Admin, Minter, Burner, Freezer, Force Transfer, Whitelist) to the `initialAdmin`.
+    /// @param name The name of the token.
+    /// @param symbol The symbol of the token.
+    /// @param initialAdmin The address to receive initial administrative and operational roles.
+    constructor(string memory name, string memory symbol, address initialAdmin) ERC20(name, symbol) {
+        _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
+        _grantRole(MINTER_ROLE, initialAdmin);
+        _grantRole(BURNER_ROLE, initialAdmin);
+        _grantRole(FREEZING_ROLE, initialAdmin);
+        _grantRole(WHITELIST_ROLE, initialAdmin);
+        _grantRole(FORCE_TRANSFER_ROLE, initialAdmin);
+    }
+
+    /// @inheritdoc IERC7943Fungible
+    function canTransfer(address from, address to, uint256 amount) public view virtual override returns (bool allowed) {
+        uint256 frozen = getFrozenTokens(from);
+        if (frozen > 0) {
+            uint256 fromBalance = balanceOf(from);
+            uint256 unfrozen = fromBalance > frozen ? fromBalance - frozen : 0;
+            if (amount > unfrozen) return allowed;
+        }
+        if (!canSend(from) || !canReceive(to)) return allowed;
+        allowed = true;
+    }
+
+    /// @inheritdoc IERC7943Fungible
+    function canSend(address account) public view virtual override returns (bool allowed) {
+        allowed = _sendWhitelist[account];
+    }
+
+    /// @inheritdoc IERC7943Fungible
+    function canReceive(address account) public view virtual override returns (bool allowed) {
+        allowed = _receiveWhitelist[account];
+    }
+
+    /// @inheritdoc IERC7943Fungible
+    function getFrozenTokens(address account) public view virtual override returns (uint256 amount) {
+        amount = _frozenTokens[account];
+    }
+
+    /// @notice Updates the send whitelist status for a given account.
+    /// @dev Can only be called by accounts holding the `WHITELIST_ROLE`.
+    /// Emits a {SendWhitelisted} event upon successful update.
+    /// @param account The address whose whitelist status is to be changed.
+    /// @param status The new whitelist status (true = whitelisted, false = not whitelisted).
+    function changeSendWhitelist(address account, bool status) external onlyRole(WHITELIST_ROLE) {
+        _sendWhitelist[account] = status;
+        emit SendWhitelisted(account, status);
+    }
+
+    /// @notice Updates the receive whitelist status for a given account.
+    /// @dev Can only be called by accounts holding the `WHITELIST_ROLE`.
+    /// Emits a {ReceiveWhitelisted} event upon successful update.
+    /// @param account The address whose whitelist status is to be changed.
+    /// @param status The new whitelist status (true = whitelisted, false = not whitelisted).
+    function changeReceiveWhitelist(address account, bool status) external onlyRole(WHITELIST_ROLE) {
+        _receiveWhitelist[account] = status;
+        emit ReceiveWhitelisted(account, status);
+    }
+
+    /// @notice Creates `amount` new tokens and assigns them to `to`.
+    /// @dev Can only be called by accounts holding the `MINTER_ROLE`.
+    /// Requires `to` to be allowed according to {canReceive}.
+    /// Emits a {Transfer} event with `from` set to the zero address.
+    /// @param to The address that will receive the minted tokens.
+    /// @param amount The amount of tokens to mint.
+    function mint(address to, uint256 amount) external onlyRole(MINTER_ROLE) {
+        _mint(to, amount);
+    }
+
+    /// @notice Destroys `amount` tokens from the caller's account.
+    /// @dev Can only be called by accounts holding the `BURNER_ROLE`.
+    /// Emits a {Transfer} event with `to` set to the zero address.
+    /// @param amount The amount of tokens to burn.
+    function burn(uint256 amount) external onlyRole(BURNER_ROLE) {
+        _burn(_msgSender(), amount);
+    }
+
+    /// @inheritdoc IERC7943Fungible
+    /// @dev Can only be called by accounts holding the `FREEZING_ROLE`
+    function setFrozenTokens(address account, uint256 amount)
+        public
+        virtual
+        override
+        onlyRole(FREEZING_ROLE)
+        returns (bool result)
+    {
+        _frozenTokens[account] = amount;
+        emit Frozen(account, amount);
+        result = true;
+    }
+
+    /// @inheritdoc IERC7943Fungible
+    /// @dev Can only be called by accounts holding the `FORCE_TRANSFER_ROLE`.
+    function forcedTransfer(address from, address to, uint256 amount)
+        public
+        virtual
+        override
+        onlyRole(FORCE_TRANSFER_ROLE)
+        returns (bool result)
+    {
+        require(to != address(0), ERC20InvalidReceiver(address(0)));
+        require(from != address(0), ERC20InvalidSender(address(0)));
+        require(canReceive(to), ERC7943CannotReceive(to));
+        _excessFrozenUpdate(from, amount);
+        super._update(from, to, amount); // Directly update balances, bypassing overridden _update
+        emit ForcedTransfer(from, to, amount);
+        result = true;
+    }
+
+    /// @notice Updates frozen token amount when a forced transfer or burn exceeds the unfrozen balance.
+    /// @dev This function reduces the frozen token amount to ensure consistency when tokens are forcibly
+    /// moved or burned beyond the unfrozen balance. Emits a {Frozen} event when frozen amount is reduced.
+    /// @param account The address whose frozen tokens may need adjustment.
+    /// @param amount The amount being forcibly transferred or burned.
+    function _excessFrozenUpdate(address account, uint256 amount) internal {
+        uint256 unfrozenBalance = _unfrozenBalance(account);
+        if (amount > unfrozenBalance && amount <= balanceOf(account)) {
+            _frozenTokens[account] -= amount - unfrozenBalance;
+            emit Frozen(account, getFrozenTokens(account));
+        }
+    }
+
+    /// @notice Calculates the unfrozen token balance for an account.
+    /// @dev Returns the amount of tokens that are available for transfer, which is the total balance
+    /// minus the frozen amount. If frozen tokens exceed the balance, returns 0 to prevent underflow.
+    /// This is a helper function used throughout the contract for transfer validation.
+    /// @param account The address to calculate unfrozen balance for.
+    /// @return unfrozenBalance The amount of tokens available for transfer.
+    function _unfrozenBalance(address account) internal view returns (uint256 unfrozenBalance) {
+        unfrozenBalance =
+            balanceOf(account) < getFrozenTokens(account) ? 0 : balanceOf(account) - getFrozenTokens(account);
+    }
+
+    /// @notice Hook that is called during any token transfer, including minting and burning.
+    /// @dev Overrides the ERC-20 `_update` hook. Enforces transfer restrictions based on {canTransfer}, {canSend} and {canReceive} logic.
+    /// Reverts with {ERC7943InsufficientUnfrozenBalance} | {ERC7943CannotSend} | {ERC7943CannotReceive} if any check fails.
+    /// @param from The address sending tokens (zero address for minting).
+    /// @param to The address receiving tokens (zero address for burning).
+    /// @param amount The amount being transferred.
+    function _update(address from, address to, uint256 amount) internal virtual override {
+        if (from != address(0) && to != address(0)) {
+            // Transfer
+            uint256 unfrozenFromBalance = _unfrozenBalance(from);
+            uint256 fromBalance = balanceOf(from);
+            require(fromBalance >= amount, ERC20InsufficientBalance(from, fromBalance, amount));
+            require(
+                amount <= unfrozenFromBalance, ERC7943InsufficientUnfrozenBalance(from, amount, unfrozenFromBalance)
+            );
+            require(canSend(from), ERC7943CannotSend(from));
+            require(canReceive(to), ERC7943CannotReceive(to));
+        } else if (from == address(0)) {
+            // Mint
+            require(canReceive(to), ERC7943CannotReceive(to));
+        } else {
+            // Burn
+            require(canSend(from), ERC7943CannotSend(from));
+            _excessFrozenUpdate(from, amount);
+        }
+
+        super._update(from, to, amount);
+    }
+
+    /// @dev Mock-only: a dynamic arg before `amount` lets tests exercise the executor's amount-by-index decode.
+    function swap(uint256 a, uint256[] calldata t, uint256 amount) external {}
+
+    /// @notice See {IERC165-supportsInterface}.
+    /// @dev Indicates support for the {IERC7943Fungible} interface in addition to inherited interfaces.
+    /// @param interfaceId The interface identifier, as specified in ERC-165.
+    /// @return True if the contract implements `interfaceId`, false otherwise.
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(AccessControlEnumerable, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IERC7943Fungible).interfaceId || interfaceId == type(IERC20).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+}

--- a/assets/erc-8226/foundry.toml
+++ b/assets/erc-8226/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "contracts"
+test = "test"
+solc = "0.8.30"
+optimizer = true
+optimizer_runs = 200

--- a/assets/erc-8226/remappings.txt
+++ b/assets/erc-8226/remappings.txt
@@ -1,0 +1,3 @@
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+forge-std/=lib/openzeppelin-contracts/lib/forge-std/src/
+openzeppelin-contracts/=lib/openzeppelin-contracts/

--- a/assets/erc-8226/test/AgentExecutor.t.sol
+++ b/assets/erc-8226/test/AgentExecutor.t.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC7943Fungible} from "../contracts/regulated-asset-mock/IERC7943.sol";
+
+import {AgentExecutor} from "../contracts/AgentExecutor.sol";
+import {AgentMandate} from "../contracts/AgentMandate.sol";
+import {ComplianceProvider} from "../contracts/ComplianceProvider.sol";
+import {IAgentMandate} from "../contracts/interfaces/IAgentMandate.sol";
+import {uRWA20} from "../contracts/regulated-asset-mock/uRWA20.sol";
+
+/// @notice Tests the executor venue against the real registry, compliance provider, and a uRWA-20 asset.
+contract AgentExecutorTest is Test {
+    AgentExecutor executor;
+    AgentMandate mandate;
+    ComplianceProvider compliance;
+    uRWA20 token;
+
+    address admin = makeAddr("admin");
+    address complianceOwner = makeAddr("complianceOwner");
+    address executorOwner = makeAddr("executorOwner");
+    address enforcer = makeAddr("enforcer");
+    address principal = makeAddr("principal");
+    address agent = makeAddr("agent");
+    address recipient = makeAddr("recipient");
+    address stranger = makeAddr("stranger");
+    address spender = makeAddr("spender");
+
+    bytes32 constant IDREF = keccak256("kyc-principal");
+    bytes4 constant TRANSFER_FROM = IERC20.transferFrom.selector;
+    bytes4 constant APPROVE = IERC20.approve.selector;
+    bytes4 constant SWAP = uRWA20.swap.selector;
+
+    function setUp() public {
+        compliance = new ComplianceProvider(complianceOwner);
+        mandate = new AgentMandate(admin);
+        token = new uRWA20("Regulated", "RWA", admin);
+        executor = new AgentExecutor(IAgentMandate(address(mandate)), principal, executorOwner);
+
+        vm.prank(complianceOwner);
+        compliance.grantPrincipal(principal, IDREF, 0);
+
+        vm.startPrank(admin);
+        token.changeSendWhitelist(principal, true);
+        token.changeReceiveWhitelist(principal, true);
+        token.changeReceiveWhitelist(recipient, true);
+        token.mint(principal, 10_000);
+        vm.stopPrank();
+
+        bytes32[] memory actions = new bytes32[](3);
+        actions[0] = bytes32(TRANSFER_FROM);
+        actions[1] = bytes32(APPROVE);
+        actions[2] = bytes32(SWAP);
+        IAgentMandate.GrantMandateParams memory p = IAgentMandate.GrantMandateParams({
+            agent: agent,
+            validFrom: 0,
+            validUntil: uint48(block.timestamp + 1 days),
+            principal: principal,
+            complianceProvider: address(compliance),
+            identityRef: IDREF,
+            asset: address(token),
+            maxTransactionValue: 1000,
+            maxCumulativeValue: 1500,
+            metadata: bytes32(0),
+            actions: actions,
+            deadline: 0
+        });
+        vm.prank(principal);
+        mandate.grantMandate(p, "");
+
+        vm.startPrank(admin);
+        mandate.grantRole(mandate.RECORDER_ROLE(), address(executor));
+        vm.stopPrank();
+        vm.prank(executorOwner);
+        executor.setAction(TRANSFER_FROM, true, true, 2);
+
+        vm.prank(principal);
+        token.approve(address(executor), type(uint256).max);
+    }
+
+    function _transfer(address to, uint256 amount) internal {
+        vm.prank(agent);
+        executor.execute(address(token), abi.encodeWithSelector(TRANSFER_FROM, principal, to, amount));
+    }
+
+    function test_AmountArgReadByIndexWithDynamicArgBefore() public {
+        // swap(uint256 a, uint256[] t, uint256 amount): amount is arg index 2. The dynamic `t` at index 1
+        // only stores an offset in its head slot, so amount still sits at 4 + 32*2 and must decode as 42.
+        vm.prank(executorOwner);
+        executor.setAction(SWAP, true, true, 2);
+
+        uint256[] memory arr = new uint256[](3);
+        arr[0] = 1;
+        arr[1] = 2;
+        arr[2] = 3;
+        vm.prank(agent);
+        executor.execute(address(token), abi.encodeWithSelector(SWAP, uint256(111), arr, uint256(42)));
+
+        assertEq(mandate.getMandate(agent, principal).cumulativeUsed, 42);
+    }
+
+    function test_ApproveWithAmountAtDifferentIndex() public {
+        // A second action whose amount sits at arg index 1 (approve(spender, amount)).
+        vm.prank(executorOwner);
+        executor.setAction(APPROVE, true, true, 1);
+
+        vm.prank(agent);
+        executor.execute(address(token), abi.encodeWithSelector(APPROVE, spender, uint256(400)));
+
+        assertEq(token.allowance(address(executor), spender), 400);
+        assertEq(mandate.getMandate(agent, principal).cumulativeUsed, 400);
+    }
+
+    function test_Misconfig_ValueBearingActionAsValueless_BypassesCap() public {
+        // RISK: registering a value-bearing action (approve) as hasAmount=false makes the executor gate it
+        // at amount 0, bypassing maxTransactionValue. Owners MUST register value-bearing actions as hasAmount=true.
+        vm.prank(executorOwner);
+        executor.setAction(APPROVE, true, false, 0);
+
+        vm.prank(agent);
+        executor.execute(address(token), abi.encodeWithSelector(APPROVE, spender, uint256(700)));
+
+        assertEq(token.allowance(address(executor), spender), 700); // the forwarded call still ran
+        assertEq(mandate.getMandate(agent, principal).cumulativeUsed, 0); // but the cap was untouched
+    }
+
+    function test_RevertsOverCumulativeCap() public {
+        _transfer(recipient, 1000); // cumulative 1000
+        vm.prank(agent);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentExecutor.CannotExecute.selector, agent, address(token), TRANSFER_FROM, uint256(1000)
+            )
+        );
+        executor.execute(address(token), abi.encodeWithSelector(TRANSFER_FROM, principal, recipient, uint256(1000)));
+    }
+
+    function test_RevertsOverPerTxCap() public {
+        vm.prank(agent);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentExecutor.CannotExecute.selector, agent, address(token), TRANSFER_FROM, uint256(1500)
+            )
+        );
+        executor.execute(address(token), abi.encodeWithSelector(TRANSFER_FROM, principal, recipient, uint256(1500)));
+    }
+
+    function test_RevertsUnsupportedSelector() public {
+        bytes4 unknown = bytes4(keccak256("foo()"));
+        vm.prank(agent);
+        vm.expectRevert(abi.encodeWithSelector(AgentExecutor.UnsupportedAction.selector, unknown));
+        executor.execute(address(token), abi.encodeWithSelector(unknown));
+    }
+
+    function test_RevertsWhenFrozen() public {
+        vm.startPrank(admin);
+        mandate.grantRole(mandate.ENFORCER_ROLE(), enforcer);
+        vm.stopPrank();
+        vm.prank(enforcer);
+        mandate.freezeAgent(agent);
+
+        vm.prank(agent);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentExecutor.CannotExecute.selector, agent, address(token), TRANSFER_FROM, uint256(500)
+            )
+        );
+        executor.execute(address(token), abi.encodeWithSelector(TRANSFER_FROM, principal, recipient, uint256(500)));
+    }
+
+    function test_RevertsWhenRevoked() public {
+        vm.prank(principal);
+        mandate.revokeMandate(agent, principal, 0, "");
+        vm.prank(agent);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentExecutor.CannotExecute.selector, agent, address(token), TRANSFER_FROM, uint256(500)
+            )
+        );
+        executor.execute(address(token), abi.encodeWithSelector(TRANSFER_FROM, principal, recipient, uint256(500)));
+    }
+
+    function test_SetActionCanDisable() public {
+        vm.prank(executorOwner);
+        executor.setAction(TRANSFER_FROM, false, true, 2);
+
+        (bool supported,,) = executor.actions(TRANSFER_FROM);
+        assertFalse(supported);
+
+        vm.prank(agent);
+        vm.expectRevert(abi.encodeWithSelector(AgentExecutor.UnsupportedAction.selector, TRANSFER_FROM));
+        executor.execute(address(token), abi.encodeWithSelector(TRANSFER_FROM, principal, recipient, uint256(100)));
+    }
+
+    function test_SetActionOnlyOwner() public {
+        vm.prank(agent);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, agent));
+        executor.setAction(TRANSFER_FROM, true, true, 2);
+    }
+
+    function test_SetActionRegisters() public {
+        vm.prank(executorOwner);
+        executor.setAction(APPROVE, true, true, 1);
+
+        (bool supported, bool hasAmount, uint8 amountIndex) = executor.actions(APPROVE);
+        assertTrue(supported);
+        assertTrue(hasAmount);
+        assertEq(amountIndex, 1);
+    }
+
+    function test_TokenComplianceBlocksIndependently() public {
+        bytes memory inner = abi.encodeWithSelector(IERC7943Fungible.ERC7943CannotReceive.selector, stranger);
+        vm.prank(agent);
+        vm.expectRevert(abi.encodeWithSelector(AgentExecutor.CallFailed.selector, inner));
+        executor.execute(address(token), abi.encodeWithSelector(TRANSFER_FROM, principal, stranger, uint256(500)));
+    }
+
+    function test_TransfersAndRecords() public {
+        _transfer(recipient, 500);
+        assertEq(token.balanceOf(recipient), 500);
+        assertEq(mandate.getMandate(agent, principal).cumulativeUsed, 500);
+    }
+}

--- a/assets/erc-8226/test/AgentMandate.t.sol
+++ b/assets/erc-8226/test/AgentMandate.t.sol
@@ -1,0 +1,549 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+import {AgentMandate} from "../contracts/AgentMandate.sol";
+import {ComplianceProvider} from "../contracts/ComplianceProvider.sol";
+import {IComplianceProvider} from "../contracts/interfaces/IComplianceProvider.sol";
+import {IAgentMandate} from "../contracts/interfaces/IAgentMandate.sol";
+import {uRWA20} from "../contracts/regulated-asset-mock/uRWA20.sol";
+
+contract MockWallet {
+    using ECDSA for bytes32;
+
+    address public immutable owner;
+
+    constructor(address _owner) {
+        owner = _owner;
+    }
+
+    function isValidSignature(bytes32 hash, bytes calldata sig) external view returns (bytes4) {
+        return hash.recover(sig) == owner ? bytes4(0x1626ba7e) : bytes4(0xffffffff);
+    }
+}
+
+contract AgentMandateTest is Test {
+    AgentMandate mandate;
+    ComplianceProvider compliance;
+    uRWA20 token;
+
+    address admin = makeAddr("admin");
+    address complianceOwner = makeAddr("complianceOwner");
+    address agent = makeAddr("agent");
+    address recipient = makeAddr("recipient");
+    address operator = makeAddr("operator");
+    address relayer = makeAddr("relayer");
+    address stranger = makeAddr("stranger");
+    address recorder = makeAddr("recorder");
+    address enforcer = makeAddr("enforcer");
+
+    address principal;
+    uint256 principalPk;
+
+    bytes32 enforcerRole;
+    bytes32 recorderRole;
+    bytes32 adminRole;
+
+    bytes32 constant IDREF = keccak256("kyc-principal");
+    bytes4 constant TRANSFER_FROM = IERC20.transferFrom.selector;
+    bytes32 constant ACTION = bytes32(IERC20.transferFrom.selector);
+    bytes32 constant OTHER_ACTION = bytes32(uint256(0xdead));
+
+    bytes32 constant GRANT_TYPEHASH = keccak256(
+        "GrantMandate(address agent,uint48 validFrom,uint48 validUntil,address principal,address complianceProvider,bytes32 identityRef,address asset,uint256 maxTransactionValue,uint256 maxCumulativeValue,bytes32 metadata,bytes32[] actions,uint256 nonce,uint256 deadline)"
+    );
+    bytes32 constant REVOKE_TYPEHASH =
+        keccak256("RevokeMandate(address agent,address principal,uint256 nonce,uint256 deadline)");
+    bytes32 constant EXTEND_TYPEHASH =
+        keccak256("ExtendMandate(address agent,address principal,uint48 newValidUntil,uint256 nonce,uint256 deadline)");
+    bytes32 constant SETOP_TYPEHASH =
+        keccak256("SetOperator(address principal,address operator,bool approved,uint256 nonce,uint256 deadline)");
+
+    function setUp() public {
+        (principal, principalPk) = makeAddrAndKey("principal");
+
+        mandate = new AgentMandate(admin);
+        compliance = new ComplianceProvider(complianceOwner);
+        token = new uRWA20("Regulated", "RWA", admin);
+
+        enforcerRole = mandate.ENFORCER_ROLE();
+        recorderRole = mandate.RECORDER_ROLE();
+        adminRole = mandate.DEFAULT_ADMIN_ROLE();
+
+        vm.prank(complianceOwner);
+        compliance.grantPrincipal(principal, IDREF, 0);
+    }
+
+    function _params() internal view returns (IAgentMandate.GrantMandateParams memory p) {
+        bytes32[] memory actions = new bytes32[](1);
+        actions[0] = ACTION;
+        p = IAgentMandate.GrantMandateParams({
+            agent: agent,
+            validFrom: 0,
+            validUntil: uint48(block.timestamp + 1 days),
+            principal: principal,
+            complianceProvider: address(compliance),
+            identityRef: IDREF,
+            asset: address(token),
+            maxTransactionValue: 1000,
+            maxCumulativeValue: 1500,
+            metadata: bytes32(0),
+            actions: actions,
+            deadline: 0
+        });
+    }
+
+    function _grant() internal {
+        vm.prank(principal);
+        mandate.grantMandate(_params(), "");
+    }
+
+    function _sign(uint256 pk, bytes32 structHash) internal view returns (bytes memory) {
+        bytes32 digest = keccak256(abi.encodePacked(hex"1901", mandate.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _grantStructHash(IAgentMandate.GrantMandateParams memory p, uint256 nonce)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                GRANT_TYPEHASH,
+                p.agent,
+                p.validFrom,
+                p.validUntil,
+                p.principal,
+                p.complianceProvider,
+                p.identityRef,
+                p.asset,
+                p.maxTransactionValue,
+                p.maxCumulativeValue,
+                p.metadata,
+                keccak256(abi.encodePacked(p.actions)),
+                nonce,
+                p.deadline
+            )
+        );
+    }
+
+    function test_AdminCannotAlsoBeEnforcer() public {
+        vm.startPrank(admin);
+        vm.expectRevert(AgentMandate.AdminEnforcerOverlap.selector);
+        mandate.grantRole(enforcerRole, admin);
+        vm.stopPrank();
+    }
+
+    function test_CanExecuteActionNotEnabled() public {
+        _grant();
+        assertFalse(mandate.canExecute(agent, principal, address(token), OTHER_ACTION, 100));
+    }
+
+    function test_CanExecuteNonexistentMandate() public view {
+        assertFalse(mandate.canExecute(agent, principal, address(token), ACTION, 100));
+    }
+
+    function test_CanExecuteOutsideWindow() public {
+        _grant();
+        vm.warp(block.timestamp + 2 days);
+        assertFalse(mandate.canExecute(agent, principal, address(token), ACTION, 100));
+    }
+
+    function test_CanExecuteWrongAsset() public {
+        _grant();
+        assertFalse(mandate.canExecute(agent, principal, address(0xBEEF), ACTION, 100));
+    }
+
+    function test_EnforcerCannotAlsoBeAdmin() public {
+        vm.startPrank(admin);
+        mandate.grantRole(enforcerRole, enforcer);
+        vm.expectRevert(AgentMandate.AdminEnforcerOverlap.selector);
+        mandate.grantRole(adminRole, enforcer);
+        vm.stopPrank();
+    }
+
+    function test_ExtendByOperator() public {
+        _grant();
+        vm.prank(principal);
+        mandate.setOperator(principal, operator, true, 0, "");
+        uint48 newUntil = uint48(block.timestamp + 10 days);
+        vm.prank(operator);
+        mandate.extendMandate(agent, principal, newUntil, 0, "");
+        assertEq(mandate.getMandate(agent, principal).validUntil, newUntil);
+    }
+
+    function test_ExtendByPrincipal() public {
+        _grant();
+        uint48 newUntil = uint48(block.timestamp + 10 days);
+        vm.prank(principal);
+        mandate.extendMandate(agent, principal, newUntil, 0, "");
+        assertEq(mandate.getMandate(agent, principal).validUntil, newUntil);
+    }
+
+    function test_ExtendBySignature() public {
+        _grant();
+        uint48 newUntil = uint48(block.timestamp + 10 days);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory sig = _sign(
+            principalPk,
+            keccak256(abi.encode(EXTEND_TYPEHASH, agent, principal, newUntil, mandate.nonces(principal), deadline))
+        );
+        vm.prank(relayer);
+        mandate.extendMandate(agent, principal, newUntil, deadline, sig);
+        assertEq(mandate.getMandate(agent, principal).validUntil, newUntil);
+    }
+
+    function test_ExtendPreservesCumulativeUsed() public {
+        _grant();
+        vm.prank(principal);
+        mandate.recordExecution(agent, principal, ACTION, 500);
+        vm.prank(principal);
+        mandate.extendMandate(agent, principal, uint48(block.timestamp + 10 days), 0, "");
+        assertEq(mandate.getMandate(agent, principal).cumulativeUsed, 500);
+    }
+
+    function test_ExtendRevertsInvalidExpiry() public {
+        _grant();
+        uint48 current = mandate.getMandate(agent, principal).validUntil;
+        vm.prank(principal);
+        vm.expectRevert(AgentMandate.InvalidExpiry.selector);
+        mandate.extendMandate(agent, principal, current, 0, "");
+    }
+
+    function test_ExtendRevertsWhenExpired() public {
+        IAgentMandate.GrantMandateParams memory p = _params();
+        p.validUntil = uint48(block.timestamp + 100);
+        vm.prank(principal);
+        mandate.grantMandate(p, "");
+
+        vm.warp(block.timestamp + 101);
+        vm.prank(principal);
+        vm.expectRevert(AgentMandate.NoActiveMandate.selector);
+        mandate.extendMandate(agent, principal, uint48(block.timestamp + 10 days), 0, "");
+    }
+
+    function test_FreezeByEnforcerBlocksAndUnfreeze() public {
+        _grant();
+        vm.startPrank(admin);
+        mandate.grantRole(enforcerRole, enforcer);
+        vm.stopPrank();
+
+        vm.prank(enforcer);
+        mandate.freezeAgent(agent);
+        assertTrue(mandate.isFrozen(agent));
+        assertFalse(mandate.canExecute(agent, principal, address(token), ACTION, 100));
+
+        vm.prank(enforcer);
+        mandate.unfreezeAgent(agent);
+        assertTrue(mandate.canExecute(agent, principal, address(token), ACTION, 100));
+    }
+
+    function test_FreezeOnlyEnforcer() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, enforcerRole)
+        );
+        mandate.freezeAgent(agent);
+    }
+
+    function test_GrantByContractWallet_EIP1271() public {
+        (address walletOwner, uint256 walletOwnerPk) = makeAddrAndKey("walletOwner");
+        MockWallet wallet = new MockWallet(walletOwner);
+
+        vm.prank(complianceOwner);
+        compliance.grantPrincipal(address(wallet), IDREF, 0);
+
+        IAgentMandate.GrantMandateParams memory p = _params();
+        p.principal = address(wallet);
+        p.deadline = block.timestamp + 1 hours;
+        bytes memory sig = _sign(walletOwnerPk, _grantStructHash(p, mandate.nonces(address(wallet))));
+
+        vm.prank(relayer);
+        mandate.grantMandate(p, sig);
+
+        assertTrue(mandate.canExecute(agent, address(wallet), address(token), ACTION, 100));
+    }
+
+    function test_GrantBySignature() public {
+        IAgentMandate.GrantMandateParams memory p = _params();
+        p.deadline = block.timestamp + 1 hours;
+        bytes memory sig = _sign(principalPk, _grantStructHash(p, mandate.nonces(principal)));
+
+        vm.prank(relayer);
+        mandate.grantMandate(p, sig);
+
+        assertTrue(mandate.canExecute(agent, principal, address(token), ACTION, 100));
+        assertEq(mandate.nonces(principal), 1);
+    }
+
+    function test_GrantDirectByPrincipal() public {
+        _grant();
+        assertEq(mandate.getMandate(agent, principal).principal, principal);
+        assertTrue(mandate.isActionEnabled(agent, principal, ACTION));
+        assertTrue(mandate.canExecute(agent, principal, address(token), ACTION, 1000));
+    }
+
+    function test_GrantRevertsAlreadyActive() public {
+        _grant();
+        vm.prank(principal);
+        vm.expectRevert(AgentMandate.MandateAlreadyActive.selector);
+        mandate.grantMandate(_params(), "");
+    }
+
+    function test_GrantRevertsBadSignature() public {
+        (, uint256 wrongPk) = makeAddrAndKey("wrong");
+        IAgentMandate.GrantMandateParams memory p = _params();
+        p.deadline = block.timestamp + 1 hours;
+        bytes memory sig = _sign(wrongPk, _grantStructHash(p, mandate.nonces(principal)));
+        vm.prank(relayer);
+        vm.expectRevert(AgentMandate.InvalidSignature.selector);
+        mandate.grantMandate(p, sig);
+    }
+
+    function test_GrantRevertsInvalidExpiry() public {
+        IAgentMandate.GrantMandateParams memory p = _params();
+        p.validUntil = uint48(block.timestamp);
+        vm.prank(principal);
+        vm.expectRevert(AgentMandate.InvalidExpiry.selector);
+        mandate.grantMandate(p, "");
+    }
+
+    function test_GrantRevertsNotEligible() public {
+        vm.prank(complianceOwner);
+        compliance.revokePrincipal(principal, IComplianceProvider.ReasonCode.AML_FLAG);
+        vm.prank(principal);
+        vm.expectRevert(AgentMandate.PrincipalNotEligible.selector);
+        mandate.grantMandate(_params(), "");
+    }
+
+    function test_GrantRevertsNotPrincipalWhenNoSig() public {
+        vm.prank(stranger);
+        vm.expectRevert(AgentMandate.NotPrincipal.selector);
+        mandate.grantMandate(_params(), "");
+    }
+
+    function test_GrantRevertsZeroProvider() public {
+        IAgentMandate.GrantMandateParams memory p = _params();
+        p.complianceProvider = address(0);
+        vm.prank(principal);
+        vm.expectRevert(AgentMandate.ZeroComplianceProvider.selector);
+        mandate.grantMandate(p, "");
+    }
+
+    function test_NoLimitCapsAllowHugeAmount() public {
+        IAgentMandate.GrantMandateParams memory p = _params();
+        p.maxTransactionValue = type(uint256).max;
+        p.maxCumulativeValue = type(uint256).max;
+        vm.prank(principal);
+        mandate.grantMandate(p, "");
+
+        uint256 huge = type(uint256).max;
+        assertTrue(mandate.canExecute(agent, principal, address(token), ACTION, huge));
+        vm.prank(principal);
+        mandate.recordExecution(agent, principal, ACTION, huge);
+        assertEq(mandate.getMandate(agent, principal).cumulativeUsed, huge);
+    }
+
+    function test_OperatorCannotGrant() public {
+        vm.prank(principal);
+        mandate.setOperator(principal, operator, true, 0, "");
+        vm.prank(operator);
+        vm.expectRevert(AgentMandate.NotPrincipal.selector);
+        mandate.grantMandate(_params(), "");
+    }
+
+    function test_RecordByAsset() public {
+        _grant();
+        vm.prank(address(token));
+        mandate.recordExecution(agent, principal, ACTION, 100);
+        assertEq(mandate.getMandate(agent, principal).cumulativeUsed, 100);
+    }
+
+    function test_RecordByPrincipal() public {
+        _grant();
+        vm.prank(principal);
+        mandate.recordExecution(agent, principal, ACTION, 100);
+        assertEq(mandate.getMandate(agent, principal).cumulativeUsed, 100);
+    }
+
+    function test_RecordByRecorderRole() public {
+        _grant();
+        vm.startPrank(admin);
+        mandate.grantRole(recorderRole, recorder);
+        vm.stopPrank();
+        vm.prank(recorder);
+        mandate.recordExecution(agent, principal, ACTION, 100);
+        assertEq(mandate.getMandate(agent, principal).cumulativeUsed, 100);
+    }
+
+    function test_RecordRevertsActionNotEnabled() public {
+        _grant();
+        vm.prank(principal);
+        vm.expectRevert(AgentMandate.NotExecutable.selector);
+        mandate.recordExecution(agent, principal, OTHER_ACTION, 100);
+    }
+
+    function test_RecordRevertsOverCumulativeCap() public {
+        _grant();
+        vm.startPrank(principal);
+        mandate.recordExecution(agent, principal, ACTION, 1000);
+        vm.expectRevert(AgentMandate.ExceedsCumulativeCap.selector);
+        mandate.recordExecution(agent, principal, ACTION, 1000);
+        vm.stopPrank();
+    }
+
+    function test_RecordRevertsOverTxCap() public {
+        _grant();
+        vm.prank(principal);
+        vm.expectRevert(AgentMandate.ExceedsTransactionCap.selector);
+        mandate.recordExecution(agent, principal, ACTION, 1001);
+    }
+
+    function test_RecordRevertsUnauthorized() public {
+        _grant();
+        vm.prank(stranger);
+        vm.expectRevert(AgentMandate.UnauthorizedRecorder.selector);
+        mandate.recordExecution(agent, principal, ACTION, 100);
+    }
+
+    function test_RecordRevertsWhenFrozen() public {
+        _grant();
+        vm.startPrank(admin);
+        mandate.grantRole(enforcerRole, enforcer);
+        vm.stopPrank();
+        vm.prank(enforcer);
+        mandate.freezeAgent(agent);
+
+        vm.prank(principal);
+        vm.expectRevert(AgentMandate.NotExecutable.selector);
+        mandate.recordExecution(agent, principal, ACTION, 100);
+    }
+
+    function test_RecordRevertsWhenRevoked() public {
+        _grant();
+        vm.startPrank(principal);
+        mandate.revokeMandate(agent, principal, 0, "");
+        vm.expectRevert(AgentMandate.NotExecutable.selector);
+        mandate.recordExecution(agent, principal, ACTION, 100);
+        vm.stopPrank();
+    }
+
+    function test_RegrantAfterExpiry() public {
+        IAgentMandate.GrantMandateParams memory p = _params();
+        p.validUntil = uint48(block.timestamp + 100);
+        vm.prank(principal);
+        mandate.grantMandate(p, "");
+
+        vm.warp(block.timestamp + 101);
+        vm.prank(principal);
+        mandate.grantMandate(_params(), "");
+        assertTrue(mandate.canExecute(agent, principal, address(token), ACTION, 100));
+    }
+
+    function test_RegrantAfterRevoke() public {
+        _grant();
+        vm.prank(principal);
+        mandate.revokeMandate(agent, principal, 0, "");
+        vm.prank(principal);
+        mandate.grantMandate(_params(), "");
+        assertTrue(mandate.canExecute(agent, principal, address(token), ACTION, 100));
+    }
+
+    function test_RevokeByOperator() public {
+        _grant();
+        vm.prank(principal);
+        mandate.setOperator(principal, operator, true, 0, "");
+        vm.prank(operator);
+        mandate.revokeMandate(agent, principal, 0, "");
+        assertFalse(mandate.canExecute(agent, principal, address(token), ACTION, 100));
+    }
+
+    function test_RevokeByPrincipal() public {
+        _grant();
+        vm.prank(principal);
+        mandate.revokeMandate(agent, principal, 0, "");
+        assertFalse(mandate.canExecute(agent, principal, address(token), ACTION, 100));
+    }
+
+    function test_RevokeBySignature() public {
+        _grant();
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory sig = _sign(
+            principalPk, keccak256(abi.encode(REVOKE_TYPEHASH, agent, principal, mandate.nonces(principal), deadline))
+        );
+        vm.prank(relayer);
+        mandate.revokeMandate(agent, principal, deadline, sig);
+        assertFalse(mandate.canExecute(agent, principal, address(token), ACTION, 100));
+    }
+
+    function test_RevokeRevertsNoActiveMandate() public {
+        vm.prank(principal);
+        vm.expectRevert(AgentMandate.NoActiveMandate.selector);
+        mandate.revokeMandate(agent, principal, 0, "");
+    }
+
+    function test_RevokeRevertsNotAuthorized() public {
+        _grant();
+        vm.prank(stranger);
+        vm.expectRevert(AgentMandate.NotAuthorized.selector);
+        mandate.revokeMandate(agent, principal, 0, "");
+    }
+
+    function test_SetOperatorBySignature() public {
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory sig = _sign(
+            principalPk,
+            keccak256(abi.encode(SETOP_TYPEHASH, principal, operator, true, mandate.nonces(principal), deadline))
+        );
+        vm.prank(relayer);
+        mandate.setOperator(principal, operator, true, deadline, sig);
+        assertTrue(mandate.isOperator(principal, operator));
+    }
+
+    function test_SignatureExpired() public {
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory sig = _sign(
+            principalPk,
+            keccak256(abi.encode(SETOP_TYPEHASH, principal, operator, true, mandate.nonces(principal), deadline))
+        );
+        vm.warp(deadline + 1);
+        vm.prank(relayer);
+        vm.expectRevert(AgentMandate.SignatureExpired.selector);
+        mandate.setOperator(principal, operator, true, deadline, sig);
+    }
+
+    function test_SignatureReplayRejected() public {
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory sig = _sign(
+            principalPk,
+            keccak256(abi.encode(SETOP_TYPEHASH, principal, operator, true, mandate.nonces(principal), deadline))
+        );
+        vm.prank(relayer);
+        mandate.setOperator(principal, operator, true, deadline, sig);
+
+        vm.prank(relayer);
+        vm.expectRevert(AgentMandate.InvalidSignature.selector);
+        mandate.setOperator(principal, operator, true, deadline, sig);
+    }
+
+    function test_SupportsInterface() public view {
+        assertTrue(mandate.supportsInterface(type(IAgentMandate).interfaceId));
+        assertTrue(mandate.supportsInterface(type(IERC165).interfaceId));
+        assertFalse(mandate.supportsInterface(0xffffffff));
+    }
+
+    function test_UnfreezeOnlyEnforcer() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, enforcerRole)
+        );
+        mandate.unfreezeAgent(agent);
+    }
+}

--- a/assets/erc-8226/test/ComplianceProvider.t.sol
+++ b/assets/erc-8226/test/ComplianceProvider.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {Test} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+import {ComplianceProvider} from "../contracts/ComplianceProvider.sol";
+import {IComplianceProvider} from "../contracts/interfaces/IComplianceProvider.sol";
+
+contract ComplianceProviderTest is Test {
+    ComplianceProvider provider;
+
+    address complianceOwner = makeAddr("complianceOwner");
+    address principal = makeAddr("principal");
+    address stranger = makeAddr("stranger");
+
+    bytes32 constant IDREF = keccak256("kyc-1");
+    bytes32 constant OTHER_REF = keccak256("kyc-2");
+
+    event PrincipalGranted(address indexed principal, bytes32 indexed identityRef);
+    event PrincipalRevoked(
+        address indexed principal, bytes32 indexed identityRef, IComplianceProvider.ReasonCode reason
+    );
+
+    function setUp() public {
+        provider = new ComplianceProvider(complianceOwner);
+    }
+
+    function _check(bytes32 ref)
+        internal
+        view
+        returns (bool eligible, IComplianceProvider.ReasonCode reason, uint48 expiresAt)
+    {
+        return provider.checkPrincipal(principal, ref);
+    }
+
+    function _reason(IComplianceProvider.ReasonCode r) internal pure returns (uint256) {
+        return uint256(r);
+    }
+
+    function test_CheckUnknownPrincipal() public view {
+        (bool eligible, IComplianceProvider.ReasonCode reason,) = _check(IDREF);
+        assertFalse(eligible);
+        assertEq(_reason(reason), _reason(IComplianceProvider.ReasonCode.IDENTITY_NOT_FOUND));
+    }
+
+    function test_CheckWrongIdentityRef() public {
+        vm.prank(complianceOwner);
+        provider.grantPrincipal(principal, IDREF, 0);
+
+        (bool eligible, IComplianceProvider.ReasonCode reason,) = _check(OTHER_REF);
+        assertFalse(eligible);
+        assertEq(_reason(reason), _reason(IComplianceProvider.ReasonCode.IDENTITY_NOT_FOUND));
+    }
+
+    function test_ExpiryBlocksAfterDeadline() public {
+        uint48 expiry = uint48(block.timestamp + 100);
+        vm.prank(complianceOwner);
+        provider.grantPrincipal(principal, IDREF, expiry);
+
+        (bool okBefore,, uint48 e1) = _check(IDREF);
+        assertTrue(okBefore);
+        assertEq(e1, expiry);
+
+        vm.warp(block.timestamp + 101);
+        (bool okAfter, IComplianceProvider.ReasonCode reason, uint48 e2) = _check(IDREF);
+        assertFalse(okAfter);
+        assertEq(_reason(reason), _reason(IComplianceProvider.ReasonCode.KYC_EXPIRED));
+        assertEq(e2, expiry);
+    }
+
+    function test_GrantMakesEligibleAndEmits() public {
+        vm.expectEmit(true, true, false, true, address(provider));
+        emit PrincipalGranted(principal, IDREF);
+        vm.prank(complianceOwner);
+        provider.grantPrincipal(principal, IDREF, 0);
+
+        (bool eligible, IComplianceProvider.ReasonCode reason, uint48 expiresAt) = _check(IDREF);
+        assertTrue(eligible);
+        assertEq(_reason(reason), _reason(IComplianceProvider.ReasonCode.COMPLIANT));
+        assertEq(expiresAt, 0);
+    }
+
+    function test_GrantOnlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stranger));
+        provider.grantPrincipal(principal, IDREF, 0);
+    }
+
+    function test_GrantRevertsZeroIdentityRef() public {
+        vm.prank(complianceOwner);
+        vm.expectRevert(ComplianceProvider.ZeroIdentityRef.selector);
+        provider.grantPrincipal(principal, bytes32(0), 0);
+    }
+
+    function test_NoExpiryNeverExpires() public {
+        vm.prank(complianceOwner);
+        provider.grantPrincipal(principal, IDREF, 0);
+
+        vm.warp(block.timestamp + 365 days);
+        (bool eligible,,) = _check(IDREF);
+        assertTrue(eligible);
+    }
+
+    function test_RegrantAfterRevoke() public {
+        vm.startPrank(complianceOwner);
+        provider.grantPrincipal(principal, IDREF, 0);
+        provider.revokePrincipal(principal, IComplianceProvider.ReasonCode.AML_FLAG);
+        provider.grantPrincipal(principal, OTHER_REF, 0); // overwrites the revoked record
+        vm.stopPrank();
+
+        (bool eligible, IComplianceProvider.ReasonCode reason,) = _check(OTHER_REF);
+        assertTrue(eligible);
+        assertEq(_reason(reason), _reason(IComplianceProvider.ReasonCode.COMPLIANT));
+    }
+
+    function test_RevokeBlocksAndEmits() public {
+        vm.prank(complianceOwner);
+        provider.grantPrincipal(principal, IDREF, 0);
+
+        vm.expectEmit(true, true, false, true, address(provider));
+        emit PrincipalRevoked(principal, IDREF, IComplianceProvider.ReasonCode.AML_FLAG);
+        vm.prank(complianceOwner);
+        provider.revokePrincipal(principal, IComplianceProvider.ReasonCode.AML_FLAG);
+
+        (bool eligible, IComplianceProvider.ReasonCode reason,) = _check(IDREF);
+        assertFalse(eligible);
+        assertEq(_reason(reason), _reason(IComplianceProvider.ReasonCode.AML_FLAG));
+    }
+
+    function test_RevokeOnlyOwner() public {
+        vm.prank(complianceOwner);
+        provider.grantPrincipal(principal, IDREF, 0);
+
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stranger));
+        provider.revokePrincipal(principal, IComplianceProvider.ReasonCode.AML_FLAG);
+    }
+
+    function test_RevokeRevertsWhenAlreadyRevoked() public {
+        vm.startPrank(complianceOwner);
+        provider.grantPrincipal(principal, IDREF, 0);
+        provider.revokePrincipal(principal, IComplianceProvider.ReasonCode.AML_FLAG);
+        vm.expectRevert(abi.encodeWithSelector(ComplianceProvider.NotActive.selector, principal));
+        provider.revokePrincipal(principal, IComplianceProvider.ReasonCode.OTHER);
+        vm.stopPrank();
+    }
+
+    function test_RevokeRevertsWhenNeverGranted() public {
+        vm.prank(complianceOwner);
+        vm.expectRevert(abi.encodeWithSelector(ComplianceProvider.NotActive.selector, principal));
+        provider.revokePrincipal(principal, IComplianceProvider.ReasonCode.AML_FLAG);
+    }
+
+    function test_SupportsInterface() public view {
+        assertTrue(provider.supportsInterface(type(IComplianceProvider).interfaceId));
+        assertTrue(provider.supportsInterface(type(IERC165).interfaceId));
+        assertFalse(provider.supportsInterface(0xffffffff));
+    }
+}


### PR DESCRIPTION
this pr updates ERC-8226 (Regulated Agent Mandate) with a reference implementation and spec refinements from review.

Spec:

- Mandatory compliance provider at grant
- Clarified cap denomination and venue-agnostic enforcement (token hook, EIP-7702 account, executor)

Reference implementation (assets/erc-8226/)

- AgentMandate registry
- ComplianceProvider, optional AgentExecutor, and an ERC-7943 (uRWA-20) integration