### PR TITLE
Update ERC-8048: add optional Metadata Authority extension

### DIFF
--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -159,18 +159,22 @@ This optional, standalone extension lets the account authorized to write a token
 
 An implementation of this extension MUST also implement `IERC8048Metadata` (the core interface above) and MUST implement [ERC-165](./eip-165.md).
 
-The standardized surface is a single read function.
+The standardized surface is a single read function and one event.
 
 ```solidity
 interface IERC8048MetadataAuthority {
     /// @notice The current metadata authority for `tokenId`.
     function metadataAuthority(uint256 tokenId) external view returns (address);
+
+    /// @notice Emitted whenever `tokenId`'s metadata authority is set, changed, or cleared.
+    /// `authority` is the new authority, or the zero address when cleared.
+    event MetadataAuthoritySet(uint256 indexed tokenId, address indexed authority);
 }
 ```
 
 #### Extension Interface Detection
 
-The extension interface ID is `0xf9cb127d`, the selector of its only function, `metadataAuthority(uint256)`.
+The extension interface ID is `0xf9cb127d`, the selector of its only function, `metadataAuthority(uint256)`. Events do not affect [ERC-165](./eip-165.md) interface IDs, which cover function selectors only, so declaring `MetadataAuthoritySet` leaves this ID unchanged.
 
 Contracts implementing this extension MUST return `true` from `supportsInterface` for `0xf9cb127d` (this extension), `0xdf670be1` (the core `IERC8048Metadata` interface), and `0x01ffc9a7` ([ERC-165](./eip-165.md) itself).
 
@@ -191,7 +195,7 @@ A **smart authority** can enforce its own per-caller and per-key rules when auth
 
 #### Setting the authority (implementation-specific)
 
-Setting, changing, or clearing the authority is NOT part of this extension's interface and is implementation-defined. Implementations SHOULD emit an event when the authority changes; the event's signature is implementation-specific.
+Setting, changing, or clearing the authority is NOT part of this extension's interface and is implementation-defined. Whatever mechanism an implementation uses, it MUST emit `MetadataAuthoritySet` whenever a token's metadata authority is set, changed, or cleared, with `authority` set to the new authority, or to `address(0)` when the authority is cleared.
 
 The RECOMMENDED policy is: the token's unique owner MAY set the authority while it is unset; once set, only the current authority MAY change or clear it; the authority is asset-bound, so a token transfer does not clear it; the owner cannot reclaim write permission while an authority is set; and passing the zero address clears the authority and restores the default write permission (the [ERC-721](./eip-721.md) owner, approved, or operator), after which setting a new first authority is again owner-only.
 
@@ -253,7 +257,7 @@ Security: clients SHOULD only call metadata contracts they consider trustworthy;
 
 ## Rationale
 
-This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract's chosen write policy, and `MetadataSet` provides an onchain audit trail. The **Metadata Authority** extension standardizes a read for discovering whether metadata write authority rests with the token's [ERC-721](./eip-721.md) owner/approved/operator (when no authority is set) or with the exact authority (when one is set), plus the authorization semantics implementations must enforce; it deliberately leaves authority assignment policy implementation-specific. **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
+This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract's chosen write policy, and `MetadataSet` provides an onchain audit trail. The **Metadata Authority** extension standardizes a read for discovering whether metadata write authority rests with the token's [ERC-721](./eip-721.md) owner/approved/operator (when no authority is set) or with the exact authority (when one is set), plus the authorization semantics implementations must enforce and a standardized `MetadataAuthoritySet` event that indexers can rely on across implementations; it deliberately leaves authority assignment policy implementation-specific. **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
 
 ## Backwards Compatibility
 
@@ -315,9 +319,10 @@ interface IERC165 {
 /// @dev Reference implementation of the core interface plus the metadata authority
 ///      extension, using Diamond Storage. It is `abstract`: a concrete contract
 ///      supplies `_uniqueOwnerOf` (the token's unique current owner, or `address(0)`
-///      if the token does not exist). `setMetadataAuthority` and the
-///      `MetadataAuthoritySet` event below are one example assignment policy (the
-///      RECOMMENDED one) and are NOT part of the standardized interface.
+///      if the token does not exist). `setMetadataAuthority` is one example
+///      assignment policy (the RECOMMENDED one) and is NOT part of the standardized
+///      interface; the `MetadataAuthoritySet` it emits is the standardized interface
+///      event, inherited from `IERC8048MetadataAuthority`.
 abstract contract OnchainMetadataAuthorityDiamondExample is
     IERC8048Metadata,
     IERC8048MetadataAuthority,
@@ -327,10 +332,6 @@ abstract contract OnchainMetadataAuthorityDiamondExample is
         mapping(uint256 tokenId => mapping(string key => bytes value)) metadata;
         mapping(uint256 tokenId => address authority) metadataAuthority;
     }
-
-    /// @notice Emitted when this example changes a token's authority. The event is
-    ///         implementation-specific and is NOT part of IERC8048MetadataAuthority.
-    event MetadataAuthoritySet(uint256 indexed tokenId, address indexed previousAuthority, address indexed newAuthority);
 
     // keccak256("erc8048.onchain.metadata.storage")
     bytes32 private constant ONCHAIN_METADATA_STORAGE_LOCATION =
@@ -404,7 +405,7 @@ abstract contract OnchainMetadataAuthorityDiamondExample is
             require(msg.sender == previous, "not authority");
         }
         $.metadataAuthority[tokenId] = newAuthority;
-        emit MetadataAuthoritySet(tokenId, previous, newAuthority);
+        emit MetadataAuthoritySet(tokenId, newAuthority);
     }
 
     /// @dev Example burn hook: clears the authority so a reused token ID cannot
@@ -415,7 +416,7 @@ abstract contract OnchainMetadataAuthorityDiamondExample is
         address previous = $.metadataAuthority[tokenId];
         if (previous != address(0)) {
             delete $.metadataAuthority[tokenId];
-            emit MetadataAuthoritySet(tokenId, previous, address(0));
+            emit MetadataAuthoritySet(tokenId, address(0));
         }
     }
 

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -193,7 +193,7 @@ A **smart authority** can enforce its own per-caller and per-key rules when auth
 
 Setting, changing, or clearing the authority is NOT part of this extension's interface and is implementation-defined. Implementations SHOULD emit an event when the authority changes; the event's signature is implementation-specific.
 
-The RECOMMENDED policy is: the token's unique owner MAY set the authority while it is unset; once set, only the current authority MAY change or clear it; the authority is asset-bound, so a token transfer does not clear it; the owner cannot reclaim write authority while an authority is set; and passing the zero address clears the authority and restores zero-authority metadata-write authority (the [ERC-721](./eip-721.md) owner, approved, or operator), after which setting a new first authority is again owner-only.
+The RECOMMENDED policy is: the token's unique owner MAY set the authority while it is unset; once set, only the current authority MAY change or clear it; the authority is asset-bound, so a token transfer does not clear it; the owner cannot reclaim write permission while an authority is set; and passing the zero address clears the authority and restores the default write permission (the [ERC-721](./eip-721.md) owner, approved, or operator), after which setting a new first authority is again owner-only.
 
 `metadataAuthority` MUST be a total function that never reverts; it MUST return `address(0)` for an unset, cleared, burned, or nonexistent token. Implementations that reuse a token ID after burn MUST clear the authority on burn, so a newly created token cannot inherit stale authority state.
 

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -43,7 +43,7 @@ interface IERC8048Metadata {
 
 - `metadata(tokenId, key)`: Returns the metadata value for the given token ID and key as bytes
 
-Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract. Where the **Metadata Controller** extension (below) is implemented, every function that writes metadata for a token MUST apply that extension's controller-versus-owner authorization semantics.
+Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract. Where the **Metadata Controller** extension (below) is implemented, every function that writes metadata for a token MUST apply that extension's authorization semantics: the [ERC-721](./eip-721.md) owner/approved/operator when no controller is set, otherwise the exact controller.
 
 Contracts implementing this ERC MUST emit the following event when metadata is set:
 
@@ -145,7 +145,7 @@ For example, the Chain Identifier for Ethereum mainnet (chain ID `1`) is `0x0001
 
 #### Marketplace compatibility
 
-`tokenURI(uint256)` remains the ERC-721 marketplace metadata mechanism and is unchanged by this profile. Contracts SHOULD keep `tokenURI` JSON compatible with existing marketplaces (`name`, `description`, `image`). Agent-aware clients SHOULD read the keys above from this ERC's records rather than from `tokenURI`, and SHOULD treat both endpoints and `context` as untrusted input. Transferring the token transfers ownership of the record, not any offchain server, key, balance, or memory the records may reference. Where the **Metadata Controller** extension is in use, clients SHOULD read `metadataController(tokenId)` to determine whether the current owner or a distinct controller has metadata write authority.
+`tokenURI(uint256)` remains the ERC-721 marketplace metadata mechanism and is unchanged by this profile. Contracts SHOULD keep `tokenURI` JSON compatible with existing marketplaces (`name`, `description`, `image`). Agent-aware clients SHOULD read the keys above from this ERC's records rather than from `tokenURI`, and SHOULD treat both endpoints and `context` as untrusted input. Transferring the token transfers ownership of the record, not any offchain server, key, balance, or memory the records may reference. Where the **Metadata Controller** extension is in use, clients SHOULD read `metadataController(tokenId)` to determine whether [ERC-721](./eip-721.md) management authority (owner, approved, or operator) or a distinct controller holds metadata write authority.
 
 ### Optional Metadata Hooks
 
@@ -164,7 +164,8 @@ The standardized surface is a single read function; how a controller is set is i
 ```solidity
 interface IERC8048MetadataController {
     /// @notice The current metadata controller for `tokenId`, or the zero address if
-    ///         none is set (owner is then authorized). MUST NOT revert.
+    ///         none is set (the ERC-721 owner/approved/operator then hold metadata
+    ///         write authority). MUST NOT revert.
     function metadataController(uint256 tokenId) external view returns (address);
 }
 ```
@@ -177,16 +178,16 @@ Contracts implementing this extension MUST return `true` from `supportsInterface
 
 #### Applicability (unique current owner required)
 
-This extension applies only to tokens for which a `tokenId` has an unambiguous, unique current owner. [ERC-721](./eip-721.md) tokens qualify: each token has exactly one owner. [ERC-721](./eip-721.md) approvals and operators MUST NOT be treated as owners for this extension. Ordinary multi-holder [ERC-1155](./eip-1155.md) and [ERC-6909](./eip-6909.md) balances have no unique owner and therefore do not qualify; an implementation that cannot determine a canonical unique current owner MUST NOT implement this extension. A sidecar metadata contract (see **Onchain Metadata Contract Reference**, below) MAY implement this extension only if it can reliably determine the token's unique current owner.
+This extension applies only to tokens for which a `tokenId` has an unambiguous, unique current owner. [ERC-721](./eip-721.md) tokens qualify: each token has exactly one owner. [ERC-721](./eip-721.md) approvals and operators are not owners and do not satisfy this unique-owner requirement, even though they are authorized to write metadata in the zero-controller case (see Authorization). Ordinary multi-holder [ERC-1155](./eip-1155.md) and [ERC-6909](./eip-6909.md) balances have no unique owner and therefore do not qualify; an implementation that cannot determine a canonical unique current owner MUST NOT implement this extension. A sidecar metadata contract (see **Onchain Metadata Contract Reference**, below) MAY implement this extension only if it can reliably determine the token's unique current owner.
 
 #### Authorization
 
 For every function that writes metadata for a token, implementations MUST apply the following authorization semantics:
 
-- When `metadataController(tokenId) == address(0)`, only the token's current unique owner is authorized to write that token's metadata.
-- When `metadataController(tokenId) != address(0)`, only that controller is authorized to write that token's metadata; ownership alone MUST NOT authorize a metadata write while a controller is set.
+- When `metadataController(tokenId) == address(0)`, `setMetadata` MUST authorize `msg.sender` if it is the token's current unique [ERC-721](./eip-721.md) owner, the address returned by `getApproved(tokenId)`, or an operator for which `isApprovedForAll(owner, msg.sender)` is true.
+- When `metadataController(tokenId) != address(0)`, only that exact controller is authorized to write that token's metadata; the owner, `getApproved(tokenId)`, and `isApprovedForAll` MUST NOT authorize a metadata write while a controller is set.
 
-Authorization MUST be determined by direct `msg.sender` comparison against the owner or the controller, with no callback into the controller. [ERC-721](./eip-721.md) approvals and operators MUST NOT authorize a metadata write. Regardless of the implementation-specific controller administration described below, the value returned by `metadataController(tokenId)` MUST determine metadata write authority according to the rules above, and the function MUST return `address(0)` when no controller is set.
+These rules govern metadata-record writes (`setMetadata`) only, and are distinct from setting the controller, which is implementation-specific (see below). Authorization for a metadata write MUST be determined by direct comparison of `msg.sender` against the addresses named above, with no callback into the controller. [ERC-721](./eip-721.md) approvals and operators therefore authorize a metadata write ONLY in the zero-controller case; once a controller is set, they do not. Regardless of the implementation-specific controller administration described below, the value returned by `metadataController(tokenId)` MUST determine metadata write authority according to the rules above, and the function MUST return `address(0)` when no controller is set.
 
 A **smart controller** can enforce its own per-caller and per-key rules when authorizing metadata writes. Reads through `metadata` are unchanged and unaffected. A successful metadata write emits `MetadataSet` exactly as required by the core interface; a call that fails authorization MUST NOT emit `MetadataSet` and MUST revert.
 
@@ -194,7 +195,7 @@ A **smart controller** can enforce its own per-caller and per-key rules when aut
 
 Setting, changing, or clearing the controller is NOT part of this extension's interface and is implementation-defined. Implementations SHOULD emit an event when the controller changes; the event's signature is implementation-specific.
 
-The RECOMMENDED policy is: the token's unique owner MAY set the controller while it is unset; once set, only the current controller MAY change or clear it; the controller is asset-bound, so a token transfer does not clear it; the owner cannot reclaim write authority while a controller is set; and passing the zero address clears the controller and restores owner authority.
+The RECOMMENDED policy is: the token's unique owner MAY set the controller while it is unset; once set, only the current controller MAY change or clear it; the controller is asset-bound, so a token transfer does not clear it; the owner cannot reclaim write authority while a controller is set; and passing the zero address clears the controller and restores zero-controller metadata-write authority (the [ERC-721](./eip-721.md) owner, approved, or operator), after which setting a new first controller is again owner-only.
 
 `metadataController` MUST be a total function that never reverts; it MUST return `address(0)` for an unset, cleared, burned, or nonexistent token. Implementations that reuse a token ID after burn MUST clear the controller on burn, so a newly created token cannot inherit stale controller state.
 
@@ -254,7 +255,7 @@ Security: clients SHOULD only call metadata contracts they consider trustworthy;
 
 ## Rationale
 
-This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract's chosen write policy, and `MetadataSet` provides an onchain audit trail. The **Metadata Controller** extension standardizes a read for discovering whether metadata write authority belongs to the token owner or to a distinct controller, plus the authorization semantics implementations must enforce; it deliberately leaves controller assignment policy implementation-specific. **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
+This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract's chosen write policy, and `MetadataSet` provides an onchain audit trail. The **Metadata Controller** extension standardizes a read for discovering whether metadata write authority rests with the token's [ERC-721](./eip-721.md) owner/approved/operator (when no controller is set) or with the exact controller (when one is set), plus the authorization semantics implementations must enforce; it deliberately leaves controller assignment policy implementation-specific. **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
 
 ## Backwards Compatibility
 
@@ -350,6 +351,13 @@ abstract contract OnchainMetadataControllerDiamondExample is
     ///      approvals and operators MUST NOT be returned here.
     function _uniqueOwnerOf(uint256 tokenId) internal view virtual returns (address);
 
+    /// @dev Conceptual ERC-721 approval views the concrete contract wires to its token
+    ///      logic: the single approved address for `tokenId` (`getApproved`) and operator
+    ///      approval for `owner` (`isApprovedForAll`). Used only in the zero-controller
+    ///      metadata-write branch below; they never authorize setting the controller.
+    function _getApproved(uint256 tokenId) internal view virtual returns (address);
+    function _isApprovedForAll(address owner, address operator) internal view virtual returns (bool);
+
     // --- Reads (unchanged by the extension) ---
 
     function metadata(uint256 tokenId, string calldata key)
@@ -362,7 +370,7 @@ abstract contract OnchainMetadataControllerDiamondExample is
         return _getOnchainMetadataStorage().metadataController[tokenId];
     }
 
-    // --- Writes (controller-vs-owner authorization; direct msg.sender equality) ---
+    // --- Writes (metadata records: owner or ERC-721 approval when no controller; else controller) ---
 
     function setMetadata(uint256 tokenId, string calldata key, bytes calldata value)
         external {
@@ -370,7 +378,13 @@ abstract contract OnchainMetadataControllerDiamondExample is
         address controller = $.metadataController[tokenId];
         if (controller == address(0)) {
             address owner = _uniqueOwnerOf(tokenId);
-            require(owner != address(0) && msg.sender == owner, "not authorized");
+            require(owner != address(0), "nonexistent token");
+            require(
+                msg.sender == owner
+                    || msg.sender == _getApproved(tokenId)
+                    || _isApprovedForAll(owner, msg.sender),
+                "not authorized"
+            );
         } else {
             require(msg.sender == controller, "not controller");
         }
@@ -428,7 +442,7 @@ Implementations that choose to use the optional Diamond Storage pattern should c
 
 ### Metadata Controller Extension
 
-- A buyer MAY receive a token for which `metadataController(tokenId)` is non-zero. While it remains non-zero, ownership alone cannot authorize metadata writes. Wallets and marketplaces SHOULD surface the controller address before acquisition.
+- A buyer MAY receive a token for which `metadataController(tokenId)` is non-zero. While it remains non-zero, neither ownership nor [ERC-721](./eip-721.md) approvals or operators authorize metadata writes — only the controller does. Wallets and marketplaces SHOULD surface the controller address before acquisition.
 - Controller assignment, change, clearing, and recovery policies are implementation-specific. Users SHOULD inspect that policy before relying on the controller value; depending on the policy, a lost, misconfigured, or buggy controller could freeze metadata or a privileged party could replace the controller.
 - Implementations that reuse token IDs SHOULD ensure their implementation-specific token lifecycle does not unintentionally expose a newly created token to stale controller state.
 - Implementations that consult a controller contract while authorizing writes SHOULD apply standard reentrancy protections around any external call.

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -159,13 +159,11 @@ This optional, standalone extension lets the account authorized to write a token
 
 An implementation of this extension MUST also implement `IERC8048Metadata` (the core interface above) and MUST implement [ERC-165](./eip-165.md).
 
-The standardized surface is a single read function; how a controller is set is implementation-specific.
+The standardized surface is a single read function.
 
 ```solidity
 interface IERC8048MetadataController {
-    /// @notice The current metadata controller for `tokenId`, or the zero address if
-    ///         none is set (the ERC-721 owner/approved/operator then hold metadata
-    ///         write authority). MUST NOT revert.
+    /// @notice The current metadata controller for `tokenId`.
     function metadataController(uint256 tokenId) external view returns (address);
 }
 ```
@@ -178,18 +176,18 @@ Contracts implementing this extension MUST return `true` from `supportsInterface
 
 #### Applicability (unique current owner required)
 
-This extension applies only to tokens for which a `tokenId` has an unambiguous, unique current owner. [ERC-721](./eip-721.md) tokens qualify: each token has exactly one owner. [ERC-721](./eip-721.md) approvals and operators are not owners and do not satisfy this unique-owner requirement, even though they are authorized to write metadata in the zero-controller case (see Authorization). Ordinary multi-holder [ERC-1155](./eip-1155.md) and [ERC-6909](./eip-6909.md) balances have no unique owner and therefore do not qualify; an implementation that cannot determine a canonical unique current owner MUST NOT implement this extension. A sidecar metadata contract (see **Onchain Metadata Contract Reference**, below) MAY implement this extension only if it can reliably determine the token's unique current owner.
+An implementation MUST NOT implement this extension unless it can determine a canonical unique current owner for each `tokenId`. [ERC-721](./eip-721.md) tokens qualify because each token has exactly one owner (approvals and operators are not owners, though they may write metadata in the zero-controller case). Ordinary multi-holder [ERC-1155](./eip-1155.md) and [ERC-6909](./eip-6909.md) balances do not qualify because they lack a unique owner. A sidecar metadata contract (see **Onchain Metadata Contract Reference**, below) MAY implement this extension only if it can reliably determine that owner.
 
 #### Authorization
 
 For every function that writes metadata for a token, implementations MUST apply the following authorization semantics:
 
-- When `metadataController(tokenId) == address(0)`, `setMetadata` MUST authorize `msg.sender` if it is the token's current unique [ERC-721](./eip-721.md) owner, the address returned by `getApproved(tokenId)`, or an operator for which `isApprovedForAll(owner, msg.sender)` is true.
-- When `metadataController(tokenId) != address(0)`, only that exact controller is authorized to write that token's metadata; the owner, `getApproved(tokenId)`, and `isApprovedForAll` MUST NOT authorize a metadata write while a controller is set.
+- When `metadataController(tokenId) == address(0)`, `setMetadata` MUST authorize `msg.sender` when it equals the token's unique owner or `getApproved(tokenId)`, or when `isApprovedForAll(owner, msg.sender)` is true.
+- When `metadataController(tokenId) != address(0)`, `setMetadata` MUST authorize only that exact controller.
 
-These rules govern metadata-record writes (`setMetadata`) only, and are distinct from setting the controller, which is implementation-specific (see below). Authorization for a metadata write MUST be determined by direct comparison of `msg.sender` against the addresses named above, with no callback into the controller. [ERC-721](./eip-721.md) approvals and operators therefore authorize a metadata write ONLY in the zero-controller case; once a controller is set, they do not. Regardless of the implementation-specific controller administration described below, the value returned by `metadataController(tokenId)` MUST determine metadata write authority according to the rules above, and the function MUST return `address(0)` when no controller is set.
+Authorization for a metadata write MUST compare `msg.sender` directly against the addresses above, with no callback into the controller. These rules govern metadata-record writes (`setMetadata`) only, not setting the controller.
 
-A **smart controller** can enforce its own per-caller and per-key rules when authorizing metadata writes. Reads through `metadata` are unchanged and unaffected. A successful metadata write emits `MetadataSet` exactly as required by the core interface; a call that fails authorization MUST NOT emit `MetadataSet` and MUST revert.
+A **smart controller** can enforce its own per-caller and per-key rules when authorizing metadata writes. Reads through `metadata` are unaffected. A successful metadata write emits `MetadataSet` exactly as required by the core interface; a call that fails authorization MUST NOT emit `MetadataSet` and MUST revert.
 
 #### Setting the controller (implementation-specific)
 

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -43,7 +43,7 @@ interface IERC8048Metadata {
 
 - `metadata(tokenId, key)`: Returns the metadata value for the given token ID and key as bytes
 
-Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract. Where the **Metadata Authority** extension (below) is implemented, every function that writes metadata for a token MUST apply that extension's authorization semantics: the [ERC-721](./eip-721.md) owner/approved/operator when no authority is set, otherwise the exact authority.
+Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract.
 
 Contracts implementing this ERC MUST emit the following event when metadata is set:
 

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -153,16 +153,18 @@ Contracts implementing this ERC MAY use metadata hooks to redirect record resolu
 
 For the full specification of metadata hooks, see [ERC-8121](./eip-8121.md) (Metadata Hooks). Hooks are encoded in the metadata value itself and allow clients to **jump** to another contract to resolve the metadata value. When using hooks for token metadata with this ERC, the return type MUST be `bytes` and the hook encoding MUST be `bytes`.
 
-### Metadata Controller
+### Optional Metadata Controller Extension
 
 This optional, standalone extension lets the account authorized to write a token's metadata be a **metadata controller** that is distinct from the token's current owner. It is intended for assets where a party other than the holder governs certain records — for example a registered authority that maintains regulated fields on a real-world asset.
 
 An implementation of this extension MUST also implement `IERC8048Metadata` (the core interface above) and MUST implement [ERC-165](./eip-165.md).
 
+The standardized surface is a single read function; how a controller is set is implementation-specific.
+
 ```solidity
 interface IERC8048MetadataController {
-    /// @notice The current metadata controller for `tokenId`, or the zero address
-    ///         if none is set.
+    /// @notice The current metadata controller for `tokenId`, or the zero address if
+    ///         none is set (owner is then authorized). MUST NOT revert.
     function metadataController(uint256 tokenId) external view returns (address);
 }
 ```
@@ -181,12 +183,20 @@ This extension applies only to tokens for which a `tokenId` has an unambiguous, 
 
 For every function that writes metadata for a token, implementations MUST apply the following authorization semantics:
 
-- When `metadataController(tokenId) == address(0)`, the token's current unique owner controls that token's metadata according to the contract's write policy.
-- When `metadataController(tokenId) != address(0)`, that controller controls the token's metadata. Metadata writes MUST be authorized by the controller, and ownership alone MUST NOT authorize a metadata write.
+- When `metadataController(tokenId) == address(0)`, only the token's current unique owner is authorized to write that token's metadata.
+- When `metadataController(tokenId) != address(0)`, only that controller is authorized to write that token's metadata; ownership alone MUST NOT authorize a metadata write while a controller is set.
 
-The extension does not standardize a function for setting, changing, or clearing the controller, nor does it standardize an event for controller changes. Implementations decide how the value returned by `metadataController` is administered, including who may change it and by what mechanism. Regardless of that implementation-specific policy, the value returned by `metadataController(tokenId)` MUST determine metadata write authority according to the rules above, and the function MUST return `address(0)` when no controller is set.
+Authorization MUST be determined by direct `msg.sender` comparison against the owner or the controller, with no callback into the controller. [ERC-721](./eip-721.md) approvals and operators MUST NOT authorize a metadata write. Regardless of the implementation-specific controller administration described below, the value returned by `metadataController(tokenId)` MUST determine metadata write authority according to the rules above, and the function MUST return `address(0)` when no controller is set.
 
 A **smart controller** can enforce its own per-caller and per-key rules when authorizing metadata writes. Reads through `metadata` are unchanged and unaffected. A successful metadata write emits `MetadataSet` exactly as required by the core interface; a call that fails authorization MUST NOT emit `MetadataSet` and MUST revert.
+
+#### Setting the controller (implementation-specific)
+
+Setting, changing, or clearing the controller is NOT part of this extension's interface and is implementation-defined. Implementations SHOULD emit an event when the controller changes; the event's signature is implementation-specific.
+
+The RECOMMENDED policy is: the token's unique owner MAY set the controller while it is unset; once set, only the current controller MAY change or clear it; the controller is asset-bound, so a token transfer does not clear it; the owner cannot reclaim write authority while a controller is set; and passing the zero address clears the controller and restores owner authority.
+
+`metadataController` MUST be a total function that never reverts; it MUST return `address(0)` for an unset, cleared, burned, or nonexistent token. Implementations that reuse a token ID after burn MUST clear the controller on burn, so a newly created token cannot inherit stale controller state.
 
 #### Example: owner and authority fields on a real-world asset
 
@@ -303,12 +313,12 @@ interface IERC165 {
     function supportsInterface(bytes4 interfaceId) external view returns (bool);
 }
 
-/// @dev Reference implementation of the core interface plus the Metadata Controller
-///      extension, using Diamond Storage. It is `abstract`: a concrete
-///      contract supplies `_uniqueOwnerOf` (the token's unique current owner, or
-///      `address(0)` if the token does not exist). Its owner-only
-///      `setMetadataController` is one example assignment policy, not part of the
-///      standardized interface.
+/// @dev Reference implementation of the core interface plus the metadata controller
+///      extension, using Diamond Storage. It is `abstract`: a concrete contract
+///      supplies `_uniqueOwnerOf` (the token's unique current owner, or `address(0)`
+///      if the token does not exist). `setMetadataController` and the
+///      `MetadataControllerSet` event below are one example assignment policy — the
+///      RECOMMENDED one — and are NOT part of the standardized interface.
 abstract contract OnchainMetadataControllerDiamondExample is
     IERC8048Metadata,
     IERC8048MetadataController,
@@ -318,6 +328,10 @@ abstract contract OnchainMetadataControllerDiamondExample is
         mapping(uint256 tokenId => mapping(string key => bytes value)) metadata;
         mapping(uint256 tokenId => address controller) metadataController;
     }
+
+    /// @notice Emitted when this example changes a token's controller. The event is
+    ///         implementation-specific and is NOT part of IERC8048MetadataController.
+    event MetadataControllerSet(uint256 indexed tokenId, address indexed previousController, address indexed newController);
 
     // keccak256("erc8048.onchain.metadata.storage")
     bytes32 private constant ONCHAIN_METADATA_STORAGE_LOCATION =
@@ -365,13 +379,32 @@ abstract contract OnchainMetadataControllerDiamondExample is
     }
 
     /// @dev Example assignment policy only; not part of IERC8048MetadataController.
-    ///      This implementation lets the current owner set, change, or clear the
-    ///      controller. Other implementations may use a different policy or mechanism.
+    ///      Demonstrates the RECOMMENDED policy: the owner may set the controller
+    ///      while it is unset; once set, only the current controller may change or
+    ///      clear it (the zero address clears it). Other implementations may differ.
     function setMetadataController(uint256 tokenId, address newController) external {
-        address owner = _uniqueOwnerOf(tokenId);
-        require(owner != address(0), "nonexistent token");
-        require(msg.sender == owner, "not owner");
-        _getOnchainMetadataStorage().metadataController[tokenId] = newController;
+        OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
+        address previous = $.metadataController[tokenId];
+        if (previous == address(0)) {
+            address owner = _uniqueOwnerOf(tokenId);
+            require(owner != address(0) && msg.sender == owner, "not owner");
+        } else {
+            require(msg.sender == previous, "not controller");
+        }
+        $.metadataController[tokenId] = newController;
+        emit MetadataControllerSet(tokenId, previous, newController);
+    }
+
+    /// @dev Example burn hook: clears the controller so a reused token ID cannot
+    ///      inherit stale controller state, per the extension's burn requirement.
+    ///      Concrete contracts MUST call this when a token is burned or its ID retired.
+    function _clearMetadataControllerOnBurn(uint256 tokenId) internal {
+        OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
+        address previous = $.metadataController[tokenId];
+        if (previous != address(0)) {
+            delete $.metadataController[tokenId];
+            emit MetadataControllerSet(tokenId, previous, address(0));
+        }
     }
 
     // --- Introspection ---

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -43,7 +43,7 @@ interface IERC8048Metadata {
 
 - `metadata(tokenId, key)`: Returns the metadata value for the given token ID and key as bytes
 
-Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract.
+Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract. Where the **Metadata Controller** extension (below) is implemented, every function that writes metadata for a token MUST apply that extension's controller-versus-owner authorization semantics.
 
 Contracts implementing this ERC MUST emit the following event when metadata is set:
 
@@ -145,13 +145,57 @@ For example, the Chain Identifier for Ethereum mainnet (chain ID `1`) is `0x0001
 
 #### Marketplace compatibility
 
-`tokenURI(uint256)` remains the ERC-721 marketplace metadata mechanism and is unchanged by this profile. Contracts SHOULD keep `tokenURI` JSON compatible with existing marketplaces (`name`, `description`, `image`). Agent-aware clients SHOULD read the keys above from this ERC's records rather than from `tokenURI`, and SHOULD treat both endpoints and `context` as untrusted input. Transferring the token transfers ownership of the record, not any offchain server, key, balance, or memory the records may reference.
+`tokenURI(uint256)` remains the ERC-721 marketplace metadata mechanism and is unchanged by this profile. Contracts SHOULD keep `tokenURI` JSON compatible with existing marketplaces (`name`, `description`, `image`). Agent-aware clients SHOULD read the keys above from this ERC's records rather than from `tokenURI`, and SHOULD treat both endpoints and `context` as untrusted input. Transferring the token transfers ownership of the record, not any offchain server, key, balance, or memory the records may reference. Where the **Metadata Controller** extension is in use, clients SHOULD read `metadataController(tokenId)` to determine whether the current owner or a distinct controller has metadata write authority.
 
 ### Optional Metadata Hooks
 
 Contracts implementing this ERC MAY use metadata hooks to redirect record resolution to a different contract for secure resolution from known contracts, such as singleton registries with verifiable security properties.
 
 For the full specification of metadata hooks, see [ERC-8121](./eip-8121.md) (Metadata Hooks). Hooks are encoded in the metadata value itself and allow clients to **jump** to another contract to resolve the metadata value. When using hooks for token metadata with this ERC, the return type MUST be `bytes` and the hook encoding MUST be `bytes`.
+
+### Metadata Controller
+
+This optional, standalone extension lets the account authorized to write a token's metadata be a **metadata controller** that is distinct from the token's current owner. It is intended for assets where a party other than the holder governs certain records — for example a registered authority that maintains regulated fields on a real-world asset.
+
+An implementation of this extension MUST also implement `IERC8048Metadata` (the core interface above) and MUST implement [ERC-165](./eip-165.md).
+
+```solidity
+interface IERC8048MetadataController {
+    /// @notice The current metadata controller for `tokenId`, or the zero address
+    ///         if none is set.
+    function metadataController(uint256 tokenId) external view returns (address);
+}
+```
+
+#### Extension Interface Detection
+
+The extension interface ID is `0x0a4a3661`, the selector of its only function, `metadataController(uint256)`.
+
+Contracts implementing this extension MUST return `true` from `supportsInterface` for `0x0a4a3661` (this extension), `0xdf670be1` (the core `IERC8048Metadata` interface), and `0x01ffc9a7` ([ERC-165](./eip-165.md) itself).
+
+#### Applicability (unique current owner required)
+
+This extension applies only to tokens for which a `tokenId` has an unambiguous, unique current owner. [ERC-721](./eip-721.md) tokens qualify: each token has exactly one owner. [ERC-721](./eip-721.md) approvals and operators MUST NOT be treated as owners for this extension. Ordinary multi-holder [ERC-1155](./eip-1155.md) and [ERC-6909](./eip-6909.md) balances have no unique owner and therefore do not qualify; an implementation that cannot determine a canonical unique current owner MUST NOT implement this extension. A sidecar metadata contract (see **Onchain Metadata Contract Reference**, below) MAY implement this extension only if it can reliably determine the token's unique current owner.
+
+#### Authorization
+
+For every function that writes metadata for a token, implementations MUST apply the following authorization semantics:
+
+- When `metadataController(tokenId) == address(0)`, the token's current unique owner controls that token's metadata according to the contract's write policy.
+- When `metadataController(tokenId) != address(0)`, that controller controls the token's metadata. Metadata writes MUST be authorized by the controller, and ownership alone MUST NOT authorize a metadata write.
+
+The extension does not standardize a function for setting, changing, or clearing the controller, nor does it standardize an event for controller changes. Implementations decide how the value returned by `metadataController` is administered, including who may change it and by what mechanism. Regardless of that implementation-specific policy, the value returned by `metadataController(tokenId)` MUST determine metadata write authority according to the rules above, and the function MUST return `address(0)` when no controller is set.
+
+A **smart controller** can enforce its own per-caller and per-key rules when authorizing metadata writes. Reads through `metadata` are unchanged and unaffected. A successful metadata write emits `MetadataSet` exactly as required by the core interface; a call that fails authorization MUST NOT emit `MetadataSet` and MUST revert.
+
+#### Example: owner and authority fields on a real-world asset
+
+Consider a house tokenized as an [ERC-721](./eip-721.md). The owner maintains owner-controlled fields while a housing authority maintains regulated fields:
+
+- The owner writes `usr.<key>` records (for example `usr.listing-note`).
+- The housing authority writes `gov.housing-authority.size` (the assessed size).
+
+The authority is not the token owner, so the implementation assigns a policy contract as the controller using its implementation-specific mechanism. While `metadataController(tokenId)` returns that policy contract's address, metadata writes must be authorized by the policy contract; owner status alone is insufficient. The policy contract can authorize the owner to write `usr.*` and the authority to write `gov.housing-authority.*`. How the controller is assigned, changed, or cleared is outside this extension's standardized interface.
 
 ### Onchain Metadata Contract Reference (Optional Extension)
 
@@ -200,7 +244,7 @@ Security: clients SHOULD only call metadata contracts they consider trustworthy;
 
 ## Rationale
 
-This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract’s chosen write policy, and `MetadataSet` provides an onchain audit trail. **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
+This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract's chosen write policy, and `MetadataSet` provides an onchain audit trail. The **Metadata Controller** extension standardizes a read for discovering whether metadata write authority belongs to the token owner or to a distinct controller, plus the authorization semantics implementations must enforce; it deliberately leaves controller assignment policy implementation-specific. **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
 
 ## Backwards Compatibility
 
@@ -253,14 +297,26 @@ contract OnchainMetadataExample is IERC8048Metadata, IERC165 {
 pragma solidity ^0.8.20;
 
 import "./IERC8048Metadata.sol";
+import "./IERC8048MetadataController.sol";
 
 interface IERC165 {
     function supportsInterface(bytes4 interfaceId) external view returns (bool);
 }
 
-contract OnchainMetadataDiamondExample is IERC8048Metadata, IERC165 {
+/// @dev Reference implementation of the core interface plus the Metadata Controller
+///      extension, using Diamond Storage. It is `abstract`: a concrete
+///      contract supplies `_uniqueOwnerOf` (the token's unique current owner, or
+///      `address(0)` if the token does not exist). Its owner-only
+///      `setMetadataController` is one example assignment policy, not part of the
+///      standardized interface.
+abstract contract OnchainMetadataControllerDiamondExample is
+    IERC8048Metadata,
+    IERC8048MetadataController,
+    IERC165
+{
     struct OnchainMetadataStorage {
         mapping(uint256 tokenId => mapping(string key => bytes value)) metadata;
+        mapping(uint256 tokenId => address controller) metadataController;
     }
 
     // keccak256("erc8048.onchain.metadata.storage")
@@ -274,22 +330,57 @@ contract OnchainMetadataDiamondExample is IERC8048Metadata, IERC165 {
         }
     }
 
-    function metadata(uint256 tokenId, string calldata key) 
+    /// @dev The unique current owner of `tokenId`, or `address(0)` if it does not exist.
+    ///      Concrete contracts wire this to their token logic (e.g. ERC-721 `ownerOf`,
+    ///      returning zero instead of reverting for a nonexistent token). ERC-721
+    ///      approvals and operators MUST NOT be returned here.
+    function _uniqueOwnerOf(uint256 tokenId) internal view virtual returns (address);
+
+    // --- Reads (unchanged by the extension) ---
+
+    function metadata(uint256 tokenId, string calldata key)
         external view override returns (bytes memory) {
-        OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
-        return $.metadata[tokenId][key];
+        return _getOnchainMetadataStorage().metadata[tokenId][key];
     }
-    
-    function setMetadata(uint256 tokenId, string calldata key, bytes calldata value) 
+
+    /// @notice Return the current controller, or zero when none is set.
+    function metadataController(uint256 tokenId) external view override returns (address) {
+        return _getOnchainMetadataStorage().metadataController[tokenId];
+    }
+
+    // --- Writes (controller-vs-owner authorization; direct msg.sender equality) ---
+
+    function setMetadata(uint256 tokenId, string calldata key, bytes calldata value)
         external {
         OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
+        address controller = $.metadataController[tokenId];
+        if (controller == address(0)) {
+            address owner = _uniqueOwnerOf(tokenId);
+            require(owner != address(0) && msg.sender == owner, "not authorized");
+        } else {
+            require(msg.sender == controller, "not controller");
+        }
         $.metadata[tokenId][key] = value;
         emit MetadataSet(tokenId, key, key, value);
     }
 
-    /// @notice ERC-165 interface detection
+    /// @dev Example assignment policy only; not part of IERC8048MetadataController.
+    ///      This implementation lets the current owner set, change, or clear the
+    ///      controller. Other implementations may use a different policy or mechanism.
+    function setMetadataController(uint256 tokenId, address newController) external {
+        address owner = _uniqueOwnerOf(tokenId);
+        require(owner != address(0), "nonexistent token");
+        require(msg.sender == owner, "not owner");
+        _getOnchainMetadataStorage().metadataController[tokenId] = newController;
+    }
+
+    // --- Introspection ---
+
+    /// @notice ERC-165 interface detection: core, controller extension, and ERC-165.
     function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
-        return interfaceId == 0xdf670be1 || interfaceId == type(IERC165).interfaceId;
+        return interfaceId == 0xdf670be1
+            || interfaceId == 0x0a4a3661
+            || interfaceId == type(IERC165).interfaceId;
     }
 }
 ```
@@ -300,7 +391,14 @@ Implementations should follow the standard [ERC-721](./eip-721.md), [ERC-1155](.
 
 This ERC is designed to put metadata onchain, providing security benefits through onchain storage.
 
-Implementations that choose to use the optional Diamond Storage pattern should consider the security considerations of [ERC-8042](./eip-8042.md). 
+Implementations that choose to use the optional Diamond Storage pattern should consider the security considerations of [ERC-8042](./eip-8042.md).
+
+### Metadata Controller Extension
+
+- A buyer MAY receive a token for which `metadataController(tokenId)` is non-zero. While it remains non-zero, ownership alone cannot authorize metadata writes. Wallets and marketplaces SHOULD surface the controller address before acquisition.
+- Controller assignment, change, clearing, and recovery policies are implementation-specific. Users SHOULD inspect that policy before relying on the controller value; depending on the policy, a lost, misconfigured, or buggy controller could freeze metadata or a privileged party could replace the controller.
+- Implementations that reuse token IDs SHOULD ensure their implementation-specific token lifecycle does not unintentionally expose a newly created token to stale controller state.
+- Implementations that consult a controller contract while authorizing writes SHOULD apply standard reentrancy protections around any external call.
 
 ## Copyright
 

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -79,8 +79,8 @@ It is possible to use this standard to tokenize an agent as an NFT: each token I
 
 Two key patterns:
 
-- **`context`** — one key. UTF-8 Markdown is enough for humans and models; issuers MAY also embed a JSON code block so clients can parse token lists, policy URIs, or version fields without a second key.
-- **`endpoint[<type>]`** — one URL per protocol; `<type>` is lowercase (`mcp`, `a2a`, `ag-ui`, …).
+- **`context`**: one key. UTF-8 Markdown is enough for humans and models; issuers MAY also embed a JSON code block so clients can parse token lists, policy URIs, or version fields without a second key.
+- **`endpoint[<type>]`**: one URL per protocol; `<type>` is lowercase (`mcp`, `a2a`, `ag-ui`, …).
 
 Example for `tokenId == 1`: store the UTF-8 encoding of a Markdown document like the following as the `bytes` value for `"context"` (shown as a file; not a Solidity literal):
 
@@ -128,16 +128,16 @@ Keys are case-sensitive (the value of `key` is compared as exact bytes). Endpoin
 
 The canonical endpoint types are:
 
-- `mcp` — Model Context Protocol endpoint.
-- `a2a` — Agent-to-Agent endpoint.
-- `web` — general web endpoint (aligned with [ERC-8004](./eip-8004.md) `web` service usage; the value MAY be any URI, with `https` RECOMMENDED).
-- `x402` — payment-enabled endpoint.
+- `mcp`: Model Context Protocol endpoint.
+- `a2a`: Agent-to-Agent endpoint.
+- `web`: general web endpoint (aligned with [ERC-8004](./eip-8004.md) `web` service usage; the value MAY be any URI, with `https` RECOMMENDED).
+- `x402`: payment-enabled endpoint.
 
 Additional endpoint types MAY be used without changing this profile, provided they use the `endpoint[<type>]` form. Standards that reserve new types SHOULD define their exact canonical (lowercase) spelling.
 
 #### Chain-keyed addresses
 
-In `address[<chain-id>]`, `<chain-id>` is the [ERC-7930](./eip-7930.md) **Chain Identifier** — an Interoperable Address with a zero-length address part — encoded as a lowercase `0x`-prefixed hex string. The stored value is a normal 20-byte EVM address, not an ERC-7930 interoperable address; ERC-7930 is used only to name the chain.
+In `address[<chain-id>]`, `<chain-id>` is the [ERC-7930](./eip-7930.md) **Chain Identifier**, an Interoperable Address with a zero-length address part, encoded as a lowercase `0x`-prefixed hex string. The stored value is a normal 20-byte EVM address, not an ERC-7930 interoperable address; ERC-7930 is used only to name the chain.
 
 For example, the Chain Identifier for Ethereum mainnet (chain ID `1`) is `0x00010000010100`, and for Base (chain ID `8453`, i.e. `0x2105`) is `0x000100000202210500`. The agent's mainnet account would be stored as:
 
@@ -155,7 +155,7 @@ For the full specification of metadata hooks, see [ERC-8121](./eip-8121.md) (Met
 
 ### Optional Metadata Controller Extension
 
-This optional, standalone extension lets the account authorized to write a token's metadata be a **metadata controller** that is distinct from the token's current owner. It is intended for assets where a party other than the holder governs certain records — for example a registered authority that maintains regulated fields on a real-world asset.
+This optional, standalone extension lets the account authorized to write a token's metadata be a **metadata controller** that is distinct from the token's current owner. It is intended for assets where a party other than the holder governs certain records, for example a registered authority that maintains regulated fields on a real-world asset.
 
 An implementation of this extension MUST also implement `IERC8048Metadata` (the core interface above) and MUST implement [ERC-165](./eip-165.md).
 
@@ -316,8 +316,8 @@ interface IERC165 {
 ///      extension, using Diamond Storage. It is `abstract`: a concrete contract
 ///      supplies `_uniqueOwnerOf` (the token's unique current owner, or `address(0)`
 ///      if the token does not exist). `setMetadataController` and the
-///      `MetadataControllerSet` event below are one example assignment policy — the
-///      RECOMMENDED one — and are NOT part of the standardized interface.
+///      `MetadataControllerSet` event below are one example assignment policy (the
+///      RECOMMENDED one) and are NOT part of the standardized interface.
 abstract contract OnchainMetadataControllerDiamondExample is
     IERC8048Metadata,
     IERC8048MetadataController,
@@ -440,7 +440,7 @@ Implementations that choose to use the optional Diamond Storage pattern should c
 
 ### Metadata Controller Extension
 
-- A buyer MAY receive a token for which `metadataController(tokenId)` is non-zero. While it remains non-zero, neither ownership nor [ERC-721](./eip-721.md) approvals or operators authorize metadata writes — only the controller does. Wallets and marketplaces SHOULD surface the controller address before acquisition.
+- A buyer MAY receive a token for which `metadataController(tokenId)` is non-zero. While it remains non-zero, neither ownership nor [ERC-721](./eip-721.md) approvals or operators authorize metadata writes; only the controller does. Wallets and marketplaces SHOULD surface the controller address before acquisition.
 - Controller assignment, change, clearing, and recovery policies are implementation-specific. Users SHOULD inspect that policy before relying on the controller value; depending on the policy, a lost, misconfigured, or buggy controller could freeze metadata or a privileged party could replace the controller.
 - Implementations that reuse token IDs SHOULD ensure their implementation-specific token lifecycle does not unintentionally expose a newly created token to stale controller state.
 - Implementations that consult a controller contract while authorizing writes SHOULD apply standard reentrancy protections around any external call.

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -43,7 +43,7 @@ interface IERC8048Metadata {
 
 - `metadata(tokenId, key)`: Returns the metadata value for the given token ID and key as bytes
 
-Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract. Where the **Metadata Controller** extension (below) is implemented, every function that writes metadata for a token MUST apply that extension's authorization semantics: the [ERC-721](./eip-721.md) owner/approved/operator when no controller is set, otherwise the exact controller.
+Contracts implementing this ERC MAY also expose a `setMetadata(uint256 tokenId, string calldata key, bytes calldata value)` function to allow metadata updates, with write policy determined by the contract. Where the **Metadata Authority** extension (below) is implemented, every function that writes metadata for a token MUST apply that extension's authorization semantics: the [ERC-721](./eip-721.md) owner/approved/operator when no authority is set, otherwise the exact authority.
 
 Contracts implementing this ERC MUST emit the following event when metadata is set:
 
@@ -145,7 +145,7 @@ For example, the Chain Identifier for Ethereum mainnet (chain ID `1`) is `0x0001
 
 #### Marketplace compatibility
 
-`tokenURI(uint256)` remains the ERC-721 marketplace metadata mechanism and is unchanged by this profile. Contracts SHOULD keep `tokenURI` JSON compatible with existing marketplaces (`name`, `description`, `image`). Agent-aware clients SHOULD read the keys above from this ERC's records rather than from `tokenURI`, and SHOULD treat both endpoints and `context` as untrusted input. Transferring the token transfers ownership of the record, not any offchain server, key, balance, or memory the records may reference. Where the **Metadata Controller** extension is in use, clients SHOULD read `metadataController(tokenId)` to determine whether [ERC-721](./eip-721.md) management authority (owner, approved, or operator) or a distinct controller holds metadata write authority.
+`tokenURI(uint256)` remains the ERC-721 marketplace metadata mechanism and is unchanged by this profile. Contracts SHOULD keep `tokenURI` JSON compatible with existing marketplaces (`name`, `description`, `image`). Agent-aware clients SHOULD read the keys above from this ERC's records rather than from `tokenURI`, and SHOULD treat both endpoints and `context` as untrusted input. Transferring the token transfers ownership of the record, not any offchain server, key, balance, or memory the records may reference. Where the **Metadata Authority** extension is in use, clients SHOULD read `metadataAuthority(tokenId)` to determine whether [ERC-721](./eip-721.md) management authority (owner, approved, or operator) or a distinct metadata authority holds write authority.
 
 ### Optional Metadata Hooks
 
@@ -153,49 +153,49 @@ Contracts implementing this ERC MAY use metadata hooks to redirect record resolu
 
 For the full specification of metadata hooks, see [ERC-8121](./eip-8121.md) (Metadata Hooks). Hooks are encoded in the metadata value itself and allow clients to **jump** to another contract to resolve the metadata value. When using hooks for token metadata with this ERC, the return type MUST be `bytes` and the hook encoding MUST be `bytes`.
 
-### Optional Metadata Controller Extension
+### Optional Metadata Authority Extension
 
-This optional, standalone extension lets the account authorized to write a token's metadata be a **metadata controller** that is distinct from the token's current owner. It is intended for assets where a party other than the holder governs certain records, for example a registered authority that maintains regulated fields on a real-world asset.
+This optional, standalone extension lets the account authorized to write a token's metadata be a **metadata authority** that is distinct from the token's current owner. It is intended for assets where a party other than the holder governs certain records, for example a registered authority that maintains regulated fields on a real-world asset.
 
 An implementation of this extension MUST also implement `IERC8048Metadata` (the core interface above) and MUST implement [ERC-165](./eip-165.md).
 
 The standardized surface is a single read function.
 
 ```solidity
-interface IERC8048MetadataController {
-    /// @notice The current metadata controller for `tokenId`.
-    function metadataController(uint256 tokenId) external view returns (address);
+interface IERC8048MetadataAuthority {
+    /// @notice The current metadata authority for `tokenId`.
+    function metadataAuthority(uint256 tokenId) external view returns (address);
 }
 ```
 
 #### Extension Interface Detection
 
-The extension interface ID is `0x0a4a3661`, the selector of its only function, `metadataController(uint256)`.
+The extension interface ID is `0xf9cb127d`, the selector of its only function, `metadataAuthority(uint256)`.
 
-Contracts implementing this extension MUST return `true` from `supportsInterface` for `0x0a4a3661` (this extension), `0xdf670be1` (the core `IERC8048Metadata` interface), and `0x01ffc9a7` ([ERC-165](./eip-165.md) itself).
+Contracts implementing this extension MUST return `true` from `supportsInterface` for `0xf9cb127d` (this extension), `0xdf670be1` (the core `IERC8048Metadata` interface), and `0x01ffc9a7` ([ERC-165](./eip-165.md) itself).
 
 #### Applicability (unique current owner required)
 
-An implementation MUST NOT implement this extension unless it can determine a canonical unique current owner for each `tokenId`. [ERC-721](./eip-721.md) tokens qualify because each token has exactly one owner (approvals and operators are not owners, though they may write metadata in the zero-controller case). Ordinary multi-holder [ERC-1155](./eip-1155.md) and [ERC-6909](./eip-6909.md) balances do not qualify because they lack a unique owner. A sidecar metadata contract (see **Onchain Metadata Contract Reference**, below) MAY implement this extension only if it can reliably determine that owner.
+An implementation MUST NOT implement this extension unless it can determine a canonical unique current owner for each `tokenId`. [ERC-721](./eip-721.md) tokens qualify because each token has exactly one owner (approvals and operators are not owners, though they may write metadata in the zero-authority case). Ordinary multi-holder [ERC-1155](./eip-1155.md) and [ERC-6909](./eip-6909.md) balances do not qualify because they lack a unique owner. A sidecar metadata contract (see **Onchain Metadata Contract Reference**, below) MAY implement this extension only if it can reliably determine that owner.
 
 #### Authorization
 
 For every function that writes metadata for a token, implementations MUST apply the following authorization semantics:
 
-- When `metadataController(tokenId) == address(0)`, `setMetadata` MUST authorize `msg.sender` when it equals the token's unique owner or `getApproved(tokenId)`, or when `isApprovedForAll(owner, msg.sender)` is true.
-- When `metadataController(tokenId) != address(0)`, `setMetadata` MUST authorize only that exact controller.
+- When `metadataAuthority(tokenId) == address(0)`, `setMetadata` MUST authorize `msg.sender` when it equals the token's unique owner or `getApproved(tokenId)`, or when `isApprovedForAll(owner, msg.sender)` is true.
+- When `metadataAuthority(tokenId) != address(0)`, `setMetadata` MUST authorize only that exact authority.
 
-Authorization for a metadata write MUST compare `msg.sender` directly against the addresses above, with no callback into the controller. These rules govern metadata-record writes (`setMetadata`) only, not setting the controller.
+Authorization for a metadata write MUST compare `msg.sender` directly against the addresses above, with no callback into the authority. These rules govern metadata-record writes (`setMetadata`) only, not setting the authority.
 
-A **smart controller** can enforce its own per-caller and per-key rules when authorizing metadata writes. Reads through `metadata` are unaffected. A successful metadata write emits `MetadataSet` exactly as required by the core interface; a call that fails authorization MUST NOT emit `MetadataSet` and MUST revert.
+A **smart authority** can enforce its own per-caller and per-key rules when authorizing metadata writes. Reads through `metadata` are unaffected. A successful metadata write emits `MetadataSet` exactly as required by the core interface; a call that fails authorization MUST NOT emit `MetadataSet` and MUST revert.
 
-#### Setting the controller (implementation-specific)
+#### Setting the authority (implementation-specific)
 
-Setting, changing, or clearing the controller is NOT part of this extension's interface and is implementation-defined. Implementations SHOULD emit an event when the controller changes; the event's signature is implementation-specific.
+Setting, changing, or clearing the authority is NOT part of this extension's interface and is implementation-defined. Implementations SHOULD emit an event when the authority changes; the event's signature is implementation-specific.
 
-The RECOMMENDED policy is: the token's unique owner MAY set the controller while it is unset; once set, only the current controller MAY change or clear it; the controller is asset-bound, so a token transfer does not clear it; the owner cannot reclaim write authority while a controller is set; and passing the zero address clears the controller and restores zero-controller metadata-write authority (the [ERC-721](./eip-721.md) owner, approved, or operator), after which setting a new first controller is again owner-only.
+The RECOMMENDED policy is: the token's unique owner MAY set the authority while it is unset; once set, only the current authority MAY change or clear it; the authority is asset-bound, so a token transfer does not clear it; the owner cannot reclaim write authority while an authority is set; and passing the zero address clears the authority and restores zero-authority metadata-write authority (the [ERC-721](./eip-721.md) owner, approved, or operator), after which setting a new first authority is again owner-only.
 
-`metadataController` MUST be a total function that never reverts; it MUST return `address(0)` for an unset, cleared, burned, or nonexistent token. Implementations that reuse a token ID after burn MUST clear the controller on burn, so a newly created token cannot inherit stale controller state.
+`metadataAuthority` MUST be a total function that never reverts; it MUST return `address(0)` for an unset, cleared, burned, or nonexistent token. Implementations that reuse a token ID after burn MUST clear the authority on burn, so a newly created token cannot inherit stale authority state.
 
 #### Example: owner and authority fields on a real-world asset
 
@@ -204,7 +204,7 @@ Consider a house tokenized as an [ERC-721](./eip-721.md). The owner maintains ow
 - The owner writes `usr.<key>` records (for example `usr.listing-note`).
 - The housing authority writes `gov.housing-authority.size` (the assessed size).
 
-The authority is not the token owner, so the implementation assigns a policy contract as the controller using its implementation-specific mechanism. While `metadataController(tokenId)` returns that policy contract's address, metadata writes must be authorized by the policy contract; owner status alone is insufficient. The policy contract can authorize the owner to write `usr.*` and the authority to write `gov.housing-authority.*`. How the controller is assigned, changed, or cleared is outside this extension's standardized interface.
+The housing authority is not the token owner, so the implementation assigns a policy contract as the metadata authority using its implementation-specific mechanism. While `metadataAuthority(tokenId)` returns that policy contract's address, metadata writes must be authorized by the policy contract; owner status alone is insufficient. The policy contract can authorize the owner to write `usr.*` and the housing authority to write `gov.housing-authority.*`. How the metadata authority is assigned, changed, or cleared is outside this extension's standardized interface.
 
 ### Onchain Metadata Contract Reference (Optional Extension)
 
@@ -253,7 +253,7 @@ Security: clients SHOULD only call metadata contracts they consider trustworthy;
 
 ## Rationale
 
-This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract's chosen write policy, and `MetadataSet` provides an onchain audit trail. The **Metadata Controller** extension standardizes a read for discovering whether metadata write authority rests with the token's [ERC-721](./eip-721.md) owner/approved/operator (when no controller is set) or with the exact controller (when one is set), plus the authorization semantics implementations must enforce; it deliberately leaves controller assignment policy implementation-specific. **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
+This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract's chosen write policy, and `MetadataSet` provides an onchain audit trail. The **Metadata Authority** extension standardizes a read for discovering whether metadata write authority rests with the token's [ERC-721](./eip-721.md) owner/approved/operator (when no authority is set) or with the exact authority (when one is set), plus the authorization semantics implementations must enforce; it deliberately leaves authority assignment policy implementation-specific. **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
 
 ## Backwards Compatibility
 
@@ -306,31 +306,31 @@ contract OnchainMetadataExample is IERC8048Metadata, IERC165 {
 pragma solidity ^0.8.20;
 
 import "./IERC8048Metadata.sol";
-import "./IERC8048MetadataController.sol";
+import "./IERC8048MetadataAuthority.sol";
 
 interface IERC165 {
     function supportsInterface(bytes4 interfaceId) external view returns (bool);
 }
 
-/// @dev Reference implementation of the core interface plus the metadata controller
+/// @dev Reference implementation of the core interface plus the metadata authority
 ///      extension, using Diamond Storage. It is `abstract`: a concrete contract
 ///      supplies `_uniqueOwnerOf` (the token's unique current owner, or `address(0)`
-///      if the token does not exist). `setMetadataController` and the
-///      `MetadataControllerSet` event below are one example assignment policy (the
+///      if the token does not exist). `setMetadataAuthority` and the
+///      `MetadataAuthoritySet` event below are one example assignment policy (the
 ///      RECOMMENDED one) and are NOT part of the standardized interface.
-abstract contract OnchainMetadataControllerDiamondExample is
+abstract contract OnchainMetadataAuthorityDiamondExample is
     IERC8048Metadata,
-    IERC8048MetadataController,
+    IERC8048MetadataAuthority,
     IERC165
 {
     struct OnchainMetadataStorage {
         mapping(uint256 tokenId => mapping(string key => bytes value)) metadata;
-        mapping(uint256 tokenId => address controller) metadataController;
+        mapping(uint256 tokenId => address authority) metadataAuthority;
     }
 
-    /// @notice Emitted when this example changes a token's controller. The event is
-    ///         implementation-specific and is NOT part of IERC8048MetadataController.
-    event MetadataControllerSet(uint256 indexed tokenId, address indexed previousController, address indexed newController);
+    /// @notice Emitted when this example changes a token's authority. The event is
+    ///         implementation-specific and is NOT part of IERC8048MetadataAuthority.
+    event MetadataAuthoritySet(uint256 indexed tokenId, address indexed previousAuthority, address indexed newAuthority);
 
     // keccak256("erc8048.onchain.metadata.storage")
     bytes32 private constant ONCHAIN_METADATA_STORAGE_LOCATION =
@@ -351,8 +351,8 @@ abstract contract OnchainMetadataControllerDiamondExample is
 
     /// @dev Conceptual ERC-721 approval views the concrete contract wires to its token
     ///      logic: the single approved address for `tokenId` (`getApproved`) and operator
-    ///      approval for `owner` (`isApprovedForAll`). Used only in the zero-controller
-    ///      metadata-write branch below; they never authorize setting the controller.
+    ///      approval for `owner` (`isApprovedForAll`). Used only in the zero-authority
+    ///      metadata-write branch below; they never authorize setting the authority.
     function _getApproved(uint256 tokenId) internal view virtual returns (address);
     function _isApprovedForAll(address owner, address operator) internal view virtual returns (bool);
 
@@ -363,18 +363,18 @@ abstract contract OnchainMetadataControllerDiamondExample is
         return _getOnchainMetadataStorage().metadata[tokenId][key];
     }
 
-    /// @notice Return the current controller, or zero when none is set.
-    function metadataController(uint256 tokenId) external view override returns (address) {
-        return _getOnchainMetadataStorage().metadataController[tokenId];
+    /// @notice Return the current authority, or zero when none is set.
+    function metadataAuthority(uint256 tokenId) external view override returns (address) {
+        return _getOnchainMetadataStorage().metadataAuthority[tokenId];
     }
 
-    // --- Writes (metadata records: owner or ERC-721 approval when no controller; else controller) ---
+    // --- Writes (metadata records: owner or ERC-721 approval when no authority; else authority) ---
 
     function setMetadata(uint256 tokenId, string calldata key, bytes calldata value)
         external {
         OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
-        address controller = $.metadataController[tokenId];
-        if (controller == address(0)) {
+        address authority = $.metadataAuthority[tokenId];
+        if (authority == address(0)) {
             address owner = _uniqueOwnerOf(tokenId);
             require(owner != address(0), "nonexistent token");
             require(
@@ -384,47 +384,47 @@ abstract contract OnchainMetadataControllerDiamondExample is
                 "not authorized"
             );
         } else {
-            require(msg.sender == controller, "not controller");
+            require(msg.sender == authority, "not authority");
         }
         $.metadata[tokenId][key] = value;
         emit MetadataSet(tokenId, key, key, value);
     }
 
-    /// @dev Example assignment policy only; not part of IERC8048MetadataController.
-    ///      Demonstrates the RECOMMENDED policy: the owner may set the controller
-    ///      while it is unset; once set, only the current controller may change or
+    /// @dev Example assignment policy only; not part of IERC8048MetadataAuthority.
+    ///      Demonstrates the RECOMMENDED policy: the owner may set the authority
+    ///      while it is unset; once set, only the current authority may change or
     ///      clear it (the zero address clears it). Other implementations may differ.
-    function setMetadataController(uint256 tokenId, address newController) external {
+    function setMetadataAuthority(uint256 tokenId, address newAuthority) external {
         OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
-        address previous = $.metadataController[tokenId];
+        address previous = $.metadataAuthority[tokenId];
         if (previous == address(0)) {
             address owner = _uniqueOwnerOf(tokenId);
             require(owner != address(0) && msg.sender == owner, "not owner");
         } else {
-            require(msg.sender == previous, "not controller");
+            require(msg.sender == previous, "not authority");
         }
-        $.metadataController[tokenId] = newController;
-        emit MetadataControllerSet(tokenId, previous, newController);
+        $.metadataAuthority[tokenId] = newAuthority;
+        emit MetadataAuthoritySet(tokenId, previous, newAuthority);
     }
 
-    /// @dev Example burn hook: clears the controller so a reused token ID cannot
-    ///      inherit stale controller state, per the extension's burn requirement.
+    /// @dev Example burn hook: clears the authority so a reused token ID cannot
+    ///      inherit stale authority state, per the extension's burn requirement.
     ///      Concrete contracts MUST call this when a token is burned or its ID retired.
-    function _clearMetadataControllerOnBurn(uint256 tokenId) internal {
+    function _clearMetadataAuthorityOnBurn(uint256 tokenId) internal {
         OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
-        address previous = $.metadataController[tokenId];
+        address previous = $.metadataAuthority[tokenId];
         if (previous != address(0)) {
-            delete $.metadataController[tokenId];
-            emit MetadataControllerSet(tokenId, previous, address(0));
+            delete $.metadataAuthority[tokenId];
+            emit MetadataAuthoritySet(tokenId, previous, address(0));
         }
     }
 
     // --- Introspection ---
 
-    /// @notice ERC-165 interface detection: core, controller extension, and ERC-165.
+    /// @notice ERC-165 interface detection: core, authority extension, and ERC-165.
     function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
         return interfaceId == 0xdf670be1
-            || interfaceId == 0x0a4a3661
+            || interfaceId == 0xf9cb127d
             || interfaceId == type(IERC165).interfaceId;
     }
 }
@@ -438,12 +438,12 @@ This ERC is designed to put metadata onchain, providing security benefits throug
 
 Implementations that choose to use the optional Diamond Storage pattern should consider the security considerations of [ERC-8042](./eip-8042.md).
 
-### Metadata Controller Extension
+### Metadata Authority Extension
 
-- A buyer MAY receive a token for which `metadataController(tokenId)` is non-zero. While it remains non-zero, neither ownership nor [ERC-721](./eip-721.md) approvals or operators authorize metadata writes; only the controller does. Wallets and marketplaces SHOULD surface the controller address before acquisition.
-- Controller assignment, change, clearing, and recovery policies are implementation-specific. Users SHOULD inspect that policy before relying on the controller value; depending on the policy, a lost, misconfigured, or buggy controller could freeze metadata or a privileged party could replace the controller.
-- Implementations that reuse token IDs SHOULD ensure their implementation-specific token lifecycle does not unintentionally expose a newly created token to stale controller state.
-- Implementations that consult a controller contract while authorizing writes SHOULD apply standard reentrancy protections around any external call.
+- A buyer MAY receive a token for which `metadataAuthority(tokenId)` is non-zero. While it remains non-zero, neither ownership nor [ERC-721](./eip-721.md) approvals or operators authorize metadata writes; only the authority does. Wallets and marketplaces SHOULD surface the authority address before acquisition.
+- Authority assignment, change, clearing, and recovery policies are implementation-specific. Users SHOULD inspect that policy before relying on the authority value; depending on the policy, a lost, misconfigured, or buggy authority could freeze metadata or a privileged party could replace the authority.
+- Implementations that reuse token IDs SHOULD ensure their implementation-specific token lifecycle does not unintentionally expose a newly created token to stale authority state.
+- Implementations that consult an authority contract while authorizing writes SHOULD apply standard reentrancy protections around any external call.
 
 ## Copyright
 

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -174,32 +174,24 @@ interface IERC8048MetadataAuthority {
 
 #### Extension Interface Detection
 
-The extension interface ID is `0xf9cb127d`, the selector of its only function, `metadataAuthority(uint256)`. Events do not affect [ERC-165](./eip-165.md) interface IDs, which cover function selectors only, so declaring `MetadataAuthoritySet` leaves this ID unchanged.
-
-Contracts implementing this extension MUST return `true` from `supportsInterface` for `0xf9cb127d` (this extension), `0xdf670be1` (the core `IERC8048Metadata` interface), and `0x01ffc9a7` ([ERC-165](./eip-165.md) itself).
+This extension's [ERC-165](./eip-165.md) interface ID is `0xf9cb127d`; contracts implementing it MUST return `true` from `supportsInterface` for `0xf9cb127d`.
 
 #### Applicability (unique current owner required)
 
-An implementation MUST NOT implement this extension unless it can determine a canonical unique current owner for each `tokenId`. [ERC-721](./eip-721.md) tokens qualify because each token has exactly one owner (approvals and operators are not owners, though they may write metadata in the zero-authority case). Ordinary multi-holder [ERC-1155](./eip-1155.md) and [ERC-6909](./eip-6909.md) balances do not qualify because they lack a unique owner. A sidecar metadata contract (see **Onchain Metadata Contract Reference**, below) MAY implement this extension only if it can reliably determine that owner.
+An implementation MUST NOT implement this extension unless it can determine a canonical unique current owner for each `tokenId`. [ERC-721](./eip-721.md) tokens qualify because each token has exactly one owner (approvals and operators are not owners, though they may write metadata in the zero-authority case). Ordinary multi-holder [ERC-1155](./eip-1155.md) and [ERC-6909](./eip-6909.md) balances do not qualify because they lack a unique owner.
 
 #### Authorization
 
 For every function that writes metadata for a token, implementations MUST apply the following authorization semantics:
 
-- When `metadataAuthority(tokenId) == address(0)`, `setMetadata` MUST authorize `msg.sender` when it equals the token's unique owner or `getApproved(tokenId)`, or when `isApprovedForAll(owner, msg.sender)` is true.
+- When `metadataAuthority(tokenId) == address(0)`, `setMetadata` MUST authorize the token's owner, its `getApproved(tokenId)` address, or any operator approved for the owner via `isApprovedForAll`.
 - When `metadataAuthority(tokenId) != address(0)`, `setMetadata` MUST authorize only that exact authority.
 
-Authorization for a metadata write MUST compare `msg.sender` directly against the addresses above, with no callback into the authority. These rules govern metadata-record writes (`setMetadata`) only, not setting the authority.
-
-A **smart authority** can enforce its own per-caller and per-key rules when authorizing metadata writes. Reads through `metadata` are unaffected. A successful metadata write emits `MetadataSet` exactly as required by the core interface; a call that fails authorization MUST NOT emit `MetadataSet` and MUST revert.
+A successful metadata write emits `MetadataSet`. A call that fails authorization MUST NOT emit `MetadataSet` and MUST revert.
 
 #### Setting the authority (implementation-specific)
 
 Setting, changing, or clearing the authority is NOT part of this extension's interface and is implementation-defined. Whatever mechanism an implementation uses, it MUST emit `MetadataAuthoritySet` whenever a token's metadata authority is set, changed, or cleared, with `authority` set to the new authority, or to `address(0)` when the authority is cleared.
-
-The RECOMMENDED policy is: the token's unique owner MAY set the authority while it is unset; once set, only the current authority MAY change or clear it; the authority is asset-bound, so a token transfer does not clear it; the owner cannot reclaim write permission while an authority is set; and passing the zero address clears the authority and restores the default write permission (the [ERC-721](./eip-721.md) owner, approved, or operator), after which setting a new first authority is again owner-only.
-
-`metadataAuthority` MUST be a total function that never reverts; it MUST return `address(0)` for an unset, cleared, burned, or nonexistent token. Implementations that reuse a token ID after burn MUST clear the authority on burn, so a newly created token cannot inherit stale authority state.
 
 #### Example: owner and authority fields on a real-world asset
 
@@ -257,7 +249,7 @@ Security: clients SHOULD only call metadata contracts they consider trustworthy;
 
 ## Rationale
 
-This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract's chosen write policy, and `MetadataSet` provides an onchain audit trail. The **Metadata Authority** extension standardizes a read for discovering whether metadata write authority rests with the token's [ERC-721](./eip-721.md) owner/approved/operator (when no authority is set) or with the exact authority (when one is set), plus the authorization semantics implementations must enforce and a standardized `MetadataAuthoritySet` event that indexers can rely on across implementations; it deliberately leaves authority assignment policy implementation-specific. **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
+This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract's chosen write policy, and `MetadataSet` provides an onchain audit trail. The **Metadata Authority** extension standardizes a read for discovering whether metadata write authority rests with the token's [ERC-721](./eip-721.md) owner/approved/operator (when no authority is set). **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
 
 ## Backwards Compatibility
 
@@ -408,18 +400,6 @@ abstract contract OnchainMetadataAuthorityDiamondExample is
         emit MetadataAuthoritySet(tokenId, newAuthority);
     }
 
-    /// @dev Example burn hook: clears the authority so a reused token ID cannot
-    ///      inherit stale authority state, per the extension's burn requirement.
-    ///      Concrete contracts MUST call this when a token is burned or its ID retired.
-    function _clearMetadataAuthorityOnBurn(uint256 tokenId) internal {
-        OnchainMetadataStorage storage $ = _getOnchainMetadataStorage();
-        address previous = $.metadataAuthority[tokenId];
-        if (previous != address(0)) {
-            delete $.metadataAuthority[tokenId];
-            emit MetadataAuthoritySet(tokenId, address(0));
-        }
-    }
-
     // --- Introspection ---
 
     /// @notice ERC-165 interface detection: core, authority extension, and ERC-165.
@@ -431,20 +411,11 @@ abstract contract OnchainMetadataAuthorityDiamondExample is
 }
 ```
 
-Implementations should follow the standard [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), or [ERC-6909](./eip-6909.md) patterns while adding the required metadata function and event.
-
 ## Security Considerations
 
 This ERC is designed to put metadata onchain, providing security benefits through onchain storage.
 
 Implementations that choose to use the optional Diamond Storage pattern should consider the security considerations of [ERC-8042](./eip-8042.md).
-
-### Metadata Authority Extension
-
-- A buyer MAY receive a token for which `metadataAuthority(tokenId)` is non-zero. While it remains non-zero, neither ownership nor [ERC-721](./eip-721.md) approvals or operators authorize metadata writes; only the authority does. Wallets and marketplaces SHOULD surface the authority address before acquisition.
-- Authority assignment, change, clearing, and recovery policies are implementation-specific. Users SHOULD inspect that policy before relying on the authority value; depending on the policy, a lost, misconfigured, or buggy authority could freeze metadata or a privileged party could replace the authority.
-- Implementations that reuse token IDs SHOULD ensure their implementation-specific token lifecycle does not unintentionally expose a newly created token to stale authority state.
-- Implementations that consult an authority contract while authorizing writes SHOULD apply standard reentrancy protections around any external call.
 
 ## Copyright
 


### PR DESCRIPTION
Adds an optional **Metadata Authority** extension to ERC-8048.

## What it adds

A per-token read, `metadataAuthority(uint256) → address`, that discovers who holds metadata write authority for a token:

- **No authority set (`address(0)`, the default):** `setMetadata` authorizes the token's ERC-721 owner, its `getApproved(tokenId)` address, or an operator (`isApprovedForAll`). This mirrors ordinary ERC-721 management authority.
- **Authority set (non-zero):** only that exact authority may write the token's metadata; ownership, approvals, and operators do not. A smart-contract authority can enforce its own per-caller and per-key rules.

The extension standardizes only the **read** (`metadataAuthority`) plus the authorization semantics and a `MetadataAuthoritySet` event that indexers can rely on across implementations. Setting/changing/clearing the authority is deliberately left implementation-specific.

## Interface

```solidity
interface IERC8048MetadataAuthority {
    /// @notice The current metadata authority for `tokenId`.
    function metadataAuthority(uint256 tokenId) external view returns (address);

    /// @notice Emitted whenever `tokenId`'s metadata authority is set, changed, or cleared.
    /// `authority` is the new authority, or the zero address when cleared.
    event MetadataAuthoritySet(uint256 indexed tokenId, address indexed authority);
}
```

- Extension interface ID: `0xf9cb127d` (advertised via ERC-165 `supportsInterface`; events do not affect the ID).
- Applies only to tokens with a unique current owner (ERC-721); multi-holder ERC-1155/ERC-6909 balances do not qualify.

A Diamond Storage reference implementation demonstrates the extension, and a real-world-asset worked example (owner-writable fields plus authority-writable regulated fields) motivates it.