### PR TITLE
Update ERC-5484: Fixed minor typo in Burn Authorization

### DIFF
--- a/ERCS/erc-5484.md
+++ b/ERCS/erc-5484.md
@@ -89,7 +89,7 @@ One problem with current soulbound token implementations that extend from [EIP-7
 We want maximum freedom when it comes to interface usage. A flexible and predetermined rule to burn is crucial. Here are some sample scenarios for different burn authorizations:
 
 - `IssuerOnly`: Loan record
-- `ReceiverOnly`: Paid membership
+- `OwnerOnly`: Paid membership
 - `Both`: Credentials
 - `Neither`: Credit history
 


### PR DESCRIPTION
Currently the Burn Authorization section speaks of `ReceiverOnly` while the Contract Interface has it as `OwnerOnly`.
Assuming the Contract Interface to be API defining it would be be better to use `OwnerOnly` in the Burn Authorization as well to mitigate any ambiguity while remaining backwards compatible.