### PR TITLE
Fix RSS feed self links and non-ERC feed filtering

### DIFF
--- a/rss/all.xml
+++ b/rss/all.xml
@@ -7,7 +7,7 @@ layout: null
     <title>Ethereum EIPs</title>
     <description>A feed of all EIPs</description>
     <link>{{ site.url }}</link>
-    <atom:link href="{{ site.url }}/all.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="{{ site.url }}/rss/all.xml" rel="self" type="application/rss+xml" />
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     {% assign eips = site.pages | sort: 'eip' %}
     {% for eip in eips %}

--- a/rss/erc-last-call.xml
+++ b/rss/erc-last-call.xml
@@ -7,7 +7,7 @@ layout: null
     <title>Ethereum EIPs - Last Call Review</title>
     <description>All EIPs which are in the "last call" status, please help review these and provide your feedback!</description>
     <link>{{ site.url }}</link>
-    <atom:link href="{{ site.url }}/rss/last-call.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="{{ site.url }}/rss/erc-last-call.xml" rel="self" type="application/rss+xml" />
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     {% assign eips = site.pages | sort: 'eip' %}
     {% for eip in eips %}

--- a/rss/nonerc-last-call.xml
+++ b/rss/nonerc-last-call.xml
@@ -7,7 +7,7 @@ layout: null
     <title>Ethereum EIPs - Last Call Review</title>
     <description>All EIPs which are in the two-week "last call" status, please help review these and provide your feedback!</description>
     <link>{{ site.url }}</link>
-    <atom:link href="{{ site.url }}/rss/last-call.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="{{ site.url }}/rss/nonerc-last-call.xml" rel="self" type="application/rss+xml" />
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     {% assign eips = site.pages | sort: 'eip' %}
     {% for eip in eips %}

--- a/rss/nonerc.xml
+++ b/rss/nonerc.xml
@@ -7,14 +7,13 @@ layout: null
     <title>Ethereum EIPs</title>
     <description>All EIPs that are not ERCs</description>
     <link>{{ site.url }}</link>
-    <atom:link href="{{ site.url }}/rss/last-call.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="{{ site.url }}/rss/nonerc.xml" rel="self" type="application/rss+xml" />
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     {% assign eips = site.pages | sort: 'eip' %}
     {% for eip in eips %}
       {% unless eip.category == "ERC" %}
-      {% if eip.status == "Last Call" %}
       {% capture description %}
-        <p><strong>EIP #{{ eip.eip }} - {{eip.title }}</strong> is in Last Call status. It is authored by {{ eip.author }} and was originally created {{ eip.created }}. It is in the {{ eip.category }} category of type {{ eip.type }}. Please review and note any changes that should block acceptance.</p>
+        <p><strong>EIP #{{ eip.eip }} - {{eip.title }}</strong> is in the {{ eip.category }} category of type {{ eip.type }} and was just updated.</p>
         {% if eip.discussions-to %}
           <p>The author has requested that discussions happen at the following URL: <a href="{{ eip.discussions-to }}">{{ eip.discussions-to }}</a></p>
         {% endif %}
@@ -28,7 +27,6 @@ layout: null
         <link>{{ site.url }}/{{ eip.url }}</link>
         <guid isPermaLink="true">{{ site.url }}/{{ eip.url }}</guid>
       </item>
-      {% endif %}
       {% endunless %}
     {% endfor %}
   </channel>


### PR DESCRIPTION
## Summary

Fix several RSS feed template copy-paste issues.

The `atom:link rel="self"` values for a few RSS templates pointed to another feed instead of the feed being rendered. This updates those self links so each RSS template points to its own `/rss/...` path.

This also fixes `rss/nonerc.xml`, which described itself as the feed for all non-ERC EIPs but was still using the Last Call-only filter and Last Call item description. The template now mirrors the regular update-feed behavior while keeping the non-ERC category filter.

## Testing

- Ran a local RSS template consistency check to verify each `atom:link rel="self"` matches its feed path.

