### PR TITLE
Config: Remove execution-spec-tests from allowed link exceptions

### DIFF
--- a/ERCS/eip-1.md
+++ b/ERCS/eip-1.md
@@ -216,27 +216,7 @@ Permitted Execution Client Specifications URLs must anchor to a specific commit,
 ^(https://github.com/ethereum/execution-specs/(blob|commit)/[0-9a-f]{40}/.*|https://github.com/ethereum/execution-specs/tree/[0-9a-f]{40}/.*)$
 ```
 
-### Execution Specification Tests
-
-Links to the Ethereum Execution Specification Tests (EEST) may be included using normal markdown syntax, such as:
-
-```markdown
-[Ethereum Execution Specification Tests](https://github.com/ethereum/execution-spec-tests/blob/c9b9307ff320c9bb0ecb9a951aeab0da4d9d1684/README.md)
-```
-
-Which renders to:
-
-[Ethereum Execution Specification Tests](https://github.com/ethereum/execution-spec-tests/blob/c9b9307ff320c9bb0ecb9a951aeab0da4d9d1684/README.md)
-
-Permitted Execution Specification Tests URLs must anchor to a specific commit, and so must match one of these regular expressions:
-
-```regex
-^https://(www\.)?github\.com/ethereum/execution-spec-tests/(blob|tree)/[a-f0-9]{40}/.+$
-```
-
-```regex
-^https://(www\.)?github\.com/ethereum/execution-spec-tests/commit/[a-f0-9]{40}$
-```
+The Ethereum Execution Client Specifications repository also contains the Ethereum Execution Specification Tests, under its `tests/` directory. Links to specific commits of those test files are permitted under the same rule.
 
 ### Consensus Layer Specifications
 
@@ -412,24 +392,6 @@ Permitted Yellow Paper URLs must anchor to a specific commit, and so must match 
 
 ```regex
 ^(https://github\.com/ethereum/yellowpaper/blob/[0-9a-f]{40}/paper\.pdf)$
-```
-
-### Execution Client Specification Tests
-
-Links to the Ethereum Execution Client Specification Tests may be included using normal markdown syntax, such as:
-
-```markdown
-[Ethereum Execution Client Specification Tests](https://github.com/ethereum/execution-spec-tests/blob/d5a3188f122912e137aa2e21ed2a1403e806e424/README.md)
-```
-
-Which renders to:
-
-[Ethereum Execution Client Specification Tests](https://github.com/ethereum/execution-spec-tests/blob/d5a3188f122912e137aa2e21ed2a1403e806e424/README.md)
-
-Permitted Execution Client Specification Tests URLs must anchor to a specific commit, and so must match this regular expression:
-
-```regex
-^(https://github.com/ethereum/execution-spec-tests/(blob|commit)/[0-9a-f]{40}/.*|https://github.com/ethereum/execution-spec-tests/tree/[0-9a-f]{40}/.*)$
 ```
 
 ### Digital Object Identifier System

--- a/config/eipw.toml
+++ b/config/eipw.toml
@@ -141,8 +141,6 @@ exceptions = [
     '^https://(www\.)?github\.com/ethereum/consensus-specs/commit/[a-f0-9]{40}$',
     '^https://(www\.)?github\.com/ethereum/execution-specs/(blob|tree)/[a-f0-9]{40}/.+$',
     '^https://(www\.)?github\.com/ethereum/execution-specs/commit/[a-f0-9]{40}$',
-    '^https://(www\.)?github\.com/ethereum/execution-spec-tests/(blob|tree)/[a-f0-9]{40}/.+$',
-    '^https://(www\.)?github\.com/ethereum/execution-spec-tests/commit/[a-f0-9]{40}$',
     '^https://(www\.)?github\.com/ethereum/yellowpaper/(blob|tree)/[a-f0-9]{40}/.+$',
     '^https://(www\.)?github\.com/ethereum/yellowpaper/commit/[a-f0-9]{40}$',
     '^https://(www\.)?github\.com/ethereum/devp2p/(blob|tree)/[0-9a-f]{40}/.+$',


### PR DESCRIPTION
This PR mirrors the changes proposed by https://github.com/ethereum/EIPs/pull/11845 to remove the [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) repo from allowed link exceptions. 

Reason: The execution layer consensus tests moved from [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) to [ethereum/execution-specs](https://github.com/ethereum/execution-specs) in October 2025 as part of "The Weld", please find more background in [this blog post](https://steel.ethereum.foundation/blog/2025-11-04_weld_final/). The execution-spec-tests repo was archived on 2026-07-02.
