### PR TITLE
Config: Update pull request template with EIP number note

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md
 
+**DO NOT**: assign your own EIP number; Editors will do it for you.
+
 We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:
 
  - The PR edits only existing draft PRs.


### PR DESCRIPTION
Added a note to the pull request template regarding EIP number assignment.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
