### PR TITLE
Update ERC-1450: Move to Final

### DIFF
--- a/ERCS/erc-1450.md
+++ b/ERCS/erc-1450.md
@@ -4,8 +4,7 @@ title: RTA-Controlled Security Token
 description: Security tokens where the Registered Transfer Agent has exclusive control over transfers for regulatory compliance
 author: Howard Marks (@howardmarks) <howard@startengine.com>, Devender Gollapally (@devender-startengine) <devender@startengine.com>, Joe Mathews (@se-joe) <joe@startengine.com>, Jordan Jahja (@jordan-jahja) <jordan.jahja@startengine.com>, John Shiple (@johnshiple), David Zhang (@david-colab) <david@startengine.com>
 discussions-to: https://ethereum-magicians.org/t/erc-1450-rta-controlled-security-token-standard/26385
-status: Last Call
-last-call-deadline: 2026-07-14
+status: Final
 type: Standards Track
 category: ERC
 created: 2018-09-25


### PR DESCRIPTION
Moves ERC-1450 from Last Call to Final.

The Last Call period (`last-call-deadline: 2026-07-14`) has elapsed with no normative changes to the specification. This PR is a status-only change: `status: Last Call` -> `status: Final` and removal of the now-expired `last-call-deadline` field. No normative text is modified.

Readiness:
- Spec <-> implementation reconciled: the normative core exactly matches the audited reference implementation (v1.17.0, Halborn), running in production on Polygon mainnet behind 410 deployed securities.
- Optional extensions (document management, structured recovery) are marked OPTIONAL (#1811); `controllerTransfer` remains REQUIRED as the recovery baseline.
- Reference implementation + Test Cases links are live and public (StartEngine/erc1450-reference).
- Ladder history: Draft #1335 (6/11) -> #1811 optionality (6/12) -> Review #1812 (6/12) -> version refresh #1820 (6/16) -> Last Call #1835 (6/23).
