### PR TITLE
Update ERC-8049: add ERC-20Agent metadata profile

### DIFF
--- a/ERCS/erc-8049.md
+++ b/ERCS/erc-8049.md
@@ -8,12 +8,12 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2025-10-10
-requires: 165
+requires: 20, 165, 7930
 ---
 
 ## Abstract
 
-This ERC defines a standard for storing contract-level metadata onchain. It extends [ERC-7572](./eip-7572.md)'s contract-level metadata concept by providing onchain storage. Contracts MAY optionally use [ERC-8042](./eip-8042.md)'s Diamond Storage pattern for predictable storage locations, enabling cross-chain compatibility and supporting upgradable contracts.
+This ERC lets a contract store metadata about itself onchain as key-value pairs, with arbitrary bytes as values. Every update emits an event, and clients read the records directly from the contract.
 
 ## Motivation
 
@@ -84,6 +84,45 @@ A contract can specify its ENS name using this standard:
 - Key: `"ens_name"` → Value: `bytes("mycontract.eth")`
 
 This allows clients to discover the contract's ENS name and resolve it to get additional information about the contract.
+
+### AI Agent Metadata Profile
+
+This profile defines a reserved set of this ERC's contract-level metadata keys that associate an [ERC-20](./eip-20.md) token contract with a single AI agent, and is nicknamed **ERC-20Agent**. It is a standard *use* of this ERC's existing key-value interface; it does **not** define a new Solidity interface, a new [ERC-165](./eip-165.md) interface ID, new functions, or new events. Consumers read and write these records through `contractMetadata(string)` and rely on the `ContractMetadataUpdated` event for change notifications, exactly as for any other key under this ERC.
+
+Because this ERC's records are contract-level, that agent belongs to the token contract as a whole, not to any holder or balance. What that agent is used for is left to the issuer. It might provide information about the token through agent-user or agent-UI chat, represent token-based governance, or serve any other mechanism the issuer intends.
+
+A contract implementing this profile MUST implement [ERC-20](./eip-20.md) and this ERC. The profile reserves the following keys:
+
+| Key | Meaning | Value (`bytes`) |
+| :--- | :--- | :--- |
+| `context` | Agent context for the contract. | UTF-8 text. Markdown is RECOMMENDED; issuers MAY embed a fenced JSON block for machine-readable fields. |
+| `endpoint[<type>]` | Endpoint URI for the named protocol `<type>`. | UTF-8 URI. For `endpoint[web]`, an `https` URI is RECOMMENDED. |
+| `address[<chain-id>]` | The agent's account on the chain identified by `<chain-id>`, where `<chain-id>` is the [ERC-7930](./eip-7930.md) Chain Identifier (see "Chain-keyed addresses" below). | The 20-byte EVM address (raw, not text). |
+
+#### Endpoint types
+
+Keys are case-sensitive (the value of `key` is compared as exact bytes). Endpoint types in this profile are therefore lowercase: `endpoint[mcp]` and `endpoint[MCP]` are distinct keys, and only the lowercase spelling carries the meaning reserved here. Implementations MUST write the canonical lowercase spelling for the types this profile reserves.
+
+The canonical endpoint types are:
+
+- `mcp`: Model Context Protocol endpoint.
+- `a2a`: Agent-to-Agent endpoint.
+- `web`: general web endpoint. The value MAY be any URI, with `https` RECOMMENDED.
+- `x402`: payment-enabled endpoint.
+
+Additional endpoint types MAY be used without changing this profile, provided they use the `endpoint[<type>]` form. Standards that reserve new types SHOULD define their exact canonical (lowercase) spelling.
+
+#### Chain-keyed addresses
+
+In `address[<chain-id>]`, `<chain-id>` is the [ERC-7930](./eip-7930.md) **Chain Identifier**, an Interoperable Address with a zero-length address part, encoded as a lowercase `0x`-prefixed hex string. The stored value is a normal 20-byte EVM address, not an ERC-7930 interoperable address; ERC-7930 is used only to name the chain.
+
+For example, the Chain Identifier for Ethereum mainnet (chain ID `1`) is `0x00010000010100`. The agent's mainnet account would be stored as:
+
+- Key: `"address[0x00010000010100]"` → Value: the 20 bytes of the EVM address.
+
+#### Client expectations
+
+Clients SHOULD treat both `context` and endpoints as untrusted input: they are issuer-supplied data, and reading them implies no verification of the servers, keys, balances, or memory they reference.
 
 ### Optional Metadata Hooks
 


### PR DESCRIPTION
Adds an optional AI agent metadata profile to ERC-8049, nicknamed **ERC-20Agent**, which associates a single AI agent with an ERC-20 token contract.

The profile is a standard *use* of this ERC's existing key-value interface. It defines no new Solidity interface, no new ERC-165 interface ID, no new functions, and no new events. Records are read and written through `contractMetadata(string)` and tracked via `ContractMetadataUpdated`, exactly as for any other key.

Because this ERC's records are contract-level, the agent belongs to the token contract as a whole rather than to any holder or balance.

### Reserved keys

| Key | Meaning |
| :--- | :--- |
| `context` | Agent context for the contract. UTF-8 text, Markdown RECOMMENDED. |
| `endpoint[<type>]` | Endpoint URI for the named protocol `<type>`. |
| `address[<chain-id>]` | The agent's account on the chain named by an ERC-7930 Chain Identifier. |

Canonical endpoint types are `mcp`, `a2a`, `web`, and `x402`. Keys are compared as exact bytes, so the reserved spellings are lowercase and implementations MUST write them that way. Additional types MAY be used without changing the profile.

In `address[<chain-id>]`, ERC-7930 is used only to name the chain: the stored value is a plain 20-byte EVM address, not an interoperable address.

### Other changes

- `requires` updated from `165` to `20, 165, 7930`.
- Abstract rewritten to describe the mechanism directly rather than by reference to other standards.
