### PR TITLE
Update ERC-8326: editorial post-merge proposed changes

### DIFF
--- a/ERCS/erc-8326.md
+++ b/ERCS/erc-8326.md
@@ -100,7 +100,7 @@ the selected normalization profile.
 lowercase ASCII without parameters. For example, `application/json;
 charset=utf-8` is represented by `keccak256("application/json")`.
 
-`filenameHash` MUST be derived by treating U+002F (`/`) and U+005C (`\\`) as
+`filenameHash` MUST be derived by treating U+002F (`/`) and U+005C (`\`) as
 path separators, retaining the substring after the final separator, applying
 ASCII lowercase conversion to `A` through `Z`, applying Unicode NFC
 normalization, encoding the result as UTF-8, and applying `keccak256`.
@@ -146,9 +146,10 @@ transformation.
 
 For `PROFILE_JSON_RFC8785`, the output bytes are the UTF-8 serialization
 produced by [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785). Implementations
-MUST reject inputs that cannot be processed under the RFC 8785 and I-JSON
-constraints, including duplicate object keys, invalid Unicode, lone surrogates,
-and numbers outside the interoperable range. JSON string values are preserved;
+MUST reject inputs that cannot be processed under the RFC 8785 and
+[I-JSON](https://www.rfc-editor.org/rfc/rfc7493) constraints, including
+duplicate object keys, invalid Unicode, lone surrogates, and numbers outside
+the interoperable range. JSON string values are preserved;
 this profile does not apply Unicode normalization to them.
 
 For `PROFILE_XML_C14N11`, the output bytes are produced by
@@ -347,8 +348,8 @@ mechanism is implementation-defined and MUST be documented.
 `role`, or zero `documentCount`. It MUST reject `oldBundleHash ==
 newBundleHash`.
 
-The old record MUST exist, MUST not already be superseded, and MUST be the active
-bundle for the specified slot. The new triple MUST not already exist.
+The old record MUST exist, MUST NOT already be superseded, and MUST be the active
+bundle for the specified slot. The new triple MUST NOT already exist.
 
 The caller MUST be authorized to supersede that slot. Authorization is
 implementation-defined, but an unrelated authorized anchorer MUST NOT be able to


### PR DESCRIPTION
Hi @david-hay, these are some post-merge editorial suggestions: (if you approve this PR it directly merges):

1. I-JSON directly links to [RFC 7493](https://datatracker.ietf.org/doc/html/rfc7493) so it is clear directly for readers unfamilar with this concept that this is the concept which is meant (assuming this is indeed the case)
2. Removed one backtick `\` to render U+005C correctly (see current render: https://eips.ethereum.org/EIPS/eip-8326 (CTRL-F `U+005C`), the `\\` renders as two backticks, first is not an escape character, so this should be rendered as (?) `\`) 
3.  "MERGE not" -> "MERGE NOT" to use RFC 2119 normative keyword casing correctly