### PR TITLE
Update ERC-8328: Move to Review

### DIFF
--- a/ERCS/erc-8328.md
+++ b/ERCS/erc-8328.md
@@ -607,10 +607,11 @@ the rule engine deciding which combinations are valid.
 
 ### Prior Art
 
-[ERC-8106](./eip-8106.md) defines [ERC-20](./eip-20.md) value-flow
-observations, Compliance Entity and Decentralized Entity (CE/DE)
-classification, compliance flags, and `bizId` correlation. This ERC instead
-stores subject-linked lifecycle records with authority and evidence fields,
+The RWA Event-Based Compliance Framework proposal defines
+[ERC-20](./eip-20.md) value-flow observations, Compliance Entity and
+Decentralized Entity (CE/DE) classification, compliance flags, and `bizId`
+correlation. This ERC instead stores subject-linked lifecycle records with
+authority and evidence fields,
 versioned payloads, type indexing, and correction chains. It does not define
 CE/DE classification or require each record to correspond to an ERC-20 balance
 change.
@@ -624,13 +625,13 @@ identity checks.
 including transfer eligibility, freezing, and forced transfers. This ERC
 records attributed lifecycle assertions independently of any token interface.
 
-[ERC-7512](./eip-7512.md) defines an on-chain representation of audit reports.
-This ERC instead defines a subject-indexed compliance-event timeline and
-correction model.
+The Onchain Representation for Audits proposal defines an on-chain
+representation of audit reports. This ERC instead defines a subject-indexed
+compliance-event timeline and correction model.
 
-[ERC-5851](./eip-5851.md) defines on-chain verifiable credentials. Credentials
-can authorize or identify a recorder, but they do not define this event-log
-schema.
+The On-Chain Verifiable Credentials proposal defines on-chain verifiable
+credentials. Credentials can authorize or identify a recorder, but they do not
+define this event-log schema.
 
 Generic attestation systems can represent compliance assertions through custom
 schemas. This ERC defines a dedicated stored interface, base identifiers,

--- a/ERCS/erc-8328.md
+++ b/ERCS/erc-8328.md
@@ -4,7 +4,7 @@ title: Subject-Linked Compliance Event Log
 description: Defines append-only subject-linked compliance records with attribution, evidence, indexing, and correction provenance
 author: Chris Turner <c.turner@kula.com>, David Hay (@david-hay), Reagan Simpson (@krumg111), Collins Musyimi (@Musyimi97)
 discussions-to: https://ethereum-magicians.org/t/erc-8328-subject-linked-compliance-event-log/28937
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2026-07-05


### PR DESCRIPTION
## Summary

Moves **ERC-8328: Subject-Linked Compliance Event Log** from **Draft** to **Review**.

## Rationale

The proposal has incorporated the initial editorial feedback and is ready for broader community and technical review.

## Changes

- Updates the ERC status from `Draft` to `Review`
- Refers to unstable prior-art proposals by name to satisfy proposal-status linting
- Makes no normative changes to the specification or reference implementation