### PR TITLE
Update ERC-7562: editorial pass for grammar, clarity, and consistency

### DIFF
--- a/ERCS/erc-7562.md
+++ b/ERCS/erc-7562.md
@@ -91,7 +91,7 @@ Local rules are explicitly designated in the [Local Rules](#local-rules) section
    The validation rules only apply during the validation phase. Once a `UserOperation` is validated, it is guaranteed to pay. There are no restrictions on execution, neither on the account's `callData` nor on the paymaster's `postOp`.
 
 3. **Entity**: A contract that is explicitly specified by the `UserOperation`.
-   Entities include the `factory`, `paymaster`, `aggregator`, and staked `account`, as discussed below.
+   Entities include the `factory`, `paymaster`, `aggregator`, and staked `account`, as discussed in the [Entity-specific Rules](#entity-specific-rules) section below.
    Each validation frame is attributed to a single entity.
    Entity contracts must have code deployed on-chain.
 4. **Canonical Mempool**: The rules defined in this document apply to the main mempool shared by all bundlers on the network.
@@ -141,7 +141,7 @@ The reputation refresh rate limits a malicious paymaster to processing at most `
 4. The validation rules prevent an unstaked entity from altering its behavior between simulation and execution of the `UserOperation`.
    However, a malicious staked entity can detect that it is running as part of a bundle validation and cause a revert. Thus, a third tracing simulation of the entire bundle should be performed before submission.
 5. Any failed `UserOperation` must be dropped from the bundle.
-6. The bundler should update the reputation of the staked entity that violated the rules, considering it `THROTTLED`/`BANNED` as described below.
+6. The bundler should update the reputation of the staked entity that violated the rules, considering it `THROTTLED`/`BANNED` as described in the [General Reputation Rules](#general-reputation-rules) section below.
 
 ### Mempool Validation Rules
 
@@ -172,18 +172,20 @@ The reputation refresh rate limits a malicious paymaster to processing at most `
         * `BASEFEE` (`0x48`)
         * `BLOBHASH` (`0x49`)
         * `BLOBBASEFEE` (`0x4A`)
-        * `CREATE` (`0xF0`), except as allowed in the "Contract Creation" and "Staked factory creation" sections below
+        * `CREATE` (`0xF0`), except as allowed by the [Contract Creation](#contract-creation) and [Staked Factory Creation Rules](#staked-factory-creation-rules) rules below
         * `INVALID` (`0xFE`)
         * `SELFDESTRUCT` (`0xFF`)
     * **[OP-012]** `GAS` (`0x5A`) opcode is allowed, but only if followed immediately by `*CALL` instructions, otherwise it is blocked.
       This is a common way to pass all remaining gas to an external call, meaning the actual value is consumed from the stack immediately and cannot be accessed by any other opcode.
     * **[OP-013]** any "unassigned" opcode.
 * **[OP-020]** Revert on "out of gas" is forbidden as it can "leak" the gas limit or the current call stack depth.
-* Contract creation:
-    * **[OP-031]** `CREATE2` is allowed exactly once in the deployment frame and must deploy code for the "sender" address.
-      This can be done either by the factory itself, or by a utility contract it calls.
-    * **[OP-032]** If there is a `factory`, even an unstaked one, the `sender` contract is allowed to use the `CREATE` opcode.
-      This applies only to the sender contract itself, not via a utility contract.
+
+#### Contract Creation
+
+* **[OP-031]** `CREATE2` is allowed exactly once in the deployment frame and must deploy code for the "sender" address.
+  This can be done either by the factory itself, or by a utility contract it calls.
+* **[OP-032]** If there is a `factory`, even an unstaked one, the `sender` contract is allowed to use the `CREATE` opcode.
+  This applies only to the sender contract itself, not via a utility contract.
 * Access to an address without deployed code is forbidden:
     * **[OP-041]** For `EXTCODE*` and `*CALL` opcodes.
     * **[OP-042]** Exception: access to the "sender" address is allowed.
@@ -273,10 +275,12 @@ The following reputation rules apply to all staked entities and to unstaked paym
 * **[EREP-055]** A `context`'s size may not change between validation and bundle creation.
     If bundle creation reverts and a paymaster's context size was modified, that paymaster
     is `BANNED`, regardless of whether the `UserOperation` that reverted used that paymaster or not.
-* Staked factory creation rules:
-  * **[EREP-060]** If the factory is staked, either the factory itself or the sender may use the `CREATE2` and `CREATE` opcodes.
-    The sender is allowed to use `CREATE` with an unstaked factory as well, per OP-032.
-  * **[EREP-061]** A staked factory may also use a utility contract that calls the `CREATE` opcode.
+
+#### Staked Factory Creation Rules
+
+* **[EREP-060]** If the factory is staked, either the factory itself or the sender may use the `CREATE2` and `CREATE` opcodes.
+  The sender is allowed to use `CREATE` with an unstaked factory as well, per OP-032.
+* **[EREP-061]** A staked factory may also use a utility contract that calls the `CREATE` opcode.
 * **[EREP-070]** During bundle creation, if a staked entity reduces its validation gas by more than 10%
     compared to the second validation, that entity is throttled, even if the UserOperation itself did not revert
     (since this might affect the gas calculation defined by [EIP-7623](./eip-7623)).
@@ -284,7 +288,7 @@ The following reputation rules apply to all staked entities and to unstaked paym
 ### Unstaked Entities Reputation Rules
 
 * Definitions:
-    * **`opsSeen`, `opsIncluded`, and reputation calculation** are defined above.
+    * **`opsSeen`, `opsIncluded`, and reputation calculation** are defined in the [Reputation Definitions](#reputation-definitions) and [Reputation Calculation](#reputation-calculation) sections above.
     * The `UnstakedReputation` of an entity determines the maximum number of entries using this entity allowed in the mempool.
     * `opsAllowed` is a reputation-based calculation for an unstaked entity, representing how many `UserOperations` it is allowed to have in the mempool.
     * Rules:

--- a/ERCS/erc-7562.md
+++ b/ERCS/erc-7562.md
@@ -40,33 +40,24 @@ However, the rules apply to any Account Abstraction framework that uses EVM code
 
 ## Specification
 
-### Validation Rule Types
-We define two types of validation rules: **network-wide rules** and **local rules**.
-
 A violation of any validation rule by a UserOperation results in the UserOperation being dropped from the mempool and excluded from a bundle.
-
-A **network-wide rule** is a rule whose violation by a UserOperation should damage the reputation of the peer bundler that sent this UserOperation into the P2P mempool.
-A peer bundler with critically low reputation will eventually be marked as a malicious **spammer** peer.
-
-A **local rule** is a rule enforced according to each bundler's own local state. This state may differ between bundlers, so different bundlers may not always agree on whether such a rule was violated.
-Thus, the bundler that sent the violating UserOperation should not suffer P2P reputation damage from its peers.
 
 ### Constants
 
 | Title                                | Value                       | Comment                                                                                                                 |
 |--------------------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | `MIN_UNSTAKE_DELAY`                  | 86400                       | 1 day, which provides a sufficient withdrawal delay to prevent most Sybil attacks                                       |
-| `MIN_STAKE_VALUE`                    | Adjustable per chain value  | Equivalent to ~$1000 in native tokens, which provides a sufficient capital requirement to prevent most Sybil attacks    |
+| `MIN_STAKE_VALUE`                    | Adjustable per chain value  | Recommended to be a non-trivial but not excessive amount (roughly ~$1000 equivalent in native tokens), sufficient to deter most Sybil attacks without being prohibitive |
 | `SAME_SENDER_MEMPOOL_COUNT`          | 4                           | Maximum number of UserOperations allowed in the mempool from a single sender                                            |
 | `SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT` | 10                          | Maximum number of UserOperations in the mempool that reference the same unstaked entity                                |
 | `THROTTLED_ENTITY_MEMPOOL_COUNT`     | 4                           | Number of `UserOperations` with a throttled entity that can stay in the mempool                                         |
 | `THROTTLED_ENTITY_LIVE_BLOCKS`       | 10                          | Number of blocks a `UserOperation` with a throttled entity can stay in the mempool                                      |
 | `THROTTLED_ENTITY_BUNDLE_COUNT`      | 4                           | Number of `UserOperations` with a throttled entity that can be added in a single bundle                                 |
-| `MIN_INCLUSION_RATE_DENOMINATOR`     | 100 (client) \ 10 (bundler) | A denominator of a formula for entity reputation calculation                                                            |
+| `MIN_INCLUSION_RATE_DENOMINATOR`     | 10                          | A denominator of a formula for entity reputation calculation                                                            |
 | `THROTTLING_SLACK`                   | 10                          | Part of a reputation formula that allows entities to legitimately reject some transactions without being throttled      |
 | `BAN_SLACK`                          | 50                          | Part of a reputation formula that allows throttled entities to reject some transactions without being throttled         |
 | `BAN_OPS_SEEN_PENALTY`               | 10000                       | A value to put into the opsSeen counter of an entity to declare it banned                                               |
-| `MAX_OPS_ALLOWED_UNSTAKED_ENTITY`    | 10000                       |                                                                                                                         |
+| `MAX_OPS_ALLOWED_UNSTAKED_ENTITY`    | 10000                       | Upper bound on `opsIncluded` used when calculating `opsAllowed` for an unstaked entity                                  |
 | `PRE_VERIFICATION_OVERHEAD_GAS`      | 50000                       | Gas used by the `EntryPoint` per `UserOp` that cannot be tracked on-chain                                               |
 | `MAX_VERIFICATION_GAS`               | 500000                      | Maximum gas verification functions may use                                                                              |
 | `MAX_USEROP_SIZE`                    | 8192                        | Maximum size of a single packed and ABI-encoded `UserOperation` in bytes                                                |
@@ -75,15 +66,17 @@ Thus, the bundler that sent the violating UserOperation should not suffer P2P re
 | `MAX_BUNDLE_CONTEXT_SIZE`            | 65536                       | Maximum total size of all `context` byte arrays returned by all paymasters in all `UserOperations` in a bundle in bytes |
 | `VALIDATION_GAS_SLACK`               | 4000                        | An amount of gas that must be added to the estimations of `verificationGasLimit` and `paymasterVerificationGasLimit`    |
 
+`PRE_VERIFICATION_OVERHEAD_GAS` and `MAX_VERIFICATION_GAS` are informational constants bundlers may use to estimate a `UserOperation`'s gas usage; they are not enforced by any rule in this document.
+
 ### Validation Rules
 
 ### Definitions
-1. **Validation Phase**: there are up to three frames during the validation phase onchain
+1. **Validation Phase**: there are up to three frames during the validation phase on-chain
     1. `sender` deployment frame (once per account)
     2. `sender` validation (required)
     3. `paymaster` validation frame (optional)
 
-2. **Execution Phase**: there are up to two frames during the execution phase onchain
+2. **Execution Phase**: there are up to two frames during the execution phase on-chain
    1. `sender` execution frame (required)
    2. `paymaster` post-transaction frame (optional)
 
@@ -242,6 +235,7 @@ The following reputation rules apply to all staked entities and to unstaked paym
     * `THROTTLED_ENTITY_MEMPOOL_COUNT` entries in the mempool.
     * `THROTTLED_ENTITY_BUNDLE_COUNT` `UserOperations` in a bundle.
     * `THROTTLED_ENTITY_LIVE_BLOCKS` blocks of residency in the mempool.
+* **[GREP-030]** REMOVED
 * **[GREP-040]** If an entity fails bundle creation after passing the second validation, its `opsSeen` is set to `BAN_OPS_SEEN_PENALTY` and its `opsIncluded` to zero, causing it to become `BANNED`.
 * **[GREP-050]** When a UserOperation is replaced (by submitting a new UserOperation with higher gas fees), and an entity (e.g., a paymaster) is replaced, then the removed entity has its reputation (opsSeen counter) decremented by 1.
 
@@ -278,7 +272,7 @@ The following reputation rules apply to all staked entities and to unstaked paym
   * **[EREP-061]** A staked factory may also use a utility contract that calls the `CREATE` opcode.
 * **[EREP-070]** During bundle creation, if a staked entity reduces its validation gas by more than 10%
     compared to the second validation, that entity is throttled, even if the UserOperation itself did not revert
-    (since this might affect the gas calculation defined by [EIP-7623](./eip-7623.md)).
+    (since this might affect the gas calculation defined by [EIP-7623](./eip-7623)).
 
 ### Unstaked Entities Reputation Rules
 

--- a/ERCS/erc-7562.md
+++ b/ERCS/erc-7562.md
@@ -12,62 +12,60 @@ created: 2023-09-01
 
 ## Abstract
 
-This document describes the rules Account Abstraction protocols should follow, during the validation phase of Account Abstraction transactions,
-such as [ERC-4337](./eip-4337) `UserOperation` or RIP-7560 (Native Account Abstraction), which are enforced off-chain by a
-block builder or a standalone bundler, and the rationale behind each one of them.
+This document describes the rules that Account Abstraction protocols should follow during the validation phase of Account Abstraction transactions, such as an [ERC-4337](./eip-4337) `UserOperation` or a RIP-7560 (Native Account Abstraction) transaction, along with the rationale behind each rule. These rules are enforced off-chain, by a block builder or a standalone bundler.
 
 ## Motivation
 
-With Account-Abstraction, instead of hard-coded logic for processing a transaction (validation, gas-payment, and execution), this logic is executed by EVM code.
-The benefits for the account are countless -
-- abstracting the validation allows the contract to use different signature schemes, multisig configuration, custom recovery, and more.
-- abstracting gas payments allows easy onboarding by 3rd party payments, paying with tokens, cross-chain gas payments
-- abstracting execution allows batch transactions
+With Account Abstraction, this logic is executed by EVM code instead of the hard-coded logic used to process a transaction (validation, gas payment, and execution).
+The benefits for the account are countless:
+- Abstracting validation allows the contract to use different signature schemes, multisig configurations, custom recovery, and more.
+- Abstracting gas payment allows easy onboarding via third-party payments, paying with tokens, and cross-chain gas payments.
+- Abstracting execution allows batch transactions.
 
 All of the above are missing from the EOA account model.
 
-However, there is one rule a transaction must follow to preserve the decentralized network: once submitted into the network (the mempool), the transaction is guaranteed to pay. This comes to prevent denial-of-service attacks on the network.
+However, there is one rule that a transaction must follow to preserve the decentralized network: once submitted to the network (the mempool), the transaction is guaranteed to pay. This rule exists to prevent denial-of-service attacks on the network.
 
-The EOA model implicitly follows the rule: a valid transaction can't become invalid without payment by the account: e.g. account balance can't be reduced (except with a higher paying transaction)
+The EOA model implicitly follows this rule: a valid transaction cannot become invalid without payment by the account. For example, the account balance cannot be reduced except by a higher-paying transaction.
 
-This rule makes the network sustainable and DoS-protected: the network can't be cheaply attacked by a mass of transactions. An attack (sending a mass of transactions) is expensive, and gets more expensive as the network clogs. Legitimate users pay more, and can delay operations to avoid the cost, but the attacker pays a huge (and increasing) amount to keep the network clogged.
+This rule makes the network sustainable and DoS-protected: the network cannot be cheaply attacked by a mass of transactions. An attack (sending a mass of transactions) is expensive, and gets more expensive as the network clogs. Legitimate users pay more, and can delay operations to avoid the cost, but the attacker pays a huge (and increasing) amount to keep the network clogged.
 
 To mimic the same incentive structure in any Account Abstraction system, we suggest the following transaction validation rules.
-These validation rules only apply to the validation phase of Account Abstraction transactions, not their entire executed code path.
+These validation rules only apply to the validation phase of Account Abstraction transactions, not to their entire executed code path.
 
-For the actual interfaces of those contract-based accounts see the definitions in ERC-4337 and RIP-7560.
+For the actual interfaces of these contract-based accounts, see the definitions in ERC-4337 and RIP-7560.
 
-This documentation uses the terminology "UserOperation" for a transaction created by a smart contract account, and closely follows [ERC-4337](./eip-4337) terminology.
-However, the rules apply to any Account Abstraction framework that uses EVM code to perform transaction validation and makes a distinction between validation (whether the operation is eligible for inclusion on the protocol level) and execution (on-chain execution and gas payment) in a public mempool.
+This document uses the term "UserOperation" for a transaction created by a smart contract account, closely following [ERC-4337](./eip-4337) terminology.
+However, the rules apply to any Account Abstraction framework that uses EVM code to perform transaction validation, and that distinguishes between validation (whether the operation is eligible for inclusion at the protocol level) and execution (on-chain execution and gas payment) in a public mempool.
 
 ## Specification
 
-### Validation Rules Types
+### Validation Rule Types
 We define two types of validation rules: **network-wide rules** and **local rules**.
 
 A violation of any validation rule by a UserOperation results in the UserOperation being dropped from the mempool and excluded from a bundle.
 
-**Network-wide rule** is a rule, that its violation by a UserOperation validation should result in a reputation damage for the peer bundler that sent this UserOperation in the p2p mempool.
-A peer bundler with a critically low reputation will eventually be marked as a malicious **spammer** peer.
+A **network-wide rule** is a rule whose violation by a UserOperation should damage the reputation of the peer bundler that sent this UserOperation into the P2P mempool.
+A peer bundler with critically low reputation will eventually be marked as a malicious **spammer** peer.
 
-**Local rule** is a rule that is enforced in the context of each bundler's local state, which may be different for each bundler and different bundlers may not always be in agreement on these rules' violations.
-Thus, The bundler that sent the violating UserOperation should not suffer a p2p reputation damage by its peers.
+A **local rule** is a rule enforced according to each bundler's own local state. This state may differ between bundlers, so different bundlers may not always agree on whether such a rule was violated.
+Thus, the bundler that sent the violating UserOperation should not suffer P2P reputation damage from its peers.
 
 ### Constants
 
 | Title                                | Value                       | Comment                                                                                                                 |
 |--------------------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------------------|
-| `MIN_UNSTAKE_DELAY`                  | 86400                       | 1 day, which provides a sufficient withdrawal delay to prevent most sybil attacks                                       |
-| `MIN_STAKE_VALUE`                    | Adjustable per chain value  | Equivalent to ~$1000 in native tokens, which provides a sufficient capital requirement to prevent most sybil attacks    |
-| `SAME_SENDER_MEMPOOL_COUNT`          | 4                           | Maximum number of allowed userops in the mempool from a single sender.                                                  |
-| `SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT` | 10                          | Maximum number allowed in the mempool of UserOperations referencing the same unstaked entity                            |
+| `MIN_UNSTAKE_DELAY`                  | 86400                       | 1 day, which provides a sufficient withdrawal delay to prevent most Sybil attacks                                       |
+| `MIN_STAKE_VALUE`                    | Adjustable per chain value  | Equivalent to ~$1000 in native tokens, which provides a sufficient capital requirement to prevent most Sybil attacks    |
+| `SAME_SENDER_MEMPOOL_COUNT`          | 4                           | Maximum number of UserOperations allowed in the mempool from a single sender                                            |
+| `SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT` | 10                          | Maximum number of UserOperations in the mempool that reference the same unstaked entity                                |
 | `THROTTLED_ENTITY_MEMPOOL_COUNT`     | 4                           | Number of `UserOperations` with a throttled entity that can stay in the mempool                                         |
-| `THROTTLED_ENTITY_LIVE_BLOCKS`       | 10                          | Number of blocks a `UserOperations` with a throttled entity can stay in mempool                                         |
+| `THROTTLED_ENTITY_LIVE_BLOCKS`       | 10                          | Number of blocks a `UserOperation` with a throttled entity can stay in the mempool                                      |
 | `THROTTLED_ENTITY_BUNDLE_COUNT`      | 4                           | Number of `UserOperations` with a throttled entity that can be added in a single bundle                                 |
 | `MIN_INCLUSION_RATE_DENOMINATOR`     | 100 (client) \ 10 (bundler) | A denominator of a formula for entity reputation calculation                                                            |
 | `THROTTLING_SLACK`                   | 10                          | Part of a reputation formula that allows entities to legitimately reject some transactions without being throttled      |
 | `BAN_SLACK`                          | 50                          | Part of a reputation formula that allows throttled entities to reject some transactions without being throttled         |
-| `BAN_OPS_SEEN_PENALTY`               | 10000                       | A value to put into the opsSeen counter of entity to declare as banned                                                  |
+| `BAN_OPS_SEEN_PENALTY`               | 10000                       | A value to put into the opsSeen counter of an entity to declare it banned                                               |
 | `MAX_OPS_ALLOWED_UNSTAKED_ENTITY`    | 10000                       |                                                                                                                         |
 | `PRE_VERIFICATION_OVERHEAD_GAS`      | 50000                       | Gas used by the `EntryPoint` per `UserOp` that cannot be tracked on-chain                                               |
 | `MAX_VERIFICATION_GAS`               | 500000                      | Maximum gas verification functions may use                                                                              |
@@ -79,7 +77,7 @@ Thus, The bundler that sent the violating UserOperation should not suffer a p2p 
 
 ### Validation Rules
 
-### **Definitions**:
+### Definitions
 1. **Validation Phase**: there are up to three frames during the validation phase onchain
     1. `sender` deployment frame (once per account)
     2. `sender` validation (required)
@@ -89,27 +87,27 @@ Thus, The bundler that sent the violating UserOperation should not suffer a p2p 
    1. `sender` execution frame (required)
    2. `paymaster` post-transaction frame (optional)
 
-   The validation rules only apply during the validation phase. Once a UserOperation is validated, it is guaranteed to pay. There are no restrictions on execution, neither account (callData) nor paymaster (postOp)
+   The validation rules only apply during the validation phase. Once a UserOperation is validated, it is guaranteed to pay. There are no restrictions on execution, neither for the account (callData) nor for the paymaster (postOp).
 
-2. **Entity**: a contract that is explicitly specified by the `UserOperation`.
-   Includes the `factory`, `paymaster`, `aggregator`, and staked `account`, as discussed below. \
+3. **Entity**: a contract that is explicitly specified by the `UserOperation`.
+   It includes the `factory`, `paymaster`, `aggregator`, and staked `account`, as discussed below. \
    Each "validation frame" is attributed to a single entity. \
    Entity contracts must have non-empty code on-chain.
-3. **Canonical Mempool**: The rules defined in this document apply to the main mempool shared by all bundlers on the network.
-4. **Staked Entity:** an entity that has a locked stake of at least `MIN_STAKE_VALUE`
+4. **Canonical Mempool**: The rules defined in this document apply to the main mempool shared by all bundlers on the network.
+5. **Staked Entity:** an entity that has a locked stake of at least `MIN_STAKE_VALUE`
    and an unstake delay of at least `MIN_UNSTAKE_DELAY`.
-5. **Associated storage:** a storage slot of any smart contract is considered to be "associated" with address `A` if:
+6. **Associated storage:** a storage slot of any smart contract is considered to be "associated" with address `A` if:
     1. The slot value is `A`
     2. The slot value was calculated as `keccak(A||x)+n`, where `x` is a `bytes32` value, and `n` is a value in the range 0..128
-6. **Using an address**: accessing the code of a given address in any way.
+7. **Using an address**: accessing the code of a given address in any way.
    This can be done by executing `*CALL` or `EXTCODE*` opcodes for a given address.
-7. **Spammer** - a P2P peer bundler that attempts a DoS attack on the mempool by sending other peers with a large number of invalid UserOperations.
+8. **Spammer**: a P2P peer bundler that attempts a DoS attack on the mempool by sending other peers a large number of invalid UserOperations.
    Bundlers MUST detect and disconnect from such peers, as described in the [Mempool Validation Rules](#mempool-validation-rules) section.
 
 ### Reputation Definitions
 1. **opsSeen**: a per-entity counter of how many times a unique valid `UserOperation` referencing this entity
    was received by this bundler.
-   This includes `UserOperation` received via incoming RPC calls or through a P2P mempool protocol.
+   This includes `UserOperation`s received via incoming RPC calls or through a P2P mempool protocol.
 
 2. **opsIncluded**: a per-entity counter of how many times a unique valid `UserOperation` referencing this entity
    appeared in an actual included `UserOperation`. \
@@ -117,7 +115,7 @@ Thus, The bundler that sent the violating UserOperation should not suffer a p2p 
    previously counted as `opsSeen` by this bundler.
 3. **Refresh rate**: Both of the above values are updated every hour as `value = value * 23 // 24` \
    Effectively, the value is reduced to 1% after 4 days.
-4. **inclusionRate**: Ratio of `opsIncluded`  to `opsSeen`
+4. **inclusionRate**: Ratio of `opsIncluded` to `opsSeen`.
 
 
 ### Reputation Calculation
@@ -132,7 +130,7 @@ The reputation state of each entity is determined as follows:
 
 Note that new entities start with an `OK` reputation.
 
-Because of the reputation `refresh rate`, note that a malicious paymaster can at most cause the network (only the p2p network, not the blockchain) to process `BAN_SLACK * MIN_INCLUSION_RATE_DENOMINATOR / 24` non-paying ops per hour.
+Because of the reputation refresh rate, a malicious paymaster can cause the network (only the P2P network, not the blockchain) to process at most `BAN_SLACK * MIN_INCLUSION_RATE_DENOMINATOR / 24` non-paying UserOperations per hour.
 
 ### Running the Validation Rules
 
@@ -140,20 +138,19 @@ Because of the reputation `refresh rate`, note that a malicious paymaster can at
 2. The bundler should trace the validation phase of the UserOperation and apply all the rules defined in this document.
 3. A bundler should also perform a full validation of the entire bundle before submission.
 4. The validation rules prevent an unstaked entity from altering its behavior between simulation and execution of the UserOperation.
-   However, a malicious staked entity can detect that it is running in a bundle validation and cause a revert. Thus, a third tracing simulation of the entire bundle should be performed before submission.
+   However, a malicious staked entity can detect that it is running as part of a bundle validation and cause a revert. Thus, a third tracing simulation of the entire bundle should be performed before submission.
 5. The failed `UserOperation` should be dropped from the bundle.
-6. The bundler should update the reputation of the staked entity that violated the rules, and consider it `THROTTLED`/`BANNED` as described below. 
+6. The bundler should update the reputation of the staked entity that violated the rules, and consider it `THROTTLED`/`BANNED` as described below.
 
 ### Mempool Validation Rules
 
 1. A `UserOperation` is broadcast over the P2P protocol with the following information:
-    1. The `UserOperation` itself
+    1. The `UserOperation` itself.
     2. The blockhash this `UserOperation` was originally verified against.
-2. Once a `UserOperation` is received from another bundler it should be verified locally by a receiving bundler.
-3. A received `UserOperation` may fail any of the reasonable static checks, such as:
-   invalid format, values below minimum, submitted with a blockhash that isn't recent, etc.
+2. Once a `UserOperation` is received from another bundler, it should be verified locally by the receiving bundler.
+3. A received `UserOperation` may fail one of several reasonable static checks, such as invalid format, values below the minimum, or having been submitted with a blockhash that is not recent, etc.
    In this case, the bundler should drop this particular `UserOperation` but keep the connection.
-4. The bundler should check the `UserOperation` against the nonces of last-included bundles and silently drop `UserOperations` with `nonce` that was recently included.
+4. The bundler should check the `UserOperation` against the nonces of last-included bundles and silently drop `UserOperations` with a `nonce` that was recently included.
    This invalidation is likely attributable to a network race condition and should not cause a reputation change.
 5. If a received `UserOperation` fails against the current block:
     1. Retry the validation against the block the `UserOperation` was originally verified against.
@@ -161,7 +158,7 @@ Because of the reputation `refresh rate`, note that a malicious paymaster can at
     3. If it fails, mark the sender as a "spammer" (disconnect from that peer and block it permanently).
 
 ### Opcode Rules
-* Block access from opcodes that access information outside of storage and code (aka "environment").
+* Opcodes that access information outside of storage and code (i.e., the "environment") are blocked:
     * **[OP-011]** Blocked opcodes:
         * `ORIGIN` (`0x32`)
         * `GASPRICE` (`0x3A`)
@@ -177,263 +174,262 @@ Because of the reputation `refresh rate`, note that a malicious paymaster can at
         * `CREATE` (`0xF0`) (except in the "Contract Creation" and "Staked factory creation" sections, below)
         * `INVALID` (`0xFE`)
         * `SELFDESTRUCT` (`0xFF`)
-    * **[OP-012]** `GAS` (`0x5A`) opcode is allowed, but only if followed immediately by `*CALL` instructions, else it is blocked.\
+    * **[OP-012]** `GAS` (`0x5A`) opcode is allowed, but only if followed immediately by `*CALL` instructions, otherwise it is blocked.\
       This is a common way to pass all remaining gas to an external call, and it means that the actual value is
       consumed from the stack immediately and cannot be accessed by any other opcode.
-    * **[OP-13]** any "unassigned" opcode.
+    * **[OP-013]** any "unassigned" opcode.
 * **[OP-020]** Revert on "out of gas" is forbidden as it can "leak" the gas limit or the current call stack depth.
 * Contract creation:
     * **[OP-031]** `CREATE2` is allowed exactly once in the deployment frame and must deploy code for the "sender" address.
-      (Either by the factory itself, or by a utility contract it calls)
-    * **[OP-032]** If there is a `factory` (even unstaked), the `sender` contract is allowed to use `CREATE` opcode
-      (That is, only the sender contract itself, not through utility contract)
-* Access to an address without a deployed code is forbidden:
+      (Either by the factory itself, or by a utility contract it calls.)
+    * **[OP-032]** If there is a `factory` (even unstaked), the `sender` contract is allowed to use the `CREATE` opcode
+      (That is, only the sender contract itself, not via a utility contract.)
+* Access to an address without deployed code is forbidden:
     * **[OP-041]** For `EXTCODE*` and `*CALL` opcodes.
     * **[OP-042]** Exception: access to the "sender" address is allowed.
       This is only possible in `factory` code during the deployment frame.
 * Allowed access to the `EntryPoint` address:
     * **[OP-051]** May call `EXTCODESIZE ISZERO`\
-      This pattern is used to check destination has a code before the `depositTo` function is called.
-    * **[OP-052]** May call `depositTo(sender)` with any value from either the `sender` or `factory`.
+      This pattern is used to check that the destination has code before the `depositTo` function is called.
+    * **[OP-052]** May call `depositTo(sender)` with any value from either the `sender` or the `factory`.
     * **[OP-053]** May call the fallback function from the `sender` with any value.
     * **[OP-054]** Any other access to the `EntryPoint` (either of the `*CALL` or `EXT*` opcodes) is forbidden.
-    * **[OP-055]** May call `incrementNonce())` from the `sender`
+    * **[OP-055]** May call `incrementNonce()` from the `sender`.
 * `*CALL` opcodes:
     * **[OP-061]** `CALL` with `value` is forbidden. The only exception is a call to the `EntryPoint` described above.
     * **[OP-062]** Precompiles:
-        * Only allow known accepted precompiles on the network, that do not access anything in the blockchain state or environment.
-        * The core precompiles 0x1 .. 0x11
-        * The RIP-7212 secp256r1 precompile, on networks that accepted it.
+        * Only known, accepted precompiles on the network that do not access anything in the blockchain state or environment are allowed.
+        * The core precompiles `0x1`–`0x11`.
+        * The RIP-7212 secp256r1 precompile, on networks that have accepted it.
 * **[OP-070]** Transient Storage slots defined in [EIP-1153](./eip-1153) and accessed using `TLOAD` (`0x5c`) and `TSTORE` (`0x5d`) opcodes
   are treated exactly like persistent storage (SLOAD/SSTORE).
-* **[OP-080]** `BALANCE` (`0x31`) and `SELFBALANCE` (`0x47`) are allowed only from a staked entity, else they are blocked.
+* **[OP-080]** `BALANCE` (`0x31`) and `SELFBALANCE` (`0x47`) are allowed only from a staked entity, otherwise they are blocked.
 
 
 ### Code Rules
 
-* **[COD-010]** Between the first and the second validations, the `EXTCODEHASH` value of any visited address,
-  entity, or referenced library, may not be changed.\
+* **[COD-010]** Between the first and second validations, the `EXTCODEHASH` value of any visited address,
+  entity, or referenced library may not be changed.\
   If the code is modified, the UserOperation is considered invalid.
 
 ### Storage Rules
 
-The storage access with `SLOAD` and `SSTORE` (and `TLOAD`, `TSTORE`) instructions within each phase is limited as follows:
+Storage access using the `SLOAD` and `SSTORE` (and `TLOAD`, `TSTORE`) instructions is limited within each phase as follows:
 
 * **[STO-010]** Access to the "account" storage is always allowed.
 * Access to associated storage of the account in an external (non-entity) contract is allowed if either:
-    * **[STO-021]**  The account already exists.
-    * **[STO-022]**  There is an `initCode` and the `factory` contract is staked.
+    * **[STO-021]** The account already exists.
+    * **[STO-022]** There is an `initCode` and the `factory` contract is staked.
 * If the entity (`paymaster`, `factory`) is staked, then it is also allowed:
     * **[STO-031]** Access the entity's own storage.
-    * **[STO-032]** Read/Write Access to storage slots that are associated with the entity, in any non-entity contract.
-    * **[STO-033]** Read-only access to any storage in non-entity contract.
+    * **[STO-032]** Read/Write access to storage slots that are associated with the entity, in any non-entity contract.
+    * **[STO-033]** Read-only access to any storage in a non-entity contract.
 
 ### Local Rules
 
 Local storage rules protect the bundler against denial of service at the time of bundling. They do not affect mempool propagation and cannot cause a bundler to be marked as a "spammer".
-* **[STO-040]** `UserOperation` may not use an entity address (`factory`/`paymaster`/`aggregator`) that is used as an "account" in another `UserOperation` in the mempool. \
-  This means that `Paymaster`, `Factory` or `Aggregator` contracts cannot practically be an "account" contract as well.
-* **[STO-041]** `UserOperation` may not use associated storage (of either its account or from staked entity) in a contract that is a "sender" of another UserOperation in the mempool.
+* **[STO-040]** A `UserOperation` may not use an entity address (`factory`/`paymaster`/`aggregator`) that is used as an "account" in another `UserOperation` in the mempool. \
+  This means that `paymaster`, `factory`, or `aggregator` contracts cannot practically be an "account" contract as well.
+* **[STO-041]** A `UserOperation` may not use associated storage (of either its account or a staked entity) in a contract that is a "sender" of another UserOperation in the mempool.
 
 ### General Reputation Rules
 
-The following reputation rules apply for all staked entities, and for unstaked paymasters. All rules apply to all of these entities unless specified otherwise.
+The following reputation rules apply to all staked entities and to unstaked paymasters. All rules apply to all of these entities unless specified otherwise.
 
 * **[GREP-010]** A `BANNED` address is not allowed into the mempool.\
   Also, all existing `UserOperations` referencing this address are removed from the mempool.
 * **[GREP-020]** A `THROTTLED` address is limited to:
     * `THROTTLED_ENTITY_MEMPOOL_COUNT` entries in the mempool.
     * `THROTTLED_ENTITY_BUNDLE_COUNT` `UserOperations` in a bundle.
-    * Can remain in the mempool only for `THROTTLED_ENTITY_LIVE_BLOCKS`.
-* **[GREP-040]** If an entity fails the bundle creation after passing second validation, its `opsSeen` set to `BAN_OPS_SEEN_PENALTY`, and `opsIncluded` to zero, causing it to be `BANNED`.
-* **[GREP-050]** When a UserOperation is replaced (by submitting a new UserOperation, with higher gas fees), and an entity (e.g. a paymaster) is replaced, then the removed entity has its reputation (opsSeen counter) decremented by 1.
+    * `THROTTLED_ENTITY_LIVE_BLOCKS` blocks of residency in the mempool.
+* **[GREP-040]** If an entity fails bundle creation after passing the second validation, its `opsSeen` is set to `BAN_OPS_SEEN_PENALTY` and its `opsIncluded` to zero, causing it to become `BANNED`.
+* **[GREP-050]** When a UserOperation is replaced (by submitting a new UserOperation with higher gas fees), and an entity (e.g., a paymaster) is replaced, then the removed entity has its reputation (opsSeen counter) decremented by 1.
 
 ### Staked Entities Reputation Rules
 
-* **[SREP-010]** The "canonical mempool" defines a staked entity if it has `MIN_STAKE_VALUE` and unstake delay of `MIN_UNSTAKE_DELAY`
+* **[SREP-010]** The "canonical mempool" defines an entity as staked if it has at least `MIN_STAKE_VALUE` and an unstake delay of at least `MIN_UNSTAKE_DELAY`.
 * **[SREP-020]** MOVED TO GREP-010
 * **[SREP-030]** MOVED TO GREP-020
-* **[SREP-040]** An `OK` staked entity is unlimited by the reputation rule.
+* **[SREP-040]** An `OK` staked entity faces no limit under the reputation rules:
     * Allowed in unlimited numbers in the mempool.
     * Allowed in unlimited numbers in a bundle.
 * **[SREP-050]** MOVED TO GREP-040
 
 ### Entity-specific Rules
 
-* **[EREP-010]** For each `paymaster`, the bundler must track the total gas `UserOperations` using this `paymaster` may consume.
-    * Bundler should not accept a new `UserOperation` with a paymaster to the mempool if the maximum total gas cost of all userops in the mempool, including this new `UserOperation`, is above the deposit of that `paymaster` at the current gas price.
+* **[EREP-010]** For each `paymaster`, the bundler must track the total gas that `UserOperations` using this `paymaster` may consume.
+    * The bundler should not accept a new `UserOperation` with a paymaster into the mempool if the maximum total gas cost of all UserOperations in the mempool, including this new `UserOperation`, is above the deposit of that `paymaster` at the current gas price.
 * **[EREP-011]** REMOVED
-* **[EREP-015]** A `paymaster` should not have its opsSeen incremented in case of a failure of factory or account
-  * When running 2nd validation (before inclusion in a bundle), if a UserOperation fails because of factory or account error (either a FailOp revert or validation rule), then the paymaster's opsSeen valid is decremented by 1.
-* **[EREP-016]** An `aggregator` should not have its opsSeen incremented in case of a failure of a factory, an account or a paymaster
-  * When running 2nd validation (before inclusion in a bundle), if a UserOperation fails because of a factory, an account or a paymaster error (either a FailOp revert or validation rule), then the aggregator's opsSeen valid is decremented by 1.
-* **[EREP-020]** If a staked factory is used, its reputation is updated for the account violating any of the validation rules accordingly. \
-  That is, if the `validateUserOp()` is rejected for any reason in a `UserOperation` that has an `initCode`, it is treated as if the factory caused this failure, and thus this affects its reputation.
-* **[EREP-030]** If a staked account is used, its reputation is updated for failures in other entities (`paymaster`, `aggregator`) even if they are staked.
+* **[EREP-015]** A `paymaster` should not have its opsSeen incremented because of a failure of the factory or account.
+  * When running the second validation (before inclusion in a bundle), if a UserOperation fails because of a factory or account error (either a FailOp revert or a validation rule violation), then the paymaster's opsSeen value is decremented by 1.
+* **[EREP-016]** An `aggregator` should not have its opsSeen incremented because of a failure of a factory, an account, or a paymaster.
+  * When running the second validation (before inclusion in a bundle), if a UserOperation fails because of a factory, an account, or a paymaster error (either a FailOp revert or a validation rule violation), then the aggregator's opsSeen value is decremented by 1.
+* **[EREP-020]** If a staked factory is used, its reputation is updated accordingly when the account violates any of the validation rules. \
+  That is, if `validateUserOp()` is rejected for any reason in a `UserOperation` that has an `initCode`, this is treated as if the factory caused the failure, and its reputation is affected accordingly.
+* **[EREP-030]** If a staked account is used, its reputation is updated based on failures of other entities (`paymaster`, `aggregator`) even if they are staked.
 * **[EREP-040]** An `aggregator` must be staked, regardless of storage usage.
 * **[EREP-050]** An unstaked `paymaster` may not return a `context`.
-* **[EREP-055]** A context size may not change between validation and bundle creation. \
-    If a bundle creation reverts, and a paymaster's context size was modified, that paymaster \
-    is BANNED, regardless if the UserOperation that reverted used that paymaster or not.
+* **[EREP-055]** A `context`'s size may not change between validation and bundle creation. \
+    If bundle creation reverts and a paymaster's context size was modified, that paymaster \
+    is `BANNED`, regardless of whether the UserOperation that reverted used that paymaster or not.
 * Staked factory creation rules:
-  * **[EREP-060]** If the factory is staked, either the factory itself or the sender may use the CREATE2 and CREATE opcode
-    (the sender is allowed to use the CREATE with unstaked factory, with OP-032)
-  * **[EREP-061]** A staked factory may also use a utility contract that calls the `CREATE`
-* **[EREP-070]** During bundle creation, if a staked entity reduce its validation gas by more than 10% 
-    compared to the second validation, that entity is throttled, even if the UserOperation itself didn't revert.
-    (as it might affect the gas calculation based on [EIP-7623](./eip-7623.md) )
+  * **[EREP-060]** If the factory is staked, either the factory itself or the sender may use the `CREATE2` and `CREATE` opcodes.
+    (The sender is allowed to use `CREATE` with an unstaked factory as well, per OP-032.)
+  * **[EREP-061]** A staked factory may also use a utility contract that calls the `CREATE` opcode.
+* **[EREP-070]** During bundle creation, if a staked entity reduces its validation gas by more than 10%
+    compared to the second validation, that entity is throttled, even if the UserOperation itself did not revert
+    (since this might affect the gas calculation defined by [EIP-7623](./eip-7623.md)).
 
 ### Unstaked Entities Reputation Rules
 
 * Definitions:
     * **`opsSeen`, `opsIncluded`, and reputation calculation** are defined above.
-    * `UnstakedReputation` of an entity determines the maximum number of entries using this entity allowed in the mempool.
+    * The `UnstakedReputation` of an entity determines the maximum number of entries using this entity allowed in the mempool.
     * `opsAllowed` is a reputation-based calculation for an unstaked entity, representing how many `UserOperations` it is allowed to have in the mempool.
     * Rules:
-        * **[UREP-010]** An unstaked sender (that is not throttled/banned) is only allowed to have `SAME_SENDER_MEMPOOL_COUNT` `UserOperation`s  in the mempool.
-        * **[UREP-020]** For an unstaked paymaster only that is not throttled/banned: \
+        * **[UREP-010]** An unstaked sender (that is not throttled/banned) is only allowed to have `SAME_SENDER_MEMPOOL_COUNT` `UserOperation`s in the mempool.
+        * **[UREP-020]** For an unstaked paymaster that is not throttled or banned: \
           `opsAllowed = SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT + inclusionRate * min(opsIncluded, MAX_OPS_ALLOWED_UNSTAKED_ENTITY)`.
-        * This is a default of `SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT` for new entity
+        * This defaults to `SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT` for a new entity.
         * **[UREP-030]** REMOVED
 
 ### Alt-mempools Rules
 
-Alternate mempool is an agreed-upon rule that the bundlers may opt into, in addition to the canonical mempool
-The alt-mempool "topic" is a unique identifier. By convention, this is the IPFS hash of the document describing (in clear test and YAML file) the specifics of this alt mempool.
+An alternate mempool is an agreed-upon rule that bundlers may opt into, in addition to the canonical mempool.
+The alt-mempool "topic" is a unique identifier. By convention, this is the IPFS hash of the document describing (in clear text and a YAML file) the specifics of this alt mempool.
 
-* **[ALT-010]** The bundler listens to the alt-mempool "topic" over the P2P protocol
-* **[ALT-020]** The alt mempool rules MUST be checked only when a canonical rule is violated
+* **[ALT-010]** The bundler listens to the alt-mempool "topic" over the P2P protocol.
+* **[ALT-020]** The alt-mempool rules MUST be checked only when a canonical rule is violated.
     * That is, if validation follows the canonical rules above, it is not considered part of an alt-mempool.
-*  **[ALT-021]** Such a `UserOperation` (that violates the canonical rules) is checked against all the "alternate mempools", and is considered part of all those alt-mempools
+*  **[ALT-021]** Such a `UserOperation` (that violates the canonical rules) is checked against all the alt-mempools, and is considered part of all those alt-mempools.
 * **[ALT-030]** Bundlers SHOULD forward `UserOperations` to other bundlers only once, regardless of how many (shared) alt-mempools they have. \
-  The receiving bundler validates the `UserOperations`, and based on the above rules (and subscribed alt-mempools) decides which alt-mempools to propagate it to.
-* **[ALT-040]** opsInclude and opsSeen of entities are kept per alt-mempool. That is, an entity can be considered throttled (or banned) in one mempool, while still active on another.
+  The receiving bundler validates the `UserOperations`, and based on the above rules (and subscribed alt-mempools) decides which alt-mempools to propagate them to.
+* **[ALT-040]** `opsIncluded` and `opsSeen` of entities are kept per alt-mempool. That is, an entity can be considered throttled (or banned) in one mempool, while still active on another.
 
 ### Alt-mempool Reputation
 
-Alt-mempools are served by the same bundlers participating in the canonical mempool, but change the rules and may introduce denial-of-service attack vectors. To prevent them from taking the canonical mempool or other alt mempools down with them, a reputation is managed for each. An alt mempool that causes too many invalidations gets throttled. This limits the scope of the attack and lets the bundler continue doing its work for other mempools.
+Alt-mempools are served by the same bundlers participating in the canonical mempool, but change the rules and may introduce denial-of-service attack vectors. To prevent them from taking the canonical mempool or other alt-mempools down with them, a reputation is managed for each. An alt-mempool that causes too many invalidations gets throttled. This limits the scope of the attack and lets the bundler continue doing its work for other mempools.
 
-* **[AREP-010]** each alt-mempool has "opsSeen" and "opsIncluded", much like entities. The opsSeen is incremented after `UserOperation` initial validation, where it is considered part of this mempool.
-  The "opsIncluded" is incremented after this UserOperation is included on-chain (either by this bundler, or another)
-* **[AREP-020]** the alt-mempool becomes `THROTTLED`/`BANNED` based on the [Reputation Calculation](#reputation-calculation)
+* **[AREP-010]** Each alt-mempool has `opsSeen` and `opsIncluded`, much like entities. The `opsSeen` is incremented after `UserOperation` initial validation, when it is considered part of this mempool.
+  The `opsIncluded` is incremented after this UserOperation is included on-chain (either by this bundler or another).
+* **[AREP-020]** The alt-mempool becomes `THROTTLED`/`BANNED` based on the [Reputation Calculation](#reputation-calculation).
 * **[AREP-030]** REMOVED
 
 ### Authorizations
 
 * **[AUTH-010]** A UserOperation may only contain a single [EIP-7702](./eip-7702) authorization tuple.
 * **[AUTH-020]** An account with EIP-7702 delegation can only be used as the Sender of the UserOperation.
-  Using authorized account as any other kind of UserOperation entity is not allowed.
+  Using the authorized account as any other kind of UserOperation entity is not allowed.
 * **[AUTH-030]** An account with EIP-7702 delegation can only be **accessed** (using `*CALL` or `EXTCODE*` opcodes) if it is the Sender of the current UserOperation.
 * **[AUTH-040]** If there are multiple UserOperations by the same sender with an authorization tuple in the mempool, they all MUST have the same delegate address.
 
 ### Limitations
 
-The validation rules attempt to guarantee a degree of isolation between individual `UserOperations`' validations.
-In order to prevent hitting the memory expansion limitations (imposed by ethereum EVM) when creating a bundle, `UserOperation`s must meet the following limitations:
+The validation rules attempt to guarantee a degree of isolation between individual `UserOperation`s' validations.
+In order to prevent hitting the memory expansion limitations (imposed by the Ethereum EVM) when creating a bundle, `UserOperation`s must meet the following limitations:
 
-* **[LIM-010]** Maximum size of a single packed and ABI-encoded `UserOperation` in bytes MUST not exceed `MAX_USEROP_SIZE`
-* **[LIM-020]** Maximum size of a `context` byte array returned by a paymaster in a single `UserOperation` in bytes MUST not exceed `MAX_CONTEXT_SIZE`
-* **[LIM-030]** The `verificationGasLimit` and `paymasterVerificationGasLimit` parameters MUST exceed the actual usage during validation of the `UserOperation` by `VALIDATION_GAS_SLACK`
-* **[LIM-040]** Maximum size of an ABI-encoded bundle call to the `handleOps` function in bytes SHOULD not exceed `MAX_BUNDLE_SIZE`
-* **[LIM-050]** Maximum total size of all `context` byte arrays returned by all paymasters in all `UserOperations` in a bundle in bytes SHOULD not exceed `MAX_BUNDLE_CONTEXT_SIZE`
+* **[LIM-010]** Maximum size of a single packed and ABI-encoded `UserOperation` in bytes MUST not exceed `MAX_USEROP_SIZE`.
+* **[LIM-020]** Maximum size of a `context` byte array returned by a paymaster in a single `UserOperation` in bytes MUST not exceed `MAX_CONTEXT_SIZE`.
+* **[LIM-030]** The `verificationGasLimit` and `paymasterVerificationGasLimit` parameters MUST exceed the actual usage during validation of the `UserOperation` by `VALIDATION_GAS_SLACK`.
+* **[LIM-040]** Maximum size of an ABI-encoded bundle call to the `handleOps` function in bytes SHOULD not exceed `MAX_BUNDLE_SIZE`.
+* **[LIM-050]** Maximum total size of all `context` byte arrays returned by all paymasters in all `UserOperations` in a bundle in bytes SHOULD not exceed `MAX_BUNDLE_CONTEXT_SIZE`.
 
 ## Rationale
 
 All transactions initiated by EOAs have an implicit validation phase where balance, nonce, and signature are
 checked to be valid for the current state of the Ethereum blockchain.
-Once the transaction is checked to be valid by a node, only another transaction by the same EOA can modify the Ethereum
+Once a node has validated the transaction, only another transaction by the same EOA can modify the Ethereum
 state in a way that makes the first transaction invalid.
 
-With Account Abstraction, however, the validation can also include an arbitrary EVM code and rely on storage as well,
+With Account Abstraction, however, the validation can also include arbitrary EVM code and rely on storage as well,
 which means that unrelated `UserOperations` or transactions may invalidate each other.
 
 If not addressed, this would make the job of maintaining a mempool of valid `UserOperations` and producing valid
 bundles computationally infeasible and susceptible to DoS attacks.
 
-This document describes a set of validation rules that if applied by a bundler before accepting a `UserOperation`
-into the mempool can prevent such attacks.
+This document describes a set of validation rules that, if applied by a bundler before accepting a `UserOperation`
+into the mempool, can prevent such attacks.
 
 ### The high-level goal
 
-The purpose of this specification is to define a consensus between nodes (bundlers or block-builders) when processing incoming UserOperations from an external source.
-This external source for UserOperations is either an end-user node (via RPC [ERC-7769](./eip-7769)) or another node in the p2p network.
+The purpose of this specification is to define a consensus between nodes (bundlers or block builders) when processing incoming UserOperations from an external source.
+This external source for UserOperations is either an end-user node (via RPC [ERC-7769](./eip-7769)) or another node in the P2P network.
 
-The protocol tries to detect "spam" - which are large bursts of UserOperations that cannot be included on-chain (and thus can't pay).
-The network is protected by throttling down requests from such spammer nodes.
+The protocol tries to detect "spam" - large bursts of UserOperations that cannot be included on-chain (and thus cannot pay).
+The network is protected by throttling requests from such spammer nodes.
 
-All nodes in the network must have the same definition of "spam": otherwise, if some nodes accept some type of UserOperations and propagate them while others consider them spam, those "forgiving" nodes will be considered "spammers" by the rest of the nodes, and the network effectively gets split.
+All nodes in the network must share the same definition of "spam": otherwise, if some nodes accept some types of UserOperations and propagate them while others consider them spam, those "forgiving" nodes will be considered "spammers" by the rest of the nodes, and the network effectively splits.
 
 ### The processing flow of a UserOperation
 
-- First, a UserOperation is received - either via RPC (submitted on behalf of a single application) or via the p2p protocol, from another node in the mempool.
-- The node performs validation on the UserOperation, and then adds it to its in-memory mempool, and submits it to its peers.
-- Lastly, when building a block, a node collects UserOperations from the mempool, performs a 2nd validation to make sure they are all still valid as a bundle and submits them into the next block.
+- First, a UserOperation is received - either via RPC (submitted on behalf of a single application) or via the P2P protocol, from another node in the mempool.
+- The node validates the UserOperation, adds it to its in-memory mempool, and submits it to its peers.
+- Lastly, when building a block, a node collects UserOperations from the mempool, performs a second validation to make sure they are all still valid as a bundle, and submits them in the next block.
 
-### The need for 2nd validation before submitting a block
+### The need for a second validation before submitting a block
 
-A normal Ethereum transaction in the mempool can be invalidated if another transaction was received with the same nonce. That other transaction had to increase the gas price in order to replace the first one, so it satisfied the rule of "must pay to get included into the mempool".
-With contract-based accounts, since the UserOperation validity may depend on mutable state, other transactions may invalidate a previously valid UserOperation, so we must check it before inclusion.
+A normal Ethereum transaction in the mempool can be invalidated if another transaction is received with the same nonce. That other transaction had to increase the gas price in order to replace the first one, so it satisfied the rule that one must pay to be included in the mempool.
+With contract-based accounts, since a UserOperation's validity may depend on mutable state, other transactions may invalidate a previously valid UserOperation, so we must check it before inclusion.
 
-### Rationale of limiting opcodes:
+### Rationale for limiting opcodes
 
-- the validation is performed off-chain, before creating a block. Some opcodes access information that is known only when creating the block.
-- using those opcodes while validating a transaction can easily create a validation rule that will succeed off-chain, but always revert on-chain, and thus cause a DoS attack.
-- a simple example is `require block.number==12345`. It can be valid when validating the UserOperation and adding it to the mempool
-  but will be invalid when attempting to include it on-chain at a later block.
+- The validation is performed off-chain, before creating a block. Some opcodes access information that is known only when creating the block.
+- Using those opcodes while validating a transaction can easily create a validation rule that will succeed off-chain, but always revert on-chain, and thus cause a DoS attack.
+- A simple example is `require block.number == 12345`. It can be valid when validating the UserOperation and adding it to the mempool, but will be invalid when attempting to include it on-chain at a later block.
 
 ### Rationale for limiting storage access
 
-- We need UserOperation validations not to overlap so that a single storage change can't easily invalidate a large number of UserOperations in the mempool. By limiting UserOperations to access storage associated with the account itself, we know that we can for sure include a single UserOperation for each account in a bundle
-- (A bundler MAY include multiple UserOperations of the same account in a bundle, but MUST first validate them together)
+- We need UserOperation validations not to overlap so that a single storage change cannot easily invalidate a large number of UserOperations in the mempool. By limiting UserOperations to access storage associated with the account itself, we can be sure that we can include a single UserOperation for each account in a bundle.
+- (A bundler MAY include multiple UserOperations of the same account in a bundle, but MUST first validate them together.)
 
-### Rationale of requiring a stake
+### Rationale for requiring a stake
 
-We want to be able to allow globally-used contracts (paymasters, factories, aggregators) to use storage not associated with the account, but still prevent them from
+We want to allow globally-used contracts (paymasters, factories, aggregators) to use storage not associated with the account, but still prevent them from
 spamming the mempool.
 If a contract causes too many UserOperations to fail in their second validation after succeeding in their first, we can throttle its use in the mempool.
-By requiring such a contract to have a stake, we prevent a "Sybil attack", by making it expensive to create a large number of such paymasters to continue the spam attack.
+By requiring such a contract to have a stake, we prevent a Sybil attack by making it expensive to create a large number of such paymasters to continue the spam attack.
 
 By following the validation rules, we can detect contracts that cause spam UserOperations, and throttle them.
-The stake comes to prevent the fast re-creation of malicious entities.
+The stake prevents the fast re-creation of malicious entities.
 The stake is never slashed (since it is only used for off-chain detection) but is locked for a period of time, which makes such an attack much more expensive.
 
 
 ### Definition of the `mass invalidation attack`
 
-A possible set of actions is considered to be a `mass invalidation attack` on the network if a large number of
-`UserOperations` that did pass the initial validation and were accepted by nodes and propagated further into the
+A possible set of actions is considered a `mass invalidation attack` on the network if a large number of
+`UserOperations` that passed the initial validation and were accepted by nodes and propagated further into the
 mempool to other bundlers in the network becomes invalid and not eligible for inclusion in a block.
 
-There are 3 ways to perform such an attack:
+There are three ways to perform such an attack:
 
 1. Submit `UserOperation`s that pass the initial validation, but later fail the re-validation
-   that is performed during the bundle creation.
+   that is performed during bundle creation.
 2. Submit `UserOperation`s that are valid in isolation during validation, but when bundled
    together become invalid.
 3. Submit valid `UserOperation`s but "front-run" them by executing a state change on the
    network that causes them to become invalid. The "front-run" in question must be economically viable.
 
 To prevent such attacks, we attempt to "sandbox" the validation code.
-We isolate the validation code from other `UserOperations`, from external changes to the storage, and
-from information about the environment such as a current block timestamp.
+We isolate the validation code from other `UserOperations`, from external changes to storage, and
+from information about the environment such as the current block timestamp.
 
 ### What is not considered a `mass invalidation attack`
 
 A `UserOperation` that fails the initial validation by a receiving node without entering its mempool is not
 considered an attack. The node is expected to apply web2 security measures and throttle requests based on API key,
 source IP address, etc.
-RPC nodes already do that to prevent being spammed with invalid transactions which also have a validation cost.
+RPC nodes already do that to prevent being spammed with invalid transactions, which also carry a validation cost.
 P2P nodes already have (and should apply) a scoring mechanism to determine spammer nodes.
 
-Also, if the invalidation of `N` UserOperations from the mempool costs `N*X` with a sufficiently large `X`, it is not considered an economically viable attack.
+Also, if the invalidation of `N` UserOperations from the mempool costs `N * X` with a sufficiently large `X`, it is not considered an economically viable attack.
 
-- The minimum change to cause an invalidation is a storage change (5k gas)
-- Assuming a Node can sustain processing 2000 invalid UserOps per block, the cost of a DoS attack is 10M gas per block.
+- The minimum change to cause an invalidation is a storage change (5k gas).
+- Assuming a node can sustain processing 2000 invalid UserOperations per block, the cost of a DoS attack is 10M gas per block.
 - The above value is high, but we take further measures to make such an attack more expensive.
 
 ## Security Considerations
 
-This document describes the security considerations bundlers must take to protect themselves (and the entire mempool network)
+This document describes the security considerations that bundlers must take to protect themselves (and the entire mempool network)
 from denial-of-service attacks.
 
 ## Copyright

--- a/ERCS/erc-7562.md
+++ b/ERCS/erc-7562.md
@@ -12,7 +12,7 @@ created: 2023-09-01
 
 ## Abstract
 
-This document describes the validation rules that Account Abstraction protocols must follow for transactions such as an [ERC-4337](./eip-4337) `UserOperation`, alongside the rationale for each rule. Block builders and standalone bundlers enforce these rules off-chain.
+This document describes the validation rules that [ERC-4337](./eip-4337) Account Abstraction protocol participants must follow for user transactions represented as `UserOperation` structs, alongside the rationale for each rule. Block builders and standalone bundlers enforce these rules off-chain.
 
 ## Motivation
 
@@ -36,7 +36,7 @@ These rules only apply to the validation phase of Account Abstraction transactio
 For the interfaces of these contract-based accounts, see [ERC-4337](./eip-4337).
 
 This document uses the term "UserOperation" for a transaction created by a smart contract account, following ERC-4337 terminology.
-However, the rules apply to any Account Abstraction framework that uses EVM code to perform transaction validation in a public mempool, and that treats validation and execution as distinct: validation determines whether the operation is eligible for inclusion at the protocol level, while execution covers the on-chain execution and gas payment.
+Notably, many of these rules can also be applicable in any other Account Abstraction framework that uses EVM code to perform transaction validation in a public mempool, and that treats validation and execution as distinct components of a transaction.
 
 ## Specification
 
@@ -202,7 +202,7 @@ The reputation refresh rate limits a malicious paymaster to processing at most `
     * **[OP-062]** Precompiles:
         * Only known, accepted precompiles on the network that do not access anything in the blockchain state or environment are allowed.
         * The core precompiles `0x1`–`0x11`.
-        * The `P256VERIFY` secp256r1 precompile defined in [EIP-7951](./eip-7951), on networks that have adopted it.
+        * The `P256VERIFY` secp256r1 precompile defined in [EIP-7951](./eip-7951).
 * **[OP-070]** Transient Storage slots defined in [EIP-1153](./eip-1153) and accessed using `TLOAD` (`0x5c`) and `TSTORE` (`0x5d`) opcodes
   are treated exactly like persistent storage accessed via `SLOAD`/`SSTORE`.
 * **[OP-080]** `BALANCE` (`0x31`) and `SELFBALANCE` (`0x47`) are allowed only from a staked entity, otherwise they are blocked.
@@ -282,8 +282,7 @@ The following reputation rules apply to all staked entities and to unstaked paym
   The sender is allowed to use `CREATE` with an unstaked factory as well, per OP-032.
 * **[EREP-061]** A staked factory may also use a utility contract that calls the `CREATE` opcode.
 * **[EREP-070]** During bundle creation, if a staked entity reduces its validation gas by more than 10%
-    compared to the second validation, that entity is throttled, even if the UserOperation itself did not revert
-    (since this might affect the gas calculation defined by [EIP-7623](./eip-7623)).
+    compared to the second validation, that entity is throttled, even if the UserOperation itself did not revert, since this might affect the gas calculation defined by [EIP-7623](./eip-7623).
 
 ### Unstaked Entities Reputation Rules
 

--- a/ERCS/erc-7562.md
+++ b/ERCS/erc-7562.md
@@ -12,7 +12,7 @@ created: 2023-09-01
 
 ## Abstract
 
-This document describes the rules that Account Abstraction protocols should follow during the validation phase of Account Abstraction transactions, such as an [ERC-4337](./eip-4337) `UserOperation` or a RIP-7560 (Native Account Abstraction) transaction, along with the rationale behind each rule. These rules are enforced off-chain, by a block builder or a standalone bundler.
+This document describes the rules that Account Abstraction protocols should follow during the validation phase of Account Abstraction transactions, such as an [ERC-4337](./eip-4337) `UserOperation`, along with the rationale behind each rule. These rules are enforced off-chain, by a block builder or a standalone bundler.
 
 ## Motivation
 
@@ -33,7 +33,7 @@ This rule makes the network sustainable and DoS-protected: the network cannot be
 To mimic the same incentive structure in any Account Abstraction system, we suggest the following transaction validation rules.
 These validation rules only apply to the validation phase of Account Abstraction transactions, not to their entire executed code path.
 
-For the actual interfaces of these contract-based accounts, see the definitions in ERC-4337 and RIP-7560.
+For the actual interfaces of these contract-based accounts, see the definitions in ERC-4337.
 
 This document uses the term "UserOperation" for a transaction created by a smart contract account, closely following [ERC-4337](./eip-4337) terminology.
 However, the rules apply to any Account Abstraction framework that uses EVM code to perform transaction validation, and that distinguishes between validation (whether the operation is eligible for inclusion at the protocol level) and execution (on-chain execution and gas payment) in a public mempool.
@@ -200,7 +200,7 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
     * **[OP-062]** Precompiles:
         * Only known, accepted precompiles on the network that do not access anything in the blockchain state or environment are allowed.
         * The core precompiles `0x1`–`0x11`.
-        * The RIP-7212 secp256r1 precompile, on networks that have accepted it.
+        * The `P256VERIFY` secp256r1 precompile defined in [EIP-7951](./eip-7951), on networks that have adopted it.
 * **[OP-070]** Transient Storage slots defined in [EIP-1153](./eip-1153) and accessed using `TLOAD` (`0x5c`) and `TSTORE` (`0x5d`) opcodes
   are treated exactly like persistent storage (SLOAD/SSTORE).
 * **[OP-080]** `BALANCE` (`0x31`) and `SELFBALANCE` (`0x47`) are allowed only from a staked entity, otherwise they are blocked.

--- a/ERCS/erc-7562.md
+++ b/ERCS/erc-7562.md
@@ -16,7 +16,7 @@ This document describes the rules that Account Abstraction protocols should foll
 
 ## Motivation
 
-With Account Abstraction, this logic is executed by EVM code instead of the hard-coded logic used to process a transaction (validation, gas payment, and execution).
+With Account Abstraction, this logic is executed by EVM code instead of the hard-coded logic conventionally used to process a transaction's validation, gas payment, and execution.
 The benefits for the account are countless:
 - Abstracting validation allows the contract to use different signature schemes, multisig configurations, custom recovery, and more.
 - Abstracting gas payment allows easy onboarding via third-party payments, paying with tokens, and cross-chain gas payments.
@@ -24,11 +24,11 @@ The benefits for the account are countless:
 
 All of the above are missing from the EOA account model.
 
-However, there is one rule that a transaction must follow to preserve the decentralized network: once submitted to the network (the mempool), the transaction is guaranteed to pay. This rule exists to prevent denial-of-service attacks on the network.
+However, there is one rule that a transaction must follow to preserve the decentralized network: once submitted to the network's mempool, the transaction is guaranteed to pay. This rule exists to prevent denial-of-service attacks on the network.
 
 The EOA model implicitly follows this rule: a valid transaction cannot become invalid without payment by the account. For example, the account balance cannot be reduced except by a higher-paying transaction.
 
-This rule makes the network sustainable and DoS-protected: the network cannot be cheaply attacked by a mass of transactions. An attack (sending a mass of transactions) is expensive, and gets more expensive as the network clogs. Legitimate users pay more, and can delay operations to avoid the cost, but the attacker pays a huge (and increasing) amount to keep the network clogged.
+This rule makes the network sustainable and DoS-protected: the network cannot be cheaply attacked by a mass of transactions. An attack that sends a mass of transactions is expensive, and gets more expensive as the network clogs. Legitimate users pay more, and can delay operations to avoid the cost, but the attacker pays a huge and increasing amount to keep the network clogged.
 
 To mimic the same incentive structure in any Account Abstraction system, we suggest the following transaction validation rules.
 These validation rules only apply to the validation phase of Account Abstraction transactions, not to their entire executed code path.
@@ -36,7 +36,7 @@ These validation rules only apply to the validation phase of Account Abstraction
 For the actual interfaces of these contract-based accounts, see the definitions in ERC-4337.
 
 This document uses the term "UserOperation" for a transaction created by a smart contract account, closely following [ERC-4337](./eip-4337) terminology.
-However, the rules apply to any Account Abstraction framework that uses EVM code to perform transaction validation, and that distinguishes between validation (whether the operation is eligible for inclusion at the protocol level) and execution (on-chain execution and gas payment) in a public mempool.
+However, the rules apply to any Account Abstraction framework that uses EVM code to perform transaction validation in a public mempool, and that treats validation and execution as distinct: validation determines whether the operation is eligible for inclusion at the protocol level, while execution covers the on-chain execution and gas payment.
 
 ## Specification
 
@@ -57,7 +57,7 @@ Local rules are called out explicitly in the [Local Rules](#local-rules) section
 | Title                                | Value                       | Comment                                                                                                                 |
 |--------------------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | `MIN_UNSTAKE_DELAY`                  | 86400                       | 1 day, which provides a sufficient withdrawal delay to prevent most Sybil attacks                                       |
-| `MIN_STAKE_VALUE`                    | Adjustable per chain value  | Recommended to be a non-trivial but not excessive amount (roughly ~$1000 equivalent in native tokens), sufficient to deter most Sybil attacks without being prohibitive |
+| `MIN_STAKE_VALUE`                    | Adjustable per chain value  | Recommended to be a non-trivial but not excessive amount, roughly $1000 equivalent in native tokens, sufficient to deter most Sybil attacks without being prohibitive |
 | `SAME_SENDER_MEMPOOL_COUNT`          | 4                           | Maximum number of UserOperations allowed in the mempool from a single sender                                            |
 | `SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT` | 10                          | Maximum number of UserOperations in the mempool that reference the same unstaked entity                                |
 | `THROTTLED_ENTITY_MEMPOOL_COUNT`     | 4                           | Number of `UserOperations` with a throttled entity that can stay in the mempool                                         |
@@ -88,7 +88,7 @@ Local rules are called out explicitly in the [Local Rules](#local-rules) section
    1. `sender` execution frame (required)
    2. `paymaster` post-transaction frame (optional)
 
-   The validation rules only apply during the validation phase. Once a UserOperation is validated, it is guaranteed to pay. There are no restrictions on execution, neither for the account (callData) nor for the paymaster (postOp).
+   The validation rules only apply during the validation phase. Once a UserOperation is validated, it is guaranteed to pay. There are no restrictions on execution, neither on the account's callData nor on the paymaster's postOp.
 
 3. **Entity**: a contract that is explicitly specified by the `UserOperation`.
    It includes the `factory`, `paymaster`, `aggregator`, and staked `account`, as discussed below. \
@@ -131,7 +131,7 @@ The reputation state of each entity is determined as follows:
 
 Note that new entities start with an `OK` reputation.
 
-Because of the reputation refresh rate, a malicious paymaster can cause the network (only the P2P network, not the blockchain) to process at most `BAN_SLACK * MIN_INCLUSION_RATE_DENOMINATOR / 24` non-paying UserOperations per hour.
+Because of the reputation refresh rate, a malicious paymaster can cause the network to process at most `BAN_SLACK * MIN_INCLUSION_RATE_DENOMINATOR / 24` non-paying UserOperations per hour. Note that this only affects the P2P network, not the blockchain.
 
 ### Running the Validation Rules
 
@@ -156,10 +156,10 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
 5. If a received `UserOperation` fails against the current block:
     1. Retry the validation against the block the `UserOperation` was originally verified against.
     2. If it succeeds, silently drop the `UserOperation` and keep the connection.
-    3. If it fails, mark the sender as a "spammer" (disconnect from that peer and block it permanently).
+    3. If it fails, mark the sender as a "spammer": disconnect from that peer and block it permanently.
 
 ### Opcode Rules
-* Opcodes that access information outside of storage and code (i.e., the "environment") are blocked:
+* Opcodes that access information outside of storage and code, referred to here as the "environment", are blocked:
     * **[OP-011]** Blocked opcodes:
         * `ORIGIN` (`0x32`)
         * `GASPRICE` (`0x3A`)
@@ -172,7 +172,7 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
         * `BASEFEE` (`0x48`)
         * `BLOBHASH` (`0x49`)
         * `BLOBBASEFEE` (`0x4A`)
-        * `CREATE` (`0xF0`) (except in the "Contract Creation" and "Staked factory creation" sections, below)
+        * `CREATE` (`0xF0`), except as allowed in the "Contract Creation" and "Staked factory creation" sections below
         * `INVALID` (`0xFE`)
         * `SELFDESTRUCT` (`0xFF`)
     * **[OP-012]** `GAS` (`0x5A`) opcode is allowed, but only if followed immediately by `*CALL` instructions, otherwise it is blocked.\
@@ -182,9 +182,9 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
 * **[OP-020]** Revert on "out of gas" is forbidden as it can "leak" the gas limit or the current call stack depth.
 * Contract creation:
     * **[OP-031]** `CREATE2` is allowed exactly once in the deployment frame and must deploy code for the "sender" address.
-      (Either by the factory itself, or by a utility contract it calls.)
-    * **[OP-032]** If there is a `factory` (even unstaked), the `sender` contract is allowed to use the `CREATE` opcode
-      (That is, only the sender contract itself, not via a utility contract.)
+      This can be done either by the factory itself, or by a utility contract it calls.
+    * **[OP-032]** If there is a `factory`, even an unstaked one, the `sender` contract is allowed to use the `CREATE` opcode.
+      This applies only to the sender contract itself, not via a utility contract.
 * Access to an address without deployed code is forbidden:
     * **[OP-041]** For `EXTCODE*` and `*CALL` opcodes.
     * **[OP-042]** Exception: access to the "sender" address is allowed.
@@ -194,7 +194,7 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
       This pattern is used to check that the destination has code before the `depositTo` function is called.
     * **[OP-052]** May call `depositTo(sender)` with any value from either the `sender` or the `factory`.
     * **[OP-053]** May call the fallback function from the `sender` with any value.
-    * **[OP-054]** Any other access to the `EntryPoint` (either of the `*CALL` or `EXT*` opcodes) is forbidden.
+    * **[OP-054]** Any other access to the `EntryPoint`, whether via `*CALL` or `EXT*` opcodes, is forbidden.
     * **[OP-055]** May call `incrementNonce()` from the `sender`.
 * `*CALL` opcodes:
     * **[OP-061]** `CALL` with `value` is forbidden. The only exception is a call to the `EntryPoint` described above.
@@ -203,7 +203,7 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
         * The core precompiles `0x1`–`0x11`.
         * The `P256VERIFY` secp256r1 precompile defined in [EIP-7951](./eip-7951), on networks that have adopted it.
 * **[OP-070]** Transient Storage slots defined in [EIP-1153](./eip-1153) and accessed using `TLOAD` (`0x5c`) and `TSTORE` (`0x5d`) opcodes
-  are treated exactly like persistent storage (SLOAD/SSTORE).
+  are treated exactly like persistent storage accessed via `SLOAD`/`SSTORE`.
 * **[OP-080]** `BALANCE` (`0x31`) and `SELFBALANCE` (`0x47`) are allowed only from a staked entity, otherwise they are blocked.
 
 
@@ -215,13 +215,13 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
 
 ### Storage Rules
 
-Storage access using the `SLOAD` and `SSTORE` (and `TLOAD`, `TSTORE`) instructions is limited within each phase as follows:
+Storage access using the `SLOAD`, `SSTORE`, `TLOAD`, and `TSTORE` instructions is limited within each phase as follows:
 
 * **[STO-010]** Access to the "account" storage is always allowed.
-* Access to associated storage of the account in an external (non-entity) contract is allowed if either:
+* Access to associated storage of the account in an external contract that is not an entity is allowed if either:
     * **[STO-021]** The account already exists.
     * **[STO-022]** There is an `initCode` and the `factory` contract is staked.
-* If the entity (`paymaster`, `factory`) is staked, then it is also allowed:
+* If the `paymaster` or `factory` entity is staked, then it is also allowed:
     * **[STO-031]** Access the entity's own storage.
     * **[STO-032]** Read/Write access to storage slots that are associated with the entity, in any non-entity contract.
     * **[STO-033]** Read-only access to any storage in a non-entity contract.
@@ -229,9 +229,9 @@ Storage access using the `SLOAD` and `SSTORE` (and `TLOAD`, `TSTORE`) instructio
 ### Local Rules
 
 Local storage rules protect the bundler against denial of service at the time of bundling. They do not affect mempool propagation and cannot cause a bundler to be marked as a "spammer".
-* **[STO-040]** A `UserOperation` may not use an entity address (`factory`/`paymaster`/`aggregator`) that is used as an "account" in another `UserOperation` in the mempool. \
+* **[STO-040]** A `UserOperation` may not use a `factory`, `paymaster`, or `aggregator` address that is used as an "account" in another `UserOperation` in the mempool. \
   This means that `paymaster`, `factory`, or `aggregator` contracts cannot practically be an "account" contract as well.
-* **[STO-041]** A `UserOperation` may not use associated storage (of either its account or a staked entity) in a contract that is a "sender" of another UserOperation in the mempool.
+* **[STO-041]** A `UserOperation` may not use associated storage of either its account or a staked entity, in a contract that is a "sender" of another UserOperation in the mempool.
 
 ### General Reputation Rules
 
@@ -245,7 +245,7 @@ The following reputation rules apply to all staked entities and to unstaked paym
     * `THROTTLED_ENTITY_LIVE_BLOCKS` blocks of residency in the mempool.
 * **[GREP-030]** REMOVED
 * **[GREP-040]** If an entity fails bundle creation after passing the second validation, its `opsSeen` is set to `BAN_OPS_SEEN_PENALTY` and its `opsIncluded` to zero, causing it to become `BANNED`.
-* **[GREP-050]** When a UserOperation is replaced (by submitting a new UserOperation with higher gas fees), and an entity (e.g., a paymaster) is replaced, then the removed entity has its reputation (opsSeen counter) decremented by 1.
+* **[GREP-050]** When a UserOperation is replaced by submitting a new UserOperation with higher gas fees, and this causes an entity, such as a paymaster, to be replaced as well, the removed entity's opsSeen counter is decremented by 1.
 
 ### Staked Entities Reputation Rules
 
@@ -263,12 +263,12 @@ The following reputation rules apply to all staked entities and to unstaked paym
     * The bundler should not accept a new `UserOperation` with a paymaster into the mempool if the maximum total gas cost of all UserOperations in the mempool, including this new `UserOperation`, is above the deposit of that `paymaster` at the current gas price.
 * **[EREP-011]** REMOVED
 * **[EREP-015]** A `paymaster` should not have its opsSeen incremented because of a failure of the factory or account.
-  * When running the second validation (before inclusion in a bundle), if a UserOperation fails because of a factory or account error (either a FailOp revert or a validation rule violation), then the paymaster's opsSeen value is decremented by 1.
+  * The second validation runs before a UserOperation is included in a bundle. If, at that point, the UserOperation fails because of a factory or account error, whether a FailOp revert or a validation rule violation, the paymaster's opsSeen value is decremented by 1.
 * **[EREP-016]** An `aggregator` should not have its opsSeen incremented because of a failure of a factory, an account, or a paymaster.
-  * When running the second validation (before inclusion in a bundle), if a UserOperation fails because of a factory, an account, or a paymaster error (either a FailOp revert or a validation rule violation), then the aggregator's opsSeen value is decremented by 1.
+  * The second validation runs before a UserOperation is included in a bundle. If, at that point, the UserOperation fails because of a factory, an account, or a paymaster error, whether a FailOp revert or a validation rule violation, the aggregator's opsSeen value is decremented by 1.
 * **[EREP-020]** If a staked factory is used, its reputation is updated accordingly when the account violates any of the validation rules. \
   That is, if `validateUserOp()` is rejected for any reason in a `UserOperation` that has an `initCode`, this is treated as if the factory caused the failure, and its reputation is affected accordingly.
-* **[EREP-030]** If a staked account is used, its reputation is updated based on failures of other entities (`paymaster`, `aggregator`) even if they are staked.
+* **[EREP-030]** If a staked account is used, its reputation is updated based on failures of other entities, such as a `paymaster` or `aggregator`, even if they are staked.
 * **[EREP-040]** An `aggregator` must be staked, regardless of storage usage.
 * **[EREP-050]** An unstaked `paymaster` may not return a `context`.
 * **[EREP-055]** A `context`'s size may not change between validation and bundle creation. \
@@ -276,7 +276,7 @@ The following reputation rules apply to all staked entities and to unstaked paym
     is `BANNED`, regardless of whether the UserOperation that reverted used that paymaster or not.
 * Staked factory creation rules:
   * **[EREP-060]** If the factory is staked, either the factory itself or the sender may use the `CREATE2` and `CREATE` opcodes.
-    (The sender is allowed to use `CREATE` with an unstaked factory as well, per OP-032.)
+    The sender is allowed to use `CREATE` with an unstaked factory as well, per OP-032.
   * **[EREP-061]** A staked factory may also use a utility contract that calls the `CREATE` opcode.
 * **[EREP-070]** During bundle creation, if a staked entity reduces its validation gas by more than 10%
     compared to the second validation, that entity is throttled, even if the UserOperation itself did not revert
@@ -289,7 +289,7 @@ The following reputation rules apply to all staked entities and to unstaked paym
     * The `UnstakedReputation` of an entity determines the maximum number of entries using this entity allowed in the mempool.
     * `opsAllowed` is a reputation-based calculation for an unstaked entity, representing how many `UserOperations` it is allowed to have in the mempool.
     * Rules:
-        * **[UREP-010]** An unstaked sender (that is not throttled/banned) is only allowed to have `SAME_SENDER_MEMPOOL_COUNT` `UserOperation`s in the mempool.
+        * **[UREP-010]** An unstaked sender that is not throttled or banned is only allowed to have `SAME_SENDER_MEMPOOL_COUNT` `UserOperation`s in the mempool.
         * **[UREP-020]** For an unstaked paymaster that is not throttled or banned: \
           `opsAllowed = SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT + inclusionRate * min(opsIncluded, MAX_OPS_ALLOWED_UNSTAKED_ENTITY)`.
         * This defaults to `SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT` for a new entity.
@@ -298,22 +298,22 @@ The following reputation rules apply to all staked entities and to unstaked paym
 ### Alt-mempools Rules
 
 An alternate mempool is an agreed-upon rule that bundlers may opt into, in addition to the canonical mempool.
-The alt-mempool "topic" is a unique identifier. By convention, this is the IPFS hash of the document describing (in clear text and a YAML file) the specifics of this alt mempool.
+The alt-mempool "topic" is a unique identifier. By convention, this is the IPFS hash of the document that describes the specifics of this alt mempool, written in clear text and a YAML file.
 
 * **[ALT-010]** The bundler listens to the alt-mempool "topic" over the P2P protocol.
 * **[ALT-020]** The alt-mempool rules MUST be checked only when a canonical rule is violated.
     * That is, if validation follows the canonical rules above, it is not considered part of an alt-mempool.
-*  **[ALT-021]** Such a `UserOperation` (that violates the canonical rules) is checked against all the alt-mempools, and is considered part of all those alt-mempools.
-* **[ALT-030]** Bundlers SHOULD forward `UserOperations` to other bundlers only once, regardless of how many (shared) alt-mempools they have. \
-  The receiving bundler validates the `UserOperations`, and based on the above rules (and subscribed alt-mempools) decides which alt-mempools to propagate them to.
-* **[ALT-040]** `opsIncluded` and `opsSeen` of entities are kept per alt-mempool. That is, an entity can be considered throttled (or banned) in one mempool, while still active on another.
+*  **[ALT-021]** Such a `UserOperation`, since it violates the canonical rules, is checked against all the alt-mempools, and is considered part of all those alt-mempools.
+* **[ALT-030]** Bundlers SHOULD forward `UserOperations` to other bundlers only once, regardless of how many alt-mempools they share. \
+  The receiving bundler validates the `UserOperations`, and, based on the above rules and its subscribed alt-mempools, decides which alt-mempools to propagate them to.
+* **[ALT-040]** `opsIncluded` and `opsSeen` of entities are kept per alt-mempool. That is, an entity can be considered throttled or banned in one mempool, while still active on another.
 
 ### Alt-mempool Reputation
 
 Alt-mempools are served by the same bundlers participating in the canonical mempool, but change the rules and may introduce denial-of-service attack vectors. To prevent them from taking the canonical mempool or other alt-mempools down with them, a reputation is managed for each. An alt-mempool that causes too many invalidations gets throttled. This limits the scope of the attack and lets the bundler continue doing its work for other mempools.
 
 * **[AREP-010]** Each alt-mempool has `opsSeen` and `opsIncluded`, much like entities. The `opsSeen` is incremented after `UserOperation` initial validation, when it is considered part of this mempool.
-  The `opsIncluded` is incremented after this UserOperation is included on-chain (either by this bundler or another).
+  The `opsIncluded` is incremented after this UserOperation is included on-chain, whether by this bundler or another.
 * **[AREP-020]** The alt-mempool becomes `THROTTLED`/`BANNED` based on the [Reputation Calculation](#reputation-calculation).
 * **[AREP-030]** REMOVED
 
@@ -322,13 +322,13 @@ Alt-mempools are served by the same bundlers participating in the canonical memp
 * **[AUTH-010]** A UserOperation may only contain a single [EIP-7702](./eip-7702) authorization tuple.
 * **[AUTH-020]** An account with EIP-7702 delegation can only be used as the Sender of the UserOperation.
   Using the authorized account as any other kind of UserOperation entity is not allowed.
-* **[AUTH-030]** An account with EIP-7702 delegation can only be **accessed** (using `*CALL` or `EXTCODE*` opcodes) if it is the Sender of the current UserOperation.
+* **[AUTH-030]** An account with EIP-7702 delegation can only be **accessed** using `*CALL` or `EXTCODE*` opcodes, and only if it is the Sender of the current UserOperation.
 * **[AUTH-040]** If there are multiple UserOperations by the same sender with an authorization tuple in the mempool, they all MUST have the same delegate address.
 
 ### Limitations
 
 The validation rules attempt to guarantee a degree of isolation between individual `UserOperation`s' validations.
-In order to prevent hitting the memory expansion limitations (imposed by the Ethereum EVM) when creating a bundle, `UserOperation`s must meet the following limitations:
+In order to prevent hitting the memory expansion limitations that the Ethereum EVM imposes when creating a bundle, `UserOperation`s must meet the following limitations:
 
 * **[LIM-010]** Maximum size of a single packed and ABI-encoded `UserOperation` in bytes MUST not exceed `MAX_USEROP_SIZE`.
 * **[LIM-020]** Maximum size of a `context` byte array returned by a paymaster in a single `UserOperation` in bytes MUST not exceed `MAX_CONTEXT_SIZE`.
@@ -356,17 +356,17 @@ into the mempool, can prevent such attacks.
 
 ### The high-level goal
 
-The purpose of this specification is to define a consensus between nodes (bundlers or block builders) when processing incoming UserOperations from an external source.
-This external source for UserOperations is either an end-user node (via RPC [ERC-7769](./eip-7769)) or another node in the P2P network.
+The purpose of this specification is to define a consensus between nodes, whether bundlers or block builders, when processing incoming UserOperations from an external source.
+This external source for UserOperations is either an end-user node submitting via the [ERC-7769](./eip-7769) RPC, or another node in the P2P network.
 
-The protocol tries to detect "spam" - large bursts of UserOperations that cannot be included on-chain (and thus cannot pay).
+The protocol tries to detect "spam" - large bursts of UserOperations that cannot be included on-chain, and thus cannot pay.
 The network is protected by throttling requests from such spammer nodes.
 
 All nodes in the network must share the same definition of "spam": otherwise, if some nodes accept some types of UserOperations and propagate them while others consider them spam, those "forgiving" nodes will be considered "spammers" by the rest of the nodes, and the network effectively splits.
 
 ### The processing flow of a UserOperation
 
-- First, a UserOperation is received - either via RPC (submitted on behalf of a single application) or via the P2P protocol, from another node in the mempool.
+- First, a UserOperation is received - either via RPC on behalf of a single application, or via the P2P protocol from another node in the mempool.
 - The node validates the UserOperation, adds it to its in-memory mempool, and submits it to its peers.
 - Lastly, when building a block, a node collects UserOperations from the mempool, performs a second validation to make sure they are all still valid as a bundle, and submits them in the next block.
 
@@ -384,18 +384,18 @@ With contract-based accounts, since a UserOperation's validity may depend on mut
 ### Rationale for limiting storage access
 
 - We need UserOperation validations not to overlap so that a single storage change cannot easily invalidate a large number of UserOperations in the mempool. By limiting UserOperations to access storage associated with the account itself, we can be sure that we can include a single UserOperation for each account in a bundle.
-- (A bundler MAY include multiple UserOperations of the same account in a bundle, but MUST first validate them together.)
+- A bundler MAY include multiple UserOperations of the same account in a bundle, but MUST first validate them together.
 
 ### Rationale for requiring a stake
 
-We want to allow globally-used contracts (paymasters, factories, aggregators) to use storage not associated with the account, but still prevent them from
+We want to allow globally-used contracts, such as paymasters, factories, and aggregators, to use storage not associated with the account, but still prevent them from
 spamming the mempool.
 If a contract causes too many UserOperations to fail in their second validation after succeeding in their first, we can throttle its use in the mempool.
 By requiring such a contract to have a stake, we prevent a Sybil attack by making it expensive to create a large number of such paymasters to continue the spam attack.
 
 By following the validation rules, we can detect contracts that cause spam UserOperations, and throttle them.
 The stake prevents the fast re-creation of malicious entities.
-The stake is never slashed (since it is only used for off-chain detection) but is locked for a period of time, which makes such an attack much more expensive.
+The stake is never slashed, since it is only used for off-chain detection, but is locked for a period of time, which makes such an attack much more expensive.
 
 
 ### Definition of the `mass invalidation attack`
@@ -423,17 +423,17 @@ A `UserOperation` that fails the initial validation by a receiving node without 
 considered an attack. The node is expected to apply web2 security measures and throttle requests based on API key,
 source IP address, etc.
 RPC nodes already do that to prevent being spammed with invalid transactions, which also carry a validation cost.
-P2P nodes already have (and should apply) a scoring mechanism to determine spammer nodes.
+P2P nodes already have, and should apply, a scoring mechanism to determine spammer nodes.
 
 Also, if the invalidation of `N` UserOperations from the mempool costs `N * X` with a sufficiently large `X`, it is not considered an economically viable attack.
 
-- The minimum change to cause an invalidation is a storage change (5k gas).
+- The minimum change to cause an invalidation is a storage change, costing 5k gas.
 - Assuming a node can sustain processing 2000 invalid UserOperations per block, the cost of a DoS attack is 10M gas per block.
 - The above value is high, but we take further measures to make such an attack more expensive.
 
 ## Security Considerations
 
-This document describes the security considerations that bundlers must take to protect themselves (and the entire mempool network)
+This document describes the security considerations that bundlers must take to protect themselves, and the entire mempool network,
 from denial-of-service attacks.
 
 ## Copyright

--- a/ERCS/erc-7562.md
+++ b/ERCS/erc-7562.md
@@ -12,30 +12,30 @@ created: 2023-09-01
 
 ## Abstract
 
-This document describes the rules that Account Abstraction protocols should follow during the validation phase of Account Abstraction transactions, such as an [ERC-4337](./eip-4337) `UserOperation`, along with the rationale behind each rule. These rules are enforced off-chain, by a block builder or a standalone bundler.
+This document describes the validation rules that Account Abstraction protocols must follow for transactions such as an [ERC-4337](./eip-4337) `UserOperation`, alongside the rationale for each rule. Block builders and standalone bundlers enforce these rules off-chain.
 
 ## Motivation
 
-With Account Abstraction, this logic is executed by EVM code instead of the hard-coded logic conventionally used to process a transaction's validation, gas payment, and execution.
-The benefits for the account are countless:
-- Abstracting validation allows the contract to use different signature schemes, multisig configurations, custom recovery, and more.
-- Abstracting gas payment allows easy onboarding via third-party payments, paying with tokens, and cross-chain gas payments.
-- Abstracting execution allows batch transactions.
+With Account Abstraction, transaction validation, gas payment, and execution are handled by EVM code rather than hard-coded protocol rules.
+This provides several benefits:
+- Abstracting validation enables custom signature schemes, multisig configurations, and account recovery.
+- Abstracting gas payment facilitates onboarding via third-party payments, ERC-20 token payments, and cross-chain fee abstraction.
+- Abstracting execution supports batched transactions.
 
-All of the above are missing from the EOA account model.
+These capabilities are unavailable in the traditional Externally Owned Account (EOA) model.
 
-However, there is one rule that a transaction must follow to preserve the decentralized network: once submitted to the network's mempool, the transaction is guaranteed to pay. This rule exists to prevent denial-of-service attacks on the network.
+However, preserving network decentralization requires one fundamental rule: once admitted to the mempool, a transaction must guarantee fee payment to prevent denial-of-service (DoS) attacks.
 
-The EOA model implicitly follows this rule: a valid transaction cannot become invalid without payment by the account. For example, the account balance cannot be reduced except by a higher-paying transaction.
+The EOA model implicitly follows this rule. A valid transaction cannot become invalid without the account paying fees. For instance, the account's balance can only be reduced by a higher-paying transaction.
 
-This rule makes the network sustainable and DoS-protected: the network cannot be cheaply attacked by a mass of transactions. An attack that sends a mass of transactions is expensive, and gets more expensive as the network clogs. Legitimate users pay more, and can delay operations to avoid the cost, but the attacker pays a huge and increasing amount to keep the network clogged.
+This property ensures network sustainability. An attack involving a massive influx of transactions is economically prohibitive, as costs escalate with network congestion. While legitimate users can delay operations to avoid high fees, an attacker must pay increasingly exorbitant amounts to maintain the congestion.
 
-To mimic the same incentive structure in any Account Abstraction system, we suggest the following transaction validation rules.
-These validation rules only apply to the validation phase of Account Abstraction transactions, not to their entire executed code path.
+To replicate this incentive structure in Account Abstraction systems, we propose a set of transaction validation rules.
+These rules only apply to the validation phase of Account Abstraction transactions, not their entire executed code path.
 
-For the actual interfaces of these contract-based accounts, see the definitions in ERC-4337.
+For the interfaces of these contract-based accounts, see [ERC-4337](./eip-4337).
 
-This document uses the term "UserOperation" for a transaction created by a smart contract account, closely following [ERC-4337](./eip-4337) terminology.
+This document uses the term "UserOperation" for a transaction created by a smart contract account, following ERC-4337 terminology.
 However, the rules apply to any Account Abstraction framework that uses EVM code to perform transaction validation in a public mempool, and that treats validation and execution as distinct: validation determines whether the operation is eligible for inclusion at the protocol level, while execution covers the on-chain execution and gas payment.
 
 ## Specification
@@ -45,12 +45,12 @@ We define two types of validation rules: **network-wide rules** and **local rule
 
 A violation of any validation rule by a UserOperation results in the UserOperation being dropped from the mempool and excluded from a bundle.
 
-A **network-wide rule** is a rule whose violation by a UserOperation should damage the reputation of the peer bundler that sent this UserOperation into the P2P mempool.
-A peer bundler with critically low reputation will eventually be marked as a malicious **spammer** peer.
+A **network-wide rule** is a rule whose violation by a `UserOperation` damages the reputation of the peer bundler that sent this `UserOperation` into the P2P mempool.
+A peer bundler with critically low reputation is eventually marked as a malicious **spammer** peer.
 
-A **local rule** is a rule enforced according to each bundler's own local state. This state may differ between bundlers, so different bundlers may not always agree on whether such a rule was violated.
-Thus, the bundler that sent the violating UserOperation should not suffer P2P reputation damage from its peers.
-Local rules are called out explicitly in the [Local Rules](#local-rules) section below; every other rule in this document is a network-wide rule.
+A **local rule** is enforced according to each bundler's own local state. Because this state may differ between bundlers, there is no need for consensus on local rule violations.
+Thus, the bundler that sent the violating `UserOperation` does not suffer P2P reputation damage from its peers.
+Local rules are explicitly designated in the [Local Rules](#local-rules) section; every other rule in this document is a network-wide rule.
 
 ### Constants
 
@@ -79,42 +79,42 @@ Local rules are called out explicitly in the [Local Rules](#local-rules) section
 ### Validation Rules
 
 ### Definitions
-1. **Validation Phase**: there are up to three frames during the validation phase on-chain
+1. **Validation Phase**: There are up to three on-chain frames during the validation phase:
     1. `sender` deployment frame (once per account)
     2. `sender` validation (required)
     3. `paymaster` validation frame (optional)
 
-2. **Execution Phase**: there are up to two frames during the execution phase on-chain
+2. **Execution Phase**: There are up to two on-chain frames during the execution phase:
    1. `sender` execution frame (required)
    2. `paymaster` post-transaction frame (optional)
 
-   The validation rules only apply during the validation phase. Once a UserOperation is validated, it is guaranteed to pay. There are no restrictions on execution, neither on the account's callData nor on the paymaster's postOp.
+   The validation rules only apply during the validation phase. Once a `UserOperation` is validated, it is guaranteed to pay. There are no restrictions on execution, neither on the account's `callData` nor on the paymaster's `postOp`.
 
-3. **Entity**: a contract that is explicitly specified by the `UserOperation`.
-   It includes the `factory`, `paymaster`, `aggregator`, and staked `account`, as discussed below. \
-   Each "validation frame" is attributed to a single entity. \
-   Entity contracts must have non-empty code on-chain.
+3. **Entity**: A contract that is explicitly specified by the `UserOperation`.
+   Entities include the `factory`, `paymaster`, `aggregator`, and staked `account`, as discussed below.
+   Each validation frame is attributed to a single entity.
+   Entity contracts must have code deployed on-chain.
 4. **Canonical Mempool**: The rules defined in this document apply to the main mempool shared by all bundlers on the network.
-5. **Staked Entity:** an entity that has a locked stake of at least `MIN_STAKE_VALUE`
+5. **Staked Entity:** An entity that has a locked stake of at least `MIN_STAKE_VALUE`
    and an unstake delay of at least `MIN_UNSTAKE_DELAY`.
-6. **Associated storage:** a storage slot of any smart contract is considered to be "associated" with address `A` if:
+6. **Associated storage:** A storage slot of any smart contract is considered to be "associated" with address `A` if:
     1. The slot value is `A`
     2. The slot value was calculated as `keccak(A||x)+n`, where `x` is a `bytes32` value, and `n` is a value in the range 0..128
-7. **Using an address**: accessing the code of a given address in any way.
+7. **Using an address**: Accessing the code of a given address in any way.
    This can be done by executing `*CALL` or `EXTCODE*` opcodes for a given address.
-8. **Spammer**: a P2P peer bundler that attempts a DoS attack on the mempool by sending other peers a large number of invalid UserOperations.
+8. **Spammer**: A P2P peer bundler that attempts a DoS attack on the mempool by sending other peers a large number of invalid `UserOperation`s.
    Bundlers MUST detect and disconnect from such peers, as described in the [Mempool Validation Rules](#mempool-validation-rules) section.
 
 ### Reputation Definitions
-1. **opsSeen**: a per-entity counter of how many times a unique valid `UserOperation` referencing this entity
+1. **opsSeen**: A per-entity counter of how many times a unique valid `UserOperation` referencing this entity
    was received by this bundler.
    This includes `UserOperation`s received via incoming RPC calls or through a P2P mempool protocol.
 
-2. **opsIncluded**: a per-entity counter of how many times a unique valid `UserOperation` referencing this entity
-   appeared in an actual included `UserOperation`. \
-   Calculation of this value is based on UserOperationEvents and is only counted for `UserOperations` that were
+2. **opsIncluded**: A per-entity counter of how many times a unique valid `UserOperation` referencing this entity
+   appeared in an actual included `UserOperation`.
+   Calculation of this value is based on `UserOperationEvent`s and is only counted for `UserOperation`s that were
    previously counted as `opsSeen` by this bundler.
-3. **Refresh rate**: Both of the above values are updated every hour as `value = value * 23 // 24` \
+3. **Refresh rate**: Both of the above values are updated every hour as `value = value * 23 // 24`.
    Effectively, the value is reduced to 1% after 4 days.
 4. **inclusionRate**: Ratio of `opsIncluded` to `opsSeen`.
 
@@ -129,19 +129,19 @@ The reputation state of each entity is determined as follows:
 2. **THROTTLED**: `max_seen > opsIncluded + THROTTLING_SLACK`
 3. **OK**: otherwise
 
-Note that new entities start with an `OK` reputation.
+New entities start with an `OK` reputation.
 
-Because of the reputation refresh rate, a malicious paymaster can cause the network to process at most `BAN_SLACK * MIN_INCLUSION_RATE_DENOMINATOR / 24` non-paying UserOperations per hour. Note that this only affects the P2P network, not the blockchain.
+The reputation refresh rate limits a malicious paymaster to processing at most `BAN_SLACK * MIN_INCLUSION_RATE_DENOMINATOR / 24` non-paying `UserOperation`s per hour. This affects only the P2P network, not the blockchain.
 
 ### Running the Validation Rules
 
 1. A block builder or a bundler should perform a full validation once before accepting a `UserOperation` into its mempool, and again before including it in a bundle/block.
-2. The bundler should trace the validation phase of the UserOperation and apply all the rules defined in this document.
+2. The bundler should trace the validation phase of the `UserOperation` and apply all the rules defined in this document.
 3. A bundler should also perform a full validation of the entire bundle before submission.
-4. The validation rules prevent an unstaked entity from altering its behavior between simulation and execution of the UserOperation.
+4. The validation rules prevent an unstaked entity from altering its behavior between simulation and execution of the `UserOperation`.
    However, a malicious staked entity can detect that it is running as part of a bundle validation and cause a revert. Thus, a third tracing simulation of the entire bundle should be performed before submission.
-5. The failed `UserOperation` should be dropped from the bundle.
-6. The bundler should update the reputation of the staked entity that violated the rules, and consider it `THROTTLED`/`BANNED` as described below.
+5. Any failed `UserOperation` must be dropped from the bundle.
+6. The bundler should update the reputation of the staked entity that violated the rules, considering it `THROTTLED`/`BANNED` as described below.
 
 ### Mempool Validation Rules
 
@@ -149,7 +149,7 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
     1. The `UserOperation` itself.
     2. The blockhash this `UserOperation` was originally verified against.
 2. Once a `UserOperation` is received from another bundler, it should be verified locally by the receiving bundler.
-3. A received `UserOperation` may fail one of several reasonable static checks, such as invalid format, values below the minimum, or having been submitted with a blockhash that is not recent, etc.
+3. A received `UserOperation` may fail one of several static checks, such as an invalid format, values below the minimum, or an outdated blockhash.
    In this case, the bundler should drop this particular `UserOperation` but keep the connection.
 4. The bundler should check the `UserOperation` against the nonces of last-included bundles and silently drop `UserOperations` with a `nonce` that was recently included.
    This invalidation is likely attributable to a network race condition and should not cause a reputation change.
@@ -175,9 +175,8 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
         * `CREATE` (`0xF0`), except as allowed in the "Contract Creation" and "Staked factory creation" sections below
         * `INVALID` (`0xFE`)
         * `SELFDESTRUCT` (`0xFF`)
-    * **[OP-012]** `GAS` (`0x5A`) opcode is allowed, but only if followed immediately by `*CALL` instructions, otherwise it is blocked.\
-      This is a common way to pass all remaining gas to an external call, and it means that the actual value is
-      consumed from the stack immediately and cannot be accessed by any other opcode.
+    * **[OP-012]** `GAS` (`0x5A`) opcode is allowed, but only if followed immediately by `*CALL` instructions, otherwise it is blocked.
+      This is a common way to pass all remaining gas to an external call, meaning the actual value is consumed from the stack immediately and cannot be accessed by any other opcode.
     * **[OP-013]** any "unassigned" opcode.
 * **[OP-020]** Revert on "out of gas" is forbidden as it can "leak" the gas limit or the current call stack depth.
 * Contract creation:
@@ -190,7 +189,7 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
     * **[OP-042]** Exception: access to the "sender" address is allowed.
       This is only possible in `factory` code during the deployment frame.
 * Allowed access to the `EntryPoint` address:
-    * **[OP-051]** May call `EXTCODESIZE ISZERO`\
+    * **[OP-051]** May call `EXTCODESIZE ISZERO`.
       This pattern is used to check that the destination has code before the `depositTo` function is called.
     * **[OP-052]** May call `depositTo(sender)` with any value from either the `sender` or the `factory`.
     * **[OP-053]** May call the fallback function from the `sender` with any value.
@@ -210,8 +209,8 @@ Because of the reputation refresh rate, a malicious paymaster can cause the netw
 ### Code Rules
 
 * **[COD-010]** Between the first and second validations, the `EXTCODEHASH` value of any visited address,
-  entity, or referenced library may not be changed.\
-  If the code is modified, the UserOperation is considered invalid.
+  entity, or referenced library may not be changed.
+  If the code is modified, the `UserOperation` is considered invalid.
 
 ### Storage Rules
 
@@ -229,7 +228,7 @@ Storage access using the `SLOAD`, `SSTORE`, `TLOAD`, and `TSTORE` instructions i
 ### Local Rules
 
 Local storage rules protect the bundler against denial of service at the time of bundling. They do not affect mempool propagation and cannot cause a bundler to be marked as a "spammer".
-* **[STO-040]** A `UserOperation` may not use a `factory`, `paymaster`, or `aggregator` address that is used as an "account" in another `UserOperation` in the mempool. \
+* **[STO-040]** A `UserOperation` may not use a `factory`, `paymaster`, or `aggregator` address that is used as an "account" in another `UserOperation` in the mempool.
   This means that `paymaster`, `factory`, or `aggregator` contracts cannot practically be an "account" contract as well.
 * **[STO-041]** A `UserOperation` may not use associated storage of either its account or a staked entity, in a contract that is a "sender" of another UserOperation in the mempool.
 
@@ -237,7 +236,7 @@ Local storage rules protect the bundler against denial of service at the time of
 
 The following reputation rules apply to all staked entities and to unstaked paymasters. All rules apply to all of these entities unless specified otherwise.
 
-* **[GREP-010]** A `BANNED` address is not allowed into the mempool.\
+* **[GREP-010]** A `BANNED` address is not allowed into the mempool.
   Also, all existing `UserOperations` referencing this address are removed from the mempool.
 * **[GREP-020]** A `THROTTLED` address is limited to:
     * `THROTTLED_ENTITY_MEMPOOL_COUNT` entries in the mempool.
@@ -266,14 +265,14 @@ The following reputation rules apply to all staked entities and to unstaked paym
   * The second validation runs before a UserOperation is included in a bundle. If, at that point, the UserOperation fails because of a factory or account error, whether a FailOp revert or a validation rule violation, the paymaster's opsSeen value is decremented by 1.
 * **[EREP-016]** An `aggregator` should not have its opsSeen incremented because of a failure of a factory, an account, or a paymaster.
   * The second validation runs before a UserOperation is included in a bundle. If, at that point, the UserOperation fails because of a factory, an account, or a paymaster error, whether a FailOp revert or a validation rule violation, the aggregator's opsSeen value is decremented by 1.
-* **[EREP-020]** If a staked factory is used, its reputation is updated accordingly when the account violates any of the validation rules. \
+* **[EREP-020]** If a staked factory is used, its reputation is updated accordingly when the account violates any of the validation rules.
   That is, if `validateUserOp()` is rejected for any reason in a `UserOperation` that has an `initCode`, this is treated as if the factory caused the failure, and its reputation is affected accordingly.
 * **[EREP-030]** If a staked account is used, its reputation is updated based on failures of other entities, such as a `paymaster` or `aggregator`, even if they are staked.
 * **[EREP-040]** An `aggregator` must be staked, regardless of storage usage.
 * **[EREP-050]** An unstaked `paymaster` may not return a `context`.
-* **[EREP-055]** A `context`'s size may not change between validation and bundle creation. \
-    If bundle creation reverts and a paymaster's context size was modified, that paymaster \
-    is `BANNED`, regardless of whether the UserOperation that reverted used that paymaster or not.
+* **[EREP-055]** A `context`'s size may not change between validation and bundle creation.
+    If bundle creation reverts and a paymaster's context size was modified, that paymaster
+    is `BANNED`, regardless of whether the `UserOperation` that reverted used that paymaster or not.
 * Staked factory creation rules:
   * **[EREP-060]** If the factory is staked, either the factory itself or the sender may use the `CREATE2` and `CREATE` opcodes.
     The sender is allowed to use `CREATE` with an unstaked factory as well, per OP-032.
@@ -290,7 +289,7 @@ The following reputation rules apply to all staked entities and to unstaked paym
     * `opsAllowed` is a reputation-based calculation for an unstaked entity, representing how many `UserOperations` it is allowed to have in the mempool.
     * Rules:
         * **[UREP-010]** An unstaked sender that is not throttled or banned is only allowed to have `SAME_SENDER_MEMPOOL_COUNT` `UserOperation`s in the mempool.
-        * **[UREP-020]** For an unstaked paymaster that is not throttled or banned: \
+        * **[UREP-020]** For an unstaked paymaster that is not throttled or banned:
           `opsAllowed = SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT + inclusionRate * min(opsIncluded, MAX_OPS_ALLOWED_UNSTAKED_ENTITY)`.
         * This defaults to `SAME_UNSTAKED_ENTITY_MEMPOOL_COUNT` for a new entity.
         * **[UREP-030]** REMOVED
@@ -304,7 +303,7 @@ The alt-mempool "topic" is a unique identifier. By convention, this is the IPFS 
 * **[ALT-020]** The alt-mempool rules MUST be checked only when a canonical rule is violated.
     * That is, if validation follows the canonical rules above, it is not considered part of an alt-mempool.
 *  **[ALT-021]** Such a `UserOperation`, since it violates the canonical rules, is checked against all the alt-mempools, and is considered part of all those alt-mempools.
-* **[ALT-030]** Bundlers SHOULD forward `UserOperations` to other bundlers only once, regardless of how many alt-mempools they share. \
+* **[ALT-030]** Bundlers SHOULD forward `UserOperations` to other bundlers only once, regardless of how many alt-mempools they share.
   The receiving bundler validates the `UserOperations`, and, based on the above rules and its subscribed alt-mempools, decides which alt-mempools to propagate them to.
 * **[ALT-040]** `opsIncluded` and `opsSeen` of entities are kept per alt-mempool. That is, an entity can be considered throttled or banned in one mempool, while still active on another.
 
@@ -340,96 +339,78 @@ In order to prevent hitting the memory expansion limitations that the Ethereum E
 
 ## Rationale
 
-All transactions initiated by EOAs have an implicit validation phase where balance, nonce, and signature are
-checked to be valid for the current state of the Ethereum blockchain.
-Once a node has validated the transaction, only another transaction by the same EOA can modify the Ethereum
-state in a way that makes the first transaction invalid.
+All transactions initiated by EOAs have an implicit validation phase where balance, nonce, and signature are checked against the current state of the Ethereum blockchain.
+Once a node has validated the transaction, only another transaction by the same EOA can modify the Ethereum state in a way that invalidates the first transaction.
 
-With Account Abstraction, however, the validation can also include arbitrary EVM code and rely on storage as well,
-which means that unrelated `UserOperations` or transactions may invalidate each other.
+With Account Abstraction, however, validation can also include arbitrary EVM code and rely on storage, which means that unrelated `UserOperation`s or transactions may invalidate each other.
 
-If not addressed, this would make the job of maintaining a mempool of valid `UserOperations` and producing valid
-bundles computationally infeasible and susceptible to DoS attacks.
+If not addressed, this would make maintaining a mempool of valid `UserOperation`s and producing valid bundles computationally infeasible and susceptible to DoS attacks.
 
-This document describes a set of validation rules that, if applied by a bundler before accepting a `UserOperation`
-into the mempool, can prevent such attacks.
+This document describes a set of validation rules that, if applied by a bundler before accepting a `UserOperation` into the mempool, prevent such attacks.
 
 ### The high-level goal
 
-The purpose of this specification is to define a consensus between nodes, whether bundlers or block builders, when processing incoming UserOperations from an external source.
-This external source for UserOperations is either an end-user node submitting via the [ERC-7769](./eip-7769) RPC, or another node in the P2P network.
+The purpose of this specification is to define a consensus between nodes, whether bundlers or block builders, when processing incoming `UserOperation`s from an external source.
+This external source is either an end-user node submitting via the [ERC-7769](./eip-7769) RPC, or another node in the P2P network.
 
-The protocol tries to detect "spam" - large bursts of UserOperations that cannot be included on-chain, and thus cannot pay.
+The protocol detects "spam" — large bursts of `UserOperation`s that cannot be included on-chain and thus cannot pay fees.
 The network is protected by throttling requests from such spammer nodes.
 
-All nodes in the network must share the same definition of "spam": otherwise, if some nodes accept some types of UserOperations and propagate them while others consider them spam, those "forgiving" nodes will be considered "spammers" by the rest of the nodes, and the network effectively splits.
+All network nodes must share the same definition of "spam". If some nodes propagate `UserOperation`s that others consider spam, the forgiving nodes risk being marked as spammers, potentially fracturing the network.
 
 ### The processing flow of a UserOperation
 
-- First, a UserOperation is received - either via RPC on behalf of a single application, or via the P2P protocol from another node in the mempool.
-- The node validates the UserOperation, adds it to its in-memory mempool, and submits it to its peers.
-- Lastly, when building a block, a node collects UserOperations from the mempool, performs a second validation to make sure they are all still valid as a bundle, and submits them in the next block.
+- First, a `UserOperation` is received, either via RPC or via the P2P protocol from another mempool node.
+- The node validates the `UserOperation`, adds it to its local mempool, and broadcasts it to its peers.
+- Finally, when building a block, a node collects `UserOperation`s from the mempool, performs a second validation to ensure they remain valid as a bundle, and includes them in the next block.
 
 ### The need for a second validation before submitting a block
 
-A normal Ethereum transaction in the mempool can be invalidated if another transaction is received with the same nonce. That other transaction had to increase the gas price in order to replace the first one, so it satisfied the rule that one must pay to be included in the mempool.
-With contract-based accounts, since a UserOperation's validity may depend on mutable state, other transactions may invalidate a previously valid UserOperation, so we must check it before inclusion.
+A standard Ethereum transaction can be invalidated if replaced by another transaction with the same nonce. The replacement transaction must pay a higher gas price, satisfying the rule that mempool inclusion requires payment.
+With contract-based accounts, a `UserOperation`'s validity may depend on mutable state. Other transactions can invalidate a previously valid `UserOperation`, necessitating a second validation before block inclusion.
 
 ### Rationale for limiting opcodes
 
-- The validation is performed off-chain, before creating a block. Some opcodes access information that is known only when creating the block.
-- Using those opcodes while validating a transaction can easily create a validation rule that will succeed off-chain, but always revert on-chain, and thus cause a DoS attack.
-- A simple example is `require block.number == 12345`. It can be valid when validating the UserOperation and adding it to the mempool, but will be invalid when attempting to include it on-chain at a later block.
+- Validation occurs off-chain, before block creation. Certain opcodes access block-specific information that is not yet finalized.
+- Using these opcodes during validation enables scenarios where a `UserOperation` succeeds off-chain but consistently reverts on-chain, facilitating DoS attacks.
+- For example, `require(block.number == 12345)` might pass during mempool validation but fail when the transaction is eventually included in a later block.
 
 ### Rationale for limiting storage access
 
-- We need UserOperation validations not to overlap so that a single storage change cannot easily invalidate a large number of UserOperations in the mempool. By limiting UserOperations to access storage associated with the account itself, we can be sure that we can include a single UserOperation for each account in a bundle.
-- A bundler MAY include multiple UserOperations of the same account in a bundle, but MUST first validate them together.
+- Validation processes must not overlap, ensuring a single storage modification cannot invalidate a large number of mempool `UserOperation`s. By restricting storage access to the account's associated storage, bundlers can guarantee the inclusion of at least one `UserOperation` per account in a bundle.
+- A bundler MAY include multiple `UserOperation`s of the same account in a bundle, but MUST first validate them together.
 
 ### Rationale for requiring a stake
 
-We want to allow globally-used contracts, such as paymasters, factories, and aggregators, to use storage not associated with the account, but still prevent them from
-spamming the mempool.
-If a contract causes too many UserOperations to fail in their second validation after succeeding in their first, we can throttle its use in the mempool.
-By requiring such a contract to have a stake, we prevent a Sybil attack by making it expensive to create a large number of such paymasters to continue the spam attack.
+We want to allow globally-used contracts, such as paymasters, factories, and aggregators, to use storage not associated with the account, but still prevent them from spamming the mempool.
+If a contract causes too many `UserOperation`s to fail in their second validation after succeeding in their first, we can throttle its use in the mempool.
 
-By following the validation rules, we can detect contracts that cause spam UserOperations, and throttle them.
-The stake prevents the fast re-creation of malicious entities.
-The stake is never slashed, since it is only used for off-chain detection, but is locked for a period of time, which makes such an attack much more expensive.
+Requiring a stake prevents Sybil attacks by making it economically unviable to spawn numerous malicious paymasters to sustain a spam attack.
+
+The validation rules allow nodes to detect and throttle contracts responsible for spam. The stake prevents the rapid recreation of these malicious entities. Because the stake serves only for off-chain detection, it is never slashed; however, the required lock-up period significantly increases the capital cost of an attack.
 
 
-### Definition of the `mass invalidation attack`
+### Definition of the mass invalidation attack
 
-A possible set of actions is considered a `mass invalidation attack` on the network if a large number of
-`UserOperations` that passed the initial validation and were accepted by nodes and propagated further into the
-mempool to other bundlers in the network becomes invalid and not eligible for inclusion in a block.
+A series of actions constitutes a **mass invalidation attack** if a large number of `UserOperation`s—having passed initial validation and propagated through the mempool—subsequently become invalid and ineligible for block inclusion.
 
-There are three ways to perform such an attack:
+There are three ways to execute such an attack:
 
-1. Submit `UserOperation`s that pass the initial validation, but later fail the re-validation
-   that is performed during bundle creation.
-2. Submit `UserOperation`s that are valid in isolation during validation, but when bundled
-   together become invalid.
-3. Submit valid `UserOperation`s but "front-run" them by executing a state change on the
-   network that causes them to become invalid. The "front-run" in question must be economically viable.
+1. Submitting `UserOperation`s that pass initial validation but fail the second validation during bundle creation.
+2. Submitting `UserOperation`s that are valid in isolation but become invalid when bundled together.
+3. Front-running valid `UserOperation`s with an economically viable state change that invalidates them.
 
-To prevent such attacks, we attempt to "sandbox" the validation code.
-We isolate the validation code from other `UserOperations`, from external changes to storage, and
-from information about the environment such as the current block timestamp.
+To prevent these attacks, the validation code is sandboxed. It is isolated from other `UserOperation`s, external storage changes, and environmental information like the current block timestamp.
 
-### What is not considered a `mass invalidation attack`
+### What is not considered a mass invalidation attack
 
-A `UserOperation` that fails the initial validation by a receiving node without entering its mempool is not
-considered an attack. The node is expected to apply web2 security measures and throttle requests based on API key,
-source IP address, etc.
-RPC nodes already do that to prevent being spammed with invalid transactions, which also carry a validation cost.
-P2P nodes already have, and should apply, a scoring mechanism to determine spammer nodes.
+A `UserOperation` that fails initial validation without entering the mempool is not considered an attack. Nodes are expected to implement standard security measures, throttling requests based on API keys, IP addresses, or P2P peer scoring, to prevent spam.
 
-Also, if the invalidation of `N` UserOperations from the mempool costs `N * X` with a sufficiently large `X`, it is not considered an economically viable attack.
+Furthermore, if invalidating `N` `UserOperation`s costs an attacker `N * X` (where `X` is sufficiently large), the attack is not considered economically viable.
 
-- The minimum change to cause an invalidation is a storage change, costing 5k gas.
-- Assuming a node can sustain processing 2000 invalid UserOperations per block, the cost of a DoS attack is 10M gas per block.
-- The above value is high, but we take further measures to make such an attack more expensive.
+- The minimum change to cause an invalidation is a storage modification, which costs 5,000 gas.
+- Assuming a node can process 2,000 invalid `UserOperation`s per block, the cost of a DoS attack is 10,000,000 gas per block.
+- While this cost is already prohibitive, the rules defined in this document impose further measures to increase the cost of an attack.
 
 ## Security Considerations
 

--- a/ERCS/erc-7562.md
+++ b/ERCS/erc-7562.md
@@ -19,7 +19,7 @@ This document describes the validation rules that [ERC-4337](./eip-4337) Account
 With Account Abstraction, transaction validation, gas payment, and execution are handled by EVM code rather than hard-coded protocol rules.
 This provides several benefits:
 - Abstracting validation enables custom signature schemes, multisig configurations, and account recovery.
-- Abstracting gas payment facilitates onboarding via third-party payments, ERC-20 token payments, and cross-chain fee abstraction.
+- Abstracting gas payment facilitates onboarding via third-party payments, [ERC-20](./eip-20) token payments, and cross-chain fee abstraction.
 - Abstracting execution supports batched transactions.
 
 These capabilities are unavailable in the traditional Externally Owned Account (EOA) model.

--- a/ERCS/erc-7562.md
+++ b/ERCS/erc-7562.md
@@ -40,7 +40,17 @@ However, the rules apply to any Account Abstraction framework that uses EVM code
 
 ## Specification
 
+### Validation Rule Types
+We define two types of validation rules: **network-wide rules** and **local rules**.
+
 A violation of any validation rule by a UserOperation results in the UserOperation being dropped from the mempool and excluded from a bundle.
+
+A **network-wide rule** is a rule whose violation by a UserOperation should damage the reputation of the peer bundler that sent this UserOperation into the P2P mempool.
+A peer bundler with critically low reputation will eventually be marked as a malicious **spammer** peer.
+
+A **local rule** is a rule enforced according to each bundler's own local state. This state may differ between bundlers, so different bundlers may not always agree on whether such a rule was violated.
+Thus, the bundler that sent the violating UserOperation should not suffer P2P reputation damage from its peers.
+Local rules are called out explicitly in the [Local Rules](#local-rules) section below; every other rule in this document is a network-wide rule.
 
 ### Constants
 
@@ -65,8 +75,6 @@ A violation of any validation rule by a UserOperation results in the UserOperati
 | `MAX_BUNDLE_SIZE`                    | 262144                      | Maximum size of an ABI-encoded bundle call to the `handleOps` function in bytes                                         |
 | `MAX_BUNDLE_CONTEXT_SIZE`            | 65536                       | Maximum total size of all `context` byte arrays returned by all paymasters in all `UserOperations` in a bundle in bytes |
 | `VALIDATION_GAS_SLACK`               | 4000                        | An amount of gas that must be added to the estimations of `verificationGasLimit` and `paymasterVerificationGasLimit`    |
-
-`PRE_VERIFICATION_OVERHEAD_GAS` and `MAX_VERIFICATION_GAS` are informational constants bundlers may use to estimate a `UserOperation`'s gas usage; they are not enforced by any rule in this document.
 
 ### Validation Rules
 
@@ -327,6 +335,8 @@ In order to prevent hitting the memory expansion limitations (imposed by the Eth
 * **[LIM-030]** The `verificationGasLimit` and `paymasterVerificationGasLimit` parameters MUST exceed the actual usage during validation of the `UserOperation` by `VALIDATION_GAS_SLACK`.
 * **[LIM-040]** Maximum size of an ABI-encoded bundle call to the `handleOps` function in bytes SHOULD not exceed `MAX_BUNDLE_SIZE`.
 * **[LIM-050]** Maximum total size of all `context` byte arrays returned by all paymasters in all `UserOperations` in a bundle in bytes SHOULD not exceed `MAX_BUNDLE_CONTEXT_SIZE`.
+* **[LIM-060]** The `verificationGasLimit` and `paymasterVerificationGasLimit` parameters MUST each be lower than `MAX_VERIFICATION_GAS`.
+* **[LIM-070]** The `preVerificationGas` parameter MUST be high enough to cover the calldata gas cost of serializing the `UserOperation`, plus `PRE_VERIFICATION_OVERHEAD_GAS`.
 
 ## Rationale
 


### PR DESCRIPTION
## Summary
- Line-by-line editorial pass over ERC-7562's prose: grammar, punctuation, and terminology consistency (P2P/Sybil/UserOperations casing, "2nd" -> "second", contractions, hyphenation, etc.)
- Fixes a handful of outright typos: `incrementNonce())` extra paren, "opsSeen valid" -> "opsSeen value" (x2), "clear test" -> "clear text", `opsInclude` -> `opsIncluded`, `OP-13` -> `OP-013` (matching the zero-padded ID convention), and a Definitions list that mis-numbered items 3-8 as "2."
- No rule IDs, constants, formulas, or normative meaning were changed - this is text quality only.
- Two new rules (`LIM-060`, `LIM-070`) to assign real enforceable meaning to previously implicit `MAX_VERIFICATION_GAS` and `PRE_VERIFICATION_OVERHEAD_GAS` limits
