### PR TITLE
Update ERC-8330: Move to Review

### DIFF
--- a/ERCS/erc-8330.md
+++ b/ERCS/erc-8330.md
@@ -4,7 +4,7 @@ title: Subject-Linked NAV Snapshot Oracle
 description: Defines subject-linked NAV streams with provider attribution, corrections, invalidation, staleness, and aggregation
 author: Chris Turner <c.turner@kula.com>, David Hay (@david-hay), Reagan Simpson (@krumg111), Collins Musyimi (@Musyimi97)
 discussions-to: https://ethereum-magicians.org/t/erc-8330-subject-linked-nav-snapshot-oracle/28939
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2026-07-05

--- a/ERCS/erc-8330.md
+++ b/ERCS/erc-8330.md
@@ -780,8 +780,8 @@ independently.
 
 ### Prior Art
 
-[ERC-7726](./eip-7726.md) defines a common quote interface returning the amount
-of one asset in another asset's terms. This ERC defines historical NAV
+The Common Quote Oracle proposal defines a common quote interface returning the
+amount of one asset in another asset's terms. This ERC defines historical NAV
 snapshots with valuation timestamps, providers, methodology, corrections,
 invalidation, and staleness metadata.
 


### PR DESCRIPTION
## Summary

Moves **ERC-8330: Subject-Linked NAV Snapshot Oracle** from **Draft** to **Review**.

## Rationale

The proposal has incorporated the initial editorial feedback and is ready for broader community and technical review.

## Changes

- Updates the ERC status from `Draft` to `Review`
- Refers to unstable prior-art proposals by name to satisfy proposal-status linting
- Makes no normative changes to the specification or reference implementation