### PR TITLE
Update ERC-8325: clarify recovery interface reference

### DIFF
--- a/ERCS/erc-8325.md
+++ b/ERCS/erc-8325.md
@@ -84,8 +84,9 @@ A **token-ID binding** binds an anchor to one token ID within a token contract.
 A **binding tuple** is `(token, bindingScope, tokenId)`.
 
 A **valid binding** is a recorded binding that has not been invalidated through
-`IAssetAnchorRegistryRecovery`. Binding validity is distinct from lifecycle
-activity.
+the optional `IAssetAnchorRegistryRecovery` interface, defined in the
+[Recovery Interface](#recovery-interface) section below. Binding validity is
+distinct from lifecycle activity.
 
 An **active anchor** is an anchor that has not been permanently deactivated and
 whose metadata has not expired.


### PR DESCRIPTION
## Summary

Post-merge editorial clarification for ERC-8325.

Adds a direct forward reference to the optional `IAssetAnchorRegistryRecovery` interface where it is first mentioned, linking readers to the later **Recovery Interface** section.

The interface remains grouped with its recovery semantics; this change improves first-pass readability without changing normative behavior.

Requested by @jochem-brouwer 