### PR TITLE
Update ERC-7730: fix smart quotes

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1440,7 +1440,7 @@ Formats applicable to `bytes` solidity type.
 | *Parameters*                | --- |
 | `calleePath` or `callee`    | A path reference or a constant value specifying the address of the contract being called. |
 | `selectorPath` or `selector`| Optional. If omitted, the first 4 bytes of the calldata are used as the selector. |
-| `chainIdPath` or `chainId`  | Optional. Specifies the chain ID if it differs from the current contract’s chain. |
+| `chainIdPath` or `chainId`  | Optional. Specifies the chain ID if it differs from the current contract's chain. |
 | `amountPath` or `amount`    | Optional. Specifies the native currency amount associated with the calldata, if applicable. If provided, the ERC-7730 descriptor for this embedded calldata MAY reference this value using the `@.value` container path. |
 | `spenderPath` or `spender`  | Optional. Specifies the spender address associated with the calldata, if applicable. If provided, the ERC-7730 descriptor for this embedded calldata MAY reference this value using the `@.from` container path. |
 | *Examples*                  | --- |


### PR DESCRIPTION
CI currently breaks because of this : https://github.com/ethereum/ERCs/actions/runs/31044649432/job/92437098903?pr=1908

```
Error: error[markdown-no-smart-quotes]: smart quotes are not allowed (use straight quotes instead)
    --> ERCS/erc-7730.md:1473:105
     |
1473 | | `chainIdPath` or `chainId`  | Optional. Specifies the chain ID if it differs from the current contract’s chain. |
     |                                                                                                         ^
     |
     = info: the pattern in question: `[\u{201C}\u{201D}]|[\u{2018}\u{2019}]`
     = help: see https://ethereum.github.io/eipw/markdown-no-smart-quotes/
Error: validation found errors :(
```