### PR TITLE
Update ERC-8161: Move to Final

### DIFF
--- a/ERCS/erc-8161.md
+++ b/ERCS/erc-8161.md
@@ -4,8 +4,7 @@ title: Transferable Tokenized Vault Requests
 description: Extension of ERC-7540 enabling optional transferability of pending deposit and redeem requests
 author: Cain O'Sullivan (@cosullivan), Jeroen Offerijns (@hieronx)
 discussions-to: https://ethereum-magicians.org/t/draft-erc-transferable-asynchronous-tokenized-vault-requests/27747
-status: Last Call
-last-call-deadline: 2026-06-16
+status: Final
 type: Standards Track
 category: ERC
 created: 2025-02-12


### PR DESCRIPTION
The Last Call period for ERC-8161 ended on 2026-06-16 with no unresolved issues raised. This PR moves the status from Last Call to Final and removes the `last-call-deadline` header.