### PR TITLE
Update ERC-8326: (chore) Add normative test vectors for ERC-8326

### DIFF
--- a/ERCS/erc-8326.md
+++ b/ERCS/erc-8326.md
@@ -597,8 +597,105 @@ Implementations should test at least:
 - positive and negative ERC-165 detection; and
 - contested-slot recovery and pre-assignment.
 
-Exact normalization inputs, canonical bytes, and expected content and bundle
-hashes should be published before this ERC advances to Review.
+### Normative Test Vectors
+
+The hexadecimal byte strings in this section are authoritative. Text renderings
+are included only for readability. None of the inputs or canonical outputs has
+an implicit byte-order mark or trailing newline unless its hexadecimal form
+includes one.
+
+The schema identifier for these vectors is:
+
+```text
+SCHEMA_V1
+0x1853dddb0c73884633f2ff8e736679ec654a11f704ed868aacca79d8ae4caf67
+```
+
+#### JSON Entry
+
+The filename input contains `e` followed by U+0301 COMBINING ACUTE ACCENT.
+Filename processing selects the basename, folds ASCII uppercase characters,
+and applies NFC, producing the UTF-8 bytes for `café.json`.
+
+```text
+input document:       {"b":2,"a":1}
+input bytes:          0x7b2262223a322c2261223a317d
+canonical document:   {"a":1,"b":2}
+canonical bytes:      0x7b2261223a312c2262223a327d
+filename input:       records/Cafe\u0301.JSON
+filename input bytes: 0x7265636f7264732f43616665cc812e4a534f4e
+canonical filename:   café.json
+filename bytes:       0x636166c3a92e6a736f6e
+role preimage:         AGREEMENT
+media type preimage:  application/json
+profile preimage:     NORM:JSON:RFC8785:V1
+contentHash:          0xb8ffb64722137f4b100665a52e3c943f8066e8ab8ba3b427e6f4b404defd82b0
+role:                 0x566614d5b403a4ea71e1ef1027b77ff1e1a13a54c7f393aa64a1368de23a5f92
+mimeTypeHash:         0x82e6a468c95da6cfe399f69ee0782fd009e354a8030ea5636ea9c7db0edcf7f5
+filenameHash:         0x3b40ecd25f3375868ddf559a0ef47c2dc15863a529ac592bec5e1b618bcbaf3e
+normProfileId:        0x464861b0846e795db3d9c52e9c49870c7e83f2bb07f73764f7e4850151994f40
+leaf:                 0xe78934e3ee972b7eae660a945de9780c77e5656203bfe437ab117413adf3ad2b
+```
+
+#### XML Entry
+
+The backslash in the filename input is a path separator. Canonical XML 1.1
+orders the unqualified attributes lexicographically. The canonical output has
+no trailing newline.
+
+```text
+input document:       <doc b="2" a="1"></doc>
+input bytes:          0x3c646f6320623d22322220613d2231223e3c2f646f633e
+canonical document:   <doc a="1" b="2"></doc>
+canonical bytes:      0x3c646f6320613d22312220623d2232223e3c2f646f633e
+filename input:       Evidence\Proof.XML
+filename input bytes: 0x45766964656e63655c50726f6f662e584d4c
+canonical filename:   proof.xml
+filename bytes:       0x70726f6f662e786d6c
+role preimage:         EVIDENCE
+media type preimage:  application/xml
+profile preimage:     NORM:XML:C14N11:V1
+contentHash:          0xde64c753c807c4620bf010c7e855bcd38bd389e980c4054b81abd5d44d45eab1
+role:                 0x7477535acdef313b25d16b4871e7023fac62af68d6312bbdbdb96203a4710dc3
+mimeTypeHash:         0x37aaf14a93fea5695fd8577aacfb548c98692a106d439219bfb9b83e3011ea2f
+filenameHash:         0x696b36bf7095c1b1564382a37b8f5ba7d259b36be7639a7a1b50c97cd13cfe39
+normProfileId:        0x72efa7a47196f4ad021a5a3758b19b14d8e09d7b7b211bf4745b35cba62e49c2
+leaf:                 0x8c72daea8a7297c8d307dd41e24038ff71065f9b0932a07e9016942abbc5c9ac
+```
+
+#### Raw Entry
+
+The input and canonical output end with one U+000A LINE FEED byte.
+
+```text
+input document:       Hello, ERC-8326!<LF>
+input bytes:          0x48656c6c6f2c204552432d38333236210a
+canonical document:   Hello, ERC-8326!<LF>
+canonical bytes:      0x48656c6c6f2c204552432d38333236210a
+filename input:       README.TXT
+filename input bytes: 0x524541444d452e545854
+canonical filename:   readme.txt
+filename bytes:       0x726561646d652e747874
+role preimage:         SUPPORTING
+media type preimage:  text/plain
+profile preimage:     NORM:RAW:V1
+contentHash:          0x06750728a91d155294f77f992fec49acabb0470481439ed5e3bb59854df82ec9
+role:                 0xb0e9b5730d97b99270ce15f439eec98a4f9580e1dfbfb8f5c9e0e3ab71d4bca6
+mimeTypeHash:         0xb25570cad408307f58d995c1dadde60bc76e94924d640305a148c9a11f8303bf
+filenameHash:         0x31f491635b16d6fb45a7d770fcbcc8cbb6eae32ac98ab622631f4bc4a8c7e9ce
+normProfileId:        0xbe97b35c60bb0caee86a5a99022973ef2aa47cbf9586dd34065141c6668b430b
+leaf:                 0xa418892b0b93cf88e9d840cf38d36f5bfa16813774f22f5cf02d6b4fcc48375a
+```
+
+#### Bundle Vector
+
+The entries sort in JSON, XML, raw order by their `role` values. Concatenating
+`SCHEMA_V1` with the three leaf values in that order produces:
+
+```text
+bundleHash:
+0xbe712c4a5eb51d9eb303f1a5c896417a8407a420936fa210626bb66b1a6d0613
+```
 
 ## Reference Implementation
 


### PR DESCRIPTION
## Summary

Adds normative interoperability test vectors for **ERC-8326: Canonical Document Bundle Anchor**.

## Motivation

ERC-8326 previously stated that exact normalization inputs, canonical bytes,
and expected content and bundle hashes should be published before the proposal
advances to Review.

This PR satisfies that requirement by embedding self-contained, authoritative
test vectors in the ERC.

## Test-vector coverage

- Raw-byte normalization, including an explicit trailing newline
- RFC 8785 JSON canonicalization
- Canonical XML 1.1 attribute ordering
- Slash and backslash filename separators
- ASCII filename case folding
- Unicode NFC filename normalization
- Content, role, media-type, filename, and normalization-profile hashes
- Leaf hashes and canonical entry ordering
- Final expected bundle hash

## Scope

- Adds normative test vectors only
- Does not change the ERC status
- Does not change the specified interfaces or hashing algorithm
- Makes no changes to the reference implementation