### PR TITLE
Update ERC-7573: Feature/erc 7573 async incept transfer

### DIFF
--- a/ERCS/erc-7573.md
+++ b/ERCS/erc-7573.md
@@ -21,6 +21,7 @@ chain (e.g., the payment) conditional to the successful transfer of another toke
 
 The scheme is realized by two smart contracts, one on each chain.
 One smart contract implements the `ILockingContract` interface on one chain (e.g. the "asset chain"), and another smart contract implements the `IDecryptionContract` interface on the other chain (e.g., the "payment chain").
+An implementation that generates the encrypted keys asynchronously may additionally implement `IDecryptionContractWithKeyGeneration`.
 The smart contract implementing `ILockingContract` locks a token (e.g., the asset) on its chain until a key is presented to encrypt to one of two given values.
 The smart contract implementing `IDecryptionContract`, decrypts one of two keys (via the decryption oracle) conditional to the success or failure of the token transfer (e.g., the payment). A stateless decryption oracle is attached to the chain running `IDecryptionContract` for the decryption.
 
@@ -54,7 +55,7 @@ Here, we propose a protocol that facilitates secure delivery-versus-payment with
 
 The following methods specify the functionality of the smart contract implementing
 the locking. For further information, please also look at the interface
-documentation [`ILockingContract.sol`](../assets/eip-7573/contracts/ILockingContract.sol).
+documentation [`ILockingContract.sol`](../assets/erc-7573/contracts/ILockingContract.sol).
 
 ##### Initiation of Transfer: `inceptTransfer`
 
@@ -120,46 +121,78 @@ interface ILockingContract {
 
 The following methods specify the functionality of the smart contract implementing
 the conditional decryption. For further information, please also look at the interface
-documentation [`IDecryptionContract.sol`](../assets/eip-7573/contracts/IDecryptionContract.sol).
+documentation [`IDecryptionContract.sol`](../assets/erc-7573/contracts/IDecryptionContract.sol).
 
 ##### Initiation of Transfer: `inceptTransfer`
 
 ```solidity
-function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
+function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external returns (bytes32 commitmentHash);
 ```
 
 Called from the receiver of the amount to initiate payment transfer. Emits a `TransferIncepted`.
 The parameter `id` is an identifier of the trade. The parameter `from` is the address of the sender of the payment (the address of the receiver is `msg.sender`).
 The parameter `keyEncryptedSuccess` is an encryption of a key and will be decrypted if the transfer is successful in a call to `transferAndDecrypt`.
 The parameter `keyEncryptedFailure` is an encryption of a key and will be decrypted if the transfer fails in a call to `transferAndDecrypt` or if `cancelAndDecrypt` is successful.
+The return value `commitmentHash` is an inception-call commitment and is required to transfer or cancel it.
+
+For both inception overloads, the commitment MUST be calculated from the canonical ABI encoding:
+
+```text
+syncArguments  = abi.encode(id, amount, from, keyEncryptedSuccess, keyEncryptedFailure)
+asyncArguments = abi.encode(id, amount, from, transaction)
+commitmentHash = keccak256(abi.encode(address(this), inceptionCaller, selector, arguments))
+```
+
+Here, `arguments` is the applicable argument encoding, `inceptionCaller` is `msg.sender`, and `selector` is the canonical selector of the applicable `inceptTransfer` overload.
+The commitment therefore binds the decryption contract, inception caller (the receiver), selected overload, and all decoded arguments.
+Non-canonical encodings or trailing calldata are not part of the commitment.
+The contract MUST store the commitment with the inception and compare the supplied value in `transferAndDecrypt` and `cancelAndDecrypt`.
+It MUST reject any later inception that would reuse the same commitment.
+The `id` MUST be unique for the lifetime of the decryption contract, so oracle requests and callbacks that carry only `id` remain unambiguous.
+Returning the commitment supports contract-to-contract calls; off-chain callers can calculate the same value from the call data without listening for an event.
+
+##### Asynchronous Initiation of Transfer: `inceptTransfer`
+
+The optional `IDecryptionContractWithKeyGeneration` interface extends `IDecryptionContract` with an overload that does not require keys to exist at inception:
+
+```solidity
+function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 commitmentHash);
+```
+
+The parameter `transaction` is the transaction specification used for asynchronous generation of the encrypted success and failure keys.
+This call stores a pending inception and returns its `commitmentHash` immediately.
+Because the keys do not exist when the call returns, this commitment binds the `transaction` argument but not the generated keys.
+The generated keys MUST be validated and stored atomically with the pending inception and MUST NOT be replaceable afterwards.
+The contract MUST emit `TransferIncepted` only after both keys have been stored.
+Calls to `transferAndDecrypt` and `cancelAndDecrypt` for a pending inception MUST revert until then.
+The key-generation mechanism is outside the scope of this interface.
 
 ##### Transfer: `transferAndDecrypt`
 
 ```solidity
-function transferAndDecrypt(uint256 id, int amount, address to, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
+function transferAndDecrypt(uint256 id, bytes32 commitmentHash) external;
 ```
 
 Called from the sender of the amount to initiate completion of the payment transfer. Emits a `TransferKeyRequested` with keys depending on completion success.
-The parameter `id` is an identifier of the trade. The parameter `to` is the address of the receiver of the payment (the sender of the payment (from) is implicitly the `msg.sender`).
-The parameter `keyEncryptedSuccess` is an encryption of the key and will be decrypted if the transfer is successful.
-The parameter `keyEncryptedFailure` is an encryption of the key and will be decrypted if the transfer fails.
+The parameter `id` is an identifier of the trade.
+The parameter `commitmentHash` is the hash returned by the matching call to `inceptTransfer`.
 
-The method will not decrypt any key and not perform a transfer of a payment if the values (`id`, `amount`, `from` `to`, `keyEncryptedSuccess`, `keyEncryptedFailure`)
-do not match a previous call to `inceptTransfer`.
+The method loads the amount, receiver, and encrypted keys from the stored inception.
+It will not decrypt any key or perform a payment transfer if `id`, `commitmentHash`, or the caller do not match that inception.
 
 ##### Cancelation of Transfer: `cancelAndDecrypt`
 
 ```solidity
-function cancelAndDecrypt(uint256 id, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
+function cancelAndDecrypt(uint256 id, bytes32 commitmentHash) external;
 ```
 
 Called from the receiver of the amount to cancel payment transfer (cancels the incept transfer).
 
 The method must be called from the caller of a previous call to `inceptTransfer`
-with the exact same arguments and cancels this specific transfer.
+with the returned `commitmentHash` and cancels this specific transfer.
 If these preconditions are met and a valid call to `transferAndDecrypt` has not been issued before,
-i.e. if `keyEncryptedSuccess` has not been issued in a `TransferKeyRequested` event,
-then this method emits a `TransferKeyRequested` with the key `keyEncryptedFailure`.
+i.e. if the stored success key has not been issued in a `TransferKeyRequested` event,
+then this method emits a `TransferKeyRequested` with the stored failure key.
 
 ##### Release of ILockingContract Access Key: `releaseKey`
 
@@ -178,13 +211,23 @@ The interface `IDecryptionContract`:
 ```solidity
 interface IDecryptionContract {
     event TransferIncepted(uint256 id, int amount, address from, address to, bytes keyEncryptedSuccess, bytes keyEncryptedFailure);
+    event TransferConfirmed(uint256 id, int amount, address from, address to, bytes keyEncryptedSuccess, bytes keyEncryptedFailure);
     event TransferKeyRequested(address sender, uint256 id, bytes encryptedKey);
     event TransferKeyReleased(address sender, uint256 id, bool success, bytes key);
 
-    function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
-    function transferAndDecrypt(uint256 id, int amount, address to, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
-    function cancelAndDecrypt(uint256 id, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
+    function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external returns (bytes32 commitmentHash);
+    function confirmTransfer(uint256 id, int amount, address to, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
+    function transferAndDecrypt(uint256 id, bytes32 commitmentHash) external;
+    function cancelAndDecrypt(uint256 id, bytes32 commitmentHash) external;
     function releaseKey(uint256 id, bytes memory key) external;
+}
+```
+
+The optional key-generation extension:
+
+```solidity
+interface IDecryptionContractWithKeyGeneration is IDecryptionContract {
+    function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 commitmentHash);
 }
 ```
 
@@ -201,6 +244,49 @@ The general flow is:
 2. The oracle proxy emits a request event containing a `requestId` (correlation id).
 3. The off-chain oracle observes the request event, performs decryption or verification off-chain, and calls `fulfill*` on the proxy.
 4. The oracle proxy calls the consumer callback `on*` with the fulfillment payload.
+
+#### Batch key generation
+
+Key generation is batch-oriented. The consumer calls
+`requestGenerateEncryptedHashedKeys` with a non-empty array of distinct `keyIds`.
+Each `keyId` identifies the semantic role of one generated key; a request for a single key
+uses a one-element array, so no separate singular method is required.
+
+```solidity
+struct EncryptedHashedKey {
+    bytes32 keyId;
+    bytes encryptedKey;
+    bytes hashedKey;
+}
+
+function requestGenerateEncryptedHashedKeys(
+    uint256 id,
+    IKeyDecryptionOracleCallback callback,
+    address receiverContract,
+    bytes calldata transaction,
+    bytes32[] calldata keyIds
+) external payable;
+
+function fulfillEncryptedHashedKeysGeneration(
+    uint256 requestId,
+    IKeyDecryptionOracleCallback.EncryptedHashedKey[] calldata keys,
+    address receiverContract,
+    bytes calldata transaction
+) external;
+
+function onEncryptedHashedKeysGenerated(
+    uint256 id,
+    EncryptedHashedKey[] calldata keys,
+    address receiverContract,
+    bytes calldata transaction
+) external;
+```
+
+The fulfillment MUST contain exactly one result for every requested `keyId`: duplicate,
+missing, or unrequested identifiers MUST be rejected. Array ordering has no semantic
+meaning. The oracle proxy MUST also verify that `receiverContract` and `transaction`
+match the request before invoking `onEncryptedHashedKeysGenerated` once with the complete
+batch. It MUST NOT deliver a partial batch.
 
 #### Callback execution semantics: strict vs best-effort
 
@@ -274,12 +360,14 @@ encrypted key *E(K)* (`keyEncrypted`) without exposing the key *K* (``key`), cf.
 The interplay of the two smart contracts is summarized
 in the following sequence diagram:
 
-![sequence diagram dvp](../assets/eip-7573/doc/DvP-Seq-Diag.png)
+![sequence diagram dvp](../assets/erc-7573/doc/DvP-Seq-Diag.png)
+
+The method declarations above are normative; the diagram illustrates the protocol flow and predates the commitment-based method signatures.
 
 ## Rationale
 
 The protocol tries to be parsimonious. The transfer
-is associated with a (preferably unique) `id` possibly
+is associated with an `id` that MUST be unique for the lifetime of the decryption contract, possibly
 generated by some additional interaction of the trading
 parties.
 
@@ -330,7 +418,7 @@ A corresponding XML sample is shown below.
 
 #### Locking is a Feature
 
-In Delivery-versus-Payment (DvP) protocols like [ERC-7573](./eip-7573.md), at least one token must be locked to ensure atomicity, even if only for a short period during the transaction.
+In Delivery-versus-Payment (DvP) protocols like [ERC-7573](./erc-7573.md), at least one token must be locked to ensure atomicity, even if only for a short period during the transaction.
 
 While locking may appear as an inconvenient necessity, it is in fact a feature that becomes valuable in the construction of conditional trades or multi-party DvPs.
 
@@ -342,30 +430,30 @@ While for a two-party DvP with two tokens only one token requires locking—and 
 
 This highlights that locking is not just a constraint, but a required feature to enable advanced and economically meaningful protocols.
 
-#### N-DvP with [ERC-7573](./eip-7573.md)
+#### N-DvP with [ERC-7573](./erc-7573.md)
 
-A multi-party DvP can be created elegantly by combining multiple (*n-1*) two-party DvPs, for example based on the [ERC-7573](./eip-7573.md) protocol.
+A multi-party DvP can be created elegantly by combining multiple (*n-1*) two-party DvPs, for example based on the [ERC-7573](./erc-7573.md) protocol.
 
-The procedure is simple: instead of finalizing the respective two-party DvP by a call to `transferAndDecrypt`, the two-party DvP is first confirmed with a call to `confirm`, leaving the finalization open.
+The procedure is simple: instead of finalizing the respective two-party DvP by a call to `transferAndDecrypt`, the two-party DvP is first confirmed with a call to `confirmTransfer`, leaving the finalization open.
 
-At any time, any party can call `cancelAndDecrypt` to release the failure key and revert all lockings.
+At any time before finalization, the original inception caller can call `cancelAndDecrypt` with the matching commitment to release the failure key and revert all lockings.
 
 Once all parties are linked with their respective two-party DvPs, a single call to `transferAndDecrypt` performs locking of the token implementing the `IDecryptionContract` and releases either the success key on success or the failure key on failure.
 
 ##### Initiation and Finalization
 
-The counterparty that initiates the multi-party DvP by making the first call
-to the `IDecryptionContract` is the one that is allowed to finalize it via `transferAndDecrypt`, the other may cancel via `cancelAndDecrypt`.
+The payment sender that confirms the transfer is allowed to finalize it via `transferAndDecrypt`;
+the original inception caller may cancel it via `cancelAndDecrypt`.
 
 ##### Sequence Diagram
 
-Below we depict the corresponding sequence diagram of a multi-party DvP via [ERC-7573](./eip-7573.md).
+Below we depict the corresponding sequence diagram of a multi-party DvP via [ERC-7573](./erc-7573.md).
 Note that the individual DvP may come in two different flavors depending on which counterparty is the receiver of the token on the `IDecryptionContract`.
 
 The diagram depicts a multi-party dvp with n+1 counterparties trading n+1 tokens out of which
 the DvPs are bound by the contract on token 0.
 
-![sequence diagram multi party dvp](../assets/eip-7573/doc/multi-party-dvp.svg)
+![sequence diagram multi party dvp](../assets/erc-7573/doc/multi-party-dvp.svg)
 
 *Note: The more general case of N counterparties trading
 M tokens is just a special case where we enumerate all combination as new counterparties and new tokens.*
@@ -376,7 +464,7 @@ The decryption oracle does not need to be a single trusted entity. Instead, a th
 
 In such cases, each participating decryption oracle will observe the decryption request from an emitted `TransferKeyRequested` event, and subsequently call the `releaseKey` method with a partial decryption result. The following sequence diagram illustrates this.
 
-![sequence diagram distributed oracle](../assets/eip-7573/doc/Distributed-Oracle.png)
+![sequence diagram distributed oracle](../assets/erc-7573/doc/Distributed-Oracle.png)
 
 See [^2] for details.
 

--- a/ERCS/erc-7573.md
+++ b/ERCS/erc-7573.md
@@ -22,6 +22,7 @@ chain (e.g., the payment) conditional to the successful transfer of another toke
 The scheme is realized by two smart contracts, one on each chain.
 One smart contract implements the `ILockingContract` interface on one chain (e.g. the "asset chain"), and another smart contract implements the `IDecryptionContract` interface on the other chain (e.g., the "payment chain").
 An implementation that generates the encrypted keys asynchronously may additionally implement `IDecryptionContractWithKeyGeneration`.
+An on-chain consumer may implement `IDecryptionContractInceptionCallback` to receive both hashes when that asynchronous inception completes.
 The smart contract implementing `ILockingContract` locks a token (e.g., the asset) on its chain until a key is presented to encrypt to one of two given values.
 The smart contract implementing `IDecryptionContract`, decrypts one of two keys (via the decryption oracle) conditional to the success or failure of the token transfer (e.g., the payment). A stateless decryption oracle is attached to the chain running `IDecryptionContract` for the decryption.
 
@@ -126,70 +127,125 @@ documentation [`IDecryptionContract.sol`](../assets/erc-7573/contracts/IDecrypti
 ##### Initiation of Transfer: `inceptTransfer`
 
 ```solidity
-function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external returns (bytes32 commitmentHash);
+function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external returns (bytes32 inceptionHash);
 ```
 
 Called from the receiver of the amount to initiate payment transfer. Emits a `TransferIncepted`.
 The parameter `id` is an identifier of the trade. The parameter `from` is the address of the sender of the payment (the address of the receiver is `msg.sender`).
 The parameter `keyEncryptedSuccess` is an encryption of a key and will be decrypted if the transfer is successful in a call to `transferAndDecrypt`.
 The parameter `keyEncryptedFailure` is an encryption of a key and will be decrypted if the transfer fails in a call to `transferAndDecrypt` or if `cancelAndDecrypt` is successful.
-The return value `commitmentHash` is an inception-call commitment and is required to transfer or cancel it.
+The return value `inceptionHash` is the hash of the canonical inception call. It is used to derive `confirmationHash` and to identify the exact inception on cancellation.
 
-For both inception overloads, the commitment MUST be calculated from the canonical ABI encoding:
+For every inception overload, the inception hash MUST be calculated from the canonical ABI encoding:
 
 ```text
-syncArguments  = abi.encode(id, amount, from, keyEncryptedSuccess, keyEncryptedFailure)
-asyncArguments = abi.encode(id, amount, from, transaction)
-commitmentHash = keccak256(abi.encode(address(this), inceptionCaller, selector, arguments))
+syncArguments          = abi.encode(id, amount, from, keyEncryptedSuccess, keyEncryptedFailure)
+asyncArguments         = abi.encode(id, amount, from, transaction)
+asyncCallbackArguments = abi.encode(id, amount, from, transaction, callback)
+inceptionHash          = keccak256(abi.encode(address(this), inceptionCaller, selector, arguments))
 ```
 
 Here, `arguments` is the applicable argument encoding, `inceptionCaller` is `msg.sender`, and `selector` is the canonical selector of the applicable `inceptTransfer` overload.
-The commitment therefore binds the decryption contract, inception caller (the receiver), selected overload, and all decoded arguments.
-Non-canonical encodings or trailing calldata are not part of the commitment.
-The contract MUST store the commitment with the inception and compare the supplied value in `transferAndDecrypt` and `cancelAndDecrypt`.
-It MUST reject any later inception that would reuse the same commitment.
-The `id` MUST be unique for the lifetime of the decryption contract, so oracle requests and callbacks that carry only `id` remain unambiguous.
-Returning the commitment supports contract-to-contract calls; off-chain callers can calculate the same value from the call data without listening for an event.
+The inception hash therefore binds the decryption contract, inception caller (the receiver), selected overload, and all decoded arguments.
+For the callback overload, this includes the immutable callback address.
+Non-canonical encodings or trailing calldata are not part of the inception hash.
+The contract MUST store it with the inception and MUST reject a later inception that would reuse it.
+
+Once the encrypted success and failure keys have both been validated, stored, and made immutable, the contract MUST derive and store:
+
+```text
+confirmationHash = keccak256(
+    abi.encode(inceptionHash, keyEncryptedSuccess, keyEncryptedFailure)
+)
+```
+
+The key order is normative: success first, failure second. Implementations receiving an unordered key batch MUST first select the keys by their semantic identifiers and MUST NOT use callback array position.
+For synchronous inception, both hashes can be calculated atomically.
+For asynchronous inception, `confirmationHash` is calculated only when key generation completes.
+The contract compares `confirmationHash` in `confirmTransfer` and `inceptionHash` in `cancelAndDecrypt`; no hash is supplied to `transferAndDecrypt`.
+
+The `id` identifies a DvP. All legs of one multi-party DvP MAY intentionally use the same `id`.
+An implementation MUST nevertheless identify every individual inception unambiguously using the participant context, for example `(from, id)` when at most one leg per payment sender is permitted.
+If repeated legs from one payment sender are supported, the implementation MUST use a more specific leg key.
+Oracle operations use their oracle-assigned `requestId` for callback correlation rather than requiring a contract-global, lifetime-unique DvP `id`.
+
+Returning `inceptionHash` supports contract-to-contract calls; off-chain callers can calculate it from the call data without listening for an event.
+After observing the immutable keys, a confirmer can calculate `confirmationHash` from the communicated `inceptionHash` and those keys; an implementation MAY additionally expose or emit the stored value.
 
 ##### Asynchronous Initiation of Transfer: `inceptTransfer`
 
-The optional `IDecryptionContractWithKeyGeneration` interface extends `IDecryptionContract` with an overload that does not require keys to exist at inception:
+The optional `IDecryptionContractWithKeyGeneration` interface extends `IDecryptionContract` with two overloads that do not require keys to exist at inception:
 
 ```solidity
-function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 commitmentHash);
+function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 inceptionHash);
+
+function inceptTransfer(
+    uint256 id,
+    int amount,
+    address from,
+    bytes memory transaction,
+    IDecryptionContractInceptionCallback callback
+) external returns (bytes32 inceptionHash);
 ```
 
 The parameter `transaction` is the transaction specification used for asynchronous generation of the encrypted success and failure keys.
-This call stores a pending inception and returns its `commitmentHash` immediately.
-Because the keys do not exist when the call returns, this commitment binds the `transaction` argument but not the generated keys.
+Both calls store a pending inception and return its `inceptionHash` immediately.
+Because the keys do not exist when the call returns, `inceptionHash` binds the `transaction` argument but not the generated keys.
+The callback overload additionally binds a nonzero callback contract and provides an on-chain completion trigger.
 The generated keys MUST be validated and stored atomically with the pending inception and MUST NOT be replaceable afterwards.
-The contract MUST emit `TransferIncepted` only after both keys have been stored.
-Calls to `transferAndDecrypt` and `cancelAndDecrypt` for a pending inception MUST revert until then.
+In the same state transition, the contract MUST select the success and failure keys by semantic role, derive and store `confirmationHash`, and complete the inception.
+The contract MUST emit `TransferIncepted` only after both keys and `confirmationHash` have been stored.
+
+For the callback overload, after storing the complete state and emitting `TransferIncepted`, the decryption contract MUST call:
+
+```solidity
+callback.onInceptionCompleted(id, inceptionHash, confirmationHash)
+```
+
+The callback MUST return `IDecryptionContractInceptionCallback.onInceptionCompleted.selector`.
+The completed state MUST already be observable so an authorized callback can directly call `confirmTransfer`.
+If the callback reverts, runs out of its bounded gas allowance, or returns any other value, the completion attempt MUST revert and leave the inception pending for the asynchronous fulfillment mechanism to retry.
+The no-callback overload remains available when event-based off-chain continuation is sufficient.
+No additional hash-ready event is required because `TransferIncepted` already signals that the keys and `confirmationHash` are final.
+
+Calls to `confirmTransfer`, `transferAndDecrypt`, and `cancelAndDecrypt` for a pending inception MUST revert until then.
 The key-generation mechanism is outside the scope of this interface.
+
+##### Confirmation of Transfer: `confirmTransfer`
+
+```solidity
+function confirmTransfer(uint256 id, bytes32 confirmationHash) external;
+```
+
+Called from the sender of the amount to confirm a completed payment inception. Emits a `TransferConfirmed` event containing the stored transfer values.
+The caller MUST be the stored payment sender (`from`), and the supplied `confirmationHash` MUST equal the hash stored for that caller's completed inception.
+The hash is an exact-state check, not an authorization capability; implementations MUST still validate the caller and lifecycle state.
+
+For a two-party DvP, a successful confirmation MAY directly invoke the internal finalization logic.
+For a multi-party DvP, the implementation MUST freeze the expected leg set and finalizer policy before accepting the first confirmation; confirmation then marks this payment leg as confirmed without finalizing the group.
+The first confirmer becomes the finalizer unless the implementation establishes the finalizer explicitly.
 
 ##### Transfer: `transferAndDecrypt`
 
 ```solidity
-function transferAndDecrypt(uint256 id, bytes32 commitmentHash) external;
+function transferAndDecrypt(uint256 id) external;
 ```
 
-Called from the sender of the amount to initiate completion of the payment transfer. Emits a `TransferKeyRequested` with keys depending on completion success.
-The parameter `id` is an identifier of the trade.
-The parameter `commitmentHash` is the hash returned by the matching call to `inceptTransfer`.
-
-The method loads the amount, receiver, and encrypted keys from the stored inception.
-It will not decrypt any key or perform a payment transfer if `id`, `commitmentHash`, or the caller do not match that inception.
+Called by the recorded finalizer to initiate completion of the confirmed payment transfer or multi-party DvP. Emits a `TransferKeyRequested` with the encrypted key selected by the completion result.
+The method loads the confirmed leg or group state and its immutable transfer values from storage.
+It MUST reject the call unless the caller is the recorded finalizer, every leg in the frozen expected set is confirmed, and neither execution nor cancellation has already been requested.
+No hash parameter is needed at finalization because every leg was bound to its stored completed state by `confirmTransfer`.
 
 ##### Cancelation of Transfer: `cancelAndDecrypt`
 
 ```solidity
-function cancelAndDecrypt(uint256 id, bytes32 commitmentHash) external;
+function cancelAndDecrypt(uint256 id, bytes32 inceptionHash) external;
 ```
 
 Called from the receiver of the amount to cancel payment transfer (cancels the incept transfer).
 
 The method must be called from the caller of a previous call to `inceptTransfer`
-with the returned `commitmentHash` and cancels this specific transfer.
+with the returned `inceptionHash` and cancels this specific transfer.
 If these preconditions are met and a valid call to `transferAndDecrypt` has not been issued before,
 i.e. if the stored success key has not been issued in a `TransferKeyRequested` event,
 then this method emits a `TransferKeyRequested` with the stored failure key.
@@ -215,10 +271,10 @@ interface IDecryptionContract {
     event TransferKeyRequested(address sender, uint256 id, bytes encryptedKey);
     event TransferKeyReleased(address sender, uint256 id, bool success, bytes key);
 
-    function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external returns (bytes32 commitmentHash);
-    function confirmTransfer(uint256 id, int amount, address to, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
-    function transferAndDecrypt(uint256 id, bytes32 commitmentHash) external;
-    function cancelAndDecrypt(uint256 id, bytes32 commitmentHash) external;
+    function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external returns (bytes32 inceptionHash);
+    function confirmTransfer(uint256 id, bytes32 confirmationHash) external;
+    function transferAndDecrypt(uint256 id) external;
+    function cancelAndDecrypt(uint256 id, bytes32 inceptionHash) external;
     function releaseKey(uint256 id, bytes memory key) external;
 }
 ```
@@ -226,8 +282,24 @@ interface IDecryptionContract {
 The optional key-generation extension:
 
 ```solidity
+interface IDecryptionContractInceptionCallback {
+    function onInceptionCompleted(
+        uint256 id,
+        bytes32 inceptionHash,
+        bytes32 confirmationHash
+    ) external returns (bytes4 acknowledgement);
+}
+
 interface IDecryptionContractWithKeyGeneration is IDecryptionContract {
-    function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 commitmentHash);
+    function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 inceptionHash);
+
+    function inceptTransfer(
+        uint256 id,
+        int amount,
+        address from,
+        bytes memory transaction,
+        IDecryptionContractInceptionCallback callback
+    ) external returns (bytes32 inceptionHash);
 }
 ```
 
@@ -240,10 +312,16 @@ This proposal additionally standardizes the on-chain interaction with external (
 
 The general flow is:
 
-1. The consumer calls `request*` on the oracle proxy contract (payable).
-2. The oracle proxy emits a request event containing a `requestId` (correlation id).
+1. The consumer calls `request*` on the oracle proxy contract (payable), receives the oracle-assigned `requestId`, and stores its operation context under `(oracleProxy, requestId)`.
+2. The oracle proxy emits a request event containing the same `requestId` and the consumer-supplied `id`.
 3. The off-chain oracle observes the request event, performs decryption or verification off-chain, and calls `fulfill*` on the proxy.
-4. The oracle proxy calls the consumer callback `on*` with the fulfillment payload.
+4. The oracle proxy calls the consumer callback `on*` with `requestId` and the fulfillment payload.
+
+The `requestId` MUST be unique within its oracle proxy. Request methods MUST return before attempting the corresponding callback so the consumer can store the returned identifier first.
+The consumer-supplied `id` remains event context and need not be globally unique.
+
+This changes the meaning, but not the ABI type, of the callback's first `uint256` argument.
+Existing callback implementations that interpret it as the consumer-supplied `id` MUST be migrated before use with a requestId-based oracle proxy; the unchanged function selector does not provide a version boundary.
 
 #### Batch key generation
 
@@ -265,7 +343,7 @@ function requestGenerateEncryptedHashedKeys(
     address receiverContract,
     bytes calldata transaction,
     bytes32[] calldata keyIds
-) external payable;
+) external payable returns (uint256 requestId);
 
 function fulfillEncryptedHashedKeysGeneration(
     uint256 requestId,
@@ -275,7 +353,7 @@ function fulfillEncryptedHashedKeysGeneration(
 ) external;
 
 function onEncryptedHashedKeysGenerated(
-    uint256 id,
+    uint256 requestId,
     EncryptedHashedKey[] calldata keys,
     address receiverContract,
     bytes calldata transaction
@@ -362,14 +440,16 @@ in the following sequence diagram:
 
 ![sequence diagram dvp](../assets/erc-7573/doc/DvP-Seq-Diag.png)
 
-The method declarations above are normative; the diagram illustrates the protocol flow and predates the commitment-based method signatures.
+The method declarations above are normative; the diagram illustrates the protocol flow and predates the two-hash scheme and requestId-based callback signatures.
 
 ## Rationale
 
-The protocol tries to be parsimonious. The transfer
-is associated with an `id` that MUST be unique for the lifetime of the decryption contract, possibly
-generated by some additional interaction of the trading
-parties.
+The protocol tries to be parsimonious. The `id` identifies the DvP and is shared by all
+inceptions belonging to the same multi-party DvP. Individual payment legs are identified
+by the DvP `id` together with their participant context. Implementations MUST reject
+overlapping live legs with the same internal leg key. Oracle requests use the separate,
+oracle-assigned `requestId` and therefore do not impose contract-global lifetime uniqueness
+on the DvP `id`.
 
 The `key` and the `encryptedKey` arguments are strings to
 allow the flexible use of different encryption schemes.
@@ -434,15 +514,22 @@ This highlights that locking is not just a constraint, but a required feature to
 
 A multi-party DvP can be created elegantly by combining multiple (*n-1*) two-party DvPs, for example based on the [ERC-7573](./erc-7573.md) protocol.
 
-The procedure is simple: instead of finalizing the respective two-party DvP by a call to `transferAndDecrypt`, the two-party DvP is first confirmed with a call to `confirmTransfer`, leaving the finalization open.
+The procedure is simple: every payment inception in the group uses the same DvP `id` but has its own `inceptionHash` and `confirmationHash`.
+Instead of finalizing the respective two-party DvP by a call to `transferAndDecrypt`, each completed payment leg is first confirmed with `confirmTransfer(id, confirmationHash)`, leaving group finalization open.
 
-At any time before finalization, the original inception caller can call `cancelAndDecrypt` with the matching commitment to release the failure key and revert all lockings.
+At any time before finalization, an original inception caller can call `cancelAndDecrypt` with that leg's matching `inceptionHash` to release the failure key and revert all lockings.
 
-Once all parties are linked with their respective two-party DvPs, a single call to `transferAndDecrypt` performs locking of the token implementing the `IDecryptionContract` and releases either the success key on success or the failure key on failure.
+Before accepting the first confirmation, the implementation MUST freeze the expected set of payment legs and the finalizer policy for the group.
+It MUST NOT add a leg after that point or treat merely all currently registered legs as a complete group.
+Every leg MUST be bound to the same group outcome: an implementation MAY use one shared success/failure key pair, or it MUST store and request the complete frozen set of per-leg outcome keys.
+
+Once every leg in the frozen set is confirmed, a single call to `transferAndDecrypt(id)` performs locking of the token implementing the `IDecryptionContract` and requests all success keys on success or all failure keys on failure.
 
 ##### Initiation and Finalization
 
-The payment sender that confirms the transfer is allowed to finalize it via `transferAndDecrypt`;
+The first payment sender that confirms a leg is allowed to finalize the group via `transferAndDecrypt`
+unless the frozen group definition records an explicit finalizer. If first confirmation determines the
+finalizer, implementations and callers MUST account for that intentionally transaction-order-dependent rule;
 the original inception caller may cancel it via `cancelAndDecrypt`.
 
 ##### Sequence Diagram
@@ -454,6 +541,8 @@ The diagram depicts a multi-party dvp with n+1 counterparties trading n+1 tokens
 the DvPs are bound by the contract on token 0.
 
 ![sequence diagram multi party dvp](../assets/erc-7573/doc/multi-party-dvp.svg)
+
+The method declarations and hash lifecycle above are normative. This historical diagram shows the transfer parameters instead of `confirmationHash` on the decryption-side confirmation.
 
 *Note: The more general case of N counterparties trading
 M tokens is just a special case where we enumerate all combination as new counterparties and new tokens.*
@@ -471,8 +560,12 @@ See [^2] for details.
 Additional considerations for the oracle proxy + callback pattern:
 
 - Callback implementations SHOULD restrict callers (e.g. `require(msg.sender == oracleProxy)`), otherwise any address could invoke `on*` directly.
+- Callback implementations MUST validate a pending `(oracleProxy, requestId)` of the expected operation kind and consume or mark it before applying callback effects.
+- Oracle proxies MUST make a request unavailable to concurrent or reentrant fulfillment before invoking its callback. A best-effort proxy MAY restore the request to pending after callback failure to permit retry.
 - Callback implementations SHOULD be cheap and should avoid unbounded loops or expensive state changes. If heavy work is required, prefer a pull/consume pattern initiated by the consumer.
 - Oracle proxy implementations SHOULD document whether they use strict or best-effort fulfillment semantics, and how retries are intended to be handled (oracle-operated retry vs consumer-operated recovery).
+
+For the optional asynchronous inception callback, implementations MUST store the completed inception before the external call, use a bounded gas allowance, validate the selector-valued acknowledgement, and rely on the asynchronous fulfillment retry path if delivery fails.
 
 ## Copyright
 

--- a/ERCS/erc-7573.md
+++ b/ERCS/erc-7573.md
@@ -3,7 +3,7 @@ eip: 7573
 title: Conditional-upon-Transfer-Decryption for DvP
 description: A Protocol for Secure Delivery-versus-Payment across two Blockchains
 author: Christian Fries (@cfries), Peter Kohl-Landgraf (@pekola)
-discussions-to: https://ethereum-magicians.org/t/erc-7573-conditional-upon-transfer-decryption-for-delivery-versus-payment/17232
+discussions-to: https://ethereum-magicians.org/t/eip-7573-conditional-upon-transfer-decryption-for-delivery-versus-payment/17232
 status: Draft
 type: Standards Track
 category: ERC
@@ -56,7 +56,7 @@ Here, we propose a protocol that facilitates secure delivery-versus-payment with
 
 The following methods specify the functionality of the smart contract implementing
 the locking. For further information, please also look at the interface
-documentation [`ILockingContract.sol`](../assets/erc-7573/contracts/ILockingContract.sol).
+documentation [`ILockingContract.sol`](../assets/eip-7573/contracts/ILockingContract.sol).
 
 ##### Initiation of Transfer: `inceptTransfer`
 
@@ -122,7 +122,7 @@ interface ILockingContract {
 
 The following methods specify the functionality of the smart contract implementing
 the conditional decryption. For further information, please also look at the interface
-documentation [`IDecryptionContract.sol`](../assets/erc-7573/contracts/IDecryptionContract.sol).
+documentation [`IDecryptionContract.sol`](../assets/eip-7573/contracts/IDecryptionContract.sol).
 
 ##### Initiation of Transfer: `inceptTransfer`
 
@@ -438,7 +438,7 @@ encrypted key *E(K)* (`keyEncrypted`) without exposing the key *K* (``key`), cf.
 The interplay of the two smart contracts is summarized
 in the following sequence diagram:
 
-![sequence diagram dvp](../assets/erc-7573/doc/DvP-Seq-Diag.png)
+![sequence diagram dvp](../assets/eip-7573/doc/DvP-Seq-Diag.png)
 
 The method declarations above are normative; the diagram illustrates the protocol flow and predates the two-hash scheme and requestId-based callback signatures.
 
@@ -498,7 +498,7 @@ A corresponding XML sample is shown below.
 
 #### Locking is a Feature
 
-In Delivery-versus-Payment (DvP) protocols like [ERC-7573](./erc-7573.md), at least one token must be locked to ensure atomicity, even if only for a short period during the transaction.
+In Delivery-versus-Payment (DvP) protocols like [ERC-7573](./eip-7573.md), at least one token must be locked to ensure atomicity, even if only for a short period during the transaction.
 
 While locking may appear as an inconvenient necessity, it is in fact a feature that becomes valuable in the construction of conditional trades or multi-party DvPs.
 
@@ -510,9 +510,9 @@ While for a two-party DvP with two tokens only one token requires locking—and 
 
 This highlights that locking is not just a constraint, but a required feature to enable advanced and economically meaningful protocols.
 
-#### N-DvP with [ERC-7573](./erc-7573.md)
+#### N-DvP with [ERC-7573](./eip-7573.md)
 
-A multi-party DvP can be created elegantly by combining multiple (*n-1*) two-party DvPs, for example based on the [ERC-7573](./erc-7573.md) protocol.
+A multi-party DvP can be created elegantly by combining multiple (*n-1*) two-party DvPs, for example based on the [ERC-7573](./eip-7573.md) protocol.
 
 The procedure is simple: every payment inception in the group uses the same DvP `id` but has its own `inceptionHash` and `confirmationHash`.
 Instead of finalizing the respective two-party DvP by a call to `transferAndDecrypt`, each completed payment leg is first confirmed with `confirmTransfer(id, confirmationHash)`, leaving group finalization open.
@@ -534,13 +534,13 @@ the original inception caller may cancel it via `cancelAndDecrypt`.
 
 ##### Sequence Diagram
 
-Below we depict the corresponding sequence diagram of a multi-party DvP via [ERC-7573](./erc-7573.md).
+Below we depict the corresponding sequence diagram of a multi-party DvP via [ERC-7573](./eip-7573.md).
 Note that the individual DvP may come in two different flavors depending on which counterparty is the receiver of the token on the `IDecryptionContract`.
 
 The diagram depicts a multi-party dvp with n+1 counterparties trading n+1 tokens out of which
 the DvPs are bound by the contract on token 0.
 
-![sequence diagram multi party dvp](../assets/erc-7573/doc/multi-party-dvp.svg)
+![sequence diagram multi party dvp](../assets/eip-7573/doc/multi-party-dvp.svg)
 
 The method declarations and hash lifecycle above are normative. This historical diagram shows the transfer parameters instead of `confirmationHash` on the decryption-side confirmation.
 
@@ -553,7 +553,7 @@ The decryption oracle does not need to be a single trusted entity. Instead, a th
 
 In such cases, each participating decryption oracle will observe the decryption request from an emitted `TransferKeyRequested` event, and subsequently call the `releaseKey` method with a partial decryption result. The following sequence diagram illustrates this.
 
-![sequence diagram distributed oracle](../assets/erc-7573/doc/Distributed-Oracle.png)
+![sequence diagram distributed oracle](../assets/eip-7573/doc/Distributed-Oracle.png)
 
 See [^2] for details.
 

--- a/assets/erc-7573/README.md
+++ b/assets/erc-7573/README.md
@@ -22,16 +22,16 @@ The smart contract implementing `IDecryptionContract`, decrypts one of two keys 
 - `contracts/IDecryptionContractWithKeyGeneration.sol` - Optional extension for asynchronous generation of the encrypted success and failure keys.
 - `contracts/IDecryptionContractInceptionCallback.sol` - Optional on-chain notification when asynchronous inception completes.
 
-All inception variants return an `inceptionHash` of the canonical inception call.
+Both decryption-contract inception variants return an `inceptionHash` of the canonical inception call.
 Once the encrypted success and failure keys are immutable, the decryption contract derives a
 `confirmationHash` from the inception hash and both keys. Confirmation supplies this
 second hash without repeating the transfer parameters. Finalization uses the confirmed DvP
 identifier, while cancellation retains the original `inceptionHash` as its exact-inception guard.
 
-The asynchronous extension offers a callback overload for contract-to-contract workflows.
+The asynchronous extension uses one `inceptTransfer` signature with an optional callback parameter.
 After storing the generated keys and `confirmationHash` and emitting `TransferIncepted`,
-the decryption contract passes both hashes to the registered callback. The original
-overload remains available for event-driven off-chain workflows.
+the decryption contract passes both hashes to a nonzero callback. Passing `address(0)`
+selects an event-driven off-chain workflow without callback delivery.
 
 #### Decryption Oracle
 

--- a/assets/erc-7573/README.md
+++ b/assets/erc-7573/README.md
@@ -20,13 +20,26 @@ The smart contract implementing `IDecryptionContract`, decrypts one of two keys 
 - `contracts/ILockingContract.sol` - Contract locking transfer with given encrypted keys or hashes.
 - `contracts/IDecryptionContract.sol` - Contract performing conditional upon transfer decryption (possibly based on an external oracle).
 - `contracts/IDecryptionContractWithKeyGeneration.sol` - Optional extension for asynchronous generation of the encrypted success and failure keys.
+- `contracts/IDecryptionContractInceptionCallback.sol` - Optional on-chain notification when asynchronous inception completes.
 
-Both inception variants return a commitment. Transfer and cancellation use this commitment to identify the stored inception without repeating its parameters.
+All inception variants return an `inceptionHash` of the canonical inception call.
+Once the encrypted success and failure keys are immutable, the decryption contract derives a
+`confirmationHash` from the inception hash and both keys. Confirmation supplies this
+second hash without repeating the transfer parameters. Finalization uses the confirmed DvP
+identifier, while cancellation retains the original `inceptionHash` as its exact-inception guard.
+
+The asynchronous extension offers a callback overload for contract-to-contract workflows.
+After storing the generated keys and `confirmationHash` and emitting `TransferIncepted`,
+the decryption contract passes both hashes to the registered callback. The original
+overload remains available for event-driven off-chain workflows.
 
 #### Decryption Oracle
 
 - `contracts/IKeyDecryptionOracle.sol` - Interface implemented by a decryption oracle proxy contract.
 - `contracts/IKeyDecryptionOracleCallback.sol` - Interface to be implemented by a callback receiving the decrypted key.
+
+Oracle request methods return a proxy-scoped `requestId`, and callbacks use that identifier.
+The caller-supplied DvP `id` remains request-event context and is not used to route callbacks.
 
 ### Documentation
 

--- a/assets/erc-7573/README.md
+++ b/assets/erc-7573/README.md
@@ -19,6 +19,9 @@ The smart contract implementing `IDecryptionContract`, decrypts one of two keys 
 
 - `contracts/ILockingContract.sol` - Contract locking transfer with given encrypted keys or hashes.
 - `contracts/IDecryptionContract.sol` - Contract performing conditional upon transfer decryption (possibly based on an external oracle).
+- `contracts/IDecryptionContractWithKeyGeneration.sol` - Optional extension for asynchronous generation of the encrypted success and failure keys.
+
+Both inception variants return a commitment. Transfer and cancellation use this commitment to identify the stored inception without repeating its parameters.
 
 #### Decryption Oracle
 
@@ -29,4 +32,3 @@ The smart contract implementing `IDecryptionContract`, decrypts one of two keys 
 
 - `doc/DvP-Seq-Diag.png` - Sequence diagram of the DvP
 - `doc/multi-party-dvp.svg` - Sequence diagram of a multi-party-dvp.
-

--- a/assets/erc-7573/contracts/IDecryptionContract.sol
+++ b/assets/erc-7573/contracts/IDecryptionContract.sol
@@ -72,45 +72,46 @@ interface IDecryptionContract {
 
     /**
      * @notice Called from the receiver of the amount to initiate payment transfer.
-     * @dev emits a {TransferIncepted}. The returned commitment MUST be stored
+     * @dev emits a {TransferIncepted}. The returned inception hash MUST be stored
      * with the inception and MUST NOT be reused for a later inception.
-     * @param id the unique trade identifier. It MUST NOT have been used for an earlier inception.
+     * @param id the DvP identifier. Multiple legs in one multi-party DvP MAY share it;
+     * each individual inception MUST remain unambiguous in its participant context.
      * @param amount the amount to be transferred.
      * @param from The address of the sender of the payment (the receiver ('to') is message.sender).
      * @param keyEncryptedSuccess Encryption of the key that is emitted upon success.
      * @param keyEncryptedFailure Encryption of the key that is emitted upon failure.
-     * @return commitmentHash The inception-call commitment.
+     * @return inceptionHash The hash of the canonical inception call.
      */
-    function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external returns (bytes32 commitmentHash);
+    function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external returns (bytes32 inceptionHash);
 
     /**
      * @notice Called by the sender of the amount to confirm the payment transfer.
-     * @dev emits a {TransferConfirmed}
+     * @dev The confirmation hash MUST be calculated as
+     * keccak256(abi.encode(inceptionHash, keyEncryptedSuccess, keyEncryptedFailure))
+     * after both encrypted keys have been validated and made immutable.
+     * Emits a {TransferConfirmed}.
      * @param id the trade identifier of the trade.
-     * @param amount the amount to be transferred.
-     * @param to The address of the receiver of the payment. Note: the sender of the payment (from) is implicitly the message.sender.
-     * @param keyEncryptedSuccess Encryption of the key that is emitted upon success.
-     * @param keyEncryptedFailure Encryption of the key that is emitted upon failure.
+     * @param confirmationHash The stored hash of the completed inception,
+     * including its encrypted success and failure keys.
      */
-    function confirmTransfer(uint256 id, int amount, address to, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
+    function confirmTransfer(uint256 id, bytes32 confirmationHash) external;
 
     /**
-     * @notice Called by the sender of (first) confirmTransfer initiate completion of the payment transfer(s).
-     *   Note: In case of a multi party DvP there may be multiple incept/confirm pays.
+     * @notice Called by the sender of the first confirmTransfer to initiate completion of the payment transfer(s).
+     *   Note: In case of a multi-party DvP there may be multiple incept/confirm pairs.
      *   In case of single DvP the previous confirmTransfer may directly call transferAndDecrypt.
      * @dev emits a {TransferKeyRequested} with keys depending on completion success.
      * @param id the trade identifier of the trade.
-     * @param commitmentHash The stored commitment returned by the matching inceptTransfer call.
      */
-    function transferAndDecrypt(uint256 id, bytes32 commitmentHash) external;
+    function transferAndDecrypt(uint256 id) external;
 
     /**
      * @notice Called from the receiver of the amount to cancel payment transfer (cancels the incept transfer).
      * @dev emits a {TransferKeyRequested}
      * @param id the trade identifier of the trade.
-     * @param commitmentHash The stored commitment returned by the matching inceptTransfer call.
+     * @param inceptionHash The stored hash returned by the matching inceptTransfer call.
      */
-    function cancelAndDecrypt(uint256 id, bytes32 commitmentHash) external;
+    function cancelAndDecrypt(uint256 id, bytes32 inceptionHash) external;
 
     /*+
      * @notice Called from the (possibly external) decryption oracle.

--- a/assets/erc-7573/contracts/IDecryptionContract.sol
+++ b/assets/erc-7573/contracts/IDecryptionContract.sol
@@ -72,14 +72,16 @@ interface IDecryptionContract {
 
     /**
      * @notice Called from the receiver of the amount to initiate payment transfer.
-     * @dev emits a {TransferIncepted}
-     * @param id the trade identifier of the trade.
+     * @dev emits a {TransferIncepted}. The returned commitment MUST be stored
+     * with the inception and MUST NOT be reused for a later inception.
+     * @param id the unique trade identifier. It MUST NOT have been used for an earlier inception.
      * @param amount the amount to be transferred.
      * @param from The address of the sender of the payment (the receiver ('to') is message.sender).
      * @param keyEncryptedSuccess Encryption of the key that is emitted upon success.
      * @param keyEncryptedFailure Encryption of the key that is emitted upon failure.
+     * @return commitmentHash The inception-call commitment.
      */
-    function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
+    function inceptTransfer(uint256 id, int amount, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external returns (bytes32 commitmentHash);
 
     /**
      * @notice Called by the sender of the amount to confirm the payment transfer.
@@ -98,18 +100,17 @@ interface IDecryptionContract {
      *   In case of single DvP the previous confirmTransfer may directly call transferAndDecrypt.
      * @dev emits a {TransferKeyRequested} with keys depending on completion success.
      * @param id the trade identifier of the trade.
+     * @param commitmentHash The stored commitment returned by the matching inceptTransfer call.
      */
-    function transferAndDecrypt(uint256 id) external;
+    function transferAndDecrypt(uint256 id, bytes32 commitmentHash) external;
 
     /**
      * @notice Called from the receiver of the amount to cancel payment transfer (cancels the incept transfer).
      * @dev emits a {TransferKeyRequested}
      * @param id the trade identifier of the trade.
-     * @param from The address of the sender of the payment. Note: the receiver of the payment (to) is implicitly the message.sender.
-     * @param keyEncryptedSuccess Encryption of the key that is emitted upon success.
-     * @param keyEncryptedFailure Encryption of the key that is emitted upon failure.
+     * @param commitmentHash The stored commitment returned by the matching inceptTransfer call.
      */
-    function cancelAndDecrypt(uint256 id, address from, bytes memory keyEncryptedSuccess, bytes memory keyEncryptedFailure) external;
+    function cancelAndDecrypt(uint256 id, bytes32 commitmentHash) external;
 
     /*+
      * @notice Called from the (possibly external) decryption oracle.

--- a/assets/erc-7573/contracts/IDecryptionContractInceptionCallback.sol
+++ b/assets/erc-7573/contracts/IDecryptionContractInceptionCallback.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity >=0.7.0;
+
+/**
+ * @title ERC-7573 asynchronous inception completion callback.
+ * @dev Optional callback implemented by a contract that must be notified when
+ * asynchronous key generation has completed an inception.
+ *
+ * Implementations MUST validate msg.sender as the expected decryption contract
+ * and MUST match inceptionHash to a pending local operation before applying
+ * effects. Returning the function selector acknowledges successful delivery.
+ */
+interface IDecryptionContractInceptionCallback {
+
+    /**
+     * @notice Called after the decryption contract has validated and stored both
+     * generated keys, derived confirmationHash, completed the inception,
+     * and emitted TransferIncepted.
+     * @param id The consumer-defined DvP identifier.
+     * @param inceptionHash The hash returned by the asynchronous
+     * inceptTransfer call.
+     * @param confirmationHash The hash of the completed inception
+     * and its immutable success and failure keys.
+     * @return acknowledgement MUST equal
+     * IDecryptionContractInceptionCallback.onInceptionCompleted.selector.
+     */
+    function onInceptionCompleted(
+        uint256 id,
+        bytes32 inceptionHash,
+        bytes32 confirmationHash
+    ) external returns (bytes4 acknowledgement);
+}

--- a/assets/erc-7573/contracts/IDecryptionContractWithKeyGeneration.sol
+++ b/assets/erc-7573/contracts/IDecryptionContractWithKeyGeneration.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity >=0.7.0;
+
+import "./IDecryptionContract.sol";
+
+/**
+ * @title ERC-7573 Decryption Contract with asynchronous key generation.
+ * @dev Extends IDecryptionContract with an inception method for transfers whose
+ * encrypted success and failure keys are generated asynchronously.
+ */
+interface IDecryptionContractWithKeyGeneration is IDecryptionContract {
+
+    /**
+     * @notice Called from the receiver of the amount to initiate payment transfer
+     * and asynchronous generation of the encrypted success and failure keys.
+     * @dev TransferIncepted is emitted only after both generated keys have been
+     * validated and stored. The returned commitment MUST be stored with the
+     * pending inception and MUST NOT be reused for a later inception.
+     * @param id the unique trade identifier. It MUST NOT have been used for an earlier inception.
+     * @param amount the amount to be transferred.
+     * @param from The address of the sender of the payment (the receiver ('to') is message.sender).
+     * @param transaction The transaction specification used to generate the keys.
+     * @return commitmentHash The inception-call commitment. It does not contain
+     * the keys generated after this call.
+     */
+    function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 commitmentHash);
+}

--- a/assets/erc-7573/contracts/IDecryptionContractWithKeyGeneration.sol
+++ b/assets/erc-7573/contracts/IDecryptionContractWithKeyGeneration.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.7.0;
 
 import "./IDecryptionContract.sol";
+import "./IDecryptionContractInceptionCallback.sol";
 
 /**
  * @title ERC-7573 Decryption Contract with asynchronous key generation.
@@ -14,14 +15,43 @@ interface IDecryptionContractWithKeyGeneration is IDecryptionContract {
      * @notice Called from the receiver of the amount to initiate payment transfer
      * and asynchronous generation of the encrypted success and failure keys.
      * @dev TransferIncepted is emitted only after both generated keys have been
-     * validated and stored. The returned commitment MUST be stored with the
-     * pending inception and MUST NOT be reused for a later inception.
-     * @param id the unique trade identifier. It MUST NOT have been used for an earlier inception.
+     * validated and stored and the confirmation hash defined by
+     * IDecryptionContract has been derived. The returned inception hash MUST be
+     * stored with the pending inception and MUST NOT be reused for a later inception.
+     * @param id the DvP identifier. Multiple legs in one multi-party DvP MAY share it;
+     * each individual inception MUST remain unambiguous in its participant context.
      * @param amount the amount to be transferred.
      * @param from The address of the sender of the payment (the receiver ('to') is message.sender).
      * @param transaction The transaction specification used to generate the keys.
-     * @return commitmentHash The inception-call commitment. It does not contain
+     * @return inceptionHash The hash of the canonical inception call. It does not contain
      * the keys generated after this call.
      */
-    function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 commitmentHash);
+    function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 inceptionHash);
+
+    /**
+     * @notice Called from the receiver of the amount to initiate payment transfer,
+     * asynchronous key generation, and an on-chain completion callback.
+     * @dev The callback is part of the canonical inception call and MUST be bound by
+     * inceptionHash. It MUST be nonzero. After the generated keys and
+     * confirmationHash have been stored, the inception has been completed,
+     * and TransferIncepted has been emitted, the implementation MUST call
+     * callback.onInceptionCompleted(id, inceptionHash, confirmationHash).
+     * The callback MUST acknowledge with its function selector. A revert, invalid
+     * return value, or insufficient callback gas MUST revert this completion attempt
+     * and leave the inception pending so that completion can be retried.
+     * @param id the DvP identifier. Multiple legs in one multi-party DvP MAY share it.
+     * @param amount the amount to be transferred.
+     * @param from The address of the sender of the payment (the receiver ('to') is message.sender).
+     * @param transaction The transaction specification used to generate the keys.
+     * @param callback The contract receiving the completed inception hashes.
+     * @return inceptionHash The hash of this canonical inception call,
+     * including callback. It does not contain the keys generated after this call.
+     */
+    function inceptTransfer(
+        uint256 id,
+        int amount,
+        address from,
+        bytes memory transaction,
+        IDecryptionContractInceptionCallback callback
+    ) external returns (bytes32 inceptionHash);
 }

--- a/assets/erc-7573/contracts/IDecryptionContractWithKeyGeneration.sol
+++ b/assets/erc-7573/contracts/IDecryptionContractWithKeyGeneration.sol
@@ -13,39 +13,31 @@ interface IDecryptionContractWithKeyGeneration is IDecryptionContract {
 
     /**
      * @notice Called from the receiver of the amount to initiate payment transfer
-     * and asynchronous generation of the encrypted success and failure keys.
+     * and asynchronous generation of the encrypted success and failure keys, with
+     * an optional on-chain completion callback.
      * @dev TransferIncepted is emitted only after both generated keys have been
      * validated and stored and the confirmation hash defined by
      * IDecryptionContract has been derived. The returned inception hash MUST be
      * stored with the pending inception and MUST NOT be reused for a later inception.
+     * The callback value is part of the canonical inception call and MUST always be
+     * bound by inceptionHash, including when it is address(0).
+     *
+     * If callback is address(0), the implementation MUST skip callback delivery.
+     * Otherwise, after the inception has been completed and
+     * TransferIncepted has been emitted, the implementation MUST call
+     * callback.onInceptionCompleted(id, inceptionHash, confirmationHash).
+     * The callback MUST acknowledge with its function selector. A revert, invalid
+     * return value, or insufficient callback gas MUST revert this completion attempt
+     * and leave the inception pending so that completion can be retried.
      * @param id the DvP identifier. Multiple legs in one multi-party DvP MAY share it;
      * each individual inception MUST remain unambiguous in its participant context.
      * @param amount the amount to be transferred.
      * @param from The address of the sender of the payment (the receiver ('to') is message.sender).
      * @param transaction The transaction specification used to generate the keys.
-     * @return inceptionHash The hash of the canonical inception call. It does not contain
-     * the keys generated after this call.
-     */
-    function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 inceptionHash);
-
-    /**
-     * @notice Called from the receiver of the amount to initiate payment transfer,
-     * asynchronous key generation, and an on-chain completion callback.
-     * @dev The callback is part of the canonical inception call and MUST be bound by
-     * inceptionHash. It MUST be nonzero. After the generated keys and
-     * confirmationHash have been stored, the inception has been completed,
-     * and TransferIncepted has been emitted, the implementation MUST call
-     * callback.onInceptionCompleted(id, inceptionHash, confirmationHash).
-     * The callback MUST acknowledge with its function selector. A revert, invalid
-     * return value, or insufficient callback gas MUST revert this completion attempt
-     * and leave the inception pending so that completion can be retried.
-     * @param id the DvP identifier. Multiple legs in one multi-party DvP MAY share it.
-     * @param amount the amount to be transferred.
-     * @param from The address of the sender of the payment (the receiver ('to') is message.sender).
-     * @param transaction The transaction specification used to generate the keys.
-     * @param callback The contract receiving the completed inception hashes.
+     * @param callback The contract receiving the completed inception hashes, or
+     * address(0) when no on-chain callback is required.
      * @return inceptionHash The hash of this canonical inception call,
-     * including callback. It does not contain the keys generated after this call.
+     * including the callback value. It does not contain the keys generated after this call.
      */
     function inceptTransfer(
         uint256 id,

--- a/assets/erc-7573/contracts/IKeyDecryptionOracle.sol
+++ b/assets/erc-7573/contracts/IKeyDecryptionOracle.sol
@@ -20,20 +20,22 @@ interface IKeyDecryptionOracle {
     /*------------------------------------------- EVENTS -------------------------------------------------------------*/
 
     /**
-     * @dev Emitted when a decryption is requested (issued by requestDecrypt).
+     * @dev Emitted when encrypted key generation is requested (issued by requestGenerateEncryptedHashedKeys).
      * @param sender The requester (msg.sender) that issued the request.
      * @param id General id (will be passed back to callback) - can be used by the requester as correlation id.
-     * @param encryptedKey Encryption of a key for which decryption is requested.
      * @param callback Callback contract to be invoked on fulfillment.
+     * @param receiverContract Contract that is eligible to request decryption.
      * @param transaction Transaction specification to be verified against the key.
+     * @param keyIds Unique semantic identifiers for the keys to generate.
      * @param requestId Correlation id for the fulfillment.
      */
-    event DecryptionRequested(
+    event EncryptedHashedKeysGenerationRequested(
         address indexed sender,
         uint256 id,
-        bytes encryptedKey,
         IKeyDecryptionOracleCallback indexed callback,
+        address receiverContract,
         bytes transaction,
+        bytes32[] keyIds,
         uint256 indexed requestId
     );
 
@@ -54,22 +56,20 @@ interface IKeyDecryptionOracle {
     );
 
     /**
-     * @dev Emitted when encrypted key generation is requested (issued by requestGenerateEncryptedHashedKeys).
+     * @dev Emitted when a decryption is requested (issued by requestDecrypt).
      * @param sender The requester (msg.sender) that issued the request.
      * @param id General id (will be passed back to callback) - can be used by the requester as correlation id.
+     * @param encryptedKey Encryption of a key for which decryption is requested.
      * @param callback Callback contract to be invoked on fulfillment.
-     * @param receiverContract Contract that is eligible to request decryption.
      * @param transaction Transaction specification to be verified against the key.
-     * @param keyIds Unique semantic identifiers for the keys to generate.
      * @param requestId Correlation id for the fulfillment.
      */
-    event EncryptedHashedKeysGenerationRequested(
+    event DecryptionRequested(
         address indexed sender,
         uint256 id,
+        bytes encryptedKey,
         IKeyDecryptionOracleCallback indexed callback,
-        address receiverContract,
         bytes transaction,
-        bytes32[] keyIds,
         uint256 indexed requestId
     );
 
@@ -102,22 +102,23 @@ interface IKeyDecryptionOracle {
     /*------------------------------------------- FUNCTIONALITY: REQUESTS --------------------------------------------*/
 
     /**
-     * @notice Performs a decryption of the given encryptedKey if and only if the caller is allowed to perform this request.
-     * The decrypted key is passed to the callback contract's onKeyReleased function, if and only if
-     * the callback and the given transaction argument validate against the specification given
-     * inside the decrypted key (see the specification of the key format).
+     * @notice Generates a batch of encrypted keys and hashes internally associated with the given
+     * contract (receiverContract) and transaction. The generated keys are passed to the callback contract.
      *
-     * @dev Emits a {DecryptionRequested} event.
+     * @dev Emits an {EncryptedHashedKeysGenerationRequested} event.
+     * Implementations MUST reject an empty `keyIds` array and duplicate identifiers.
      * @param id An id passed back to the callback function (consumerId).
-     * @param encryptedKey Encryption of a key.
      * @param callback The callback contract.
+     * @param receiverContract Contract that is eligible to receive the decryption.
      * @param transaction General purpose transaction identifier.
+     * @param keyIds Unique semantic identifiers for the keys to generate. A single-element batch is valid.
      */
-    function requestDecrypt(
+    function requestGenerateEncryptedHashedKeys(
         uint256 id,
-        bytes calldata encryptedKey,
         IKeyDecryptionOracleCallback callback,
-        bytes calldata transaction
+        address receiverContract,
+        bytes calldata transaction,
+        bytes32[] calldata keyIds
     ) external payable;
 
     /**
@@ -138,41 +139,44 @@ interface IKeyDecryptionOracle {
     ) external payable;
 
     /**
-     * @notice Generates a batch of encrypted keys and hashes internally associated with the given
-     * contract (receiverContract) and transaction. The generated keys are passed to the callback contract.
+     * @notice Performs a decryption of the given encryptedKey if and only if the caller is allowed to perform this request.
+     * The decrypted key is passed to the callback contract's onKeyReleased function, if and only if
+     * the callback and the given transaction argument validate against the specification given
+     * inside the decrypted key (see the specification of the key format).
      *
-     * @dev Emits an {EncryptedHashedKeysGenerationRequested} event.
-     * Implementations MUST reject an empty `keyIds` array and duplicate identifiers.
+     * @dev Emits a {DecryptionRequested} event.
      * @param id An id passed back to the callback function (consumerId).
+     * @param encryptedKey Encryption of a key.
      * @param callback The callback contract.
-     * @param receiverContract Contract that is eligible to receive the decryption.
      * @param transaction General purpose transaction identifier.
-     * @param keyIds Unique semantic identifiers for the keys to generate. A single-element batch is valid.
      */
-    function requestGenerateEncryptedHashedKeys(
+    function requestDecrypt(
         uint256 id,
+        bytes calldata encryptedKey,
         IKeyDecryptionOracleCallback callback,
-        address receiverContract,
-        bytes calldata transaction,
-        bytes32[] calldata keyIds
+        bytes calldata transaction
     ) external payable;
 
     /*------------------------------------------- FUNCTIONALITY: FULFILLMENT (should be guarded by onlyOracle) -------*/
 
     /**
-     * @dev Fulfillment of a decryption request (issued by requestDecrypt).
-     *
-     * Best-effort + calldata fallback:
-     * - Implementations MAY attempt to call the consumer callback and MAY NOT revert if the callback fails (incl. OOG).
-     *   In such cases the implementation SHOULD signal failure via {CallbackFailed} and allow the off-chain oracle to retry.
-     * - The fulfillment payload (e.g., `key`) is always present in the transaction calldata of this fulfill call.
-     *   Off-chain systems can use the emitted log's `transactionHash` to fetch and decode tx input calldata using this ABI.
-     * - Practical caveat: some RPC providers prune old transaction bodies; store decoded payload off-chain if needed.
+     * @dev Fulfillment of a key generation request (issued by requestGenerateEncryptedHashedKeys).
+     * Implementations MUST reject a receiver or transaction that differs from the request,
+     * and MUST reject duplicate, missing, or unrequested keyIds. Array order has no semantic
+     * meaning. A successful fulfillment MUST deliver the complete batch in one callback;
+     * partial callbacks are forbidden. Best-effort + calldata fallback: see fulfillDecryption.
      *
      * @param requestId Correlation id from the request event.
-     * @param key Decrypted key if admissible, otherwise empty bytes.
+     * @param keys Generated keys, identified by keyId.
+     * @param receiverContract Contract that is eligible to receive the decryption.
+     * @param transaction Transaction that is eligible to request decryption.
      */
-    function fulfillDecryption(uint256 requestId, bytes calldata key) external;
+    function fulfillEncryptedHashedKeysGeneration(
+        uint256 requestId,
+        IKeyDecryptionOracleCallback.EncryptedHashedKey[] calldata keys,
+        address receiverContract,
+        bytes calldata transaction
+    ) external;
 
     /**
      * @dev Fulfillment of a verification request (issued by requestVerifyEncryptedKey).
@@ -193,21 +197,20 @@ interface IKeyDecryptionOracle {
     ) external;
 
     /**
-     * @dev Fulfillment of a key generation request (issued by requestGenerateEncryptedHashedKeys).
-     * Implementations MUST reject a receiver or transaction that differs from the request,
-     * and MUST reject duplicate, missing, or unrequested keyIds. Array order has no semantic
-     * meaning. A successful fulfillment MUST deliver the complete batch in one callback;
-     * partial callbacks are forbidden. Best-effort + calldata fallback: see fulfillDecryption.
+     * @dev Fulfillment of a decryption request (issued by requestDecrypt).
+     *
+     * Best-effort + calldata fallback:
+     * - Implementations MAY attempt to call the consumer callback and MAY NOT revert if the callback fails (incl. OOG).
+     *   In such cases the implementation SHOULD signal failure via {CallbackFailed} and allow the off-chain oracle to retry.
+     * - The fulfillment payload (e.g., `key`) is always present in the transaction calldata of this fulfill call.
+     *   Off-chain systems can use the emitted log's `transactionHash` to fetch and decode tx input calldata using this ABI.
+     * - Practical caveat: some RPC providers prune old transaction bodies; store decoded payload off-chain if needed.
      *
      * @param requestId Correlation id from the request event.
-     * @param keys Generated keys, identified by keyId.
-     * @param receiverContract Contract that is eligible to receive the decryption.
-     * @param transaction Transaction that is eligible to request decryption.
+     * @param key Decrypted key if admissible, otherwise empty bytes.
      */
-    function fulfillEncryptedHashedKeysGeneration(
+    function fulfillDecryption(
         uint256 requestId,
-        IKeyDecryptionOracleCallback.EncryptedHashedKey[] calldata keys,
-        address receiverContract,
-        bytes calldata transaction
+        bytes calldata key
     ) external;
 }

--- a/assets/erc-7573/contracts/IKeyDecryptionOracle.sol
+++ b/assets/erc-7573/contracts/IKeyDecryptionOracle.sol
@@ -15,34 +15,40 @@ import "./IKeyDecryptionOracleCallback.sol";
  * Implementations MAY attempt the callback in a best-effort fashion and MUST NOT assume that
  * callback execution success is equivalent to tx success (`receipt.status == 1`).
  * Implementations SHOULD provide an explicit on-chain signal of callback outcome (e.g. CallbackSucceeded/CallbackFailed events).
+ *
+ * Request correlation:
+ * Each request method MUST allocate and return a requestId that is unique within the oracle proxy.
+ * The proxy MUST pass that requestId to the callback. The caller-supplied id is consumer context
+ * retained in the request event; it is not the callback correlation identifier.
+ * Request methods MUST return before attempting the corresponding callback.
+ * Before invoking a callback, the proxy MUST make that request unavailable to another fulfillment.
+ * A best-effort implementation MAY restore it to pending after a failed callback so it can be retried.
  */
 interface IKeyDecryptionOracle {
     /*------------------------------------------- EVENTS -------------------------------------------------------------*/
 
     /**
-     * @dev Emitted when encrypted key generation is requested (issued by requestGenerateEncryptedHashedKeys).
+     * @dev Emitted when a decryption is requested (issued by requestDecrypt).
      * @param sender The requester (msg.sender) that issued the request.
-     * @param id General id (will be passed back to callback) - can be used by the requester as correlation id.
+     * @param id Consumer-defined context emitted with the request.
+     * @param encryptedKey Encryption of a key for which decryption is requested.
      * @param callback Callback contract to be invoked on fulfillment.
-     * @param receiverContract Contract that is eligible to request decryption.
      * @param transaction Transaction specification to be verified against the key.
-     * @param keyIds Unique semantic identifiers for the keys to generate.
      * @param requestId Correlation id for the fulfillment.
      */
-    event EncryptedHashedKeysGenerationRequested(
+    event DecryptionRequested(
         address indexed sender,
         uint256 id,
+        bytes encryptedKey,
         IKeyDecryptionOracleCallback indexed callback,
-        address receiverContract,
         bytes transaction,
-        bytes32[] keyIds,
         uint256 indexed requestId
     );
 
     /**
      * @dev Emitted when a verification is requested (issued by requestVerifyEncryptedKey).
      * @param sender The requester (msg.sender) that issued the request.
-     * @param id General id (will be passed back to callback) - can be used by the requester as correlation id.
+     * @param id Consumer-defined context emitted with the request.
      * @param encryptedKey Encryption of a key for which verification is requested.
      * @param callback Receiver of the verification.
      * @param requestId Correlation id for the fulfillment.
@@ -56,20 +62,22 @@ interface IKeyDecryptionOracle {
     );
 
     /**
-     * @dev Emitted when a decryption is requested (issued by requestDecrypt).
+     * @dev Emitted when encrypted key generation is requested (issued by requestGenerateEncryptedHashedKeys).
      * @param sender The requester (msg.sender) that issued the request.
-     * @param id General id (will be passed back to callback) - can be used by the requester as correlation id.
-     * @param encryptedKey Encryption of a key for which decryption is requested.
+     * @param id Consumer-defined context emitted with the request.
      * @param callback Callback contract to be invoked on fulfillment.
+     * @param receiverContract Contract that is eligible to request decryption.
      * @param transaction Transaction specification to be verified against the key.
+     * @param keyIds Unique semantic identifiers for the keys to generate.
      * @param requestId Correlation id for the fulfillment.
      */
-    event DecryptionRequested(
+    event EncryptedHashedKeysGenerationRequested(
         address indexed sender,
         uint256 id,
-        bytes encryptedKey,
         IKeyDecryptionOracleCallback indexed callback,
+        address receiverContract,
         bytes transaction,
+        bytes32[] keyIds,
         uint256 indexed requestId
     );
 
@@ -102,24 +110,24 @@ interface IKeyDecryptionOracle {
     /*------------------------------------------- FUNCTIONALITY: REQUESTS --------------------------------------------*/
 
     /**
-     * @notice Generates a batch of encrypted keys and hashes internally associated with the given
-     * contract (receiverContract) and transaction. The generated keys are passed to the callback contract.
+     * @notice Performs a decryption of the given encryptedKey if and only if the caller is allowed to perform this request.
+     * The decrypted key is passed to the callback contract's onKeyReleased function, if and only if
+     * the callback and the given transaction argument validate against the specification given
+     * inside the decrypted key (see the specification of the key format).
      *
-     * @dev Emits an {EncryptedHashedKeysGenerationRequested} event.
-     * Implementations MUST reject an empty `keyIds` array and duplicate identifiers.
-     * @param id An id passed back to the callback function (consumerId).
+     * @dev Emits a {DecryptionRequested} event.
+     * @param id Consumer-defined context emitted with the request.
+     * @param encryptedKey Encryption of a key.
      * @param callback The callback contract.
-     * @param receiverContract Contract that is eligible to receive the decryption.
      * @param transaction General purpose transaction identifier.
-     * @param keyIds Unique semantic identifiers for the keys to generate. A single-element batch is valid.
+     * @return requestId Oracle-assigned correlation identifier passed to the callback.
      */
-    function requestGenerateEncryptedHashedKeys(
+    function requestDecrypt(
         uint256 id,
+        bytes calldata encryptedKey,
         IKeyDecryptionOracleCallback callback,
-        address receiverContract,
-        bytes calldata transaction,
-        bytes32[] calldata keyIds
-    ) external payable;
+        bytes calldata transaction
+    ) external payable returns (uint256 requestId);
 
     /**
      * @notice Performs a verification of the given encryptedKey:
@@ -128,55 +136,54 @@ interface IKeyDecryptionOracle {
      * without exposing the decrypted key.
      *
      * @dev Emits a {VerificationRequested} event.
-     * @param id An id passed back to the callback function (consumerId).
+     * @param id Consumer-defined context emitted with the request.
      * @param encryptedKey Encryption of a key.
      * @param callback The callback contract.
+     * @return requestId Oracle-assigned correlation identifier passed to the callback.
      */
     function requestVerifyEncryptedKey(
         uint256 id,
         bytes calldata encryptedKey,
         IKeyDecryptionOracleCallback callback
-    ) external payable;
+    ) external payable returns (uint256 requestId);
 
     /**
-     * @notice Performs a decryption of the given encryptedKey if and only if the caller is allowed to perform this request.
-     * The decrypted key is passed to the callback contract's onKeyReleased function, if and only if
-     * the callback and the given transaction argument validate against the specification given
-     * inside the decrypted key (see the specification of the key format).
+     * @notice Generates a batch of encrypted keys and hashes internally associated with the given
+     * contract (receiverContract) and transaction. The generated keys are passed to the callback contract.
      *
-     * @dev Emits a {DecryptionRequested} event.
-     * @param id An id passed back to the callback function (consumerId).
-     * @param encryptedKey Encryption of a key.
+     * @dev Emits an {EncryptedHashedKeysGenerationRequested} event.
+     * Implementations MUST reject an empty `keyIds` array and duplicate identifiers.
+     * @param id Consumer-defined context emitted with the request.
      * @param callback The callback contract.
+     * @param receiverContract Contract that is eligible to receive the decryption.
      * @param transaction General purpose transaction identifier.
+     * @param keyIds Unique semantic identifiers for the keys to generate. A single-element batch is valid.
+     * @return requestId Oracle-assigned correlation identifier passed to the callback.
      */
-    function requestDecrypt(
+    function requestGenerateEncryptedHashedKeys(
         uint256 id,
-        bytes calldata encryptedKey,
         IKeyDecryptionOracleCallback callback,
-        bytes calldata transaction
-    ) external payable;
+        address receiverContract,
+        bytes calldata transaction,
+        bytes32[] calldata keyIds
+    ) external payable returns (uint256 requestId);
 
     /*------------------------------------------- FUNCTIONALITY: FULFILLMENT (should be guarded by onlyOracle) -------*/
 
     /**
-     * @dev Fulfillment of a key generation request (issued by requestGenerateEncryptedHashedKeys).
-     * Implementations MUST reject a receiver or transaction that differs from the request,
-     * and MUST reject duplicate, missing, or unrequested keyIds. Array order has no semantic
-     * meaning. A successful fulfillment MUST deliver the complete batch in one callback;
-     * partial callbacks are forbidden. Best-effort + calldata fallback: see fulfillDecryption.
+     * @dev Fulfillment of a decryption request (issued by requestDecrypt).
+     *
+     * Best-effort + calldata fallback:
+     * - Implementations MAY attempt to call the consumer callback and MAY NOT revert if the callback fails (incl. OOG).
+     *   In such cases the implementation SHOULD signal failure via {CallbackFailed} and allow the off-chain oracle to retry.
+     * - The fulfillment payload (e.g., `key`) is always present in the transaction calldata of this fulfill call.
+     *   Off-chain systems can use the emitted log's `transactionHash` to fetch and decode tx input calldata using this ABI.
+     * - Practical caveat: some RPC providers prune old transaction bodies; store decoded payload off-chain if needed.
      *
      * @param requestId Correlation id from the request event.
-     * @param keys Generated keys, identified by keyId.
-     * @param receiverContract Contract that is eligible to receive the decryption.
-     * @param transaction Transaction that is eligible to request decryption.
+     * @param key Decrypted key if admissible, otherwise empty bytes.
      */
-    function fulfillEncryptedHashedKeysGeneration(
-        uint256 requestId,
-        IKeyDecryptionOracleCallback.EncryptedHashedKey[] calldata keys,
-        address receiverContract,
-        bytes calldata transaction
-    ) external;
+    function fulfillDecryption(uint256 requestId, bytes calldata key) external;
 
     /**
      * @dev Fulfillment of a verification request (issued by requestVerifyEncryptedKey).
@@ -197,20 +204,21 @@ interface IKeyDecryptionOracle {
     ) external;
 
     /**
-     * @dev Fulfillment of a decryption request (issued by requestDecrypt).
-     *
-     * Best-effort + calldata fallback:
-     * - Implementations MAY attempt to call the consumer callback and MAY NOT revert if the callback fails (incl. OOG).
-     *   In such cases the implementation SHOULD signal failure via {CallbackFailed} and allow the off-chain oracle to retry.
-     * - The fulfillment payload (e.g., `key`) is always present in the transaction calldata of this fulfill call.
-     *   Off-chain systems can use the emitted log's `transactionHash` to fetch and decode tx input calldata using this ABI.
-     * - Practical caveat: some RPC providers prune old transaction bodies; store decoded payload off-chain if needed.
+     * @dev Fulfillment of a key generation request (issued by requestGenerateEncryptedHashedKeys).
+     * Implementations MUST reject a receiver or transaction that differs from the request,
+     * and MUST reject duplicate, missing, or unrequested keyIds. Array order has no semantic
+     * meaning. A successful fulfillment MUST deliver the complete batch in one callback;
+     * partial callbacks are forbidden. Best-effort + calldata fallback: see fulfillDecryption.
      *
      * @param requestId Correlation id from the request event.
-     * @param key Decrypted key if admissible, otherwise empty bytes.
+     * @param keys Generated keys, identified by keyId.
+     * @param receiverContract Contract that is eligible to receive the decryption.
+     * @param transaction Transaction that is eligible to request decryption.
      */
-    function fulfillDecryption(
+    function fulfillEncryptedHashedKeysGeneration(
         uint256 requestId,
-        bytes calldata key
+        IKeyDecryptionOracleCallback.EncryptedHashedKey[] calldata keys,
+        address receiverContract,
+        bytes calldata transaction
     ) external;
 }

--- a/assets/erc-7573/contracts/IKeyDecryptionOracle.sol
+++ b/assets/erc-7573/contracts/IKeyDecryptionOracle.sol
@@ -54,20 +54,22 @@ interface IKeyDecryptionOracle {
     );
 
     /**
-     * @dev Emitted when an encrypted key generation is requested (issued by requestGenerateEncryptedHashedKey).
+     * @dev Emitted when encrypted key generation is requested (issued by requestGenerateEncryptedHashedKeys).
      * @param sender The requester (msg.sender) that issued the request.
      * @param id General id (will be passed back to callback) - can be used by the requester as correlation id.
      * @param callback Callback contract to be invoked on fulfillment.
      * @param receiverContract Contract that is eligible to request decryption.
      * @param transaction Transaction specification to be verified against the key.
+     * @param keyIds Unique semantic identifiers for the keys to generate.
      * @param requestId Correlation id for the fulfillment.
      */
-    event EncryptedHashedKeyGenerationRequested(
+    event EncryptedHashedKeysGenerationRequested(
         address indexed sender,
         uint256 id,
         IKeyDecryptionOracleCallback indexed callback,
         address receiverContract,
         bytes transaction,
+        bytes32[] keyIds,
         uint256 indexed requestId
     );
 
@@ -136,21 +138,23 @@ interface IKeyDecryptionOracle {
     ) external payable;
 
     /**
-     * @notice Performs a generation of an encryptedKey and a hash internally associated with the given
-     * contract (receiverContract) and the transaction. The generated encryptedKey and hashedKey are passed
-     * to the callback contract.
+     * @notice Generates a batch of encrypted keys and hashes internally associated with the given
+     * contract (receiverContract) and transaction. The generated keys are passed to the callback contract.
      *
-     * @dev Emits a {EncryptedHashedKeyGenerationRequested} event.
+     * @dev Emits an {EncryptedHashedKeysGenerationRequested} event.
+     * Implementations MUST reject an empty `keyIds` array and duplicate identifiers.
      * @param id An id passed back to the callback function (consumerId).
      * @param callback The callback contract.
      * @param receiverContract Contract that is eligible to receive the decryption.
      * @param transaction General purpose transaction identifier.
+     * @param keyIds Unique semantic identifiers for the keys to generate. A single-element batch is valid.
      */
-    function requestGenerateEncryptedHashedKey(
+    function requestGenerateEncryptedHashedKeys(
         uint256 id,
         IKeyDecryptionOracleCallback callback,
         address receiverContract,
-        bytes calldata transaction
+        bytes calldata transaction,
+        bytes32[] calldata keyIds
     ) external payable;
 
     /*------------------------------------------- FUNCTIONALITY: FULFILLMENT (should be guarded by onlyOracle) -------*/
@@ -189,19 +193,20 @@ interface IKeyDecryptionOracle {
     ) external;
 
     /**
-     * @dev Fulfillment of a key generation request (issued by requestGenerateEncryptedHashedKey).
-     * Best-effort + calldata fallback: see fulfillDecryption.
+     * @dev Fulfillment of a key generation request (issued by requestGenerateEncryptedHashedKeys).
+     * Implementations MUST reject a receiver or transaction that differs from the request,
+     * and MUST reject duplicate, missing, or unrequested keyIds. Array order has no semantic
+     * meaning. A successful fulfillment MUST deliver the complete batch in one callback;
+     * partial callbacks are forbidden. Best-effort + calldata fallback: see fulfillDecryption.
      *
      * @param requestId Correlation id from the request event.
-     * @param encryptedKey Encrypted key.
-     * @param hashedKey Hash of the key.
+     * @param keys Generated keys, identified by keyId.
      * @param receiverContract Contract that is eligible to receive the decryption.
      * @param transaction Transaction that is eligible to request decryption.
      */
-    function fulfillEncryptedHashedKeyGeneration(
+    function fulfillEncryptedHashedKeysGeneration(
         uint256 requestId,
-        bytes calldata encryptedKey,
-        bytes calldata hashedKey,
+        IKeyDecryptionOracleCallback.EncryptedHashedKey[] calldata keys,
         address receiverContract,
         bytes calldata transaction
     ) external;

--- a/assets/erc-7573/contracts/IKeyDecryptionOracleCallback.sol
+++ b/assets/erc-7573/contracts/IKeyDecryptionOracleCallback.sol
@@ -10,6 +10,8 @@ pragma solidity >=0.8.0 <0.9.0;
  *
  * Implementation guidance:
  * - Callback implementations SHOULD restrict who can call these methods (e.g. `require(msg.sender == oracleProxy)`).
+ * - Callback implementations MUST validate a pending `(msg.sender, requestId)` of the expected operation kind
+ *   and consume or mark it before applying callback effects.
  * - Callbacks SHOULD be cheap and should avoid reverting. If heavy work is required, store minimal state/events and
  *   perform the heavy logic in a separate pull/consume transaction initiated by the consumer.
  * - Callbacks MUST assume they may receive less than "all gas" (oracle may reserve headroom / cap forwarded gas).
@@ -30,25 +32,24 @@ interface IKeyDecryptionOracleCallback {
     /*------------------------------------------- EVENTS ---------------------------------------------------------------------------------------*/
 
     /**
-     * @dev Emitted when a batch of encrypted/hashed keys has been obtained.
-     * @param sender The sender (oracle/proxy).
-     * @param id The id that was passed in the request (user data).
-     * @param keys The generated keys, identified by keyId.
-     * @param receiverContract The receiving contract.
-     * @param transaction The transaction id.
+     * @dev Emitted when the decrypted key has been obtained.
+     * @param sender The sender (oracle/proxy) that released the key.
+     * @param requestId The oracle-assigned request identifier.
+     * @param key The decrypted key.
      */
-    event EncryptedHashedKeysGenerated(
-        address sender,
-        uint256 id,
-        EncryptedHashedKey[] keys,
-        address receiverContract,
-        bytes transaction
-    );
+    event KeyReleased(address sender, uint256 requestId, bytes key);
+
+    /**
+     * @dev Emitted when the decryption of a key has been denied.
+     * @param sender The sender (oracle/proxy).
+     * @param requestId The oracle-assigned request identifier.
+     */
+    event DecryptionDenied(address sender, uint256 requestId);
 
     /**
      * @dev Emitted when the verification of an encrypted key has been obtained.
      * @param sender The sender (oracle/proxy).
-     * @param id The id that was passed in the request (user data).
+     * @param requestId The oracle-assigned request identifier.
      * @param encryptedKey Encrypted key.
      * @param hashedKey Hashed key, or empty if verification failed.
      * @param receiverContract The receiving contract, or empty if verification failed.
@@ -56,7 +57,7 @@ interface IKeyDecryptionOracleCallback {
      */
     event EncryptedKeyVerified(
         address sender,
-        uint256 id,
+        uint256 requestId,
         bytes encryptedKey,
         bytes hashedKey,
         address receiverContract,
@@ -64,49 +65,51 @@ interface IKeyDecryptionOracleCallback {
     );
 
     /**
-     * @dev Emitted when the decrypted key has been obtained.
-     * @param sender The sender (oracle/proxy) that released the key.
-     * @param id The id that was passed in the request (user data).
-     * @param key The decrypted key.
-     */
-    event KeyReleased(address sender, uint256 id, bytes key);
-
-    /**
-     * @dev Emitted when the decryption of a key has been denied.
+     * @dev Emitted when a batch of encrypted/hashed keys has been obtained.
      * @param sender The sender (oracle/proxy).
-     * @param id The id that was passed in the request (user data).
-     */
-    event DecryptionDenied(address sender, uint256 id);
-
-    /*------------------------------------------- FUNCTIONALITY ---------------------------------------------------------------------------------------*/
-
-    /**
-     * @notice Called from the decryption oracle proxy contract.
-     * @dev Implementations SHOULD validate the complete batch and emit
-     * {EncryptedHashedKeysGenerated} (if eligible).
-     * @param id The id that was passed in the request (user data).
+     * @param requestId The oracle-assigned request identifier.
      * @param keys The generated keys, identified by keyId.
      * @param receiverContract The receiving contract.
      * @param transaction The transaction id.
      */
-    function onEncryptedHashedKeysGenerated(
-        uint256 id,
-        EncryptedHashedKey[] calldata keys,
+    event EncryptedHashedKeysGenerated(
+        address sender,
+        uint256 requestId,
+        EncryptedHashedKey[] keys,
         address receiverContract,
-        bytes calldata transaction
-    ) external;
+        bytes transaction
+    );
+
+    /*------------------------------------------- FUNCTIONALITY ---------------------------------------------------------------------------------------*/
+
+    /**
+     * @notice Called from the (possibly external) decryption oracle proxy.
+     * @dev Implementations SHOULD emit {KeyReleased} (if eligible).
+     * @param requestId The oracle-assigned request identifier.
+     * @param key Decrypted key.
+     */
+    function onKeyReleased(uint256 requestId, bytes calldata key) external;
+
+    /**
+     * @notice Called from the (possibly external) decryption oracle proxy.
+     * This method will only be called if a decryption request was illegal and denied.
+     *
+     * @dev Implementations SHOULD emit {DecryptionDenied}.
+     * @param requestId The oracle-assigned request identifier.
+     */
+    function onKeyDenied(uint256 requestId) external;
 
     /**
      * @notice Called from the (possibly external) decryption oracle proxy.
      * @dev Implementations SHOULD emit {EncryptedKeyVerified} (if eligible).
-     * @param id The id that was passed in the request (user data).
+     * @param requestId The oracle-assigned request identifier.
      * @param encryptedKey Encrypted key.
      * @param hashedKey Hashed key, or empty if verification failed.
      * @param receiverContract The receiving contract, or empty if verification failed.
      * @param transaction The transaction id, or empty if verification failed.
      */
     function onEncryptedKeyVerified(
-        uint256 id,
+        uint256 requestId,
         bytes calldata encryptedKey,
         bytes calldata hashedKey,
         address receiverContract,
@@ -114,19 +117,18 @@ interface IKeyDecryptionOracleCallback {
     ) external;
 
     /**
-     * @notice Called from the (possibly external) decryption oracle proxy.
-     * @dev Implementations SHOULD emit {KeyReleased} (if eligible).
-     * @param id The id that was passed in the request (user data).
-     * @param key Decrypted key.
+     * @notice Called from the decryption oracle proxy contract.
+     * @dev Implementations SHOULD validate the complete batch and emit
+     * {EncryptedHashedKeysGenerated} (if eligible).
+     * @param requestId The oracle-assigned request identifier.
+     * @param keys The generated keys, identified by keyId.
+     * @param receiverContract The receiving contract.
+     * @param transaction The transaction id.
      */
-    function onKeyReleased(uint256 id, bytes calldata key) external;
-
-    /**
-     * @notice Called from the (possibly external) decryption oracle proxy.
-     * This method will only be called if a decryption request was illegal and denied.
-     *
-     * @dev Implementations SHOULD emit {DecryptionDenied}.
-     * @param id The id that was passed in the request (user data).
-     */
-    function onKeyDenied(uint256 id) external;
+    function onEncryptedHashedKeysGenerated(
+        uint256 requestId,
+        EncryptedHashedKey[] calldata keys,
+        address receiverContract,
+        bytes calldata transaction
+    ) external;
 }

--- a/assets/erc-7573/contracts/IKeyDecryptionOracleCallback.sol
+++ b/assets/erc-7573/contracts/IKeyDecryptionOracleCallback.sol
@@ -30,19 +30,20 @@ interface IKeyDecryptionOracleCallback {
     /*------------------------------------------- EVENTS ---------------------------------------------------------------------------------------*/
 
     /**
-     * @dev Emitted when the decrypted key has been obtained.
-     * @param sender The sender (oracle/proxy) that released the key.
-     * @param id The id that was passed in the request (user data).
-     * @param key The decrypted key.
-     */
-    event KeyReleased(address sender, uint256 id, bytes key);
-
-    /**
-     * @dev Emitted when the decryption of a key has been denied.
+     * @dev Emitted when a batch of encrypted/hashed keys has been obtained.
      * @param sender The sender (oracle/proxy).
      * @param id The id that was passed in the request (user data).
+     * @param keys The generated keys, identified by keyId.
+     * @param receiverContract The receiving contract.
+     * @param transaction The transaction id.
      */
-    event DecryptionDenied(address sender, uint256 id);
+    event EncryptedHashedKeysGenerated(
+        address sender,
+        uint256 id,
+        EncryptedHashedKey[] keys,
+        address receiverContract,
+        bytes transaction
+    );
 
     /**
      * @dev Emitted when the verification of an encrypted key has been obtained.
@@ -63,39 +64,37 @@ interface IKeyDecryptionOracleCallback {
     );
 
     /**
-     * @dev Emitted when a batch of encrypted/hashed keys has been obtained.
+     * @dev Emitted when the decrypted key has been obtained.
+     * @param sender The sender (oracle/proxy) that released the key.
+     * @param id The id that was passed in the request (user data).
+     * @param key The decrypted key.
+     */
+    event KeyReleased(address sender, uint256 id, bytes key);
+
+    /**
+     * @dev Emitted when the decryption of a key has been denied.
      * @param sender The sender (oracle/proxy).
+     * @param id The id that was passed in the request (user data).
+     */
+    event DecryptionDenied(address sender, uint256 id);
+
+    /*------------------------------------------- FUNCTIONALITY ---------------------------------------------------------------------------------------*/
+
+    /**
+     * @notice Called from the decryption oracle proxy contract.
+     * @dev Implementations SHOULD validate the complete batch and emit
+     * {EncryptedHashedKeysGenerated} (if eligible).
      * @param id The id that was passed in the request (user data).
      * @param keys The generated keys, identified by keyId.
      * @param receiverContract The receiving contract.
      * @param transaction The transaction id.
      */
-    event EncryptedHashedKeysGenerated(
-        address sender,
+    function onEncryptedHashedKeysGenerated(
         uint256 id,
-        EncryptedHashedKey[] keys,
+        EncryptedHashedKey[] calldata keys,
         address receiverContract,
-        bytes transaction
-    );
-
-    /*------------------------------------------- FUNCTIONALITY ---------------------------------------------------------------------------------------*/
-
-    /**
-     * @notice Called from the (possibly external) decryption oracle proxy.
-     * @dev Implementations SHOULD emit {KeyReleased} (if eligible).
-     * @param id The id that was passed in the request (user data).
-     * @param key Decrypted key.
-     */
-    function onKeyReleased(uint256 id, bytes calldata key) external;
-
-    /**
-     * @notice Called from the (possibly external) decryption oracle proxy.
-     * This method will only be called if a decryption request was illegal and denied.
-     *
-     * @dev Implementations SHOULD emit {DecryptionDenied}.
-     * @param id The id that was passed in the request (user data).
-     */
-    function onKeyDenied(uint256 id) external;
+        bytes calldata transaction
+    ) external;
 
     /**
      * @notice Called from the (possibly external) decryption oracle proxy.
@@ -115,18 +114,19 @@ interface IKeyDecryptionOracleCallback {
     ) external;
 
     /**
-     * @notice Called from the decryption oracle proxy contract.
-     * @dev Implementations SHOULD validate the complete batch and emit
-     * {EncryptedHashedKeysGenerated} (if eligible).
+     * @notice Called from the (possibly external) decryption oracle proxy.
+     * @dev Implementations SHOULD emit {KeyReleased} (if eligible).
      * @param id The id that was passed in the request (user data).
-     * @param keys The generated keys, identified by keyId.
-     * @param receiverContract The receiving contract.
-     * @param transaction The transaction id.
+     * @param key Decrypted key.
      */
-    function onEncryptedHashedKeysGenerated(
-        uint256 id,
-        EncryptedHashedKey[] calldata keys,
-        address receiverContract,
-        bytes calldata transaction
-    ) external;
+    function onKeyReleased(uint256 id, bytes calldata key) external;
+
+    /**
+     * @notice Called from the (possibly external) decryption oracle proxy.
+     * This method will only be called if a decryption request was illegal and denied.
+     *
+     * @dev Implementations SHOULD emit {DecryptionDenied}.
+     * @param id The id that was passed in the request (user data).
+     */
+    function onKeyDenied(uint256 id) external;
 }

--- a/assets/erc-7573/contracts/IKeyDecryptionOracleCallback.sol
+++ b/assets/erc-7573/contracts/IKeyDecryptionOracleCallback.sol
@@ -18,6 +18,15 @@ pragma solidity >=0.8.0 <0.9.0;
  * @notice See documentation for details.
  */
 interface IKeyDecryptionOracleCallback {
+    /**
+     * @dev One generated encrypted/hashed key and its semantic role.
+     */
+    struct EncryptedHashedKey {
+        bytes32 keyId;
+        bytes encryptedKey;
+        bytes hashedKey;
+    }
+
     /*------------------------------------------- EVENTS ---------------------------------------------------------------------------------------*/
 
     /**
@@ -54,19 +63,17 @@ interface IKeyDecryptionOracleCallback {
     );
 
     /**
-     * @dev Emitted when an encrypted/hashed key has been obtained.
+     * @dev Emitted when a batch of encrypted/hashed keys has been obtained.
      * @param sender The sender (oracle/proxy).
      * @param id The id that was passed in the request (user data).
-     * @param encryptedKey The encrypted key.
-     * @param hashedKey The hashed key.
+     * @param keys The generated keys, identified by keyId.
      * @param receiverContract The receiving contract.
      * @param transaction The transaction id.
      */
-    event EncryptedHashedKeyGenerated(
+    event EncryptedHashedKeysGenerated(
         address sender,
         uint256 id,
-        bytes encryptedKey,
-        bytes hashedKey,
+        EncryptedHashedKey[] keys,
         address receiverContract,
         bytes transaction
     );
@@ -109,17 +116,16 @@ interface IKeyDecryptionOracleCallback {
 
     /**
      * @notice Called from the decryption oracle proxy contract.
-     * @dev Implementations SHOULD emit {EncryptedHashedKeyGenerated} (if eligible).
+     * @dev Implementations SHOULD validate the complete batch and emit
+     * {EncryptedHashedKeysGenerated} (if eligible).
      * @param id The id that was passed in the request (user data).
-     * @param encryptedKey Encrypted key.
-     * @param hashedKey Hashed key.
+     * @param keys The generated keys, identified by keyId.
      * @param receiverContract The receiving contract.
      * @param transaction The transaction id.
      */
-    function onEncryptedHashedKeyGenerated(
+    function onEncryptedHashedKeysGenerated(
         uint256 id,
-        bytes calldata encryptedKey,
-        bytes calldata hashedKey,
+        EncryptedHashedKey[] calldata keys,
         address receiverContract,
         bytes calldata transaction
     ) external;

--- a/assets/erc-7573/package.json
+++ b/assets/erc-7573/package.json
@@ -29,6 +29,8 @@
   },
   "keywords": [
     "Delivery versus Payment",
+    "Cross-Chain DvP",
+    "Multi-Party DvP",
     "HTLC",
     "EIP-7573",
     "Decryption Oracle"

--- a/assets/erc-7573/package.json
+++ b/assets/erc-7573/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finmath.net/dvp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Solidity Conditional-upon-Transfer-Decryption for DvP and nDvP",
   "author": "Christian Fries, Peter Kohl-Landgraf",
   "license": "ISC",


### PR DESCRIPTION
-  Added IDecryptionContractWithKeyGeneration that allows to inceptTransfer without providing keys, keys have to be generated by the contract (can be asynchronous).
- transferAndDecrypt and cancelAndDecrypt now allow for a commitment hash to verify the link to the 