### PR TITLE
Update ERC-7730:  Generalize "mustMatch" feature with `boundaries` object with constraints leading to automatic signing refusal

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1071,7 +1071,8 @@ Optional rule to apply before displaying a field. Rules allow defining under whi
   * `optional`: Wallets MAY display this field if possible or sensible.
 * An object with keys representing complex rules, with the following complex rules supported:
   * `ifNotIn` key with an array of values to make the field visible only when the field value does NOT match any of the specified values
-  * `mustMatch` key with an array of values to make the field always hidden AND check its value against the list. Wallet should raise an error if the value does not match the list.
+
+Value validation independent of display (e.g. requiring an exact match) is expressed with `boundaries` instead.
 
 **`separator`** 
 
@@ -1105,6 +1106,41 @@ Because encrypted values do not reveal their underlying type on-chain, authors S
   }
 }
 ```
+
+**`boundaries`**
+
+Optional object constraining the field's underlying value in order to detect implausible or disqualifying values, independent of `format` and `visible`. If the value violates the declared boundaries, the wallet SHOULD refuse to sign the transaction by default, and MAY offer the user an explicit override to proceed anyway.
+
+A `boundaries` key is a json object with:
+* An optional `min` key, the inclusive lower bound on the value, as a decimal or `0x`-prefixed hexadecimal string.
+* An optional `max` key, the inclusive upper bound on the value, as a decimal or `0x`-prefixed hexadecimal string.
+* An optional `excludes` key, an array of exact values that disqualify the field even when within the `min`/`max` range.
+* An optional `mustMatch` key, an array of values the field's value MUST match one of, regardless of `min`/`max`.
+* An optional `errorMessage` key, the message to display to the user when the value violates the boundaries. It supports the [interpolation syntax](#value-interpolation), allowing the offending value to be embedded in the message. If not provided, or if interpolation fails, the wallet falls back to a generic message.
+
+At least one of `min`, `max`, `excludes`, or `mustMatch` MUST be present.
+
+`mustMatch` does not affect display: unlike `visible`, `boundaries` never hides a field. To validate a field's value without ever displaying it, combine `boundaries` with `"visible": "never"`.
+
+*Example*
+
+Given `function pauseAccount(uint256 time)`, intended to be called with a duration of at most 10 days (864000 seconds):
+
+```json
+{
+  "path": "time",
+  "label": "Freeze duration",
+  "format": "duration",
+  "boundaries": {
+    "max": "864000",
+    "errorMessage": "You are locking your account for {time} seconds — this may be a mistake."
+  }
+}
+```
+
+A call with `time = 864000000` (~27 years) violates `max` and the wallet SHOULD refuse to sign by default.
+
+See [example-boundaries.json](../assets/erc-7730/example-boundaries.json) for a complete descriptor.
 
 #### Group format specification 
 

--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1072,8 +1072,6 @@ Optional rule to apply before displaying a field. Rules allow defining under whi
 * An object with keys representing complex rules, with the following complex rules supported:
   * `ifNotIn` key with an array of values to make the field visible only when the field value does NOT match any of the specified values
 
-Value validation independent of display (e.g. requiring an exact match) is expressed with `boundaries` instead.
-
 **`separator`** 
 
 Optional separator string to display before each element of an array. Can only be used be used for formatters that are applied to a path pointing to an array. Each element of the array is formatted using the provided formatter, and the `separator` value is displayed before each element. `separator` is a string using the interpolated syntax with one specific replacement `{index}` that gets replaced with the index of current element being displayed.

--- a/assets/erc-7730/erc7730-v3.0.0-next.schema.json
+++ b/assets/erc-7730/erc7730-v3.0.0-next.schema.json
@@ -494,6 +494,10 @@
                     "description": "Visibility override for the referenced definition.",
                     "$ref": "#/$format/rules"
                 },
+                "boundaries": {
+                    "description": "Boundaries override for the referenced definition.",
+                    "$ref": "#/$format/boundaries"
+                },
                 "encryption": {
                     "description": "Encryption override for the referenced definition.",
                     "$ref": "#/$format/encryptionParameters"
@@ -538,6 +542,9 @@
                 },
                 "visible": {
                     "$ref": "#/$format/rules"
+                },
+                "boundaries": {
+                    "$ref": "#/$format/boundaries"
                 },
                 "label": {
                     "title": "Field Label",
@@ -658,27 +665,54 @@
                             "type": ["string", "number", "boolean", "null"]
                         },
                         "minItems": 1
-                    },
-                    "mustMatch": {
-                        "type": "array",
-                        "description": "Always skip display, but value MUST match one of these values.",
-                        "items": {
-                            "type": ["string", "number", "boolean", "null"]
-                        },
-                        "minItems": 1
                     }
                 },
                 "additionalProperties": false,
-                "allOf": [
-                    {
-                    "not": {
-                        "required": ["ifNotIn", "mustMatch"]
-                    }
-                    }
-                ],
-                "description": "Conditional display rules. Either 'ifNotIn' or 'mustMatch' must be defined, but not both."
+                "description": "Conditional display rule."
                 }
-            ]    
+            ]
+        },
+        "boundaries": {
+            "title": "Value Boundaries",
+            "description": "Constraints on the field's underlying value used to detect implausible or disqualifying values. If violated, wallets SHOULD refuse to sign by default and MAY offer an explicit override.",
+            "type": "object",
+            "properties": {
+                "min": {
+                    "type": "string",
+                    "description": "Inclusive lower bound on the value, as a decimal or 0x-prefixed hexadecimal string."
+                },
+                "max": {
+                    "type": "string",
+                    "description": "Inclusive upper bound on the value, as a decimal or 0x-prefixed hexadecimal string."
+                },
+                "excludes": {
+                    "type": "array",
+                    "description": "Exact values that disqualify the field even if within the min/max range.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1
+                },
+                "mustMatch": {
+                    "type": "array",
+                    "description": "The value MUST match one of these values, regardless of min/max.",
+                    "items": {
+                        "type": ["string", "number", "boolean", "null"]
+                    },
+                    "minItems": 1
+                },
+                "errorMessage": {
+                    "type": "string",
+                    "description": "Message displayed to the user when the value violates the boundaries. Supports the interpolated string syntax. Falls back to a generic message if not provided or if interpolation fails."
+                }
+            },
+            "anyOf": [
+                {"required": ["min"]},
+                {"required": ["max"]},
+                {"required": ["excludes"]},
+                {"required": ["mustMatch"]}
+            ],
+            "additionalProperties": false
         },
         "mapReference": {
             "title": "Map Reference",

--- a/assets/erc-7730/example-boundaries.json
+++ b/assets/erc-7730/example-boundaries.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "./erc7730-v3.0.0-next.schema.json",
+
+    "$comment": "This example ERC-7730 showcases usage of value boundaries to refuse signing implausible parameter values.",
+
+    "context": {
+        "contract": {
+            "deployments": [
+                {
+                    "chainId": 1,
+                    "address": "0x00112233445566778899AABBCCDDEEFF00112233"
+                }
+            ]
+        }
+    },
+
+    "metadata": {
+        "owner": "Example",
+        "info": {
+            "url": "https://example.io/"
+        }
+    },
+
+    "display": {
+        "formats": {
+            "pauseAccount(uint256 time,uint8 mode)": {
+                "intent": "Pause account",
+                "fields": [
+                    {
+                        "$id": "Time must be a plausible freeze duration, at most 10 days",
+                        "path": "time",
+                        "label": "Freeze duration",
+                        "format": "duration",
+                        "boundaries": {
+                            "max": "864000",
+                            "errorMessage": "You are locking your account for {time} seconds — this may be a mistake."
+                        }
+                    },
+                    {
+                        "$id": "Mode must be one of the known pause modes, but is still shown to the user",
+                        "path": "mode",
+                        "label": "Pause mode",
+                        "format": "raw",
+                        "boundaries": {
+                            "mustMatch": [0, 1, 2],
+                            "errorMessage": "Unknown pause mode {mode} — refusing to sign."
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Early-stage idea, opened as a draft to gather feedback before finalizing.

Sometimes a parameter only makes sense within a bounded range (e.g. `pauseAccount(uint256 time)` intended to take a duration of at most ~10 days). A call with a wildly out-of-range value (`time = 864000000`, ~27 years) is very likely a mistake or malicious intent. Clear signing shows the raw value, but there's currently no way for a spec author to tell a wallet "this value is implausible, don't sign it without extra friction."

This PR adds an optional `boundaries` property to the field formatter (`v3.0.0-next` schema only):

```json
"boundaries": {
  "min": "0",
  "max": "864000",
  "excludes": ["1337"],
  "mustMatch": [0, 1, 2],
  "errorMessage": "You are locking your account for {time} seconds — this may be a mistake."
}
```

Wallets SHOULD refuse to sign by default when the underlying value violates the declared boundaries, and MAY offer an explicit override. It's independent of `format` and of `visible` — the field still displays normally.

As part of this, `mustMatch` moves out of `visible` into `boundaries`. It was never really a display concern — it forced the field to always be hidden and had nothing to do with visibility, it just didn't have anywhere else to live. `visible` now covers display only (`always`/`never`/`optional`/`ifNotIn`); `boundaries` covers refusal only, and no longer requires hiding the field to validate it.

## Open questions (feedback welcome)

- Should `tokenAmount`'s existing `threshold`/`message` (the "Unlimited" display swap) be related to or folded into `boundaries`? They're triggered by a similar condition (crossing a limit) but take different actions (display substitution vs. refusal) — leaning towards keeping them separate to avoid mixing display and refusal concerns again, but open to discussion.
- Byte-slice/sub-range bounds on `bytes` values, array-valued fields, and per-field severity levels (e.g. warn vs. refuse) are intentionally out of scope for now.

## Test plan

- [x] Schema changes validated as syntactically valid JSON
- [x] New `example-boundaries.json` validates against the updated schema
- [x] Existing `v3.0.0-next`-targeted examples still validate (no regressions)
- [ ] Community feedback on the shape of `boundaries` and the open questions above

🤖 Generated with [Claude Code](https://claude.com/claude-code)