### PR TITLE
Update ERC-8329: Move to Review

### DIFF
--- a/ERCS/erc-8329.md
+++ b/ERCS/erc-8329.md
@@ -608,13 +608,13 @@ recency and credential policies.
 
 ### Prior Art
 
-[ERC-7512](./eip-7512.md) defines on-chain audit-report representation. This ERC
-defines quantitative, period-bounded indicator time series with corrections and
-methodology lifecycle semantics.
+The Onchain Representation for Audits proposal defines on-chain audit-report
+representation. This ERC defines quantitative, period-bounded indicator time
+series with corrections and methodology lifecycle semantics.
 
-[ERC-5851](./eip-5851.md) defines on-chain verifiable credentials. Credentials
-can support reporter or attestor authorization but do not define this snapshot
-model.
+The On-Chain Verifiable Credentials proposal defines on-chain verifiable
+credentials. Credentials can support reporter or attestor authorization but do
+not define this snapshot model.
 
 Generic attestation systems can represent impact claims through custom schemas.
 This ERC defines a dedicated storage and query interface for indicator periods,

--- a/ERCS/erc-8329.md
+++ b/ERCS/erc-8329.md
@@ -4,7 +4,7 @@ title: Subject-Linked Impact Snapshot Log
 description: Defines append-only subject-linked impact snapshots with correction provenance, methodology versioning, and attestations
 author: Chris Turner <c.turner@kula.com>, David Hay (@david-hay), Reagan Simpson (@krumg111), Collins Musyimi (@Musyimi97)
 discussions-to: https://ethereum-magicians.org/t/erc-8329-subject-linked-impact-snapshot-log/28938
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2026-07-05


### PR DESCRIPTION
## Summary

Moves **ERC-8329: Subject-Linked Impact Snapshot Log** from **Draft** to **Review**.

## Rationale

The proposal has incorporated the initial editorial feedback and is ready for broader community and technical review.

## Changes

- Updates the ERC status from `Draft` to `Review`
- Refers to unstable prior-art proposals by name to satisfy proposal-status linting
- Makes no normative changes to the specification or reference implementation