### PR TITLE
Update ERC-7573: allow callback to be address(0) for none, sparing the overload.

### DIFF
--- a/ERCS/erc-7573.md
+++ b/ERCS/erc-7573.md
@@ -136,18 +136,17 @@ The parameter `keyEncryptedSuccess` is an encryption of a key and will be decryp
 The parameter `keyEncryptedFailure` is an encryption of a key and will be decrypted if the transfer fails in a call to `transferAndDecrypt` or if `cancelAndDecrypt` is successful.
 The return value `inceptionHash` is the hash of the canonical inception call. It is used to derive `confirmationHash` and to identify the exact inception on cancellation.
 
-For every inception overload, the inception hash MUST be calculated from the canonical ABI encoding:
+For every inception variant, the inception hash MUST be calculated from the canonical ABI encoding:
 
 ```text
 syncArguments          = abi.encode(id, amount, from, keyEncryptedSuccess, keyEncryptedFailure)
-asyncArguments         = abi.encode(id, amount, from, transaction)
-asyncCallbackArguments = abi.encode(id, amount, from, transaction, callback)
+asyncArguments         = abi.encode(id, amount, from, transaction, callback)
 inceptionHash          = keccak256(abi.encode(address(this), inceptionCaller, selector, arguments))
 ```
 
-Here, `arguments` is the applicable argument encoding, `inceptionCaller` is `msg.sender`, and `selector` is the canonical selector of the applicable `inceptTransfer` overload.
-The inception hash therefore binds the decryption contract, inception caller (the receiver), selected overload, and all decoded arguments.
-For the callback overload, this includes the immutable callback address.
+Here, `arguments` is the applicable argument encoding, `inceptionCaller` is `msg.sender`, and `selector` is the canonical selector of the applicable `inceptTransfer` signature.
+The inception hash therefore binds the decryption contract, inception caller (the receiver), selected signature, and all decoded arguments.
+For asynchronous inception, this always includes the immutable callback value, including `address(0)`.
 Non-canonical encodings or trailing calldata are not part of the inception hash.
 The contract MUST store it with the inception and MUST reject a later inception that would reuse it.
 
@@ -174,11 +173,9 @@ After observing the immutable keys, a confirmer can calculate `confirmationHash`
 
 ##### Asynchronous Initiation of Transfer: `inceptTransfer`
 
-The optional `IDecryptionContractWithKeyGeneration` interface extends `IDecryptionContract` with two overloads that do not require keys to exist at inception:
+The optional `IDecryptionContractWithKeyGeneration` interface extends `IDecryptionContract` with one asynchronous function that does not require keys to exist at inception:
 
 ```solidity
-function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 inceptionHash);
-
 function inceptTransfer(
     uint256 id,
     int amount,
@@ -189,14 +186,16 @@ function inceptTransfer(
 ```
 
 The parameter `transaction` is the transaction specification used for asynchronous generation of the encrypted success and failure keys.
-Both calls store a pending inception and return its `inceptionHash` immediately.
-Because the keys do not exist when the call returns, `inceptionHash` binds the `transaction` argument but not the generated keys.
-The callback overload additionally binds a nonzero callback contract and provides an on-chain completion trigger.
+The call stores a pending inception and returns its `inceptionHash` immediately.
+Because the keys do not exist when the call returns, `inceptionHash` binds the `transaction` and `callback` arguments but not the generated keys.
+The `callback` parameter MAY be `address(0)` when event-based off-chain continuation is sufficient.
+Solidity callers express this as `IDecryptionContractInceptionCallback(address(0))`; ABI callers supply the full twenty-byte zero address.
+Any nonzero callback MUST implement `IDecryptionContractInceptionCallback` and provide an on-chain completion trigger.
 The generated keys MUST be validated and stored atomically with the pending inception and MUST NOT be replaceable afterwards.
 In the same state transition, the contract MUST select the success and failure keys by semantic role, derive and store `confirmationHash`, and complete the inception.
 The contract MUST emit `TransferIncepted` only after both keys and `confirmationHash` have been stored.
 
-For the callback overload, after storing the complete state and emitting `TransferIncepted`, the decryption contract MUST call:
+If `callback` is not `address(0)`, after storing the complete state and emitting `TransferIncepted`, the decryption contract MUST call:
 
 ```solidity
 callback.onInceptionCompleted(id, inceptionHash, confirmationHash)
@@ -205,7 +204,7 @@ callback.onInceptionCompleted(id, inceptionHash, confirmationHash)
 The callback MUST return `IDecryptionContractInceptionCallback.onInceptionCompleted.selector`.
 The completed state MUST already be observable so an authorized callback can directly call `confirmTransfer`.
 If the callback reverts, runs out of its bounded gas allowance, or returns any other value, the completion attempt MUST revert and leave the inception pending for the asynchronous fulfillment mechanism to retry.
-The no-callback overload remains available when event-based off-chain continuation is sufficient.
+If `callback` is `address(0)`, the decryption contract MUST skip callback delivery.
 No additional hash-ready event is required because `TransferIncepted` already signals that the keys and `confirmationHash` are final.
 
 Calls to `confirmTransfer`, `transferAndDecrypt`, and `cancelAndDecrypt` for a pending inception MUST revert until then.
@@ -291,8 +290,6 @@ interface IDecryptionContractInceptionCallback {
 }
 
 interface IDecryptionContractWithKeyGeneration is IDecryptionContract {
-    function inceptTransfer(uint256 id, int amount, address from, bytes memory transaction) external returns (bytes32 inceptionHash);
-
     function inceptTransfer(
         uint256 id,
         int amount,
@@ -565,7 +562,7 @@ Additional considerations for the oracle proxy + callback pattern:
 - Callback implementations SHOULD be cheap and should avoid unbounded loops or expensive state changes. If heavy work is required, prefer a pull/consume pattern initiated by the consumer.
 - Oracle proxy implementations SHOULD document whether they use strict or best-effort fulfillment semantics, and how retries are intended to be handled (oracle-operated retry vs consumer-operated recovery).
 
-For the optional asynchronous inception callback, implementations MUST store the completed inception before the external call, use a bounded gas allowance, validate the selector-valued acknowledgement, and rely on the asynchronous fulfillment retry path if delivery fails.
+For a nonzero asynchronous inception callback, implementations MUST store the completed inception before the external call, use a bounded gas allowance, validate the selector-valued acknowledgement, and rely on the asynchronous fulfillment retry path if delivery fails.
 
 ## Copyright
 


### PR DESCRIPTION
minor documentation fix - adding the optional asynchronous inception callback