### PR TITLE
Update ERC-8048: require ERC-165 support for the metadata interface

### DIFF
--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -50,9 +50,12 @@ Contracts implementing this ERC MUST emit the following event when metadata is s
 ```solidity
 event MetadataSet(uint256 indexed tokenId, string indexed indexedKey, string key, bytes value);
 ```
-### Interface ID
+
+### ERC-165 Interface Detection
 
 The interface ID is `0xdf670be1`.
+
+Contracts implementing `IERC8048Metadata` MUST implement [ERC-165](./eip-165.md) and MUST return `true` from `supportsInterface` for both `0xdf670be1` (this interface) and `0x01ffc9a7` ([ERC-165](./eip-165.md) itself), so that callers can detect onchain-metadata support before reading records.
 
 ### Key/Value Pairs
 
@@ -216,7 +219,11 @@ pragma solidity ^0.8.25;
 
 import "./IERC8048Metadata.sol";
 
-contract OnchainMetadataExample is IERC8048Metadata {
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+contract OnchainMetadataExample is IERC8048Metadata, IERC165 {
     // Mapping from tokenId => key => value
     mapping(uint256 => mapping(string => bytes)) private _metadata;
     
@@ -232,6 +239,11 @@ contract OnchainMetadataExample is IERC8048Metadata {
         _metadata[tokenId][key] = value;
         emit MetadataSet(tokenId, key, key, value);
     }
+
+    /// @notice ERC-165 interface detection
+    function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
+        return interfaceId == 0xdf670be1 || interfaceId == type(IERC165).interfaceId;
+    }
 }
 ```
 
@@ -242,7 +254,11 @@ pragma solidity ^0.8.20;
 
 import "./IERC8048Metadata.sol";
 
-contract OnchainMetadataDiamondExample is IERC8048Metadata {
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+contract OnchainMetadataDiamondExample is IERC8048Metadata, IERC165 {
     struct OnchainMetadataStorage {
         mapping(uint256 tokenId => mapping(string key => bytes value)) metadata;
     }
@@ -269,6 +285,11 @@ contract OnchainMetadataDiamondExample is IERC8048Metadata {
         OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
         $.metadata[tokenId][key] = value;
         emit MetadataSet(tokenId, key, key, value);
+    }
+
+    /// @notice ERC-165 interface detection
+    function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
+        return interfaceId == 0xdf670be1 || interfaceId == type(IERC165).interfaceId;
     }
 }
 ```

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -51,7 +51,7 @@ Contracts implementing this ERC MUST emit the following event when metadata is s
 event MetadataSet(uint256 indexed tokenId, string indexed indexedKey, string key, bytes value);
 ```
 
-### ERC-165 Interface Detection
+### Interface Detection
 
 The interface ID is `0xdf670be1`.
 


### PR DESCRIPTION
Adds a normative requirement that contracts implementing `IERC8048Metadata` support ERC-165 interface detection.

- Contracts implementing `IERC8048Metadata` MUST implement ERC-165 and MUST return `true` from `supportsInterface` for `0xdf670be1` (the `IERC8048Metadata` interface id) and `0x01ffc9a7` (ERC-165 itself), so callers can detect onchain-metadata support before reading records.
- Both reference implementations now inherit `IERC165` and implement `supportsInterface`.

`165` was already listed in the frontmatter `requires`; this adds the corresponding normative text and reference-implementation support. The interface id `0xdf670be1` is unchanged.