### PR TITLE
Update ERC-8325: Move to Review

### DIFF
--- a/ERCS/erc-8325.md
+++ b/ERCS/erc-8325.md
@@ -561,10 +561,10 @@ or digital assets, with operations authorized by oracle attestations of control.
 This ERC is token-standard-neutral and standardizes a registry record binding,
 not proof-of-control authorization.
 
-[ERC-7929](./eip-7929.md) permanently binds one on-chain token to another and
-mirrors ownership behavior. This ERC binds token contracts or token IDs to
-records representing off-chain claims and does not define token-to-token
-ownership hierarchies.
+[ERC-7929](https://ethereum-magicians.org/t/non-fungible-asset-bound-token/23175)
+permanently binds one on-chain token to another and mirrors ownership behavior.
+This ERC binds token contracts or token IDs to records representing off-chain
+claims and does not define token-to-token ownership hierarchies.
 
 [ERC-6065](./eip-6065.md) defines an ERC-721 extension for tokenized real estate
 with property identifiers and operating-agreement data. This ERC is not limited

--- a/ERCS/erc-8325.md
+++ b/ERCS/erc-8325.md
@@ -4,7 +4,7 @@ title: Asset Anchor Registry
 description: A registry interface for registry-scoped token-to-anchor bindings for off-chain asset claims
 author: Chris Turner <c.turner@kula.com>, David Hay (@david-hay), Reagan Simpson (@krumg111), Collins Musyimi (@Musyimi97)
 discussions-to: https://ethereum-magicians.org/t/erc-8325-asset-anchor-registry/28934
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2026-07-04

--- a/ERCS/erc-8325.md
+++ b/ERCS/erc-8325.md
@@ -561,10 +561,10 @@ or digital assets, with operations authorized by oracle attestations of control.
 This ERC is token-standard-neutral and standardizes a registry record binding,
 not proof-of-control authorization.
 
-[ERC-7929](https://ethereum-magicians.org/t/non-fungible-asset-bound-token/23175)
-permanently binds one on-chain token to another and mirrors ownership behavior.
-This ERC binds token contracts or token IDs to records representing off-chain
-claims and does not define token-to-token ownership hierarchies.
+The PermaLink Asset Bound Token proposal permanently binds one on-chain token
+to another and mirrors ownership behavior. This ERC binds token contracts or
+token IDs to records representing off-chain claims and does not define
+token-to-token ownership hierarchies.
 
 [ERC-6065](./eip-6065.md) defines an ERC-721 extension for tokenized real estate
 with property identifiers and operating-agreement data. This ERC is not limited


### PR DESCRIPTION
## Summary

Moves **ERC-8325: Asset Anchor Registry** from **Draft** to **Review**.

## Rationale

The proposal has incorporated the initial editorial feedback and is ready for broader community and technical review.

## Changes

- Updates the ERC status from `Draft` to `Review`
- Makes no changes to the specification or reference implementation