### PR TITLE
CI: Re-enable cross-repo (ERCs + EIPs) lint rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,8 +233,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout ERC Repository
+        uses: actions/checkout@47fbe2df0ad0e27efb67a70beac3555f192b062f
+
       - name: Checkout EIP Repository
         uses: actions/checkout@47fbe2df0ad0e27efb67a70beac3555f192b062f
+        with:
+          repository: ethereum/EIPs
+          path: EIPs-upstream
+
+      - name: Merge Repos
+        run: |
+          # Make every proposal (EIP or ERC) resolvable as ERCS/eip-N.md so the
+          # cross-reference lints (preamble-requires-status, markdown-link-status,
+          # markdown-refs) see the same merged corpus that eips.ethereum.org is
+          # built from. The native ERCS/erc-N.md files are copied (not moved)
+          # because eipw-action locates changed files by their pull request paths.
+          cp -p $GITHUB_WORKSPACE/EIPs-upstream/EIPS/eip-*.md $GITHUB_WORKSPACE/ERCS/
+          cd $GITHUB_WORKSPACE/ERCS
+          # ERC content overwrites the EIPs repository's `Moved` stubs.
+          for f in erc-*.md; do
+            cp -p "$f" "eip-${f#erc-}"
+          done
+          rm -rf $GITHUB_WORKSPACE/EIPs-upstream
 
       - uses: ethereum/eipw-action@be3fa642ec311d0b8e1fdb811e5c9b4ada3d3d93
         id: eipw

--- a/config/eipw.toml
+++ b/config/eipw.toml
@@ -34,12 +34,13 @@ mode = "excludes"
 pattern = ":"
 message = "preamble header `description` should not contain `:`"
 
-## Disabled due to EIP/ERC repo split.
-# [lints.preamble-refs-description]
-# kind = "preamble-proposal-ref"
-# name = "description"
-# prefix = "erc-"
-# suffix = ".md"
+# Cross-repo references resolve against the merged corpus created by the
+# `Merge Repos` step in ci.yml, where every proposal exists as `eip-N.md`.
+[lints.preamble-refs-description]
+kind = "preamble-proposal-ref"
+name = "description"
+prefix = "eip-"
+suffix = ".md"
 
 [lints.preamble-enum-category]
 kind = "preamble-one-of"
@@ -69,11 +70,10 @@ mode = "excludes"
 pattern = '(?i)erc[\s]*[0-9]+'
 message = "proposals must be referenced with the form `ERC-N` (not `ERCN` or `ERC N`)"
 
-## TODO: Disabled because half the files are in another repository.
-# [lints.markdown-refs]
-# kind = "markdown-proposal-ref"
-# prefix = "erc-"
-# suffix = ".md"
+[lints.markdown-refs]
+kind = "markdown-proposal-ref"
+prefix = "eip-"
+suffix = ".md"
 
 [lints.preamble-req-withdrawal-reason]
 kind = "preamble-required-if-eq"
@@ -98,27 +98,26 @@ names = [
     "withdrawal-reason",
 ]
 
-## TODO: Disabled because half the files are in another repository.
-# [lints.preamble-requires-status]
-# prefix = "erc-"
-# suffix = ".md"
-# kind = "preamble-requires-status"
-# requires = "requires"
-# status = "status"
-# flow = [
-#     [
-#         "Draft",
-#         "Stagnant",
-#     ],
-#     ["Review"],
-#     ["Last Call"],
-#     [
-#         "Final",
-#         "Withdrawn",
-#         "Living",
-#         "Moved",
-#     ],
-# ]
+[lints.preamble-requires-status]
+prefix = "eip-"
+suffix = ".md"
+kind = "preamble-requires-status"
+requires = "requires"
+status = "status"
+flow = [
+    [
+        "Draft",
+        "Stagnant",
+    ],
+    ["Review"],
+    ["Last Call"],
+    [
+        "Final",
+        "Withdrawn",
+        "Living",
+        "Moved",
+    ],
+]
 
 [lints.markdown-order-section]
 kind = "markdown-section-order"
@@ -783,26 +782,25 @@ sections = [
     "Copyright",
 ]
 
-## Disabled because of EIP/ERC repository split.
-# [lints.markdown-link-status]
-# prefix = "erc-"
-# suffix = ".md"
-# kind = "markdown-link-status"
-# status = "status"
-# flow = [
-#     [
-#     "Draft",
-#     "Stagnant",
-# ],
-#     ["Review"],
-#     ["Last Call"],
-#     [
-#     "Final",
-#     "Withdrawn",
-#     "Living",
-#     "Moved",
-# ],
-# ]
+[lints.markdown-link-status]
+prefix = "eip-"
+suffix = ".md"
+kind = "markdown-link-status"
+status = "status"
+flow = [
+    [
+    "Draft",
+    "Stagnant",
+],
+    ["Review"],
+    ["Last Call"],
+    [
+    "Final",
+    "Withdrawn",
+    "Living",
+    "Moved",
+],
+]
 
 [lints.preamble-re-title-colon]
 kind = "preamble-regex"
@@ -898,12 +896,11 @@ mode = "includes"
 pattern = "^https://ethereum-magicians.org/t/[^/]+/[0-9]+$"
 message = "preamble header `discussions-to` should point to a thread on ethereum-magicians.org"
 
-## Disabled due to EIP/ERC repo split.
-# [lints.preamble-refs-title]
-# kind = "preamble-proposal-ref"
-# name = "title"
-# prefix = "erc-"
-# suffix = ".md"
+[lints.preamble-refs-title]
+kind = "preamble-proposal-ref"
+name = "title"
+prefix = "eip-"
+suffix = ".md"
 
 [lints.preamble-enum-status]
 kind = "preamble-one-of"


### PR DESCRIPTION
## Lints re-enabled

Five existing lint rules that were commented out after the repo split are re-enabled (all active in [ethereum/EIPs](https://github.com/ethereum/EIPs)), with `prefix = "eip-"` so they resolve against the merged corpus:

| Lint | Checks |
|---|---|
| `preamble-requires-status` | every `requires:` entry has a status at least as advanced as this proposal's (`[Draft, Stagnant] < [Review] < [Last Call] < [Final, Withdrawn, Living, Moved]`) |
| `markdown-link-status` | the same status flow for every body link to `./eip-N.md` (see below) |
| `markdown-refs` | every `EIP-N`/`ERC-N` mention in the body corresponds to an existing proposal |
| `preamble-refs-title` | same existence check for mentions in `title:` |
| `preamble-refs-description` | same existence check for mentions in `description:` |

It re-enables `markdown-lint-status` which re-adds the CI check to verify that the ERC status matches the "rules": the status of referenced EIPs/ERCs should be the same level or higher. This should have flagged now-Final [ERC-8126](https://eips.ethereum.org/EIPS/eip-8126) which require [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) and [ERC-3009](https://eips.ethereum.org/EIPS/eip-3009) (both Draft)

## Testing locally

Requires the eipw CLI at the version matching the action's pinned engine (`eipw-lint-js ^0.9.0`):

```bash
cargo install eipw --version 0.9.0
```

From the ERCs repository root, build the merged corpus in a temporary directory (replicates the `Merge Repos` CI step)

```bash
mkdir -p /tmp/eipw-merged
git clone --depth 1 https://github.com/ethereum/EIPs /tmp/eipw-merged/.eips
cp -p /tmp/eipw-merged/.eips/EIPS/eip-*.md ERCS/erc-*.md /tmp/eipw-merged/
cd /tmp/eipw-merged
for f in erc-*.md; do cp -p "$f" "eip-${f#erc-}"; done
cd -
```

Test on known-failing ERCs + one which should pass:

```
eipw --config config/eipw.toml /tmp/eipw-merged/erc-8126.md   # must fail: requires 3009, 8004 (Draft)
eipw --config config/eipw.toml /tmp/eipw-merged/erc-7786.md   # must fail: requires 7930 (Review)
eipw --config config/eipw.toml /tmp/eipw-merged/erc-6093.md   # must pass (exit 0)
```

----

(this PR once merged will cause conflicts with #1873 but these should (?) be easily resolvable (?), and once re-based using this merge step it might fix the problem [raised](https://github.com/ethereum/ERCs/pull/1873#issuecomment-4975452860) there?)

