### PR TITLE
Update ERC-7730: Improve duration format

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1386,21 +1386,42 @@ Formats applicable to `uint`/`int` solidity types.
 |-----------------|------------------------------------------------------------------------------------------|
 | *Description*   | Display an int (a number of seconds) as a time duration, rendered as `<days>d<hh>h<mm>m<ss>s` — `days` is unbounded and `hh`/`mm`/`ss` are zero-padded to two digits. This days-inclusive form avoids ambiguous large hour counts (e.g. `240:00:00`). |
 | *Parameters*    | ---                                                                                      |
-| `unboundedMessage` | Optional. Message shown when the value equals `type(uint256).max` (2²⁵⁶−1), a sentinel for an unbounded duration. Defaults to `Forever`. |
+| `specialValues` | Optional. Maps sentinel values to a message displayed in place of the formatted duration, e.g. `{"0": "Immediate"}`. Keys are written in decimal or `0x`-prefixed hexadecimal and compared numerically. `type(uint256).max` (2²⁵⁶−1) maps to `Forever` unless an explicit entry overrides it. |
 | `approximation` | Optional boolean, defaults to `false`. When `true`, an approximate calendar duration is appended in parentheses after the exact duration. Only relevant for values of at least one month; below that no suffix is appended. |
 | *Examples*      | ---                                                                                      |
 | `10d00h00m00s`  | Field Value = 864000                                                                     |
 | `0d02h17m30s`   | Field Value = 8250                                                                       |
-| `Forever`       | Field Value = `type(uint256).max`                                                        |
+| `0d00h00m00s`   | Field Value = 0 <br> no `specialValues` entry for `0`                                    |
+| `Forever`       | Field Value = `type(uint256).max` <br> no `specialValues` (implied entry)                 |
+| `Immediate`     | Field Value = 0 <br> `specialValues` = `{"0": "Immediate"}` (a timelock delay)            |
+| `No expiry`     | Field Value = 0 <br> `specialValues` = `{"0": "No expiry"}` (an expiry date)               |
+| `Max`           | Field Value = `type(uint64).max` <br> `specialValues` = `{"0xffffffffffffffff": "Max"}`   |
 | `1856d00h00m00s (approx. 5 years and 1 month)` | Field Value = 160358400 <br> `approximation` = true      |
 | `210d00h00m00s (approx. 7 months)` | Field Value = 18144000 <br> `approximation` = true                  |
 | `10d00h00m00s`  | Field Value = 864000 <br> `approximation` = true (below one month, no suffix appended)    |
 
+The `specialValues` map is resolved before the value is formatted:
+
+1. Keys are parsed as integers, decimal or `0x`-prefixed hexadecimal, and compared numerically, so
+   `"0"`, `"0x0"` and `"0x00"` all designate zero. A file MUST NOT contain two keys of equal
+   numeric value.
+2. An entry mapping `type(uint256).max` (2²⁵⁶−1) to `Forever` is implied unless explicitly
+   overridden.
+3. On a match, the message is displayed alone, without the exact duration and without an
+   approximation suffix; otherwise the value is formatted as a duration as described above.
+
+No default message is assigned to `0`, whose meaning is contract specific: a zero timelock delay
+reads as `Immediate`, a zero expiry usually the opposite. Authors SHOULD map `0` explicitly where
+the contract gives it a distinguished meaning; absent an entry it renders as `0d00h00m00s`. Because
+a message replaces the duration rather than annotating it, authors MUST only map values whose
+message is faithful to the contract's behaviour, and SHOULD map only the sentinels the contract
+actually distinguishes.
+
 When `approximation` is `true`, the approximate suffix MUST be computed as follows, so that a
 given value renders identically across all implementations:
 
-1. If the value equals `type(uint256).max`, the `unboundedMessage` is rendered alone and no suffix
-   is appended.
+1. If the value matched a `specialValues` entry, its message is rendered alone and no suffix is
+   appended.
 2. Otherwise, if the value is strictly less than one month (`2629800` seconds), no suffix is
    appended.
 3. Otherwise, define the following:

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1383,10 +1383,33 @@ Formats applicable to `uint`/`int` solidity types.
 | *Description*   | Display an int (a number of seconds) as a time duration, rendered as `<days>d<hh>h<mm>m<ss>s` — `days` is unbounded and `hh`/`mm`/`ss` are zero-padded to two digits. This days-inclusive form avoids ambiguous large hour counts (e.g. `240:00:00`). |
 | *Parameters*    | ---                                                                                      |
 | `unboundedMessage` | Optional. Message shown when the value equals `type(uint256).max` (2²⁵⁶−1), a sentinel for an unbounded duration. Defaults to `Forever`. |
+| `approximation` | Optional boolean, defaults to `false`. When `true`, an approximate calendar duration is appended in parentheses after the exact duration. Only relevant for values of at least one month; below that no suffix is appended. |
 | *Examples*      | ---                                                                                      |
 | `10d00h00m00s`  | Field Value = 864000                                                                     |
 | `0d02h17m30s`   | Field Value = 8250                                                                       |
 | `Forever`       | Field Value = `type(uint256).max`                                                        |
+| `1856d00h00m00s (approx. 5 years and 1 month)` | Field Value = 160358400 <br> `approximation` = true      |
+| `210d00h00m00s (approx. 7 months)` | Field Value = 18144000 <br> `approximation` = true                  |
+| `10d00h00m00s`  | Field Value = 864000 <br> `approximation` = true (below one month, no suffix appended)    |
+
+When `approximation` is `true`, the approximate suffix MUST be computed as follows, so that a
+given value renders identically across all implementations:
+
+1. If the value equals `type(uint256).max`, the `unboundedMessage` is rendered alone and no suffix
+   is appended.
+2. Otherwise, if the value is strictly less than one month (`2629800` seconds), no suffix is
+   appended.
+3. Otherwise, let `months` be `value / 2629800` rounded to the nearest integer, halves away from
+   zero, where `2629800` is the number of seconds in one month (30.4375 days). Twelve such months
+   are exactly one Julian year (365.25 days).
+4. Let `years` be `months / 12` (integer division) and `remainingMonths` be `months % 12`.
+5. The suffix is `" (approx. "`, then the non-zero values among `years` and `remainingMonths` — in
+   that order, joined by `" and "`, each rendered as the integer followed by `" year"` / `" years"`
+   or `" month"` / `" months"`, singular when the value is exactly `1` — then `")"`. A component
+   equal to zero MUST be omitted.
+
+Note that the approximation is a display aid only: it is appended to, and never replaces, the
+exact duration, so no precision is hidden from the user.
 
 | **`unit`**    |                   |
 |---------------|-------------------|

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1382,12 +1382,13 @@ Formats applicable to `uint`/`int` solidity types.
 | `2024-02-29T08:27:12`       | Field Value = 1709191632 <br> `encoding` = "timestamp"                                    |
 | `2024-02-29T09:00:35`       | Field Value = 19332140 <br> `encoding` = "blockheight"                                    |
 
-| **`duration`** |                                                                                         |
-|----------------|-----------------------------------------------------------------------------------------|
-| *Description*  | Display int as a duration interpreted in seconds and represented as a duration HH:MM:ss |
-| *Parameters*   | None                                                                                    |
-| *Examples*     | ---                                                                                     |
-| `02:17:30`     | Field Value = 8250                                                                      |
+| **`duration`**  |                                                                                          |
+|-----------------|------------------------------------------------------------------------------------------|
+| *Description*   | Display an int (a number of seconds) as a time duration, rendered as `<days>d<hh>h<mm>m<ss>s` — `days` is unbounded and `hh`/`mm`/`ss` are zero-padded to two digits. This days-inclusive form avoids ambiguous large hour counts (e.g. `240:00:00`). |
+| *Parameters*    | None                                                                                     |
+| *Examples*      | ---                                                                                      |
+| `10d00h00m00s`  | Field Value = 864000                                                                     |
+| `0d02h17m30s`   | Field Value = 8250                                                                       |
 
 | **`unit`**    |                   |
 |---------------|-------------------|

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1385,10 +1385,12 @@ Formats applicable to `uint`/`int` solidity types.
 | **`duration`**  |                                                                                          |
 |-----------------|------------------------------------------------------------------------------------------|
 | *Description*   | Display an int (a number of seconds) as a time duration, rendered as `<days>d<hh>h<mm>m<ss>s` — `days` is unbounded and `hh`/`mm`/`ss` are zero-padded to two digits. This days-inclusive form avoids ambiguous large hour counts (e.g. `240:00:00`). |
-| *Parameters*    | None                                                                                     |
+| *Parameters*    | ---                                                                                      |
+| `unboundedMessage` | Optional. Message shown when the value equals `type(uint256).max` (2²⁵⁶−1), a sentinel for an unbounded duration. Defaults to `Forever`. |
 | *Examples*      | ---                                                                                      |
 | `10d00h00m00s`  | Field Value = 864000                                                                     |
 | `0d02h17m30s`   | Field Value = 8250                                                                       |
+| `Forever`       | Field Value = `type(uint256).max`                                                        |
 
 | **`unit`**    |                   |
 |---------------|-------------------|

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1403,14 +1403,13 @@ given value renders identically across all implementations:
    is appended.
 2. Otherwise, if the value is strictly less than one month (`2629800` seconds), no suffix is
    appended.
-3. Otherwise, let `months` be `value / 2629800` rounded to the nearest integer, halves away from
-   zero, where `2629800` is the number of seconds in one month (30.4375 days). Twelve such months
-   are exactly one Julian year (365.25 days).
-4. Let `years` be `months / 12` (integer division) and `remainingMonths` be `months % 12`.
-5. The suffix is `" (approx. "`, then the non-zero values among `years` and `remainingMonths` — in
-   that order, joined by `" and "`, each rendered as the integer followed by `" year"` / `" years"`
-   or `" month"` / `" months"`, singular when the value is exactly `1` — then `")"`. A component
-   equal to zero MUST be omitted.
+3. Otherwise, define the following:
+- `months := value / 2629800` (2629800s = 1 month), rounded to the nearest integer
+- `approxYears := months / 12` (integer division)
+- `approxMonths := months % 12`
+- `approxTemplate := "(approximately {approxYears} years and {approxMonths} months)"`
+
+A consumer SHOULD use `approxTemplate` when rendering the signature request in English. It MAY substitute a proper localized alternative conveying the same `approxYears`/`approxMonths`.
 
 Note that the approximation is a display aid only: it is appended to, and never replaces, the
 exact duration, so no precision is hidden from the user.

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1387,10 +1387,33 @@ Formats applicable to `uint`/`int` solidity types.
 | *Description*   | Display an int (a number of seconds) as a time duration, rendered as `<days>d<hh>h<mm>m<ss>s` — `days` is unbounded and `hh`/`mm`/`ss` are zero-padded to two digits. This days-inclusive form avoids ambiguous large hour counts (e.g. `240:00:00`). |
 | *Parameters*    | ---                                                                                      |
 | `unboundedMessage` | Optional. Message shown when the value equals `type(uint256).max` (2²⁵⁶−1), a sentinel for an unbounded duration. Defaults to `Forever`. |
+| `approximation` | Optional boolean, defaults to `false`. When `true`, an approximate calendar duration is appended in parentheses after the exact duration. Only relevant for values of at least one month; below that no suffix is appended. |
 | *Examples*      | ---                                                                                      |
 | `10d00h00m00s`  | Field Value = 864000                                                                     |
 | `0d02h17m30s`   | Field Value = 8250                                                                       |
 | `Forever`       | Field Value = `type(uint256).max`                                                        |
+| `1856d00h00m00s (approx. 5 years and 1 month)` | Field Value = 160358400 <br> `approximation` = true      |
+| `210d00h00m00s (approx. 7 months)` | Field Value = 18144000 <br> `approximation` = true                  |
+| `10d00h00m00s`  | Field Value = 864000 <br> `approximation` = true (below one month, no suffix appended)    |
+
+When `approximation` is `true`, the approximate suffix MUST be computed as follows, so that a
+given value renders identically across all implementations:
+
+1. If the value equals `type(uint256).max`, the `unboundedMessage` is rendered alone and no suffix
+   is appended.
+2. Otherwise, if the value is strictly less than one month (`2629800` seconds), no suffix is
+   appended.
+3. Otherwise, let `months` be `value / 2629800` rounded to the nearest integer, halves away from
+   zero, where `2629800` is the number of seconds in one month (30.4375 days). Twelve such months
+   are exactly one Julian year (365.25 days).
+4. Let `years` be `months / 12` (integer division) and `remainingMonths` be `months % 12`.
+5. The suffix is `" (approx. "`, then the non-zero values among `years` and `remainingMonths` — in
+   that order, joined by `" and "`, each rendered as the integer followed by `" year"` / `" years"`
+   or `" month"` / `" months"`, singular when the value is exactly `1` — then `")"`. A component
+   equal to zero MUST be omitted.
+
+Note that the approximation is a display aid only: it is appended to, and never replaces, the
+exact duration, so no precision is hidden from the user.
 
 | **`unit`**    |                   |
 |---------------|-------------------|

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1378,12 +1378,13 @@ Formats applicable to `uint`/`int` solidity types.
 | `2024-02-29T08:27:12`       | Field Value = 1709191632 <br> `encoding` = "timestamp"                                    |
 | `2024-02-29T09:00:35`       | Field Value = 19332140 <br> `encoding` = "blockheight"                                    |
 
-| **`duration`** |                                                                                         |
-|----------------|-----------------------------------------------------------------------------------------|
-| *Description*  | Display int as a duration interpreted in seconds and represented as a duration HH:MM:ss |
-| *Parameters*   | None                                                                                    |
-| *Examples*     | ---                                                                                     |
-| `02:17:30`     | Field Value = 8250                                                                      |
+| **`duration`**  |                                                                                          |
+|-----------------|------------------------------------------------------------------------------------------|
+| *Description*   | Display an int (a number of seconds) as a time duration, rendered as `<days>d<hh>h<mm>m<ss>s` — `days` is unbounded and `hh`/`mm`/`ss` are zero-padded to two digits. This days-inclusive form avoids ambiguous large hour counts (e.g. `240:00:00`). |
+| *Parameters*    | None                                                                                     |
+| *Examples*      | ---                                                                                      |
+| `10d00h00m00s`  | Field Value = 864000                                                                     |
+| `0d02h17m30s`   | Field Value = 8250                                                                       |
 
 | **`unit`**    |                   |
 |---------------|-------------------|

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1381,10 +1381,12 @@ Formats applicable to `uint`/`int` solidity types.
 | **`duration`**  |                                                                                          |
 |-----------------|------------------------------------------------------------------------------------------|
 | *Description*   | Display an int (a number of seconds) as a time duration, rendered as `<days>d<hh>h<mm>m<ss>s` — `days` is unbounded and `hh`/`mm`/`ss` are zero-padded to two digits. This days-inclusive form avoids ambiguous large hour counts (e.g. `240:00:00`). |
-| *Parameters*    | None                                                                                     |
+| *Parameters*    | ---                                                                                      |
+| `unboundedMessage` | Optional. Message shown when the value equals `type(uint256).max` (2²⁵⁶−1), a sentinel for an unbounded duration. Defaults to `Forever`. |
 | *Examples*      | ---                                                                                      |
 | `10d00h00m00s`  | Field Value = 864000                                                                     |
 | `0d02h17m30s`   | Field Value = 8250                                                                       |
+| `Forever`       | Field Value = `type(uint256).max`                                                        |
 
 | **`unit`**    |                   |
 |---------------|-------------------|

--- a/assets/erc-7730/erc7730-v3.0.0-next.schema.json
+++ b/assets/erc-7730/erc7730-v3.0.0-next.schema.json
@@ -748,7 +748,7 @@
                 {
                     "title": "integer format",
                     "const": "duration",
-                    "description": "The field should be displayed as a time duration. The value is interpreted as a number of seconds and rendered as <days>d<hh>h<mm>m<ss>s, where days is unbounded and hours, minutes and seconds are zero-padded to two digits (e.g. 864000 -> 10d00h00m00s, 8250 -> 0d02h17m30s). A value equal to type(uint256).max (2^256-1) is treated as a sentinel for an unbounded duration and rendered as the unboundedMessage parameter (default \"Forever\"); see durationParameters."
+                    "description": "The field should be displayed as a time duration. The value is interpreted as a number of seconds and rendered as <days>d<hh>h<mm>m<ss>s, where days is unbounded and hours, minutes and seconds are zero-padded to two digits (e.g. 864000 -> 10d00h00m00s, 8250 -> 0d02h17m30s). A value equal to type(uint256).max (2^256-1) is treated as a sentinel for an unbounded duration and rendered as the unboundedMessage parameter (default \"Forever\"). The optional approximation parameter appends an approximate calendar duration in parentheses, e.g. \"1856d00h00m00s (approx. 5 years and 1 month)\"; see durationParameters."
                 },
                 {
                     "title": "integer format",
@@ -1030,6 +1030,12 @@
                     "title": "Unbounded Message",
                     "type": "string",
                     "description": "The message displayed when the value equals type(uint256).max (2^256-1), used as a sentinel for an unbounded duration. Defaults to \"Forever\" if omitted."
+                },
+                "approximation": {
+                    "title": "Approximation Suffix",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, an approximate calendar duration is appended in parentheses after the exact duration, e.g. \"1856d00h00m00s (approx. 5 years and 1 month)\". The value is rounded to the nearest month (one month is 30.4375 days, so twelve months are exactly one Julian year of 365.25 days) and zero year or month components are omitted. Only relevant for values of at least one month (2629800 seconds): below that, no suffix is appended. The unbounded sentinel takes precedence, so unboundedMessage is rendered alone without a suffix. Defaults to false."
                 }
             },
             "additionalProperties": false

--- a/assets/erc-7730/erc7730-v3.0.0-next.schema.json
+++ b/assets/erc-7730/erc7730-v3.0.0-next.schema.json
@@ -621,6 +621,14 @@
                     }
                 },
                 {
+                    "if": { "properties": { "format": { "const": "duration" } } },
+                    "then": {
+                        "properties": {
+                            "params": { "$ref": "#/$format/durationParameters" }
+                        }
+                    }
+                },
+                {
                     "if": { "properties": { "format": { "const": "unit" } } },
                     "then": {
                         "properties": {
@@ -740,7 +748,7 @@
                 {
                     "title": "integer format",
                     "const": "duration",
-                    "description": "The field should be displayed as a time duration. The value is interpreted as a number of seconds and rendered as <days>d<hh>h<mm>m<ss>s, where days is unbounded and hours, minutes and seconds are zero-padded to two digits (e.g. 864000 -> 10d00h00m00s, 8250 -> 0d02h17m30s)."
+                    "description": "The field should be displayed as a time duration. The value is interpreted as a number of seconds and rendered as <days>d<hh>h<mm>m<ss>s, where days is unbounded and hours, minutes and seconds are zero-padded to two digits (e.g. 864000 -> 10d00h00m00s, 8250 -> 0d02h17m30s). A value equal to type(uint256).max (2^256-1) is treated as a sentinel for an unbounded duration and rendered as the unboundedMessage parameter (default \"Forever\"); see durationParameters."
                 },
                 {
                     "title": "integer format",
@@ -1011,6 +1019,19 @@
             "required": [
                 "encoding"
             ],
+            "additionalProperties": false
+        },
+
+        "durationParameters": {
+            "title": "Duration Formatting Parameters",
+            "type": "object",
+            "properties": {
+                "unboundedMessage": {
+                    "title": "Unbounded Message",
+                    "type": "string",
+                    "description": "The message displayed when the value equals type(uint256).max (2^256-1), used as a sentinel for an unbounded duration. Defaults to \"Forever\" if omitted."
+                }
+            },
             "additionalProperties": false
         },
 

--- a/assets/erc-7730/erc7730-v3.0.0-next.schema.json
+++ b/assets/erc-7730/erc7730-v3.0.0-next.schema.json
@@ -740,7 +740,7 @@
                 {
                     "title": "integer format",
                     "const": "duration",
-                    "description": "The field should be displayed as a duration in HH:MM:ss form. Value is interpreted as a number of seconds."
+                    "description": "The field should be displayed as a time duration. The value is interpreted as a number of seconds and rendered as <days>d<hh>h<mm>m<ss>s, where days is unbounded and hours, minutes and seconds are zero-padded to two digits (e.g. 864000 -> 10d00h00m00s, 8250 -> 0d02h17m30s)."
                 },
                 {
                     "title": "integer format",

--- a/assets/erc-7730/erc7730-v3.0.0-next.schema.json
+++ b/assets/erc-7730/erc7730-v3.0.0-next.schema.json
@@ -748,7 +748,7 @@
                 {
                     "title": "integer format",
                     "const": "duration",
-                    "description": "The field should be displayed as a time duration. The value is interpreted as a number of seconds and rendered as <days>d<hh>h<mm>m<ss>s, where days is unbounded and hours, minutes and seconds are zero-padded to two digits (e.g. 864000 -> 10d00h00m00s, 8250 -> 0d02h17m30s). A value equal to type(uint256).max (2^256-1) is treated as a sentinel for an unbounded duration and rendered as the unboundedMessage parameter (default \"Forever\"). The optional approximation parameter appends an approximate calendar duration in parentheses, e.g. \"1856d00h00m00s (approx. 5 years and 1 month)\"; see durationParameters."
+                    "description": "The field should be displayed as a time duration. The value is interpreted as a number of seconds and rendered as <days>d<hh>h<mm>m<ss>s, where days is unbounded and hours, minutes and seconds are zero-padded to two digits (e.g. 864000 -> 10d00h00m00s, 8250 -> 0d02h17m30s). The optional specialValues parameter maps sentinel values to a message rendered in place of the duration, e.g. {\"0\": \"Immediate\"}; type(uint256).max (2^256-1) maps to \"Forever\" unless an explicit entry overrides it. The optional approximation parameter appends an approximate calendar duration in parentheses, e.g. \"1856d00h00m00s (approx. 5 years and 1 month)\"; see durationParameters."
                 },
                 {
                     "title": "integer format",
@@ -1026,16 +1026,23 @@
             "title": "Duration Formatting Parameters",
             "type": "object",
             "properties": {
-                "unboundedMessage": {
-                    "title": "Unbounded Message",
-                    "type": "string",
-                    "description": "The message displayed when the value equals type(uint256).max (2^256-1), used as a sentinel for an unbounded duration. Defaults to \"Forever\" if omitted."
+                "specialValues": {
+                    "title": "Special Values",
+                    "type": "object",
+                    "description": "Optional. Maps sentinel duration values to the message displayed in place of the formatted duration, e.g. {\"0\": \"Immediate\"}. Keys are written in decimal, or in hexadecimal when prefixed with 0x, and are compared to the field value numerically, so \"0\", \"0x0\" and \"0x00\" all designate zero; two keys of equal numeric value MUST NOT be present. When the field value matches a key, the corresponding message is displayed alone, without the exact duration and without an approximation suffix. Unless an explicit entry overrides it, type(uint256).max (2^256-1) maps to \"Forever\". No default message is assigned to 0, because its meaning is contract specific: a zero timelock delay reads as \"Immediate\", whereas a zero expiry commonly means an unbounded duration. Absent an entry, 0 renders as 0d00h00m00s.",
+                    "propertyNames": {
+                        "pattern": "^(0|[1-9][0-9]*|0x[0-9a-fA-F]+)$"
+                    },
+                    "additionalProperties": {
+                        "type": "string",
+                        "minLength": 1
+                    }
                 },
                 "approximation": {
                     "title": "Approximation Suffix",
                     "type": "boolean",
                     "default": false,
-                    "description": "When true, an approximate calendar duration is appended in parentheses after the exact duration, e.g. \"1856d00h00m00s (approx. 5 years and 1 month)\". The value is rounded to the nearest month (one month is 30.4375 days, so twelve months are exactly one Julian year of 365.25 days) and zero year or month components are omitted. Only relevant for values of at least one month (2629800 seconds): below that, no suffix is appended. The unbounded sentinel takes precedence, so unboundedMessage is rendered alone without a suffix. Defaults to false."
+                    "description": "When true, an approximate calendar duration is appended in parentheses after the exact duration, e.g. \"1856d00h00m00s (approx. 5 years and 1 month)\". The value is rounded to the nearest month (one month is 30.4375 days, so twelve months are exactly one Julian year of 365.25 days) and zero year or month components are omitted. Only relevant for values of at least one month (2629800 seconds): below that, no suffix is appended. A matched specialValues entry takes precedence, so its message is rendered alone without a suffix. Defaults to false."
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
## Abstract

This change amends the ERC-7730 `duration` field format. A `duration` value (a number
of seconds) is rendered as `<days>d<hh>h<mm>m<ss>s`, where `days` is unbounded and
`hh`/`mm`/`ss` are zero-padded to two digits. This replaces the previous `HH:MM:ss`
rendering, whose unbounded hours field (e.g. `240:00:00` for ten days) is ambiguous and
easily misread on a clear-signing display.

## Motivation

Durations in clear-signing are frequently authorization or validity windows (permit and
delegation expiries, operator authorizations). The prior `HH:MM:ss` format collapsed
multi-day windows into large hour counts (`240:00:00`), which users can misread — a
meaningful risk when the value governs how long access is granted. A fixed, days-inclusive
format makes the magnitude legible at a glance without adding optional styles or parameters
that would fragment wallet behavior.

## Rationale

Alternatives considered:

- **Keep `HH:MM:ss`** — rejected: ambiguous for multi-day durations (`240:00:00`).
- **ISO-8601 durations (`P10D`, `PT2H17M30S`)** — the formal standard, but rejected: cryptic
  for end users on a hardware-wallet screen.
- **Opt-in `style`/`base` parameters** — rejected: adds configuration and lets the same value
  render differently across wallets. A single imposed format is simpler and consistent.

The chosen `Dd HHh MMm SSs` form is days-inclusive, self-describing, and unambiguous, and keeps
`duration` parameter-free.

## Backwards Compatibility

This is a breaking change to the rendered output of `duration` (previously `HH:MM:ss`), so it
affects renderers, not descriptor documents (no schema-structure change; documents that
validated before still validate). It is introduced in the v3.0.0 schema line — the current
mutable `-next` major draft — and does NOT alter the released v2 schema. Wallets and libraries
implementing ERC-7730 MUST update their duration renderer to the new format when adopting v3.

## Test Cases

| Field value (seconds) | Rendered      |
|-----------------------|---------------|
| `0`                   | `0d00h00m00s` |
| `45`                  | `0d00h00m45s` |
| `3600`                | `0d01h00m00s` |
| `8250`                | `0d02h17m30s` |
| `360000`              | `4d04h00m00s` |
| `864000`              | `10d00h00m00s`|

## Reference Implementation

```ts
function formatDuration(totalSeconds: bigint): string {
  const t = totalSeconds < 0n ? -totalSeconds : totalSeconds;
  const days = t / 86400n;
  const hh = ((t % 86400n) / 3600n).toString().padStart(2, "0");
  const mm = ((t % 3600n) / 60n).toString().padStart(2, "0");
  const ss = (t % 60n).toString().padStart(2, "0");
  return `${days}d${hh}h${mm}m${ss}s`;
}
```

## Security Considerations

`duration` commonly renders a validity or authorization window (e.g. a decryption-delegation
or operator expiry). A misread duration could lead a user to authorize longer-lived access
than intended. The days-inclusive format directly reduces that misread risk versus large
unbounded hour counts. The change is rendering-only and introduces no new attack surface.
