### PR TITLE
Update ERC-7573: Fix key parameter descriptions in ILockingContract m…

### DIFF
--- a/ERCS/erc-7573.md
+++ b/ERCS/erc-7573.md
@@ -67,7 +67,7 @@ function inceptTransfer(uint256 id, int amount, address from, bytes keyHashedSel
 Called from the buyer of the token to initiate token transfer. Emits a `TransferIncepted` event.
 The parameter `id` is an identifier of the trade. The parameter `from` is the address of the seller (the address of the buyer is `msg.sender`).
 The parameter `keyHashedSeller` is a hash of the key that can be used by the seller to (re-)claim the token.
-The parameter `keyEncryptedSeller` is an encryption of the key that can be used by the buyer to claim the token.
+The parameter `keyEncryptedSeller` is an encryption of the key that can be used by the seller to (re-)claim the token.
 It is possible to implement the protocol in a way where the hashing method agrees with the  encryption method. See below on "encryption".
 
 ##### Initiation of Transfer: `confirmTransfer`
@@ -78,8 +78,8 @@ function confirmTransfer(uint256 id, int amount, address to, bytes keyHashedBuye
 
 Called from the seller of the token to confirm token transfer. Emits a `TransferConfirmed` event.
 The parameter `id` is an identifier of the trade. The parameter `to` is the address of the buyer (the address of the seller is `msg.sender`).
-The parameter `keyHashedBuyer` is a hash of the key that can be used by the buyer to (re-)claim the token.
-The parameter `keyEncryptedBuyer` is an encryption of the key that can be used by the buyer to (re-)claim the token.
+The parameter `keyHashedBuyer` is a hash of the key that can be used by the buyer to claim the token.
+The parameter `keyEncryptedBuyer` is an encryption of the key that can be used by the buyer to claim the token.
 It is possibly to implement the protocol in a way where the hashing method agrees with the  encryption method. See below on "encryption".
 
 If the trade specification, that is, the quadruple (`id`, `amount`, `from`, `to`), in a call to `confirmTransfer`


### PR DESCRIPTION
## Summary
Editorial fixes to the `ILockingContract` method descriptions. No normative or semantic change.

1. **`inceptTransfer`**: the description of `keyEncryptedSeller` said the key "can be used by the buyer to claim the token". Both parameters of this call describe the single seller key (hash and ciphertext of the same secret), as shown by the parameter naming, the symmetric wording of `confirmTransfer`, and the reference paper's sequence diagram, `inceptTransfer(H(F), E(F))`. Corrected to the seller (re-)claim key.
2. **`confirmTransfer`**: the buyer claims for the first time, so the "(re-)" prefix is removed, and `keyEncryptedBuyer` is clarified as encrypting the same key hashed by `keyHashedBuyer`.