### PR TITLE
Update ERC-8056: fix broken image asset paths (eip-8056 -> erc-8056)

### DIFF
--- a/ERCS/erc-8056.md
+++ b/ERCS/erc-8056.md
@@ -248,9 +248,9 @@ Alternative Approaches Considered:
 
 4. Off-chain Solutions: Purely off-chain solutions lack standardization and require trust in centralized providers.
 
-![Token Value Representation Approaches](../assets/eip-8056/token_value_repr.jpeg)
+![Token Value Representation Approaches](../assets/erc-8056/token_value_repr.jpeg)
 
-![Token Architecture Layers](../assets/eip-8056/token_arch_layers.jpeg)
+![Token Architecture Layers](../assets/erc-8056/token_arch_layers.jpeg)
 
 ### Backwards Compatibility
 


### PR DESCRIPTION
The two diagrams in the Rationale section render as broken images. The image paths point to `../assets/eip-8056/…` but the asset files are located at `assets/erc-8056/` — both `token_value_repr.jpeg` and `token_arch_layers.jpeg` return 404 at the referenced path and 200 at `assets/erc-8056/`. This corrects the two paths.

Editorial only — no normative changes.