### PR TITLE
Update ERC-8048: correct address encoding and add optional account key

### DIFF
--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -120,7 +120,7 @@ A contract implementing this profile MUST implement ERC-721 and this ERC. The pr
 | :--- | :--- | :--- |
 | `context` | Agent context for the token. | UTF-8 text. Markdown is RECOMMENDED; issuers MAY embed a fenced JSON block for machine-readable fields, as in the AI-agent example above. |
 | `endpoint[<type>]` | Endpoint URI for the named protocol `<type>`. | UTF-8 URI. For `endpoint[web]`, an `https` URI is RECOMMENDED. |
-| `address[<chain-id>]` | The agent's account on the chain identified by `<chain-id>`, where `<chain-id>` is the [ERC-7930](./eip-7930.md) Chain Identifier (see "Chain-keyed addresses" below). | The 20-byte EVM address (raw, not text). |
+| `address[<chain-id>]` | The agent's account on the chain identified by `<chain-id>`, where `<chain-id>` is the [ERC-7930](./eip-7930.md) Chain Identifier (see "Chain-keyed addresses" below). | The Address component of an [ERC-7930](./eip-7930.md) Interoperable Address for the chain named by `<chain-id>`. For an EVM chain, the 20-byte address. |
 
 #### Endpoint types
 
@@ -137,7 +137,7 @@ Additional endpoint types MAY be used without changing this profile, provided th
 
 #### Chain-keyed addresses
 
-In `address[<chain-id>]`, `<chain-id>` is the [ERC-7930](./eip-7930.md) **Chain Identifier**, an Interoperable Address with a zero-length address part, encoded as a lowercase `0x`-prefixed hex string. The stored value is a normal 20-byte EVM address, not an ERC-7930 interoperable address; ERC-7930 is used only to name the chain.
+In `address[<chain-id>]`, `<chain-id>` is the [ERC-7930](./eip-7930.md) **Chain Identifier**, an Interoperable Address with a zero-length address part, encoded as a lowercase `0x`-prefixed hex string. The stored value is the Address component of an ERC-7930 Interoperable Address for that chain, the chain's native address bytes. It is the Address component alone, not a full Interoperable Address.
 
 For example, the Chain Identifier for Ethereum mainnet (chain ID `1`) is `0x00010000010100`, and for Base (chain ID `8453`, i.e. `0x2105`) is `0x000100000202210500`. The agent's mainnet account would be stored as:
 

--- a/ERCS/erc-8048.md
+++ b/ERCS/erc-8048.md
@@ -121,6 +121,7 @@ A contract implementing this profile MUST implement ERC-721 and this ERC. The pr
 | `context` | Agent context for the token. | UTF-8 text. Markdown is RECOMMENDED; issuers MAY embed a fenced JSON block for machine-readable fields, as in the AI-agent example above. |
 | `endpoint[<type>]` | Endpoint URI for the named protocol `<type>`. | UTF-8 URI. For `endpoint[web]`, an `https` URI is RECOMMENDED. |
 | `address[<chain-id>]` | The agent's account on the chain identified by `<chain-id>`, where `<chain-id>` is the [ERC-7930](./eip-7930.md) Chain Identifier (see "Chain-keyed addresses" below). | The Address component of an [ERC-7930](./eip-7930.md) Interoperable Address for the chain named by `<chain-id>`. For an EVM chain, the 20-byte address. |
+| `account[<chain-id>][<index>]` | OPTIONAL. An additional account of the agent on the chain identified by `<chain-id>`, distinguished by `<index>`. See "Additional accounts" below. | The Address component of an [ERC-7930](./eip-7930.md) Interoperable Address for the chain named by `<chain-id>`. For an EVM chain, the 20-byte address. |
 
 #### Endpoint types
 
@@ -142,6 +143,20 @@ In `address[<chain-id>]`, `<chain-id>` is the [ERC-7930](./eip-7930.md) **Chain 
 For example, the Chain Identifier for Ethereum mainnet (chain ID `1`) is `0x00010000010100`, and for Base (chain ID `8453`, i.e. `0x2105`) is `0x000100000202210500`. The agent's mainnet account would be stored as:
 
 - Key: `"address[0x00010000010100]"` → Value: the 20 bytes of the EVM address.
+
+#### Additional accounts
+
+An agent MAY list additional accounts under the OPTIONAL key `account[<chain-id>][<index>]`. Any account qualifies, for example a token-bound account or a smart contract wallet.
+
+`address[<chain-id>]` is the agent's primary account on that chain. Clients SHOULD send funds to `address[<chain-id>]` and SHOULD NOT assume an account listed under `account[<chain-id>][<index>]` accepts payments.
+
+`<chain-id>` is the [ERC-7930](./eip-7930.md) Chain Identifier and the stored value is the ERC-7930 Address component for that chain, both exactly as in `address[<chain-id>]`.
+
+`<index>`, an unsigned base-10 integer with no leading zeros, distinguishes multiple accounts on the same chain.
+
+For example, an agent's additional account at index `0` on Ethereum mainnet would be stored as:
+
+- Key: `"account[0x00010000010100][0]"` → Value: the 20 bytes of the EVM address.
 
 #### Marketplace compatibility
 
@@ -250,7 +265,6 @@ Security: clients SHOULD only call metadata contracts they consider trustworthy;
 ## Rationale
 
 This ERC standardizes a simple string-key, bytes-value metadata store for existing token registries. The optional `setMetadata` function allows updates under the contract's chosen write policy, and `MetadataSet` provides an onchain audit trail. The **Metadata Authority** extension standardizes a read for discovering whether metadata write authority rests with the token's [ERC-721](./eip-721.md) owner/approved/operator (when no authority is set). **Onchain Metadata Contract Reference** extends this model to already-deployed tokens by pointing `metadata_contract` to a sidecar via a [ERC-7930](./eip-7930.md) address in `tokenURI` / `uri` JSON.
-
 ## Backwards Compatibility
 
 - Fully compatible with [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md), and [ERC-6909](./eip-6909.md).


### PR DESCRIPTION
Two changes to the ERC-721T agent profile.

**Correct the encoding of `address[<chain-id>]`.** The spec said the stored value is "a normal 20-byte EVM address", which holds only for EVM chains. Since `<chain-id>` is an ERC-7930 Chain Identifier and can name any namespace, the value is now the Address component of an ERC-7930 Interoperable Address for that chain, with the 20-byte EVM address as the concrete case.

**Add an OPTIONAL `account[<chain-id>][<index>]` key.** An agent often controls more than one account on a chain. This key lists those accounts, while `address[<chain-id>]` remains the agent's primary account. Clients SHOULD send funds to `address[<chain-id>]` and SHOULD NOT assume a listed account accepts payments.

The key is named `account` rather than `tb-account`, which an earlier draft used, because nothing on chain can verify that a listed address was derived from a token. Token-bound accounts and smart contract wallets are examples of what may be listed, not the definition.
