### PR TITLE
Update ERC-8326: Move to Review

### DIFF
--- a/ERCS/erc-8326.md
+++ b/ERCS/erc-8326.md
@@ -4,7 +4,7 @@ title: Canonical Document Bundle Anchor
 description: A deterministic document-entry bundle hash and subject-scoped anchoring interface with supersession history
 author: Chris Turner <c.turner@kula.com>, David Hay (@david-hay), Reagan Simpson (@krumg111), Collins Musyimi (@Musyimi97)
 discussions-to: https://ethereum-magicians.org/t/erc-8326-canonical-document-bundle-anchor/28935
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2026-07-05


### PR DESCRIPTION
## Summary

Moves **ERC-8326: Canonical Document Bundle Anchor** from **Draft** to **Review**.

## Rationale

The proposal has incorporated the initial editorial feedback and is ready for broader community and technical review.

## Changes

- Updates the ERC status from `Draft` to `Review`
- Makes no changes to the specification or reference implementation
