### PR TITLE
Update ERC-8327: Move to Review

### DIFF
--- a/ERCS/erc-8327.md
+++ b/ERCS/erc-8327.md
@@ -523,14 +523,14 @@ duration.
 
 ### Prior Art
 
-[ERC-1592](./eip-1592.md) defines reusable address and
+The Address and Token Transfer Rules proposal defines reusable address and
 [ERC-20](./eip-20.md) transfer rules based on sender, destination, and amount.
 This ERC instead standardizes an external lookup keyed by an ordered domain
 pair and asset class.
 
-[ERC-1462](./eip-1462.md) defines transfer-checking and document-reference
-functions for security tokens. This ERC is token agnostic and does not define a
-security-token extension.
+The Base Security Token proposal defines transfer-checking and
+document-reference functions for security tokens. This ERC is token agnostic
+and does not define a security-token extension.
 
 [ERC-3643](./eip-3643.md) defines a regulated-token architecture with identity
 registries, compliance modules, and token lifecycle functions. This ERC does

--- a/ERCS/erc-8327.md
+++ b/ERCS/erc-8327.md
@@ -4,7 +4,7 @@ title: Directional Transfer Domain Registry
 description: Defines token-agnostic directional transfer-route permissions between opaque domains by asset class
 author: Chris Turner <c.turner@kula.com>, David Hay (@david-hay), Reagan Simpson (@krumg111), Collins Musyimi (@Musyimi97)
 discussions-to: https://ethereum-magicians.org/t/erc-8327-directional-transfer-domain-registry/28936
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2026-07-05


### PR DESCRIPTION
## Summary

Moves **ERC-8327: Directional Transfer Domain Registry** from **Draft** to **Review**.

## Rationale

The proposal has incorporated the initial editorial feedback and is ready for broader community and technical review.

## Changes

- Updates the ERC status from `Draft` to `Review`
- Refers to unstable prior-art proposals by name to satisfy proposal-status linting
- Makes no normative changes to the specification or reference implementation