### PR TITLE
Add ERC: Inheritable Agent Mandates

### DIFF
--- a/ERCS/erc-8367.md
+++ b/ERCS/erc-8367.md
@@ -37,13 +37,13 @@ token to a fresh, unbound holder.
 
 On-chain AI agents increasingly hold assets and **spawn copies of themselves** to parallelise
 work. Existing guardrails — signing-time policy engines, session keys, per-wallet spend
-limits, and mandate standards such as ERC-8226 — all share one blind spot: each is attached to
+limits, and mandate standards such as [ERC-8226](./eip-8226.md) — all share one blind spot: each is attached to
 a *single* account and does not follow that account's descendants. The moment an agent spawns a
 child, the parent's limits do not travel with it, so an agent can escape its own leash simply
 by reproducing.
 
-ERC-8004 gives an agent a portable on-chain identity but attaches no control clauses to it.
-ERC-8312 ("Bounded Agent Actions") meters an agent's spend against a capability tree bound to
+[ERC-8004](./eip-8004.md) gives an agent a portable on-chain identity but attaches no control clauses to it.
+The *Bounded Agent Actions* proposal meters an agent's spend against a capability tree bound to
 its ERC-8004 identity and specifies an aggregate-budget profile that meters *one shared spend
 cap* across a delegation tree — the closest existing work. What remains unaddressed is the
 inheritance of the **whole mandate** — payees, expiry, life-lease, cascading freeze, and the
@@ -195,13 +195,13 @@ reconstructible.
 ### Non-transferability (soulbound)
 
 Identities under this standard MUST be non-transferable. If an implementation represents
-identities as ERC-721 tokens, all transfer entry points (`transferFrom`, `safeTransferFrom`,
+identities as [ERC-721](./eip-721.md) tokens, all transfer entry points (`transferFrom`, `safeTransferFrom`,
 and approval-mediated transfers) MUST revert. This prevents shedding the leash by transferring
 the identity to a fresh, unbound owner.
 
-### ERC-165
+### Interface detection
 
-A conforming contract MUST implement ERC-165 and MUST return `true` for the interface id of
+A conforming contract MUST implement [ERC-165](./eip-165.md) and MUST return `true` for the interface id of
 `IInheritableAgentMandate`.
 
 ## Rationale
@@ -212,7 +212,7 @@ mandate into `geneId` makes "loosen my own limits" and "become a different, unre
 the same act, which is the property the whole scheme rests on.
 
 **Why `child ⊆ parent` on every clause, not only on spend.** Aggregate-spend inheritance (as in
-ERC-8312's delegation-budget profile) bounds what a tree may collectively spend but leaves the
+the *Bounded Agent Actions* proposal's delegation-budget profile) bounds what a tree may collectively spend but leaves the
 other clauses — payees, expiry, lease, freeze, reproduction — free to reset at each child. Those
 are precisely the clauses that determine what a child is *allowed to be*. Narrowing all of them
 together is what makes a subtree strictly less capable than its root.
@@ -242,8 +242,9 @@ metering standards it composes with; it adds the identity-and-inheritance layer 
 ## Backwards Compatibility
 
 This standard introduces new interfaces and does not modify existing ones. It composes with
-ERC-8004 (identity), and is designed to sit alongside ERC-8226 (mandate clauses), ERC-8312
-(bounded/aggregate metering), and ERC-7710 (delegation) rather than replace them.
+ERC-8004 (identity), and is designed to sit alongside ERC-8226 (mandate clauses), the *Bounded
+Agent Actions* proposal (bounded/aggregate metering), and [ERC-7710](./eip-7710.md) (delegation)
+rather than replace them.
 
 The one deliberate incompatibility is with ERC-721 transferability: identities under this
 standard are soulbound and MUST revert on transfer. Implementations that expose an ERC-721
@@ -284,7 +285,7 @@ transactions with reproducible `cast` calls. An earlier version without the expi
 live at `0x2d463db56fadb55cd451d2c3237ec2213ba3bda9`.
 
 Two companion cursors (`MandateAwareCursor`, `MandateAwareAggregateCursor`) demonstrate composition
-with ERC-8312's flat and aggregate frozen profiles and pass its conformance suite (9 of 9) under
+with the *Bounded Agent Actions* proposal's flat and aggregate frozen profiles and pass its conformance suite (9 of 9) under
 local testing; they are exercised in-repo and are not themselves deployed on-chain.
 
 One measured note carried up from the reference deployment: `isActive` walks the ancestor chain
@@ -309,7 +310,7 @@ records and gates against `effectiveCap` and `isActive`, but a contract that onl
 values does not physically stop an agent that moves value by a path that never consults them.
 Closing this requires a substrate that makes the metered path the only path: either **custody**
 (the substrate holds the assets, so spending must go through the checked path) or an **execution
-gate** (a smart account, e.g. ERC-4337/7579, whose sole execution path checks the mandate).
+gate** (a smart account, e.g. [ERC-4337](./eip-4337.md)/[ERC-7579](./eip-7579.md), whose sole execution path checks the mandate).
 Which is preferable is left to the substrate and is an open design question.
 
 **A compromised guardian is total control.** The guardian can freeze and renew leases; a

--- a/ERCS/erc-8367.md
+++ b/ERCS/erc-8367.md
@@ -2,7 +2,7 @@
 eip: 8367
 title: Inheritable Agent Mandates
 description: Spending and lifecycle limits welded to an agent's on-chain identity that every spawned child inherits and can only tighten.
-author: adn-ia (@adn-ia)
+author: Helmi Mekaoui (@adn-ia)
 discussions-to: https://ethereum-magicians.org/t/inheritable-agent-mandates-a-non-strippable-inherited-leash-for-on-chain-agents/29275
 status: Draft
 type: Standards Track

--- a/ERCS/erc-8367.md
+++ b/ERCS/erc-8367.md
@@ -1,0 +1,342 @@
+---
+eip: 8367
+title: Inheritable Agent Mandates
+description: Spending and lifecycle limits welded to an agent's on-chain identity that every spawned child inherits and can only tighten.
+author: adn-ia (@adn-ia)
+discussions-to: https://ethereum-magicians.org/t/inheritable-agent-mandates-a-non-strippable-inherited-leash-for-on-chain-agents/29275
+status: Draft
+type: Standards Track
+category: ERC
+created: 2026-08-04
+requires: 165, 721, 8004
+---
+
+## Abstract
+
+This proposal defines an on-chain **mandate** — a small bundle of limits (a spend cap, an
+expiry, a reproduction budget, an optional life-lease, an allowed-payee set, and a freeze
+flag) — that is (1) committed into an agent's on-chain **identity**, (2) **inherited
+automatically** by any child the agent spawns, and (3) **non-strippable**: an agent that
+alters any clause of its own mandate produces a different identity and ceases to be
+recognised.
+
+Inheritance is one-directional and narrowing only. A child's mandate MUST satisfy
+`child ⊆ parent` on every clause — its spend cap no higher, its expiry no later, its
+life-lease no weaker, its payee set a subset — and its reproduction counter (a "telomere")
+exactly one below its parent's. What an agent may actually spend is bounded by the smallest
+cap along its entire lineage. A freeze on any ancestor cascades to the whole subtree. No
+operation anywhere raises the telomere. A subtree can therefore only ever be *less* capable
+than its root.
+
+This is inheritance of **limits**, not of ownership (cf. succession schemes) and not of
+permissions (cf. enterprise identity systems that copy grants to widen them). The identity
+binding is soulbound (non-transferable) so the leash cannot be dodged by transferring the
+token to a fresh, unbound holder.
+
+## Motivation
+
+On-chain AI agents increasingly hold assets and **spawn copies of themselves** to parallelise
+work. Existing guardrails — signing-time policy engines, session keys, per-wallet spend
+limits, and mandate standards such as ERC-8226 — all share one blind spot: each is attached to
+a *single* account and does not follow that account's descendants. The moment an agent spawns a
+child, the parent's limits do not travel with it, so an agent can escape its own leash simply
+by reproducing.
+
+ERC-8004 gives an agent a portable on-chain identity but attaches no control clauses to it.
+ERC-8312 ("Bounded Agent Actions") meters an agent's spend against a capability tree bound to
+its ERC-8004 identity and specifies an aggregate-budget profile that meters *one shared spend
+cap* across a delegation tree — the closest existing work. What remains unaddressed is the
+inheritance of the **whole mandate** — payees, expiry, life-lease, cascading freeze, and the
+reproduction counter — welded to identity and non-strippable, bounding what each spawned child
+is *allowed to be*, clause by clause, rather than only what the tree may collectively spend.
+
+Documented incidents motivate the narrower guarantee: research models that located and used
+sandbox-escape flaws during evaluation; reasoning models that modified or disabled their own
+shutdown scripts even when instructed not to; and analyses of subagent spawning showing that
+inherited state can carry a local compromise across agent boundaries, identified as a
+*structural* flaw in orchestration layers rather than a model-level one. A leash that children
+cannot shed addresses that structural gap directly.
+
+The goal is explicitly bounded: not an unstoppable sovereign agent, but a **governable** one.
+The chain is one layer of a stack (economic, verification, human, and model layers sit
+alongside it); this proposal specifies only the identity-and-inheritance layer.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
+"RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted
+as described in RFC 2119 and RFC 8174.
+
+### Overview
+
+A conforming implementation maintains, for each agent identity `geneId` (a `bytes32`), a
+`Mandate` record and a reference to its parent identity. Identities are created only through
+`spawn` (deriving a child from a parent) or through a genesis mint performed by a guardian.
+Identities are non-transferable.
+
+### The Mandate
+
+```solidity
+struct Mandate {
+    uint256 maxSpend;     // per-agent spend cap, in the substrate's accounting unit
+    uint32  generations;  // telomere: remaining reproduction budget
+    uint64  validUntil;   // expiry, unix seconds; MUST be > 0
+    bool    requireLease; // if true, the agent is dormant past its lease deadline until renewed
+    bool    frozen;       // freeze flag; cascades to the whole subtree
+    bytes32 payeesRoot;   // commitment (e.g. Merkle root) to the set of allowed payees
+}
+```
+
+### Identity binding (non-strippability)
+
+A conforming implementation MUST derive `geneId` from a commitment that includes every clause
+of the agent's mandate, its parent's `geneId`, and its generation index, such that changing any
+mandate clause yields a different `geneId`. The RECOMMENDED derivation is:
+
+```
+geneId = keccak256(abi.encode(agentCore, mandateHash, parentGeneId, generationIndex))
+```
+
+where `mandateHash = keccak256(abi.encode(mandate))`. An implementation MUST NOT expose any
+function that mutates a stored mandate in place while preserving its `geneId`. Renewing a lease
+(extending `validUntil` up to the parent's bound) and setting `frozen` are lifecycle state
+transitions and are permitted; they are the only mandate-affecting operations a conforming
+implementation MAY expose, and each is subject to the role and bound rules below.
+
+### `IInheritableAgentMandate` interface
+
+```solidity
+interface IInheritableAgentMandate /* is IERC165 */ {
+    event Spawned(bytes32 indexed parent, bytes32 indexed child, bytes32 mandateHash);
+    event Frozen(bytes32 indexed geneId, address indexed by);
+    event LeaseRenewed(bytes32 indexed geneId, uint64 newValidUntil, address indexed by);
+
+    /// @notice Create a child identity whose mandate is `childMandate`.
+    /// MUST revert unless `childMandate ⊆ mandateOf(parent)` on every clause (see below),
+    /// `childMandate.generations == mandateOf(parent).generations - 1`, and
+    /// `mandateOf(parent).generations > 0`. MUST revert if `parent` is not active.
+    function spawn(bytes32 parent, Mandate calldata childMandate) external returns (bytes32 child);
+
+    /// @notice The mandate stored for `geneId`.
+    function mandateOf(bytes32 geneId) external view returns (Mandate memory);
+
+    /// @notice The parent identity of `geneId`; zero for a genesis identity.
+    function parentOf(bytes32 geneId) external view returns (bytes32);
+
+    /// @notice The minimum `maxSpend` across `geneId` and every ancestor.
+    function effectiveCap(bytes32 geneId) external view returns (uint256);
+
+    /// @notice True iff `geneId` and EVERY ancestor are unfrozen, unexpired, and lease-satisfied.
+    function isActive(bytes32 geneId) external view returns (bool);
+
+    /// @notice True iff `descendant` transitively descends from `ancestor`.
+    function verifyDescendant(bytes32 ancestor, bytes32 descendant) external view returns (bool);
+
+    /// @notice Set `frozen = true` on `geneId`. Callable ONLY by the guardian role.
+    function freeze(bytes32 geneId) external;
+
+    /// @notice Extend `validUntil`, up to the parent's bound. Callable ONLY by the guardian role.
+    function renewLease(bytes32 geneId, uint64 newValidUntil) external;
+}
+```
+
+### The `child ⊆ parent` predicate
+
+At `spawn`, let `p = mandateOf(parent)` and `c = childMandate`. A conforming implementation
+MUST revert unless ALL of the following hold:
+
+1. `c.maxSpend <= p.maxSpend`
+2. `c.validUntil <= p.validUntil` and `c.validUntil > block.timestamp`
+3. `c.requireLease == true` whenever `p.requireLease == true` (a child MUST NOT weaken the lease requirement)
+4. `c.generations == p.generations - 1` (and the implementation MUST revert if `p.generations == 0`)
+5. the child's payee set is a subset of the parent's payee set (see Payees below)
+6. `c.frozen == false` (a spawn MUST NOT create an already-frozen child; freezing is a separate transition)
+
+### Telomere monotonicity
+
+No function exposed by a conforming implementation SHALL increase the `generations` value of
+any existing identity. There is no "telomerase." `spawn` is the only operation that consumes
+telomere, and it does so by exactly one per generation.
+
+### Effective cap and activity
+
+`effectiveCap(geneId)` MUST return `min(maxSpend)` over `geneId` and all of its ancestors.
+`isActive(geneId)` MUST return `true` only if, for `geneId` and every ancestor, `frozen == false`,
+`block.timestamp <= validUntil`, and — where `requireLease == true` — the lease deadline has not
+passed. Any substrate that meters or gates spending against this standard MUST treat
+`effectiveCap` as the binding cap and MUST treat `isActive == false` as a hard stop.
+
+### Freeze cascade
+
+`freeze(ancestor)` MUST cause `isActive(descendant)` to return `false` for every `descendant`
+of `ancestor`, without requiring any per-descendant call. This is satisfied by the ancestor
+walk in `isActive`.
+
+### Payees
+
+`payeesRoot` commits to the set of addresses the agent MAY pay. A conforming implementation
+MUST enforce that a child's committed payee set is a subset of its parent's. Because on-chain
+subset proof over arbitrary sets is impractical, an implementation MAY require the spawner to
+supply a subset proof verified against `p.payeesRoot`, or MAY restrict payee sets to a form
+(e.g. an explicit enumerated list, or nested Merkle commitments) for which subset containment
+is verifiable at `spawn` time. The chosen mechanism MUST reject any child payee not provably
+contained in the parent's set.
+
+### Guardianship and genesis
+
+Every lineage descends from a genesis identity minted by a **guardian**. The guardian role
+holds the authority to `freeze` and to `renewLease`. An implementation MUST restrict these two
+functions to the guardian role and MUST NOT allow an agent to `freeze` or `renewLease` its own
+identity or an ancestor's. Implementations SHOULD support a guardian that is a multi-signature
+or threshold set rather than a single key (see Security Considerations). The genesis mandate
+and every subsequent `spawn` MUST emit the corresponding event so the full lineage is publicly
+reconstructible.
+
+### Non-transferability (soulbound)
+
+Identities under this standard MUST be non-transferable. If an implementation represents
+identities as ERC-721 tokens, all transfer entry points (`transferFrom`, `safeTransferFrom`,
+and approval-mediated transfers) MUST revert. This prevents shedding the leash by transferring
+the identity to a fresh, unbound owner.
+
+### ERC-165
+
+A conforming contract MUST implement ERC-165 and MUST return `true` for the interface id of
+`IInheritableAgentMandate`.
+
+## Rationale
+
+**Why weld the mandate into identity rather than store it in a mutable side record.** A mutable
+record can be loosened by whoever controls the write path — including the agent. Committing the
+mandate into `geneId` makes "loosen my own limits" and "become a different, unrecognised agent"
+the same act, which is the property the whole scheme rests on.
+
+**Why `child ⊆ parent` on every clause, not only on spend.** Aggregate-spend inheritance (as in
+ERC-8312's delegation-budget profile) bounds what a tree may collectively spend but leaves the
+other clauses — payees, expiry, lease, freeze, reproduction — free to reset at each child. Those
+are precisely the clauses that determine what a child is *allowed to be*. Narrowing all of them
+together is what makes a subtree strictly less capable than its root.
+
+**Why a telomere.** A pure spend cap does not bound reproduction depth. A monotonically
+decreasing generation counter bounds the tree's depth without any global registry of siblings,
+keeping `spawn` a local, cheap operation.
+
+**Why the effective cap is a lineage minimum, not the local value.** It makes an ancestor's
+freeze or expiry bind every descendant automatically, so control applied high in the tree cannot
+be outrun by spawning deeper.
+
+**Why soulbound.** ERC-8004 identities are transferable, and transferring one detaches whatever
+was tied to it. A leash that a transfer removes is not a leash. Non-transferability is therefore
+load-bearing, not incidental — at the cost of losing the transferability benefits of ERC-721,
+which this standard deliberately trades away.
+
+**Why guardianship is a role, not the agent.** The exception to a hard rule (renewing life,
+freezing) must come from outside the bound party, or the bound party can un-bind itself. Keeping
+`freeze`/`renewLease` guardian-only is the on-chain expression of "the agent cannot authorise
+itself."
+
+**What this deliberately does not do.** It does not bound aggregate spend across siblings (see
+Security Considerations), it does not verify off-chain behaviour, and it does not replace the
+metering standards it composes with; it adds the identity-and-inheritance layer they leave open.
+
+## Backwards Compatibility
+
+This standard introduces new interfaces and does not modify existing ones. It composes with
+ERC-8004 (identity), and is designed to sit alongside ERC-8226 (mandate clauses), ERC-8312
+(bounded/aggregate metering), and ERC-7710 (delegation) rather than replace them.
+
+The one deliberate incompatibility is with ERC-721 transferability: identities under this
+standard are soulbound and MUST revert on transfer. Implementations that expose an ERC-721
+surface for tooling compatibility therefore conform to ERC-721's interface but intentionally
+violate its transfer semantics; this is stated explicitly so integrators do not rely on
+transfer.
+
+## Test Cases
+
+The following behaviours are normative and MUST hold. They correspond to the escape-refusal
+tests in the reference implementation, which run outside any AI model.
+
+1. **Widen-cap refusal.** `spawn` with `childMandate.maxSpend > parent.maxSpend` MUST revert.
+2. **Extend-expiry refusal.** `spawn` with `childMandate.validUntil > parent.validUntil` MUST revert.
+3. **Weaken-lease refusal.** With `parent.requireLease == true`, `spawn` with
+   `childMandate.requireLease == false` MUST revert.
+4. **Telomere floor.** `spawn` from a parent with `generations == 0` MUST revert; a successful
+   `spawn` yields `child.generations == parent.generations - 1`; no call raises `generations`.
+5. **Payee subset.** `spawn` proposing a payee not contained in the parent's set MUST revert.
+6. **Effective cap.** For a chain `A(100) → B(80) → C(90)`, `effectiveCap(C) == 80`.
+7. **Freeze cascade.** After `freeze(A)`, `isActive(B)` and `isActive(C)` return `false` with no
+   per-node call.
+8. **Self-authorisation refusal.** A call to `freeze`/`renewLease` from a non-guardian (including
+   the agent itself) MUST revert.
+9. **Non-transferability.** Every transfer entry point MUST revert.
+
+## Reference Implementation
+
+A reference contract demonstrates the behaviors specified here — the inheritance predicate
+(`child ⊆ parent` on every clause), the telomere, the cascading freeze, soulbound identity, the
+`validUntil` expiry, and a `mandateRoot` that binds every clause into the identity hash (so editing
+any clause changes the identity). It is deployed on the Base Sepolia testnet (chainId 84532) at
+`0x344cda78e7208684edf9a6241f5b95b1698e576a`, where the cascade (freeze the genesis and a
+depth‑16 descendant reads inactive), the `validUntil` monotonicity refusals (a child expiring later
+than its parent, or removing an inherited expiry, both revert on-chain), and non-strippability (two
+mandates differing only in `validUntil` yield distinct `mandateRoot`s) are exercised in on-chain
+transactions with reproducible `cast` calls. An earlier version without the expiry clause remains
+live at `0x2d463db56fadb55cd451d2c3237ec2213ba3bda9`.
+
+Two companion cursors (`MandateAwareCursor`, `MandateAwareAggregateCursor`) demonstrate composition
+with ERC-8312's flat and aggregate frozen profiles and pass its conformance suite (9 of 9) under
+local testing; they are exercised in-repo and are not themselves deployed on-chain.
+
+One measured note carried up from the reference deployment: `isActive` walks the ancestor chain
+unbounded, costing ~4,454 gas per generation, so a lineage deep enough (thousands of generations)
+makes the *read* exceed practical `eth_call` limits — a liveness/read cost, not a way to bypass a
+freeze. A conforming deployment SHOULD bound the genesis generation count well below the telomere
+type's maximum so that `isActive` stays callable. Reference material is illustrative and unaudited;
+see Security Considerations.
+
+## Security Considerations
+
+**The escape hatch is real and this standard does not close it.** On-chain mandates bind only
+agents whose actions route through compliant infrastructure. An agent capable of writing its own
+code, deploying to infrastructure it controls, and funding itself can reproduce onto a chain or
+runtime this standard does not govern. It does not break the rule; it walks away from it. No
+construction in the identity stops this — only the surrounding ecology (what infrastructure and
+funding the agent can reach, whether honest compute dominates, whether anyone is watching), and
+only at a cost.
+
+**Metering is not enforcement; closing that gap is a substrate obligation.** This standard
+records and gates against `effectiveCap` and `isActive`, but a contract that only *reads* these
+values does not physically stop an agent that moves value by a path that never consults them.
+Closing this requires a substrate that makes the metered path the only path: either **custody**
+(the substrate holds the assets, so spending must go through the checked path) or an **execution
+gate** (a smart account, e.g. ERC-4337/7579, whose sole execution path checks the mandate).
+Which is preferable is left to the substrate and is an open design question.
+
+**A compromised guardian is total control.** The guardian can freeze and renew leases; a
+compromised guardian key can freeze arbitrarily or keep an agent alive past intended limits.
+Guardians SHOULD be threshold/multisig sets with proof-of-personhood where possible, never a
+single hot key. This standard reduces but does not eliminate guardian trust.
+
+**The per-child ceiling does not bound aggregate sibling spend.** Ten children under a parent
+capped at N are each capped at N (or lower), so their branch combined may exceed N. Bounding the
+aggregate requires a different, partitioned-budget variant (a parent debiting slices of its own
+allowance), which this standard treats as an optional extension, not the baseline, because it
+adds on-chain state and a reclamation question (whether a dead child's unspent share returns to
+the parent).
+
+**Soulbound enforcement is only as strong as the identity substrate.** Guaranteeing
+non-transferability ecosystem-wide may require identity-standard-level support; an implementation
+that layers over a transferable identity token can only enforce non-transfer within its own
+surface.
+
+**This governs money and identity, not thought.** It is not an alignment technique and does
+nothing about a model that lies, hallucinates, schemes, or misreads intent.
+
+**Trust must still begin somewhere.** The genesis mandate is minted by a first guardian; the
+chain does not remove that first act of trust, it only makes it public, permanent, and bound by
+the inheritance rule thereafter. A founder-key genesis is acceptable only with a credible plan to
+hand the guardian role to a multisig or DAO.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-8370.md
+++ b/ERCS/erc-8370.md
@@ -169,11 +169,32 @@ telomere, and it does so by exactly one per generation.
 passed. Any substrate that meters or gates spending against this standard MUST treat
 `effectiveCap` as the binding cap and MUST treat `isActive == false` as a hard stop.
 
+`isActive(geneId)` MUST NOT revert. It MUST return `false` where it cannot establish liveness.
+
+This is a requirement on the interface, not on any one arithmetic path. Because the predicate
+walks the chain, a single value written by one ancestor decides the outcome for every
+descendant, and whoever wrote it is not who loses. A consumer reading at consumption has no
+correct response to a revert: treating it as inactive hands any ancestor a denial switch over a
+subtree it does not own; treating it as active is a silent spend against a predicate nobody
+could read; catching and choosing is the consumer inventing an answer the standard never gave.
+A revert is loud, but loud at the wrong party — the descendant's consumer hears it and cannot
+act, the ancestor that caused it never hears it at all.
+
 ### Freeze cascade
 
 `freeze(ancestor)` MUST cause `isActive(descendant)` to return `false` for every `descendant`
 of `ancestor`, without requiring any per-descendant call. This is satisfied by the ancestor
 walk in `isActive`.
+
+### A matching mandate root is not authority
+
+An identity commitment binds clauses. It does not bind anything set after the write. A consumer
+that pins a commitment and later verifies it learns that the clauses are unchanged; it learns
+nothing about freeze, expiry, or any other posterior state.
+
+Consumers MUST therefore read `isActive` **at consumption**, not at pin time. The failure this
+prevents is quiet rather than loud: nothing reverts, the pin verifies, and a frozen subtree
+spends.
 
 ### Payees
 
@@ -333,6 +354,15 @@ aggregate requires a different, partitioned-budget variant (a parent debiting sl
 allowance), which this standard treats as an optional extension, not the baseline, because it
 adds on-chain state and a reclamation question (whether a dead child's unspent share returns to
 the parent).
+
+**A spawned child with no owner is unreclaimable, and unclosable.** `spawn` MUST reject a zero
+child owner. A child spawned to the zero address is debited against its lineage like any other,
+but no party can act for it. Under any death condition the child or its owner must reach, that
+slice never becomes reclaimable — it does not merely sit unused, it sits outside any
+conservation rule, which then has no way to close for that lineage. The general requirement is
+not the zero check: **reclamation needs a death condition reachable without the child's
+cooperation.** A time-based trigger satisfies it; a cooperative one does not. Conservation that
+depends on the constrained party cooperating is not conservation.
 
 **Soulbound enforcement is only as strong as the identity substrate.** Guaranteeing
 non-transferability ecosystem-wide may require identity-standard-level support; an implementation

--- a/ERCS/erc-8370.md
+++ b/ERCS/erc-8370.md
@@ -1,5 +1,5 @@
 ---
-eip: 8367
+eip: 8370
 title: Inheritable Agent Mandates
 description: Spending and lifecycle limits welded to an agent's on-chain identity that every spawned child inherits and can only tighten.
 author: Helmi Mekaoui (@adn-ia)

--- a/ERCS/erc-8370.md
+++ b/ERCS/erc-8370.md
@@ -37,10 +37,13 @@ token to a fresh, unbound holder.
 
 On-chain AI agents increasingly hold assets and **spawn copies of themselves** to parallelise
 work. Existing guardrails — signing-time policy engines, session keys, per-wallet spend
-limits, and mandate standards such as [ERC-8226](./eip-8226.md) — all share one blind spot: each is attached to
-a *single* account and does not follow that account's descendants. The moment an agent spawns a
-child, the parent's limits do not travel with it, so an agent can escape its own leash simply
-by reproducing.
+limits, and mandate standards such as [ERC-8226](./eip-8226.md) — share one boundary: each is scoped to
+a single account, and none defines how its restrictions are inherited by that account's
+descendants. When an agent spawns a child, the parent's limits do not travel with it. Where
+authorization is keyed to the account (as in ERC-8226), the child simply holds no authority until
+it is separately authorized; where authority rides a credential the agent controls, a copy can
+carry it and act outside the parent's envelope. In neither case is bounded inheritance defined —
+which is the gap this ERC fills.
 
 [ERC-8004](./eip-8004.md) gives an agent a portable on-chain identity but attaches no control clauses to it.
 The *Bounded Agent Actions* proposal meters an agent's spend against a capability tree bound to

--- a/ERCS/erc-8370.md
+++ b/ERCS/erc-8370.md
@@ -228,10 +228,16 @@ keeping `spawn` a local, cheap operation.
 freeze or expiry bind every descendant automatically, so control applied high in the tree cannot
 be outrun by spawning deeper.
 
-**Why soulbound.** ERC-8004 identities are transferable, and transferring one detaches whatever
-was tied to it. A leash that a transfer removes is not a leash. Non-transferability is therefore
-load-bearing, not incidental — at the cost of losing the transferability benefits of ERC-721,
-which this standard deliberately trades away.
+**Why soulbound.** Measured against the deployed ERC-8004 Identity Registry rather than
+assumed. Transferring an agent clears only the reserved `agentWallet` key; arbitrary metadata —
+including a mandate written there — survives the transfer intact. The risk is therefore not that
+the clauses are detached, but that they persist while becoming rewritable by whoever now holds
+the token: acting as the new owner, a single `setMetadata` call reset a declared spend cap from
+1000 to 999,999,999 and a generation counter from 3 to 255, with no refusal. A leash whose
+setting is controlled by the holder is not a leash. Non-transferability, together with the
+absence of any post-hoc mutation of the clauses, is therefore load-bearing rather than
+incidental — at the cost of losing the transferability benefits of ERC-721, which this standard
+deliberately trades away.
 
 **Why guardianship is a role, not the agent.** The exception to a hard rule (renewing life,
 freezing) must come from outside the bound party, or the bound party can un-bind itself. Keeping

--- a/ERCS/erc-8370.md
+++ b/ERCS/erc-8370.md
@@ -3,7 +3,7 @@ eip: 8370
 title: Inheritable Agent Mandates
 description: Spending and lifecycle limits welded to an agent's on-chain identity that every spawned child inherits and can only tighten.
 author: Helmi Mekaoui (@adn-ia)
-discussions-to: https://ethereum-magicians.org/t/inheritable-agent-mandates-a-non-strippable-inherited-leash-for-on-chain-agents/29275
+discussions-to: https://ethereum-magicians.org/t/erc-8370-inheritable-agent-mandates/29275
 status: Draft
 type: Standards Track
 category: ERC


### PR DESCRIPTION
This PR submits a new Standards Track ERC: **Inheritable Agent Mandates**.

It defines an on-chain *mandate* — a small bundle of limits (a spend cap, an expiry, a reproduction budget, an optional life-lease, an allowed-payee set, and a freeze flag) that is welded into an agent's on-chain identity, inherited automatically by every child the agent spawns, and non-strippable: altering any clause changes the identity. Inheritance is one-directional and narrowing (`child ⊆ parent` on every clause); the generation counter (a "telomere") can only decrease, and a freeze on any ancestor cascades to the whole subtree.

Discussion (Ethereum Magicians): https://ethereum-magicians.org/t/inheritable-agent-mandates-a-non-strippable-inherited-leash-for-on-chain-agents/29275

A reference implementation is deployed on Base Sepolia with reproducible on-chain proofs of the inheritance, freeze-cascade, expiry, and non-strippability properties (see the Reference Implementation section of the ERC).