### PR TITLE
Update ERC-8153: Move to Review

### DIFF
--- a/ERCS/erc-8153.md
+++ b/ERCS/erc-8153.md
@@ -60,8 +60,8 @@ This standard reduces gas costs and eliminates off-chain selector management:
 ## Specification
 
 ### Terms
-1. A **diamond** is a smart contract that routes external function calls to one or more implementation contracts, referred to as facets. A diamond is stateful: all persistent data is stored in the diamond’s contract storage. A diamond implements the requirements in the [Implementation Requirements](#implementation-requirements) section.
-2. A **facet** is a smart contract that defines one or more external functions. A facet is deployed independently, and one or more of its functions are added to one or more diamonds. A facet’s functions are executed in the diamond’s context via `delegatecall`, so reads/writes affect the diamond’s storage. The term facet is derived from the diamond industry, referring to a flat surface of a diamond.
+1. A **diamond** is a smart contract that routes external function calls to one or more implementation contracts, referred to as facets. A diamond is stateful: all persistent data is stored in the diamond's contract storage. A diamond implements the requirements in the [Implementation Requirements](#implementation-requirements) section.
+2. A **facet** is a smart contract that defines one or more external functions. A facet is deployed independently, and one or more of its functions are added to one or more diamonds. A facet's functions are executed in the diamond's context via `delegatecall`, so reads/writes affect the diamond's storage. The term facet is derived from the diamond industry, referring to a flat surface of a diamond.
 3. An **introspection function** is a function that returns information about the facets and/or functions used by a diamond or facet.
 4. For the purposes of this specification, a **mapping** refers to a conceptual association between two items and does not refer to a specific implementation.
 
@@ -77,9 +77,9 @@ It shows that a diamond has a mapping from function to facet and that facets can
 
 When an external function is called on a diamond, its fallback function is executed. The fallback function determines which facet to call based on the first four bytes of the calldata (known as the function selector) and executes the function from the facet using `delegatecall`.
 
-A diamond’s fallback function and `delegatecall` enable a diamond to execute a facet’s function as if it was implemented by the diamond itself. The `msg.sender` and `msg.value` values do not change and only the diamond’s storage is read and written to.
+A diamond's fallback function and `delegatecall` enable a diamond to execute a facet's function as if it was implemented by the diamond itself. The `msg.sender` and `msg.value` values do not change and only the diamond's storage is read and written to.
 
-Here is an example of how a diamond’s fallback function might be implemented:
+Here is an example of how a diamond's fallback function might be implemented:
 
 ```solidity
 error FunctionNotFound(bytes4 _selector);
@@ -166,7 +166,7 @@ This also means diamonds implementing this ERC are **facet-based** rather than *
 
 ### Facet-Based Events
 
-This ERC replaces ERC-2535’s function-based events with facet-based events. 
+This ERC replaces ERC-2535's function-based events with facet-based events. 
 
 When facets are added, replaced, or removed, the diamond MUST emit the following events:
 
@@ -217,9 +217,9 @@ This event is OPTIONAL.
 
 This event can be used to record `delegatecall`s made by a diamond.
 
-This event MUST NOT be emitted for `delegatecall`s made by a diamond’s fallback function when routing calls to facets. It is only intended for `delegatecall`s made by functions in facets or a diamond’s constructor.
+This event MUST NOT be emitted for `delegatecall`s made by a diamond's fallback function when routing calls to facets. It is only intended for `delegatecall`s made by functions in facets or a diamond's constructor.
 
-This event enables tracking of changes to a diamond’s contract storage caused by `delegatecall` execution.
+This event enables tracking of changes to a diamond's contract storage caused by `delegatecall` execution.
 
 ```solidity
 /**
@@ -264,7 +264,7 @@ A facet-based diamond MUST implement the following:
    - It MUST associate function selectors with facet addresses.
 3. **Function Execution**
    - When an external function is called on a diamond:
-     - The diamond’s fallback function is executed. 
+     - The diamond's fallback function is executed. 
      - The fallback function MUST find the facet associated with the function selector.
      - The fallback function MUST execute the function on the facet using `delegatecall`.
      - If no facet is associated with the function selector, the diamond MAY execute a default function or apply another handling mechanism.
@@ -528,7 +528,7 @@ Routing calls via `delegatecall` introduces a small amount of gas overhead. In p
 
 ### Storage Layout
 
-Diamonds and facets need to use a storage layout organizational pattern because Solidity’s default storage layout doesn’t support proxy contracts or diamonds. The storage layout technique or pattern to use is not specified in this ERC. However, examples of storage layout patterns that work with diamonds are [ERC-8042 Diamond Storage](./eip-8042) and [ERC-7201 Namespaced Storage Layout](./eip-7201).
+Diamonds and facets need to use a storage layout organizational pattern because Solidity's default storage layout doesn't support proxy contracts or diamonds. The storage layout technique or pattern to use is not specified in this ERC. However, examples of storage layout patterns that work with diamonds are [ERC-8042 Diamond Storage](./eip-8042) and [ERC-7201 Namespaced Storage Layout](./eip-7201).
 
 ### Facets Sharing Storage & Functionality
 
@@ -555,7 +555,7 @@ Diamonds implementing this ERC have the same introspection functions as ERC-2535
 
 ### Arbitrary Execution with `upgradeDiamond`
 
-The `upgradeDiamond` function allows arbitrary execution with access to the diamond’s storage (through delegatecall). Access to this function must be restricted carefully.
+The `upgradeDiamond` function allows arbitrary execution with access to the diamond's storage (through delegatecall). Access to this function must be restricted carefully.
 
 ### Use Only Trusted and Verified Facets
 
@@ -563,7 +563,7 @@ Only trusted and verified facets should be added to facet-based diamonds.
 
 `exportSelectors()` MUST be `pure` and should not contain logic that varies the returned bytes. Facets should be immutable so returned selectors cannot change over time.
 
-If a facet’s `exportSelectors()` output changes, upgrades that rely on it may add/remove/replace the wrong selectors and corrupt diamonds.
+If a facet's `exportSelectors()` output changes, upgrades that rely on it may add/remove/replace the wrong selectors and corrupt diamonds.
 
 ### Upgrade Integrity Checks
 
@@ -578,7 +578,7 @@ The specified `upgradeDiamond` behavior prevents a number of upgrade mistakes. U
 - A facet provides zero selectors.
 - A facet is replaced with itself (same contract address).
 
-Selector collisions (two different signatures with the same 4-byte selector) are handled as “selector already exists” and are therefore prevented.
+Selector collisions (two different signatures with the same 4-byte selector) are handled as "selector already exists" and are therefore prevented.
 
 ### Do Not Self Destruct
 Use of selfdestruct in a facet is heavily discouraged. Misuse of it can delete a diamond or a facet.

--- a/ERCS/erc-8153.md
+++ b/ERCS/erc-8153.md
@@ -4,7 +4,7 @@ title: Facet-Based Diamonds
 description: Simplifies diamond management, deployment and upgrades.
 author: Nick Mudge (@mudgen)
 discussions-to: https://ethereum-magicians.org/t/erc-8153-facet-based-diamonds/27685
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2026-02-07
@@ -154,7 +154,7 @@ Each facet MUST implement the following pure introspection function:
 function exportSelectors() external pure returns (bytes memory selectors)
 ```
 
-`exportSelectors()` returns a `bytes` array containing one or more 4-byte function selectors. The returned `bytes` array length is a multiple of 4, and each 4-byte chunk is a selector. The function MUST not return the same selector more than once.
+`exportSelectors()` returns a `bytes` array containing one or more 4-byte function selectors. The returned `bytes` array length is a multiple of 4, and each 4-byte chunk is a selector. The function MUST not return a specific selector more than once.
 
 The `bytes` array contains selectors of functions implemented by the facet that are intended to be added to a diamond.
 
@@ -393,7 +393,7 @@ function upgradeDiamond(
 ```
 The `upgradeDiamond` function MUST adhere to the following requirements:
 
-> The complete definitions of events and custom errors referenced below are given earlier in this standard.
+> Definitions of events and custom errors referenced below are given earlier in this standard.
 
 1. **Inputs**
    - `_addFacets` array of facet addresses to add.


### PR DESCRIPTION
Moves ERC-8153 (Facet-Based Diamonds) from `Draft` to `Review`, along with two small wording clarifications:

- `status`: `Draft` → `Review`.
- `exportSelectors()`: clarify that the function MUST NOT return *a specific* selector more than once (the previous phrasing, "the same selector", was ambiguous about which selector was meant).
- `upgradeDiamond`: shorten the note above the requirements list about where the referenced events and custom errors are defined.

No normative behavior changes beyond the clarified `exportSelectors()` wording.

Discussion: https://ethereum-magicians.org/t/erc-8153-facet-based-diamonds/27685