### PR TITLE
Update ERC-8049: correct address encoding and add optional account key

### DIFF
--- a/ERCS/erc-8049.md
+++ b/ERCS/erc-8049.md
@@ -98,6 +98,7 @@ A contract implementing this profile MUST implement [ERC-20](./eip-20.md) and th
 | `context` | Agent context for the contract. | UTF-8 text. Markdown is RECOMMENDED; issuers MAY embed a fenced JSON block for machine-readable fields. |
 | `endpoint[<type>]` | Endpoint URI for the named protocol `<type>`. | UTF-8 URI. For `endpoint[web]`, an `https` URI is RECOMMENDED. |
 | `address[<chain-id>]` | The agent's account on the chain identified by `<chain-id>`, where `<chain-id>` is the [ERC-7930](./eip-7930.md) Chain Identifier (see "Chain-keyed addresses" below). | The Address component of an [ERC-7930](./eip-7930.md) Interoperable Address for the chain named by `<chain-id>`. For an EVM chain, the 20-byte address. |
+| `account[<chain-id>][<index>]` | OPTIONAL. An additional account of the agent on the chain identified by `<chain-id>`, distinguished by `<index>`. See "Additional accounts" below. | The Address component of an [ERC-7930](./eip-7930.md) Interoperable Address for the chain named by `<chain-id>`. For an EVM chain, the 20-byte address. |
 
 #### Endpoint types
 
@@ -120,6 +121,20 @@ For example, the Chain Identifier for Ethereum mainnet (chain ID `1`) is `0x0001
 
 - Key: `"address[0x00010000010100]"` → Value: the 20 bytes of the EVM address.
 
+#### Additional accounts
+
+An issuer MAY list additional accounts for the contract's agent under the OPTIONAL key `account[<chain-id>][<index>]`. The accounts are contract-level and belong to the token contract's agent as a whole, not to any holder or balance. Any account qualifies, for example a token-bound account or a smart contract wallet.
+
+`address[<chain-id>]` is the agent's primary account on that chain. Clients SHOULD send funds to `address[<chain-id>]` and SHOULD NOT assume an account listed under `account[<chain-id>][<index>]` accepts payments.
+
+`<chain-id>` is the [ERC-7930](./eip-7930.md) Chain Identifier and the stored value is the ERC-7930 Address component for that chain, both exactly as in `address[<chain-id>]`.
+
+`<index>`, an unsigned base-10 integer with no leading zeros, distinguishes multiple accounts on the same chain.
+
+For example, the agent's additional account at index `0` on Ethereum mainnet would be stored as:
+
+- Key: `"account[0x00010000010100][0]"` → Value: the 20 bytes of the EVM address.
+
 #### Client expectations
 
 Clients SHOULD treat both `context` and endpoints as untrusted input: they are issuer-supplied data, and reading them implies no verification of the servers, keys, balances, or memory they reference.
@@ -131,7 +146,6 @@ Contracts implementing this ERC MAY use hooks to redirect metadata resolution to
 ## Rationale
 
 This design prioritizes simplicity and flexibility by using a string-key, bytes-value store that provides an intuitive interface for any type of contract metadata. The minimal interface with a single `contractMetadata` function provides all necessary functionality. The optional `setContractMetadata` function enables flexible access control for metadata updates. The required `ContractMetadataUpdated` event provides transparent audit trails with indexed key for efficient filtering. Contracts that need predictable storage locations can optionally use Diamond Storage pattern. This makes the standard suitable for diverse use cases including contract identification, collaboration tracking, and custom metadata storage.
-
 ## Backwards Compatibility
 
 - Fully compatible with existing smart contracts.

--- a/ERCS/erc-8049.md
+++ b/ERCS/erc-8049.md
@@ -97,7 +97,7 @@ A contract implementing this profile MUST implement [ERC-20](./eip-20.md) and th
 | :--- | :--- | :--- |
 | `context` | Agent context for the contract. | UTF-8 text. Markdown is RECOMMENDED; issuers MAY embed a fenced JSON block for machine-readable fields. |
 | `endpoint[<type>]` | Endpoint URI for the named protocol `<type>`. | UTF-8 URI. For `endpoint[web]`, an `https` URI is RECOMMENDED. |
-| `address[<chain-id>]` | The agent's account on the chain identified by `<chain-id>`, where `<chain-id>` is the [ERC-7930](./eip-7930.md) Chain Identifier (see "Chain-keyed addresses" below). | The 20-byte EVM address (raw, not text). |
+| `address[<chain-id>]` | The agent's account on the chain identified by `<chain-id>`, where `<chain-id>` is the [ERC-7930](./eip-7930.md) Chain Identifier (see "Chain-keyed addresses" below). | The Address component of an [ERC-7930](./eip-7930.md) Interoperable Address for the chain named by `<chain-id>`. For an EVM chain, the 20-byte address. |
 
 #### Endpoint types
 
@@ -114,7 +114,7 @@ Additional endpoint types MAY be used without changing this profile, provided th
 
 #### Chain-keyed addresses
 
-In `address[<chain-id>]`, `<chain-id>` is the [ERC-7930](./eip-7930.md) **Chain Identifier**, an Interoperable Address with a zero-length address part, encoded as a lowercase `0x`-prefixed hex string. The stored value is a normal 20-byte EVM address, not an ERC-7930 interoperable address; ERC-7930 is used only to name the chain.
+In `address[<chain-id>]`, `<chain-id>` is the [ERC-7930](./eip-7930.md) **Chain Identifier**, an Interoperable Address with a zero-length address part, encoded as a lowercase `0x`-prefixed hex string. The stored value is the Address component of an ERC-7930 Interoperable Address for that chain, the chain's native address bytes. It is the Address component alone, not a full Interoperable Address.
 
 For example, the Chain Identifier for Ethereum mainnet (chain ID `1`) is `0x00010000010100`. The agent's mainnet account would be stored as:
 


### PR DESCRIPTION
Two changes to the ERC-20Agent contract-level profile, mirroring the same changes to ERC-8048.

**Correct the encoding of `address[<chain-id>]`.** The spec said the stored value is "a normal 20-byte EVM address", which holds only for EVM chains. Since `<chain-id>` is an ERC-7930 Chain Identifier and can name any namespace, the value is now the Address component of an ERC-7930 Interoperable Address for that chain, with the 20-byte EVM address as the concrete case.

**Add an OPTIONAL `account[<chain-id>][<index>]` key.** An agent often controls more than one account on a chain. This key lets an issuer list those accounts for the contract's agent, while `address[<chain-id>]` remains the primary account. The accounts are contract-level and belong to the token contract's agent as a whole, not to any holder or balance. Clients SHOULD send funds to `address[<chain-id>]` and SHOULD NOT assume a listed account accepts payments.

The key is named `account` rather than `tb-account`, which an earlier draft used, because nothing on chain can verify that a listed address was derived from a token. Token-bound accounts and smart contract wallets are examples of what may be listed, not the definition.
