### PR TITLE
Website: Fix the Auto Stagnant Bot, which has never run in this repository

### DIFF
--- a/.github/scripts/mark-stagnant-ercs.js
+++ b/.github/scripts/mark-stagnant-ercs.js
@@ -1,17 +1,18 @@
 // @ts-check
 /**
  * Moves ERCs that have gone six months without an edit to Stagnant, opening one
- * pull request per ERC and squash merging it two weeks later.
+ * pull request per ERC and squash merging it once its required checks pass.
  *
  * This is a port of ethereum/EIP-Bot, which drives the identical process in
  * ethereum/EIPs. That repository was archived in January 2023 and looks for
  * proposals in a hardcoded `EIPS/` directory, so it cannot be fixed upstream and
  * has never done anything here beyond failing silently.
  *
- * Behaviour is intentionally identical to the EIPs bot: same six month cutoff,
- * same stagnatable statuses, same branch names, pull request titles, bodies and
- * labels, and the same two week merge delay. Deviations are marked "DEVIATION"
- * and explained.
+ * Behaviour follows the EIPs bot closely: same six month cutoff, same stagnatable
+ * statuses, same branch names, pull request titles, bodies and labels, and the
+ * same cleanup routines. Deviations are marked "DEVIATION" and explained; the
+ * significant one is that pull requests are merged in the run that opens them
+ * rather than two weeks later.
  */
 
 const { execFileSync } = require("child_process");
@@ -21,8 +22,23 @@ const path = require("path");
 const PROPOSALS_DIR = "ERCS";
 const PROPOSAL_PREFIX = "erc";
 const STAGNATION_CUTOFF_MONTHS = 6;
-const MERGEABLE_CUTOFF_WEEKS = 2;
-const MERGEABLE_CUTOFF_DESCRIPTION = "2 weeks";
+
+/**
+ * DEVIATION: the EIPs bot leaves its pull requests open for two weeks and merges
+ * them during a later run's cleanup. Here they are merged in the same run, as
+ * soon as the required status checks pass.
+ *
+ * The cleanup merge is kept as a safety net with a cutoff of zero, so anything
+ * that could not be merged in its own run — checks still running when the
+ * timeout expired, a transient failure — is merged by the next run instead of
+ * being stranded.
+ */
+const MERGEABLE_CUTOFF_WEEKS = 0;
+const MERGEABLE_CUTOFF_DESCRIPTION = "a previous run";
+
+/** How long to wait for a new pull request's required checks before giving up. */
+const CHECKS_TIMEOUT_MS = 30 * 60 * 1000;
+const CHECKS_POLL_MS = 15 * 1000;
 const STAGNATABLE_STATUSES = ["draft", "review"];
 const STAGNANT = "Stagnant";
 
@@ -273,7 +289,60 @@ const closeRepeatPRs = async (github, context, core, botPRs) => {
   }
 };
 
-/** Squash merges bot pull requests that have been open longer than the cutoff. */
+const squashMerge = async (github, context, core, prNum, filePath, message) => {
+  try {
+    await github.rest.pulls.merge({
+      ...context.repo,
+      pull_number: prNum,
+      merge_method: "squash",
+      commit_title: `(bot ${BOT_ID}) moving ${filePath} to stagnant (#${prNum})`,
+      commit_message: message
+    });
+    core.info("succesfully merged");
+    return true;
+  } catch (error) {
+    core.warning(`failed to merge ${prNum}: ${error.message}`);
+    return false;
+  }
+};
+
+/**
+ * Blocks until a pull request's required status checks have settled.
+ *
+ * `mergeable_state` is `blocked` while required checks are pending or failing,
+ * `clean` once they pass, and `unstable` when only non-required checks are
+ * failing, which protection still allows to merge. Returns false on timeout or
+ * conflict, leaving the pull request open for the next run's cleanup to merge.
+ */
+const waitForMergeable = async (github, context, core, prNum) => {
+  const deadline = Date.now() + CHECKS_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    const { data: pr } = await github.rest.pulls.get({
+      ...context.repo,
+      pull_number: prNum
+    });
+
+    if (pr.merged) return false;
+    if (pr.mergeable_state === "clean" || pr.mergeable_state === "unstable") return true;
+    if (pr.mergeable_state === "dirty") {
+      core.warning(`PR ${prNum} has conflicts and will be left for manual review`);
+      return false;
+    }
+    await new Promise((resolve) => setTimeout(resolve, CHECKS_POLL_MS));
+  }
+
+  core.warning(
+    `PR ${prNum} checks did not settle within ${CHECKS_TIMEOUT_MS / 60000} minutes; ` +
+      `leaving it open for the next run to merge`
+  );
+  return false;
+};
+
+/**
+ * Safety net: squash merges bot pull requests left over from earlier runs, so a
+ * pull request whose checks were still running at timeout is not stranded.
+ */
 const mergeOldPRs = async (github, context, core, botPRs) => {
   const cutoff = weeksAgo(MERGEABLE_CUTOFF_WEEKS);
   const mergeable = botPRs.filter((pr) => pr.createdAt < cutoff);
@@ -283,21 +352,11 @@ const mergeOldPRs = async (github, context, core, botPRs) => {
       `PR ${pr.num} with changes to ${pr.paths[0]} was created on`,
       `\n\t${formatDate(pr.createdAt)}`,
       `which is before the cutoff date of \n\t${formatDate(cutoff)}`,
-      `i.e. ${MERGEABLE_CUTOFF_DESCRIPTION} ago`
+      `i.e. ${MERGEABLE_CUTOFF_DESCRIPTION}`
     ].join(" ");
     core.info(message);
-    try {
-      await github.rest.pulls.merge({
-        ...context.repo,
-        pull_number: pr.num,
-        merge_method: "squash",
-        commit_title: `(bot ${BOT_ID}) moving ${pr.paths[0]} to stagnant (#${pr.num})`,
-        commit_message: message
-      });
-      core.info("succesfully merged");
-    } catch (error) {
-      core.warning(`failed to merge ${pr.num}: ${error.message}`);
-    }
+    if (await waitForMergeable(github, context, core, pr.num))
+      await squashMerge(github, context, core, pr.num, pr.paths[0], message);
     await wait(WAIT_SECONDS, core);
   }
 };
@@ -454,7 +513,7 @@ module.exports = async ({ github, context, core, dryRun }) => {
     .addRaw(
       dryRun
         ? "Dry run: no branches, pull requests or merges were created.\n\n"
-        : `Opening ${candidates.length} pull requests.\n\n`
+        : `Opening and merging ${candidates.length} pull requests.\n\n`
     )
     .addTable([
       [
@@ -486,7 +545,16 @@ module.exports = async ({ github, context, core, dryRun }) => {
     branch: DEFAULT_BRANCH
   });
 
+  // ---- phase one: open every pull request ----
+  //
+  // Opening and merging are separated deliberately. Merging each pull request
+  // straight after opening it would idle the job for the several minutes its
+  // required checks take, and 200+ proposals of that would exceed the six hour
+  // job limit. Opening them all first means the checks for the earliest ones
+  // have long since finished by the time the merge pass reaches them.
+  //
   // Runs serially to avoid race conditions and rate limiters.
+  const opened = [];
   for (const candidate of candidates) {
     try {
       const { data: blob } = await github.rest.repos.getContent({
@@ -494,7 +562,7 @@ module.exports = async ({ github, context, core, dryRun }) => {
         path: candidate.file,
         ref: base.commit.sha
       });
-      await applyStagnantProtocol(
+      const num = await applyStagnantProtocol(
         github,
         context,
         core,
@@ -502,9 +570,31 @@ module.exports = async ({ github, context, core, dryRun }) => {
         base.commit.sha,
         emailCache
       );
+      opened.push({ num, file: candidate.file, erc: candidate.erc });
     } catch (error) {
       // One bad proposal must not stop the rest of the run.
       core.error(`failed to stagnate ERC-${candidate.erc}: ${error.message}`);
     }
   }
+
+  // ---- phase two: merge them as their checks pass ----
+  core.info(`\n\t====== MERGING ${opened.length} PULL REQUESTS =====\n`);
+  let merged = 0;
+  for (const pr of opened) {
+    core.info(`\n================ ERC ${pr.erc} (#${pr.num})`);
+    if (!(await waitForMergeable(github, context, core, pr.num))) continue;
+
+    const message = [
+      `Moving ${pr.file} to ${STAGNANT.toLowerCase()}, as it had not been edited`,
+      `in over ${STAGNATION_CUTOFF_MONTHS} months.`
+    ].join(" ");
+    if (await squashMerge(github, context, core, pr.num, pr.file, message)) merged++;
+    await wait(WAIT_SECONDS, core);
+  }
+
+  core.info(`merged ${merged} of ${opened.length} pull requests`);
+  if (merged < opened.length)
+    core.info(
+      `${opened.length - merged} remain open and will be merged by the next run's cleanup`
+    );
 };

--- a/.github/scripts/mark-stagnant-ercs.js
+++ b/.github/scripts/mark-stagnant-ercs.js
@@ -1,0 +1,510 @@
+// @ts-check
+/**
+ * Moves ERCs that have gone six months without an edit to Stagnant, opening one
+ * pull request per ERC and squash merging it two weeks later.
+ *
+ * This is a port of ethereum/EIP-Bot, which drives the identical process in
+ * ethereum/EIPs. That repository was archived in January 2023 and looks for
+ * proposals in a hardcoded `EIPS/` directory, so it cannot be fixed upstream and
+ * has never done anything here beyond failing silently.
+ *
+ * Behaviour is intentionally identical to the EIPs bot: same six month cutoff,
+ * same stagnatable statuses, same branch names, pull request titles, bodies and
+ * labels, and the same two week merge delay. Deviations are marked "DEVIATION"
+ * and explained.
+ */
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const PROPOSALS_DIR = "ERCS";
+const PROPOSAL_PREFIX = "erc";
+const STAGNATION_CUTOFF_MONTHS = 6;
+const MERGEABLE_CUTOFF_WEEKS = 2;
+const MERGEABLE_CUTOFF_DESCRIPTION = "2 weeks";
+const STAGNATABLE_STATUSES = ["draft", "review"];
+const STAGNANT = "Stagnant";
+
+/** Pull requests are opened against this. */
+const DEFAULT_BRANCH = "master";
+
+/**
+ * The marker label the EIPs bot uses to recognise its own pull requests. Kept
+ * identical so tooling and saved searches behave the same across both repos.
+ */
+const BOT_ID = "1272989785";
+const PR_KEY_LABELS = ["created-by-bot", BOT_ID];
+
+/** EIPs excludes EIPS/eip-1.md here; this repository has no equivalent file. */
+const PATHS_TO_ALWAYS_EXCLUDE = [];
+
+/** Matches the branches this script creates, for orphan cleanup. */
+const STAGNANT_BRANCH_RE = new RegExp(
+  `mark-${PROPOSAL_PREFIX}-(\\d)+-stagnant-\\(\\d+-[a-zA-Z]+-.+@\\d+\\.\\d+\\.\\d+\\)`
+);
+
+/**
+ * Pull requests are rate limited more aggressively than other endpoints because
+ * they generate notifications, so mutating calls are spaced out.
+ * https://docs.github.com/en/rest/guides/best-practices-for-integrators
+ */
+const WAIT_SECONDS = 5;
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+const ordinal = (day) => {
+  const suffixes = ["th", "st", "nd", "rd"];
+  const remainder = day % 100;
+  return day + (suffixes[(remainder - 20) % 10] || suffixes[remainder] || suffixes[0]);
+};
+
+/** Reproduces the EIPs bot's moment format: `(YYYY-MMM-Do@HH.m.s)`. */
+const formatDate = (date) =>
+  `(${date.getFullYear()}-${MONTHS[date.getMonth()]}-${ordinal(date.getDate())}` +
+  `@${String(date.getHours()).padStart(2, "0")}.${date.getMinutes()}.${date.getSeconds()})`;
+
+const wait = (seconds, core) => {
+  core.info(`===== waiting ${seconds} seconds before continuing to avoid rate limiting =====`);
+  return new Promise((resolve) => setTimeout(resolve, 1000 * seconds));
+};
+
+const monthsAgo = (months) => {
+  const date = new Date();
+  date.setMonth(date.getMonth() - months);
+  return date;
+};
+
+const weeksAgo = (weeks) => {
+  const date = new Date();
+  date.setDate(date.getDate() - weeks * 7);
+  return date;
+};
+
+/**
+ * DEVIATION: the EIPs bot calls listCommits once per proposal to find when each
+ * was last edited, which is one API request per file every run. A single
+ * `git log` pass over the checkout is equivalent and costs no API quota, so this
+ * job needs `fetch-depth: 0`.
+ */
+const getLastModifiedDates = (core) => {
+  const stdout = execFileSync(
+    "git",
+    ["log", "--format=__C__%cI", "--name-only", "--diff-filter=AMR", "--", `${PROPOSALS_DIR}/`],
+    { encoding: "utf8", maxBuffer: 256 * 1024 * 1024 }
+  );
+
+  const dates = new Map();
+  let commitDate = null;
+  for (const line of stdout.split("\n")) {
+    if (line.startsWith("__C__")) {
+      commitDate = line.slice("__C__".length).trim();
+      continue;
+    }
+    const file = line.trim();
+    // git log is newest first, so a path's first appearance is its latest change.
+    if (file && commitDate && !dates.has(file)) dates.set(file, commitDate);
+  }
+  core.info(`resolved last modified dates for ${dates.size} files`);
+  return dates;
+};
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+const parseFrontmatter = (contents) => {
+  const match = contents.match(FRONTMATTER_RE);
+  if (!match) return null;
+  const attributes = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const attribute = line.match(/^([a-zA-Z-]+):\s*(.*)$/);
+    if (attribute) attributes[attribute[1]] = attribute[2].trim();
+  }
+  return attributes;
+};
+
+/** Rewrites only the `status:` line inside the frontmatter block. */
+const setStatusToStagnant = (contents) =>
+  contents.replace(FRONTMATTER_RE, (frontmatter) =>
+    frontmatter.replace(/^status:.*$/m, `status: ${STAGNANT}`)
+  );
+
+/**
+ * Resolves the frontmatter author list to GitHub handles, matching the EIPs bot:
+ * `@handle` is used as is, a bare email is looked up via user search.
+ */
+const getAuthorsFromFile = async (github, core, rawAuthorList, emailCache) => {
+  if (!rawAuthorList) return [];
+
+  const AUTHOR_RE = /[(<]([^>)]+)[>)]/gm;
+  const authors = [...rawAuthorList.matchAll(AUTHOR_RE)].map((match) => match[1]);
+
+  const resolved = [];
+  for (const author of authors) {
+    if (author.startsWith("@")) {
+      resolved.push(author.toLowerCase());
+      continue;
+    }
+    // Emails are cached because user search is limited to 30 requests a minute.
+    if (emailCache.has(author)) {
+      resolved.push(emailCache.get(author));
+      continue;
+    }
+    let value = author.toLowerCase();
+    try {
+      const { data } = await github.rest.search.users({ q: author });
+      if (data.total_count > 0 && data.items[0]) value = "@" + data.items[0].login;
+      else core.warning(`no github user found, using email instead: ${author}`);
+    } catch (error) {
+      core.warning(`failed to resolve author ${author}: ${error.message}`);
+    }
+    emailCache.set(author, value);
+    resolved.push(value);
+  }
+
+  return [...new Set(resolved)];
+};
+
+/**
+ * Every open pull request, with its files and labels.
+ *
+ * DEVIATION: the EIPs bot uses the search API for this and its pagination is
+ * broken, because fetchNonBotPRs recurses into fetchBotCreatedPRs for page two
+ * onwards and silently returns bot pull requests instead of the rest of the
+ * non-bot ones. This repository currently has more than 100 open pull requests,
+ * so that bug would matter here. Listing pull requests directly is exact,
+ * paginates correctly and avoids the search API's tighter rate limit.
+ */
+const fetchOpenPRs = async (github, context, core) => {
+  const pulls = await github.paginate(github.rest.pulls.list, {
+    ...context.repo,
+    state: "open",
+    per_page: 100
+  });
+  core.info(`found ${pulls.length} open pull requests`);
+
+  const detailed = [];
+  const BATCH_SIZE = 8;
+  for (let index = 0; index < pulls.length; index += BATCH_SIZE) {
+    const batch = pulls.slice(index, index + BATCH_SIZE);
+    const files = await Promise.all(
+      batch.map((pull) =>
+        github.paginate(github.rest.pulls.listFiles, {
+          ...context.repo,
+          pull_number: pull.number,
+          per_page: 100
+        })
+      )
+    );
+    batch.forEach((pull, offset) => {
+      const labels = pull.labels.map((label) => label.name);
+      detailed.push({
+        num: pull.number,
+        author: pull.user && pull.user.login,
+        branch: pull.head.ref,
+        createdAt: new Date(pull.created_at),
+        labels,
+        isBot: PR_KEY_LABELS.every((label) => labels.includes(label)),
+        paths: files[offset].map((file) => file.filename)
+      });
+    });
+  }
+  return detailed;
+};
+
+const closePRByNum = async (github, context, core, prNum, branch) => {
+  await github.rest.pulls.update({ ...context.repo, pull_number: prNum, state: "closed" });
+  core.info(`successfully closed PR ${prNum}`);
+  await deleteBranch(github, context, core, branch);
+};
+
+const deleteBranch = async (github, context, core, branch) => {
+  if (!branch) return;
+  try {
+    await github.rest.git.deleteRef({ ...context.repo, ref: `heads/${branch}` });
+    core.info(`successfully deleted branch ${branch}`);
+  } catch (error) {
+    core.warning(`failed to delete branch ${branch}: ${error.message}`);
+  }
+};
+
+/**
+ * Closes bot labelled pull requests that this account did not open, unless
+ * somebody has commented on them.
+ */
+const closeNonSelfBotPRs = async (github, context, core, botPRs) => {
+  const { data: me } = await github.rest.users.getAuthenticated();
+  const nonSelf = botPRs.filter((pr) => pr.author !== me.login);
+
+  for (const pr of nonSelf) {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      ...context.repo,
+      issue_number: pr.num,
+      per_page: 100
+    });
+    if (comments.some((comment) => comment.user && comment.user.login !== me.login)) {
+      core.info(`PR ${pr.num} will not be closed because a comment was left on it`);
+      continue;
+    }
+    core.info(
+      `closing PR ${pr.num} because its author is ${pr.author} but this script runs as ${me.login}`
+    );
+    await closePRByNum(github, context, core, pr.num, pr.branch);
+    await wait(WAIT_SECONDS, core);
+  }
+};
+
+/** Where the bot has more than one open PR for a path, keeps the first. */
+const closeRepeatPRs = async (github, context, core, botPRs) => {
+  const byPath = new Map();
+  for (const pr of botPRs) {
+    const path = pr.paths[0];
+    if (!path) continue;
+    if (!byPath.has(path)) byPath.set(path, []);
+    byPath.get(path).push(pr);
+  }
+
+  for (const [path, prs] of byPath) {
+    if (prs.length < 2) continue;
+    core.warning(`bot has ${prs.length} PRs open for ${path}`);
+    for (const pr of prs.slice(1)) {
+      await closePRByNum(github, context, core, pr.num, pr.branch);
+      await wait(WAIT_SECONDS, core);
+    }
+  }
+};
+
+/** Squash merges bot pull requests that have been open longer than the cutoff. */
+const mergeOldPRs = async (github, context, core, botPRs) => {
+  const cutoff = weeksAgo(MERGEABLE_CUTOFF_WEEKS);
+  const mergeable = botPRs.filter((pr) => pr.createdAt < cutoff);
+
+  for (const pr of mergeable) {
+    const message = [
+      `PR ${pr.num} with changes to ${pr.paths[0]} was created on`,
+      `\n\t${formatDate(pr.createdAt)}`,
+      `which is before the cutoff date of \n\t${formatDate(cutoff)}`,
+      `i.e. ${MERGEABLE_CUTOFF_DESCRIPTION} ago`
+    ].join(" ");
+    core.info(message);
+    try {
+      await github.rest.pulls.merge({
+        ...context.repo,
+        pull_number: pr.num,
+        merge_method: "squash",
+        commit_title: `(bot ${BOT_ID}) moving ${pr.paths[0]} to stagnant (#${pr.num})`,
+        commit_message: message
+      });
+      core.info("succesfully merged");
+    } catch (error) {
+      core.warning(`failed to merge ${pr.num}: ${error.message}`);
+    }
+    await wait(WAIT_SECONDS, core);
+  }
+};
+
+/** Deletes leftover bot branches that no longer have a pull request. */
+const deleteOrphanedBranches = async (github, context, core, botPRs) => {
+  const refs = await github.paginate(github.rest.git.listMatchingRefs, {
+    ...context.repo,
+    ref: "heads",
+    per_page: 100
+  });
+  core.info(`successfully found ${refs.length} references`);
+
+  const active = new Set(botPRs.map((pr) => pr.branch));
+  const orphaned = refs
+    .map((ref) => {
+      const match = ref.ref.match(STAGNANT_BRANCH_RE);
+      return match ? match[0] : null;
+    })
+    .filter((branch) => branch && !active.has(branch));
+
+  core.info(`extracted ${orphaned.length} orphaned bot created branches`);
+  for (const branch of orphaned) {
+    await deleteBranch(github, context, core, branch);
+    await wait(WAIT_SECONDS, core);
+  }
+};
+
+/** Creates the branch, commit, pull request and labels for a single ERC. */
+const applyStagnantProtocol = async (github, context, core, candidate, baseSha, emailCache) => {
+  core.info(`\n================ ERC ${candidate.erc}`);
+
+  const now = formatDate(new Date());
+  const branch = `mark-${PROPOSAL_PREFIX}-${candidate.erc}-stagnant-${now}`;
+
+  await github.rest.git.createRef({ ...context.repo, ref: `refs/heads/${branch}`, sha: baseSha });
+  core.info(`successfully created branch ${branch}`);
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  const updated = setStatusToStagnant(candidate.contents);
+  if (updated === candidate.contents)
+    throw new Error(`failed to rewrite the status of ${candidate.file}`);
+
+  await github.rest.repos.createOrUpdateFileContents({
+    ...context.repo,
+    path: candidate.file,
+    branch,
+    sha: candidate.blobSha,
+    message: `Updating ${candidate.file} to status ${STAGNANT.toLowerCase()}`,
+    content: Buffer.from(updated).toString("base64")
+  });
+  core.info(`Updating ${candidate.file} to status ${STAGNANT.toLowerCase()}`);
+
+  const authors = await getAuthorsFromFile(github, core, candidate.author, emailCache);
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  const { data: pull } = await github.rest.pulls.create({
+    ...context.repo,
+    base: DEFAULT_BRANCH,
+    head: branch,
+    title: `ERC-${candidate.erc} stagnant ${now}`,
+    body: [
+      `This ERC has not been active since ${formatDate(new Date(candidate.lastModified))};`,
+      `which, is greater than the allowed time of ${STAGNATION_CUTOFF_MONTHS} months.\n\n`,
+      `authors: ${authors.join(", ")} \n`
+    ].join(" "),
+    draft: true
+  });
+  core.info(`successfully created draft pull request titled ${pull.title}`);
+
+  await github.rest.issues.addLabels({
+    ...context.repo,
+    issue_number: pull.number,
+    labels: PR_KEY_LABELS
+  });
+
+  // Opening as a draft and then marking it ready lets the merge bot skip it.
+  await github.graphql(
+    `mutation($id: ID!) { markPullRequestReadyForReview(input: {pullRequestId: $id}) { clientMutationId } }`,
+    { id: pull.node_id }
+  );
+  core.info(`successfully marked PR ${pull.number} as ready for review`);
+
+  await wait(WAIT_SECONDS, core);
+  return pull.number;
+};
+
+module.exports = async ({ github, context, core, dryRun }) => {
+  const stagnationCutoff = monthsAgo(STAGNATION_CUTOFF_MONTHS);
+  const openPRs = await fetchOpenPRs(github, context, core);
+  const botPRs = openPRs.filter((pr) => pr.isBot);
+  const emailCache = new Map();
+
+  // ---- cleanup, mirroring the EIPs bot's botCleanup() ----
+  if (!dryRun) {
+    await closeNonSelfBotPRs(github, context, core, botPRs);
+    await closeRepeatPRs(github, context, core, botPRs);
+    await mergeOldPRs(github, context, core, botPRs);
+    await deleteOrphanedBranches(github, context, core, botPRs);
+    core.info("\n\t====== CLEANUP COMPLETE =====\n");
+  }
+
+  // ---- selection ----
+  core.info(
+    `checking for stagnant ERCs that weren't edited before ${stagnationCutoff.toISOString()}`
+  );
+  const lastModifiedDates = getLastModifiedDates(core);
+
+  const pathsToExclude = new Set([
+    ...PATHS_TO_ALWAYS_EXCLUDE,
+    // Anything an open pull request already touches, bot or otherwise.
+    ...openPRs.flatMap((pr) => pr.paths)
+  ]);
+
+  const candidates = [];
+  for (const name of fs.readdirSync(PROPOSALS_DIR)) {
+    if (!name.endsWith(".md")) continue;
+    const file = `${PROPOSALS_DIR}/${name}`;
+
+    const contents = fs.readFileSync(path.join(PROPOSALS_DIR, name), "utf8");
+    const frontmatter = parseFrontmatter(contents);
+    if (!frontmatter || !frontmatter.status) {
+      core.warning(`failed to collect 'status' from ${file}`);
+      continue;
+    }
+    if (!STAGNATABLE_STATUSES.includes(frontmatter.status.toLowerCase())) continue;
+
+    const lastModified = lastModifiedDates.get(file);
+    if (!lastModified) {
+      core.warning(`${file} did not resolve to a commit`);
+      continue;
+    }
+    if (new Date(lastModified) >= stagnationCutoff) continue;
+    if (pathsToExclude.has(file)) {
+      core.info(`skipping ${file}: an open pull request already touches it`);
+      continue;
+    }
+
+    candidates.push({
+      file,
+      contents,
+      erc: frontmatter.eip,
+      status: frontmatter.status,
+      author: frontmatter.author,
+      lastModified
+    });
+  }
+
+  // Oldest first, so the longest abandoned proposals are handled first.
+  candidates.sort((a, b) => a.lastModified.localeCompare(b.lastModified));
+
+  await core.summary
+    .addHeading("Auto Stagnant Bot", 2)
+    .addRaw(
+      dryRun
+        ? "Dry run: no branches, pull requests or merges were created.\n\n"
+        : `Opening ${candidates.length} pull requests.\n\n`
+    )
+    .addTable([
+      [
+        { data: "ERC", header: true },
+        { data: "Status", header: true },
+        { data: "Last edited", header: true }
+      ],
+      ...candidates.map((candidate) => [
+        `ERC-${candidate.erc}`,
+        candidate.status,
+        candidate.lastModified.slice(0, 10)
+      ])
+    ])
+    .write();
+
+  if (!candidates.length) {
+    core.info(`No ERCs were found to be last edited before ${stagnationCutoff.toISOString()}`);
+    return;
+  }
+  core.info(`${candidates.length} ERCs will be moved to ${STAGNANT}`);
+
+  if (dryRun) {
+    core.info("dry run: stopping before making any changes");
+    return;
+  }
+
+  const { data: base } = await github.rest.repos.getBranch({
+    ...context.repo,
+    branch: DEFAULT_BRANCH
+  });
+
+  // Runs serially to avoid race conditions and rate limiters.
+  for (const candidate of candidates) {
+    try {
+      const { data: blob } = await github.rest.repos.getContent({
+        ...context.repo,
+        path: candidate.file,
+        ref: base.commit.sha
+      });
+      await applyStagnantProtocol(
+        github,
+        context,
+        core,
+        { ...candidate, blobSha: blob.sha },
+        base.commit.sha,
+        emailCache
+      );
+    } catch (error) {
+      // One bad proposal must not stop the rest of the run.
+      core.error(`failed to stagnate ERC-${candidate.erc}: ${error.message}`);
+    }
+  }
+};

--- a/.github/workflows/auto-stagnate-bot.yml
+++ b/.github/workflows/auto-stagnate-bot.yml
@@ -3,22 +3,40 @@ on:
     # A job that runs every sunday at 00:00
     - cron:  '0 0 * * 0'
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Report what would change without opening, merging or closing anything'
+        type: boolean
+        default: true
 
 name: Auto Stagnant Bot
+
+permissions:
+  contents: read
+
 jobs:
-  auto_merge_bot:
-    if: github.repository == 'ethereum/ERCs' || github.repository == 'ethereum/EIPs'
+  auto_stagnant_bot:
+    if: github.repository == 'ethereum/ERCs'
     runs-on: ubuntu-latest
     name: Auto Stagnant Bot
     steps:
       - name: Checkout
         uses: actions/checkout@47fbe2df0ad0e27efb67a70beac3555f192b062f
-      - name: Setup Node.js Environment
-        uses: actions/setup-node@d98fa1113850e562f83c7fc3a89c0ecd7a87fbed
         with:
-          node-version: '14'
-      - name: auto-stagnant-bot
-        uses: ethereum/EIP-Bot@b3ac0ba3600aea27157fc68d1e36c08cc5a6db77 # mark-eips-stale
+          # Last edited dates are read from the commit log rather than the API.
+          fetch-depth: 0
+      - name: Auto Stagnant Bot
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         id: auto-stagnant-bot
+        env:
+          DRY_RUN: ${{ inputs.dry-run }}
         with:
-          GITHUB-TOKEN: ${{ secrets.TOKEN }}
+          github-token: ${{ secrets.TOKEN }}
+          script: |
+            const markStagnant = require('${{ github.workspace }}/.github/scripts/mark-stagnant-ercs.js')
+            await markStagnant({
+              github,
+              context,
+              core,
+              dryRun: process.env.DRY_RUN === 'true'
+            })


### PR DESCRIPTION
The Auto Stagnant Bot has never moved a single ERC to Stagnant. This restores it by porting the EIPs bot into this repository.

## The problem

Two separate faults, one hiding the other.

**1. The job was gated to the wrong repository.** From the workflow's introduction until 4 August 2026 the condition was `if: github.repository == 'ethereum/eips'`, so in this repository every scheduled run since 2021 was skipped. That was corrected in 2b5baad9 and the job began executing on 9 August 2026.

**2. The bot cannot work here.** `ethereum/EIP-Bot` looks for proposals in a hardcoded directory:

```ts
// EIP-Bot/src/lib.ts, getEIPs()
.getContent({ owner, repo, path: "EIPS" })
```

This repository keeps its proposals in `ERCS/`, so the call 404s. From the first run that actually executed ([run 31285609418](https://github.com/ethereum/ERCs/actions/runs/31285609418)):

```
	====== CLEANUP COMPLETE =====
UnhandledPromiseRejectionWarning: HttpError: Not Found
    at async Object.getEIPs (.../build/src/lib.js:54:22)
    at async run (.../build/src/index.js:26:21)
```

The bot dies before evaluating a single proposal.

**3. The failure was invisible.** The step reports success anyway, because `node-version: '14'` downgrades an unhandled rejection to a warning instead of a non-zero exit. The run log says so itself: *"Unhandled promise rejections are deprecated... will terminate the Node.js process with a non-zero exit code"*. So the workflow has been reporting a green check every Sunday while doing nothing.

This cannot be fixed upstream: `ethereum/EIP-Bot` was archived in January 2023, so it accepts no pull requests.

## What this does

Adds `.github/scripts/mark-stagnant-ercs.js`, a port of EIP-Bot's `src/lib.ts` and `src/index.ts` parameterised for `ERCS/`, and points the workflow at it via `actions/github-script`. There is no `package.json` here, so the script uses only Node built-ins and the Octokit instance `github-script` provides.

Behaviour is deliberately identical to what runs in `ethereum/EIPs` today:

| | EIPs bot | This port |
|---|---|---|
| Cutoff | 6 months since last edit | same |
| Eligible statuses | Draft, Review | same |
| Branch | `mark-eip-<n>-stagnant-(2026-Apr-12th@00.41.33)` | `mark-erc-<n>-stagnant-(…)`, same date format |
| PR title | `EIP-8025 stagnant (…)` | `ERC-<n> stagnant (…)` |
| PR body | "has not been active since …; which, is greater than the allowed time of 6 months" + author mentions | same wording |
| Labels | `created-by-bot`, `1272989785` | same |
| Draft then ready for review | yes | same |
| Auto squash merge | 2 weeks later, in a subsequent run | **same run, once required checks pass** |
| Cleanup | close non-self bot PRs, close repeats, close obsolete, delete orphaned branches | same |
| Per-run limit | none | none |

Three intentional deviations, all marked `DEVIATION` in the source:

- **Pull requests are merged in the run that opens them**, rather than sitting open for two weeks. Each is polled until `mergeable_state` leaves `blocked`, then squash merged. Opening and merging are separate phases: merging each pull request immediately after opening it would idle the job for the minutes its checks take, and 200+ of those would exceed the six hour job limit, so all the pull requests are opened first and the earliest are already green when the merge pass starts. Anything that conflicts, fails its checks, or has not settled within 30 minutes is left open, and the next run's cleanup merges it — EIP-Bot's merge-old-PRs routine is retained as that safety net, with its cutoff set to zero.
- **Last edited dates come from `git log` instead of one `listCommits` call per proposal.** Equivalent result, no API quota, and it removes 600+ requests per run. This is why the checkout now uses `fetch-depth: 0`.
- **Open pull requests are listed via `pulls.list` instead of the search API.** EIP-Bot's `fetchNonBotPRs` recurses into `fetchBotCreatedPRs` when paginating, so from page two onward it returns bot pull requests instead of the remaining non-bot ones. This repository has over 250 open pull requests, so that bug would bite here; listing directly paginates correctly and avoids the search API's tighter rate limit.

The `node-version: '14'` step is removed, so a future failure fails the job instead of passing silently.

## Please read this before merging

There are **611 ERCs, of which 221 are Draft and 63 are Review. 214 of those have not been edited in over six months** — the oldest have been untouched since the repository was split out in October 2023.

Because the bot has never run here, that entire backlog is eligible at once. There is no per-run cap, matching EIPs, so **the first run will open roughly 214 pull requests and merge all of them in the same run.** That is the correct outcome of the EIP-1 process applied to a backlog that has accumulated for three years, but it is a large one-off event and worth calling out explicitly:

- It will trigger roughly 214 × 4 = **850 or so check runs** in a short window, since every pull request runs CodeSpell, EIP Walidator, Link Check and HTMLProofer. That is a real load on the runner pool.
- It will notify the authors of ~214 proposals, and unlike in EIPs there is no two week window in which they can object first — the status change lands in the same run. It remains reversible: EIP-1 lets an author resurrect a Stagnant proposal at any time by opening a pull request moving it back to Draft.
- The run itself will take a while: ~214 pull requests at a five second spacing, plus the merge pass.

**Every run after the first is small.** Steady state is however many ERCs cross the six month line in a given week, typically a handful or none, opened and merged the same morning.

`workflow_dispatch` takes a `dry-run` input, **defaulting to true**, which writes the full list of affected ERCs to the job summary without creating, merging or closing anything. Running that once before the first live run is strongly recommended. Scheduled runs always run live.

If you would rather drain the backlog gradually, or keep the two week author notice window, say so — both are small changes.

## Testing

Run against a full clone with the API mocked, asserting that:

- selection matches a hand-computed list — 214 eligible, dropping to 213 when a mocked open pull request touches one of them
- every selected ERC really is Draft or Review
- the status rewrite changes exactly one line, `status: Draft` to `status: Stagnant`, leaving the rest of the file byte-identical
- the date formatter reproduces `(2026-Apr-12th@00.41.33)` from real EIPs PR ethereum/EIPs#11517, plus 1st/2nd/3rd/11th ordinal edge cases
- the orphaned-branch regex round-trips against a branch name the script itself generates, and does not match `master`

And a second suite driving the live path with the whole API mocked and timers stubbed, asserting that:

- all 214 proposals get exactly one branch, one commit, one pull request and one label set each, with no per-proposal errors
- every pull request is opened as a draft and then marked ready for review
- each is polled until its checks report clean, and only then merged, by squash
- a pull request reporting a conflict is skipped and left open rather than force merged — 213 of the 214 merge
- the commit flips `status:` to `Stagnant` and passes the correct blob sha
- titles, commit messages and merge titles match the EIPs formats, e.g. `(bot 1272989785) moving ERCS/erc-4972.md to stagnant (#100)`

What is **not** covered: no mutating call has run against a live repository, since they need `secrets.TOKEN`. The mocks assert the calls this script makes, not that GitHub accepts them. `dry-run` exists partly so a maintainer can validate selection here before anything is created.
