### PR TITLE
Website: Add Test Cases section and conformance fixture

### DIFF
--- a/ERCS/erc-7303.md
+++ b/ERCS/erc-7303.md
@@ -84,6 +84,10 @@ The `hasRole(bytes32, address)` signature deliberately matches the function of t
 
 This ERC is designed to be compatible for [ERC-721](./eip-721), [ERC-1155](./eip-1155), and [ERC-5679](./eip-5679) respectively.
 
+## Test Cases
+
+A redeployable conformance fixture and test suite are provided in [this ERC's assets directory](../assets/eip-7303/). The suite recomputes the `IERC7303` interface identifier (the XOR of its three function selectors, `0x4ee69337`) and asserts the ERC-165 declaration, the introspection getters and association events against a fixed canonical role structure, the grant/check/revoke lifecycle through both token standards including OR/AND role composition, and a functionally identical legacy contract that must be classified as not implementing this ERC. The expected values are defined by the fixture sources, not by any particular deployment, and are identical on any chain.
+
 ## Reference Implementation
 
 ERC-7303 provides a modifier to facilitate the implementation of TCTC access control in applications. This modifier checks if an account possesses the necessary role. ERC-7303 also includes a function that grants a specific role to a designated account, and implements the `IERC7303` introspection interface.

--- a/assets/erc-7303/.gitignore
+++ b/assets/erc-7303/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+artifacts/
+cache/
+typechain-types/
+package-lock.json

--- a/assets/erc-7303/README.md
+++ b/assets/erc-7303/README.md
@@ -1,0 +1,73 @@
+# ERC-7303 Conformance Fixture
+
+A redeployable fixture and test suite answering one question: **does a contract actually implement ERC-7303?**
+
+The durable part of this fixture is the sources in `contracts/` and the expected values asserted in [`test/conformance.js`](./test/conformance.js) — everything is recomputable and redeployable on any chain. Concrete testnet addresses are listed at the end for convenience only; they are not the fixture.
+
+## Layout
+
+| File | Purpose |
+|------|---------|
+| [`contracts/IERC7303.sol`](./contracts/IERC7303.sol) | The introspection interface from the ERC text |
+| [`contracts/ERC7303.sol`](./contracts/ERC7303.sol) | The reference implementation from the ERC text |
+| [`contracts/FixtureTarget.sol`](./contracts/FixtureTarget.sol) | Compliant fixture with a fixed, canonical role structure |
+| [`contracts/LegacyTarget.sol`](./contracts/LegacyTarget.sol) | Negative fixture: identical balance gating, no `IERC7303` |
+| [`contracts/ERC721ControlToken.sol`](./contracts/ERC721ControlToken.sol) | Minimal issuer-burnable ERC-721 control token |
+| [`contracts/ERC1155ControlToken.sol`](./contracts/ERC1155ControlToken.sol) | Minimal issuer-burnable ERC-1155 control token |
+| [`test/conformance.js`](./test/conformance.js) | Assertions of all expected values below |
+
+## Running
+
+```sh
+npm install
+npx hardhat test
+```
+
+## Expected values
+
+### Interface identifier
+
+The `IERC7303` identifier is the XOR of its three function selectors (events do not contribute):
+
+| Function | Selector |
+|----------|----------|
+| `hasRole(bytes32,address)` | `0x91d14854` |
+| `getERC721ControlTokens(bytes32)` | `0xa2911fab` |
+| `getERC1155ControlTokens(bytes32)` | `0x7da6c4c8` |
+| **XOR** | **`0x4ee69337`** |
+
+A compliant contract answers `supportsInterface(0x01ffc9a7)` = `true`, `supportsInterface(0x4ee69337)` = `true`, and `supportsInterface(0xffffffff)` = `false`.
+
+### Canonical role structure of `FixtureTarget`
+
+Deployed as `FixtureTarget(ct721, ct1155)`:
+
+| Role | `getERC721ControlTokens` | `getERC1155ControlTokens` |
+|------|--------------------------|---------------------------|
+| `keccak256("MINTER_ROLE")` | `[ct721]` | `([ct1155], [1])` |
+| `keccak256("BURNER_ROLE")` | `[]` | `([ct1155], [2])` |
+| any other role | `[]` | `([], [])` |
+
+Deployment emits exactly one `ERC721ControlTokenAdded` and two `ERC1155ControlTokenAdded` events matching the table.
+
+Roles compose in two directions:
+
+* **OR within a role** — holding **either** entry of `MINTER_ROLE` grants the role.
+* **AND across roles** — `reissue(tokenId, to)` stacks the modifiers of `MINTER_ROLE` and `BURNER_ROLE` and succeeds only for a caller holding **both**, whether the two roles are satisfied through the same standard (ERC-1155 + ERC-1155) or across standards (ERC-721 + ERC-1155).
+
+### Role lifecycle
+
+For each control-token path: `hasRole` is `false` before minting, `true` after the issuer mints, and `false` again after the issuer burns — with no cooperation from the holder (the kill switch). The gated functions (`safeMint`, `burn`) succeed exactly when the caller holds the role and otherwise revert with `"ERC7303: not has a required token"`.
+
+### Negative case
+
+`LegacyTarget` gates identically to `FixtureTarget` (same control tokens, same revert string) but pre-dates `IERC7303`: it exposes no `hasRole`/getter functions and `supportsInterface(0x4ee69337)` answers `false`. Discovery tooling encountering such a contract must classify it as **not** implementing this ERC, behavioral equivalence notwithstanding. This is the boundary the fixture pins down: conformance is the declared, machine-readable interface — not the gating behavior.
+
+## Convenience deployments (informational, not normative)
+
+An instance of each case is deployed on Sepolia. Testnets are ephemeral; if these disappear, redeploy the sources above — the expected values are unchanged on any chain.
+
+| Case | Address |
+|------|---------|
+| Compliant (`IERC7303`, interfaceId `0x4ee69337`) | `0x4C0a78803D47154B9C6F42EC4AEbab2D1C94c97D` |
+| Legacy negative (pre-`IERC7303`) | `0xa52fe39D0de852e88488faa34e723E861D0b09BD` |

--- a/assets/erc-7303/contracts/ERC1155ControlToken.sol
+++ b/assets/erc-7303/contracts/ERC1155ControlToken.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @notice Minimal ERC-1155 control token for the conformance fixture.
+/// The issuer (owner) grants a role by minting and revokes it by burning
+/// without the holder's cooperation — the issuer-side kill switch described
+/// in the ERC's Security Considerations.
+contract ERC1155ControlToken is ERC1155, Ownable {
+    constructor() ERC1155("") Ownable(msg.sender) {}
+
+    function mint(address to, uint256 id, uint256 amount) external onlyOwner {
+        _mint(to, id, amount, "");
+    }
+
+    function burnByIssuer(address account, uint256 id) external onlyOwner {
+        _burn(account, id, balanceOf(account, id));
+    }
+}

--- a/assets/erc-7303/contracts/ERC721ControlToken.sol
+++ b/assets/erc-7303/contracts/ERC721ControlToken.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @notice Minimal ERC-721 control token for the conformance fixture.
+/// The issuer (owner) grants a role by minting and revokes it by burning
+/// without the holder's cooperation — the issuer-side kill switch described
+/// in the ERC's Security Considerations.
+contract ERC721ControlToken is ERC721, Ownable {
+    uint256 private _nextId;
+
+    constructor() ERC721("FixtureControl721", "FC721") Ownable(msg.sender) {}
+
+    function mint(address to) external onlyOwner returns (uint256 tokenId) {
+        tokenId = ++_nextId;
+        _safeMint(to, tokenId);
+    }
+
+    function burnByIssuer(uint256 tokenId) external onlyOwner {
+        _burn(tokenId);
+    }
+}

--- a/assets/erc-7303/contracts/ERC7303.sol
+++ b/assets/erc-7303/contracts/ERC7303.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: CC0-1.0
+// Reference implementation of ERC-7303, identical to the one in the ERC text.
+
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "./IERC7303.sol";
+
+abstract contract ERC7303 is IERC7303 {
+    struct ERC721Token {
+        address contractId;
+    }
+
+    struct ERC1155Token {
+        address contractId;
+        uint256 typeId;
+    }
+
+    mapping (bytes32 => ERC721Token[]) private _ERC721_Contracts;
+    mapping (bytes32 => ERC1155Token[]) private _ERC1155_Contracts;
+
+    modifier onlyHasToken(bytes32 role, address account) {
+        require(_checkHasToken(role, account), "ERC7303: not has a required token");
+        _;
+    }
+
+    /**
+     * @notice Check whether `account` currently holds `role`.
+     */
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return _checkHasToken(role, account);
+    }
+
+    /**
+     * @notice Enumerate the ERC-721 control tokens associated with `role`.
+     */
+    function getERC721ControlTokens(bytes32 role) public view returns (address[] memory contractIds) {
+        ERC721Token[] memory tokens = _ERC721_Contracts[role];
+        contractIds = new address[](tokens.length);
+        for (uint i = 0; i < tokens.length; i++) {
+            contractIds[i] = tokens[i].contractId;
+        }
+    }
+
+    /**
+     * @notice Enumerate the ERC-1155 control tokens associated with `role`.
+     */
+    function getERC1155ControlTokens(bytes32 role) public view returns (address[] memory contractIds, uint256[] memory typeIds) {
+        ERC1155Token[] memory tokens = _ERC1155_Contracts[role];
+        contractIds = new address[](tokens.length);
+        typeIds = new uint256[](tokens.length);
+        for (uint i = 0; i < tokens.length; i++) {
+            contractIds[i] = tokens[i].contractId;
+            typeIds[i] = tokens[i].typeId;
+        }
+    }
+
+    /**
+     * @notice Grant a role to user who owns a control token specified by the ERC-721 contractId.
+     * Multiple calls are allowed, in this case the user must own at least one of the specified token.
+     * @param role byte32 The role which you want to grant.
+     * @param contractId address The address of contractId of which token the user required to own.
+     */
+    function _grantRoleByERC721(bytes32 role, address contractId) internal {
+        require(
+            IERC165(contractId).supportsInterface(type(IERC721).interfaceId),
+            "ERC7303: provided contract does not support ERC721 interface"
+        );
+        _ERC721_Contracts[role].push(ERC721Token(contractId));
+        emit ERC721ControlTokenAdded(role, contractId);
+    }
+
+    /**
+     * @notice Grant a role to user who owns a control token specified by the ERC-1155 contractId.
+     * Multiple calls are allowed, in this case the user must own at least one of the specified token.
+     * @param role byte32 The role which you want to grant.
+     * @param contractId address The address of contractId of which token the user required to own.
+     * @param typeId uint256 The token type id that the user required to own.
+     */
+    function _grantRoleByERC1155(bytes32 role, address contractId, uint256 typeId) internal {
+        require(
+            IERC165(contractId).supportsInterface(type(IERC1155).interfaceId),
+            "ERC7303: provided contract does not support ERC1155 interface"
+        );
+        _ERC1155_Contracts[role].push(ERC1155Token(contractId, typeId));
+        emit ERC1155ControlTokenAdded(role, contractId, typeId);
+    }
+
+    function _checkHasToken(bytes32 role, address account) internal view returns (bool) {
+        ERC721Token[] memory ERC721Tokens = _ERC721_Contracts[role];
+        for (uint i = 0; i < ERC721Tokens.length; i++) {
+            if (IERC721(ERC721Tokens[i].contractId).balanceOf(account) > 0) return true;
+        }
+
+        ERC1155Token[] memory ERC1155Tokens = _ERC1155_Contracts[role];
+        for (uint i = 0; i < ERC1155Tokens.length; i++) {
+            if (IERC1155(ERC1155Tokens[i].contractId).balanceOf(account, ERC1155Tokens[i].typeId) > 0) return true;
+        }
+
+        return false;
+    }
+}

--- a/assets/erc-7303/contracts/FixtureTarget.sol
+++ b/assets/erc-7303/contracts/FixtureTarget.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "./ERC7303.sol";
+
+/// @notice Canonical compliant fixture. Its role structure is fixed so that
+/// the introspection getters have deterministic expected values relative to
+/// the two control-token addresses supplied at deployment:
+///
+///   MINTER_ROLE = keccak256("MINTER_ROLE")
+///     - ERC-721 control token  `ct721`
+///     - ERC-1155 control token `ct1155`, typeId 1
+///     (two entries: holding either one grants the role — OR semantics)
+///   BURNER_ROLE = keccak256("BURNER_ROLE")
+///     - ERC-1155 control token `ct1155`, typeId 2
+///     (no ERC-721 entry: the ERC-721 getter answers an empty array)
+contract FixtureTarget is ERC721, ERC7303 {
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+
+    constructor(address ct721, address ct1155) ERC721("FixtureTarget", "FT") {
+        _grantRoleByERC721(MINTER_ROLE, ct721);
+        _grantRoleByERC1155(MINTER_ROLE, ct1155, 1);
+        _grantRoleByERC1155(BURNER_ROLE, ct1155, 2);
+    }
+
+    function safeMint(address to, uint256 tokenId)
+        public onlyHasToken(MINTER_ROLE, msg.sender)
+    {
+        _safeMint(to, tokenId);
+    }
+
+    function burn(uint256 tokenId)
+        public onlyHasToken(BURNER_ROLE, msg.sender)
+    {
+        _burn(tokenId);
+    }
+
+    /// @notice Stacking the modifiers of two roles composes them with AND
+    /// semantics: reissuing requires both the burn and the mint privilege.
+    function reissue(uint256 tokenId, address to)
+        public
+        onlyHasToken(MINTER_ROLE, msg.sender)
+        onlyHasToken(BURNER_ROLE, msg.sender)
+    {
+        _burn(tokenId);
+        _safeMint(to, tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public view override returns (bool)
+    {
+        return interfaceId == type(IERC7303).interfaceId || super.supportsInterface(interfaceId);
+    }
+}

--- a/assets/erc-7303/contracts/IERC7303.sol
+++ b/assets/erc-7303/contracts/IERC7303.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.9;
+
+interface IERC7303 {
+    /// @notice Emitted when an ERC-721 control token is associated with `role`.
+    event ERC721ControlTokenAdded(bytes32 indexed role, address indexed contractId);
+
+    /// @notice Emitted when an ERC-1155 control token is associated with `role`.
+    event ERC1155ControlTokenAdded(bytes32 indexed role, address indexed contractId, uint256 indexed typeId);
+
+    /// @notice Check whether `account` currently holds `role`, per the
+    ///         balance check described in this ERC.
+    function hasRole(bytes32 role, address account) external view returns (bool);
+
+    /// @notice Enumerate the ERC-721 control tokens associated with `role`.
+    function getERC721ControlTokens(bytes32 role) external view returns (address[] memory contractIds);
+
+    /// @notice Enumerate the ERC-1155 control tokens associated with `role`.
+    function getERC1155ControlTokens(bytes32 role) external view returns (address[] memory contractIds, uint256[] memory typeIds);
+}

--- a/assets/erc-7303/contracts/LegacyTarget.sol
+++ b/assets/erc-7303/contracts/LegacyTarget.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+
+/// @notice Negative fixture. Functionally identical balance gating to
+/// `FixtureTarget` (same roles, same control tokens, same revert string),
+/// but written in the pre-IERC7303 style: no introspection interface and no
+/// ERC-165 registration of the IERC7303 identifier, so
+/// `supportsInterface(0x4ee69337)` answers `false`. Discovery tooling
+/// encountering this contract must classify it as NOT implementing this ERC,
+/// even though its gating behaves identically on-chain.
+contract LegacyTarget is ERC721 {
+    IERC721 private immutable _ct721;
+    IERC1155 private immutable _ct1155;
+
+    constructor(address ct721, address ct1155) ERC721("LegacyTarget", "LT") {
+        _ct721 = IERC721(ct721);
+        _ct1155 = IERC1155(ct1155);
+    }
+
+    function safeMint(address to, uint256 tokenId) public {
+        require(
+            _ct721.balanceOf(msg.sender) > 0 || _ct1155.balanceOf(msg.sender, 1) > 0,
+            "ERC7303: not has a required token"
+        );
+        _safeMint(to, tokenId);
+    }
+
+    function burn(uint256 tokenId) public {
+        require(
+            _ct1155.balanceOf(msg.sender, 2) > 0,
+            "ERC7303: not has a required token"
+        );
+        _burn(tokenId);
+    }
+}

--- a/assets/erc-7303/hardhat.config.js
+++ b/assets/erc-7303/hardhat.config.js
@@ -1,0 +1,11 @@
+import "@nomicfoundation/hardhat-toolbox";
+
+export default {
+  solidity: {
+    version: "0.8.28",
+    settings: {
+      optimizer: { enabled: true, runs: 200 },
+      evmVersion: "cancun",
+    },
+  },
+};

--- a/assets/erc-7303/package.json
+++ b/assets/erc-7303/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "erc-7303-conformance-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "hardhat test"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "^5.0.0"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^6.1.0",
+    "hardhat": "^2.28.0"
+  }
+}

--- a/assets/erc-7303/test/conformance.js
+++ b/assets/erc-7303/test/conformance.js
@@ -1,0 +1,212 @@
+import { expect } from "chai";
+import hre from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers.js";
+
+const { ethers } = hre;
+
+// The durable expected values of the conformance fixture. Everything below
+// is recomputable from the sources in ../contracts and holds on any chain.
+const IERC7303_ID = "0x4ee69337";
+const ERC165_ID = "0x01ffc9a7";
+const INVALID_ID = "0xffffffff";
+const MINTER_ROLE = ethers.id("MINTER_ROLE");
+const BURNER_ROLE = ethers.id("BURNER_ROLE");
+const REVERT_NO_TOKEN = "ERC7303: not has a required token";
+
+async function deployFixture() {
+  const [issuer, alice, bob, carol] = await ethers.getSigners();
+  const ct721 = await ethers.deployContract("ERC721ControlToken");
+  const ct1155 = await ethers.deployContract("ERC1155ControlToken");
+  const target = await ethers.deployContract("FixtureTarget", [
+    ct721.target,
+    ct1155.target,
+  ]);
+  const legacy = await ethers.deployContract("LegacyTarget", [
+    ct721.target,
+    ct1155.target,
+  ]);
+  return { issuer, alice, bob, carol, ct721, ct1155, target, legacy };
+}
+
+describe("ERC-7303 conformance fixture", function () {
+  describe("interface identifier", function () {
+    it("recomputes to 0x4ee69337 from the three IERC7303 selectors", function () {
+      const signatures = [
+        "hasRole(bytes32,address)",
+        "getERC721ControlTokens(bytes32)",
+        "getERC1155ControlTokens(bytes32)",
+      ];
+      let acc = 0n;
+      for (const sig of signatures) {
+        acc ^= BigInt(ethers.dataSlice(ethers.id(sig), 0, 4));
+      }
+      expect("0x" + acc.toString(16).padStart(8, "0")).to.equal(IERC7303_ID);
+    });
+
+    it("is declared via ERC-165 by the compliant fixture", async function () {
+      const { target } = await loadFixture(deployFixture);
+      expect(await target.supportsInterface(ERC165_ID)).to.equal(true);
+      expect(await target.supportsInterface(IERC7303_ID)).to.equal(true);
+      expect(await target.supportsInterface(INVALID_ID)).to.equal(false);
+    });
+  });
+
+  describe("introspection getters", function () {
+    it("enumerates the canonical MINTER_ROLE structure", async function () {
+      const { target, ct721, ct1155 } = await loadFixture(deployFixture);
+      expect(await target.getERC721ControlTokens(MINTER_ROLE)).to.deep.equal([
+        ct721.target,
+      ]);
+      const [contractIds, typeIds] =
+        await target.getERC1155ControlTokens(MINTER_ROLE);
+      expect(contractIds).to.deep.equal([ct1155.target]);
+      expect(typeIds).to.deep.equal([1n]);
+    });
+
+    it("enumerates the canonical BURNER_ROLE structure, including the empty ERC-721 list", async function () {
+      const { target, ct1155 } = await loadFixture(deployFixture);
+      expect(await target.getERC721ControlTokens(BURNER_ROLE)).to.deep.equal([]);
+      const [contractIds, typeIds] =
+        await target.getERC1155ControlTokens(BURNER_ROLE);
+      expect(contractIds).to.deep.equal([ct1155.target]);
+      expect(typeIds).to.deep.equal([2n]);
+    });
+
+    it("answers empty lists for an unconfigured role", async function () {
+      const { target } = await loadFixture(deployFixture);
+      const unknown = ethers.id("UNKNOWN_ROLE");
+      expect(await target.getERC721ControlTokens(unknown)).to.deep.equal([]);
+      const [contractIds, typeIds] =
+        await target.getERC1155ControlTokens(unknown);
+      expect(contractIds).to.deep.equal([]);
+      expect(typeIds).to.deep.equal([]);
+    });
+  });
+
+  describe("association events", function () {
+    it("emitted one ERC721ControlTokenAdded and two ERC1155ControlTokenAdded at deployment", async function () {
+      const { target, ct721, ct1155 } = await loadFixture(deployFixture);
+
+      const erc721Events = await target.queryFilter(
+        target.filters.ERC721ControlTokenAdded()
+      );
+      expect(erc721Events).to.have.lengthOf(1);
+      expect(erc721Events[0].args.role).to.equal(MINTER_ROLE);
+      expect(erc721Events[0].args.contractId).to.equal(ct721.target);
+
+      const erc1155Events = await target.queryFilter(
+        target.filters.ERC1155ControlTokenAdded()
+      );
+      expect(erc1155Events).to.have.lengthOf(2);
+      expect(erc1155Events[0].args.role).to.equal(MINTER_ROLE);
+      expect(erc1155Events[0].args.contractId).to.equal(ct1155.target);
+      expect(erc1155Events[0].args.typeId).to.equal(1n);
+      expect(erc1155Events[1].args.role).to.equal(BURNER_ROLE);
+      expect(erc1155Events[1].args.contractId).to.equal(ct1155.target);
+      expect(erc1155Events[1].args.typeId).to.equal(2n);
+    });
+  });
+
+  describe("role lifecycle (grant = mint, check = balanceOf, revoke = burn)", function () {
+    it("tracks the ERC-721 control-token balance, including the issuer kill switch", async function () {
+      const { target, ct721, alice } = await loadFixture(deployFixture);
+
+      expect(await target.hasRole(MINTER_ROLE, alice.address)).to.equal(false);
+      await expect(
+        target.connect(alice).safeMint(alice.address, 1)
+      ).to.be.revertedWith(REVERT_NO_TOKEN);
+
+      await ct721.mint(alice.address); // tokenId 1
+      expect(await target.hasRole(MINTER_ROLE, alice.address)).to.equal(true);
+      await target.connect(alice).safeMint(alice.address, 1);
+      expect(await target.ownerOf(1)).to.equal(alice.address);
+
+      await ct721.burnByIssuer(1); // revocation needs no holder cooperation
+      expect(await target.hasRole(MINTER_ROLE, alice.address)).to.equal(false);
+      await expect(
+        target.connect(alice).safeMint(alice.address, 2)
+      ).to.be.revertedWith(REVERT_NO_TOKEN);
+    });
+
+    it("tracks the ERC-1155 control-token balance per typeId", async function () {
+      const { target, ct1155, bob } = await loadFixture(deployFixture);
+
+      await ct1155.mint(bob.address, 1, 1); // typeId 1 = MINTER_ROLE only
+      expect(await target.hasRole(MINTER_ROLE, bob.address)).to.equal(true);
+      expect(await target.hasRole(BURNER_ROLE, bob.address)).to.equal(false);
+
+      await target.connect(bob).safeMint(bob.address, 10);
+      await expect(target.connect(bob).burn(10)).to.be.revertedWith(
+        REVERT_NO_TOKEN
+      );
+
+      await ct1155.mint(bob.address, 2, 1); // typeId 2 = BURNER_ROLE
+      expect(await target.hasRole(BURNER_ROLE, bob.address)).to.equal(true);
+      await target.connect(bob).burn(10);
+
+      await ct1155.burnByIssuer(bob.address, 2);
+      expect(await target.hasRole(BURNER_ROLE, bob.address)).to.equal(false);
+    });
+
+    it("requires every stacked role for a doubly-guarded function (AND semantics across modifiers)", async function () {
+      const { target, ct721, ct1155, alice, bob, carol } =
+        await loadFixture(deployFixture);
+
+      await ct721.mint(alice.address); // MINTER_ROLE only
+      await ct1155.mint(bob.address, 2, 1); // BURNER_ROLE only
+      await ct1155.mint(carol.address, 1, 1); // MINTER_ROLE...
+      await ct1155.mint(carol.address, 2, 1); // ...and BURNER_ROLE
+
+      await target.connect(alice).safeMint(alice.address, 30);
+      await expect(
+        target.connect(alice).reissue(30, bob.address)
+      ).to.be.revertedWith(REVERT_NO_TOKEN);
+      await expect(
+        target.connect(bob).reissue(30, bob.address)
+      ).to.be.revertedWith(REVERT_NO_TOKEN);
+
+      await target.connect(carol).reissue(30, bob.address);
+      expect(await target.ownerOf(30)).to.equal(bob.address);
+
+      // Cross-standard AND: alice already holds MINTER_ROLE via the ERC-721
+      // control token; granting BURNER_ROLE via the ERC-1155 control token
+      // must satisfy the conjunction just as the 1155+1155 pairing does.
+      await ct1155.mint(alice.address, 2, 1);
+      await target.connect(alice).reissue(30, carol.address);
+      expect(await target.ownerOf(30)).to.equal(carol.address);
+    });
+
+    it("grants MINTER_ROLE through either control token (OR semantics across entries)", async function () {
+      const { target, ct721, ct1155, alice, carol } =
+        await loadFixture(deployFixture);
+
+      await ct721.mint(alice.address); // ERC-721 path only
+      await ct1155.mint(carol.address, 1, 1); // ERC-1155 path only
+
+      expect(await target.hasRole(MINTER_ROLE, alice.address)).to.equal(true);
+      expect(await target.hasRole(MINTER_ROLE, carol.address)).to.equal(true);
+      await target.connect(alice).safeMint(alice.address, 21);
+      await target.connect(carol).safeMint(carol.address, 22);
+    });
+  });
+
+  describe("negative case: functionally identical legacy contract", function () {
+    it("gates identically but does not declare IERC7303", async function () {
+      const { legacy, ct721, alice } = await loadFixture(deployFixture);
+
+      // Same gating behavior as the compliant fixture...
+      await expect(
+        legacy.connect(alice).safeMint(alice.address, 1)
+      ).to.be.revertedWith(REVERT_NO_TOKEN);
+      await ct721.mint(alice.address);
+      await legacy.connect(alice).safeMint(alice.address, 1);
+
+      // ...but discovery must classify it as NOT implementing this ERC:
+      expect(await legacy.supportsInterface(ERC165_ID)).to.equal(true);
+      expect(await legacy.supportsInterface(IERC7303_ID)).to.equal(false);
+      expect(legacy.interface.getFunction("hasRole(bytes32,address)")).to.equal(
+        null
+      );
+    });
+  });
+});


### PR DESCRIPTION
Author update to ERC-7303 (Draft). Adds a one-paragraph Test Cases section and a redeployable conformance fixture with test suite under `assets/erc-7303/`: interface-identifier recomputation (`0x4ee69337`), introspection getters and events, the grant/check/revoke lifecycle with OR/AND role composition, and a functionally identical legacy contract as the negative case — 11 assertions passing via `npx hardhat test`. Follows a proposal in the discussions-to thread to land a canonical conformance fixture in the ERC's own assets.

Discussion: https://ethereum-magicians.org/t/erc-7303-token-controlled-token-circulation/15020