### PR TITLE
Update ERC-8153: Move to Review

### DIFF
--- a/ERCS/erc-8153.md
+++ b/ERCS/erc-8153.md
@@ -60,8 +60,8 @@ This standard reduces gas costs and eliminates off-chain selector management:
 ## Specification
 
 ### Terms
-1. A **diamond** is a smart contract that routes external function calls to one or more implementation contracts, referred to as facets. A diamond is stateful: all persistent data is stored in the diamond’s contract storage. A diamond implements the requirements in the [Implementation Requirements](#implementation-requirements) section.
-2. A **facet** is a smart contract that defines one or more external functions. A facet is deployed independently, and one or more of its functions are added to one or more diamonds. A facet’s functions are executed in the diamond’s context via `delegatecall`, so reads/writes affect the diamond’s storage. The term facet is derived from the diamond industry, referring to a flat surface of a diamond.
+1. A **diamond** is a smart contract that routes external function calls to one or more implementation contracts, referred to as facets. A diamond is stateful: all persistent data is stored in the diamond's contract storage. A diamond implements the requirements in the [Implementation Requirements](#implementation-requirements) section.
+2. A **facet** is a smart contract that defines one or more external functions. A facet is deployed independently, and one or more of its functions are added to one or more diamonds. A facet's functions are executed in the diamond's context via `delegatecall`, so reads/writes affect the diamond's storage. The term facet is derived from the diamond industry, referring to a flat surface of a diamond.
 3. An **introspection function** is a function that returns information about the facets and/or functions used by a diamond or facet.
 4. For the purposes of this specification, a **mapping** refers to a conceptual association between two items and does not refer to a specific implementation.
 
@@ -77,9 +77,9 @@ It shows that a diamond has a mapping from function to facet and that facets can
 
 When an external function is called on a diamond, its fallback function is executed. The fallback function determines which facet to call based on the first four bytes of the calldata (known as the function selector) and executes the function from the facet using `delegatecall`.
 
-A diamond’s fallback function and `delegatecall` enable a diamond to execute a facet’s function as if it was implemented by the diamond itself. The `msg.sender` and `msg.value` values do not change and only the diamond’s storage is read and written to.
+A diamond's fallback function and `delegatecall` enable a diamond to execute a facet's function as if it was implemented by the diamond itself. The `msg.sender` and `msg.value` values do not change and only the diamond's storage is read and written to.
 
-Here is an example of how a diamond’s fallback function might be implemented:
+Here is an example of how a diamond's fallback function might be implemented:
 
 ```solidity
 error FunctionNotFound(bytes4 _selector);
@@ -166,7 +166,7 @@ This also means diamonds implementing this ERC are **facet-based** rather than *
 
 ### Facet-Based Events
 
-This ERC replaces ERC-2535’s function-based events with facet-based events. 
+This ERC replaces ERC-2535's function-based events with facet-based events. 
 
 When facets are added, replaced, or removed, the diamond MUST emit the following events:
 
@@ -217,9 +217,9 @@ This event is OPTIONAL.
 
 This event can be used to record `delegatecall`s made by a diamond.
 
-This event MUST NOT be emitted for `delegatecall`s made by a diamond’s fallback function when routing calls to facets. It is only intended for `delegatecall`s made by functions in facets or a diamond’s constructor.
+This event MUST NOT be emitted for `delegatecall`s made by a diamond's fallback function when routing calls to facets. It is only intended for `delegatecall`s made by functions in facets or a diamond's constructor.
 
-This event enables tracking of changes to a diamond’s contract storage caused by `delegatecall` execution.
+This event enables tracking of changes to a diamond's contract storage caused by `delegatecall` execution.
 
 ```solidity
 /**
@@ -264,7 +264,7 @@ A facet-based diamond MUST implement the following:
    - It MUST associate function selectors with facet addresses.
 3. **Function Execution**
    - When an external function is called on a diamond:
-     - The diamond’s fallback function is executed. 
+     - The diamond's fallback function is executed. 
      - The fallback function MUST find the facet associated with the function selector.
      - The fallback function MUST execute the function on the facet using `delegatecall`.
      - If no facet is associated with the function selector, the diamond MAY execute a default function or apply another handling mechanism.
@@ -528,7 +528,7 @@ Routing calls via `delegatecall` introduces a small amount of gas overhead. In p
 
 ### Storage Layout
 
-Diamonds and facets need to use a storage layout organizational pattern because Solidity’s default storage layout doesn’t support proxy contracts or diamonds. The storage layout technique or pattern to use is not specified in this ERC. However, examples of storage layout patterns that work with diamonds are [ERC-8042 Diamond Storage](./eip-8042) and [ERC-7201 Namespaced Storage Layout](./eip-7201).
+Diamonds and facets need to use a storage layout organizational pattern because Solidity's default storage layout doesn't support proxy contracts or diamonds. The storage layout technique or pattern to use is not specified in this ERC. However, examples of storage layout patterns that work with diamonds are [ERC-8042 Diamond Storage](./eip-8042) and [ERC-7201 Namespaced Storage Layout](./eip-7201).
 
 ### Facets Sharing Storage & Functionality
 
@@ -555,7 +555,7 @@ Diamonds implementing this ERC have the same introspection functions as ERC-2535
 
 ### Arbitrary Execution with `upgradeDiamond`
 
-The `upgradeDiamond` function allows arbitrary execution with access to the diamond’s storage (through delegatecall). Access to this function must be restricted carefully.
+The `upgradeDiamond` function allows arbitrary execution with access to the diamond's storage (through delegatecall). Access to this function must be restricted carefully.
 
 ### Use Only Trusted and Verified Facets
 
@@ -563,7 +563,7 @@ Only trusted and verified facets should be added to facet-based diamonds.
 
 `exportSelectors()` MUST be `pure` and should not contain logic that varies the returned bytes. Facets should be immutable so returned selectors cannot change over time.
 
-If a facet’s `exportSelectors()` output changes, upgrades that rely on it may add/remove/replace the wrong selectors and corrupt diamonds.
+If a facet's `exportSelectors()` output changes, upgrades that rely on it may add/remove/replace the wrong selectors and corrupt diamonds.
 
 ### Upgrade Integrity Checks
 
@@ -578,7 +578,7 @@ The specified `upgradeDiamond` behavior prevents a number of upgrade mistakes. U
 - A facet provides zero selectors.
 - A facet is replaced with itself (same contract address).
 
-Selector collisions (two different signatures with the same 4-byte selector) are handled as “selector already exists” and are therefore prevented.
+Selector collisions (two different signatures with the same 4-byte selector) are handled as "selector already exists" and are therefore prevented.
 
 ### Do Not Self Destruct
 Use of selfdestruct in a facet is heavily discouraged. Misuse of it can delete a diamond or a facet.

--- a/ERCS/erc-8153.md
+++ b/ERCS/erc-8153.md
@@ -16,7 +16,7 @@ A diamond is a proxy contract that `delegatecall`s to multiple implementation co
 
 ![Diagram showing how a diamond contract works](../assets/eip-8153/basic-diamond-diagram.svg)
 
-Diamond contracts were originally standardized by [ERC-2535](./eip-2535). This ERC builds on that foundation by defining a facet-based architecture in which facets self-describe their function selectors through a standardized introspection interface.
+Diamond contracts were originally standardized by [ERC-2535](./eip-2535.md). This ERC builds on that foundation by defining a facet-based architecture in which facets self-describe their function selectors through a standardized introspection interface.
 
 By moving selector discovery on-chain, this approach eliminates the need for off-chain selector management. As a result, diamond deployment and upgrades become simpler, more deterministic, and more gas efficient.
 
@@ -24,7 +24,7 @@ This ERC introduces a facet introspection function, `exportSelectors()`, which e
 
 This ERC also defines facet-based events for adding, replacing, and removing facets.
 
-Additionally, the ERC also defines an optional `upgradeDiamond` function. This function uses `exportSelectors()` to automatically determine which selectors should be added, replaced, or removed when applying facet changes.
+Additionally, the ERC defines an optional `upgradeDiamond` function. This function uses `exportSelectors()` to automatically determine which selectors should be added, replaced, or removed when applying facet changes.
 
 ## Motivation
 
@@ -40,7 +40,7 @@ This architecture is well suited to **immutable** smart-contract systems, where 
 
 For upgradeable systems, diamonds enable incremental development: new functionality can be added, and existing functionality modified, without redeploying unaffected facets.
 
-Additional motivation and background for diamond-based smart-contract systems can be found in [ERC-1538](./eip-1538) and [ERC-2535](./eip-2535).
+Additional motivation and background for diamond-based smart-contract systems can be found in [ERC-1538](./eip-1538.md) and [ERC-2535](./eip-2535.md).
 
 ### Motivation for this Standard
 
@@ -77,7 +77,7 @@ It shows that a diamond has a mapping from function to facet and that facets can
 
 When an external function is called on a diamond, its fallback function is executed. The fallback function determines which facet to call based on the first four bytes of the calldata (known as the function selector) and executes the function from the facet using `delegatecall`.
 
-A diamond's fallback function and `delegatecall` enable a diamond to execute a facet's function as if it was implemented by the diamond itself. The `msg.sender` and `msg.value` values do not change and only the diamond's storage is read and written to.
+A diamond's fallback function and `delegatecall` enable a diamond to execute a facet's function as if it were implemented by the diamond itself. The `msg.sender` and `msg.value` values do not change and only the diamond's storage is read and written to.
 
 Here is an example of how a diamond's fallback function might be implemented:
 
@@ -113,7 +113,7 @@ If the fallback function cannot find a facet for a function selector, and there 
 
 ### Inspecting Diamonds
 
-An [ERC-8153](./eip-8153) diamond MUST implement the same introspection functions as defined in ERC-2535.
+A diamond implementing this standard MUST implement the same introspection functions as defined in ERC-2535.
 Specifically, these functions MUST be implemented:
 
 ```solidity
@@ -151,10 +151,12 @@ Typically, these functions are implemented in a facet and the facet is added to 
 Each facet MUST implement the following pure introspection function:
 
 ```solidity
-function exportSelectors() external pure returns (bytes memory selectors)
+interface IFacet {
+    function exportSelectors() external pure returns (bytes memory selectors);
+}
 ```
 
-`exportSelectors()` returns a `bytes` array containing one or more 4-byte function selectors. The returned `bytes` array length is a multiple of 4, and each 4-byte chunk is a selector. The function MUST not return a specific selector more than once.
+`exportSelectors()` returns a `bytes` array containing one or more 4-byte function selectors. The returned `bytes` array length MUST be a multiple of 4, and each 4-byte chunk is a selector. The function MUST NOT return a specific selector more than once.
 
 The `bytes` array contains selectors of functions implemented by the facet that are intended to be added to a diamond.
 
@@ -209,11 +211,11 @@ event FacetRemoved(address indexed _facet);
 
 Block explorers and other tooling can obtain the function selectors for any of the facets referenced by these events by calling `exportSelectors()` on the facet address.
 
-### Optional Upgrade Events
+### Optional Events
 
 #### Recording Non-Fallback `delegatecall`s
 
-This event is OPTIONAL.
+This event is OPTIONAL, except `upgradeDiamond` functions MUST emit it as specified in this standard.
 
 This event can be used to record `delegatecall`s made by a diamond.
 
@@ -223,7 +225,7 @@ This event enables tracking of changes to a diamond's contract storage caused by
 
 ```solidity
 /**
-* @notice Emitted when a diamond's constructor function or function from a
+* @notice Emitted when a diamond's constructor or function from a
 *         facet makes a `delegatecall`. 
 * 
 * @param _delegate         The contract that was the target of the `delegatecall`.
@@ -235,7 +237,7 @@ event DiamondDelegateCall(address indexed _delegate, bytes _delegateCalldata);
 
 #### Diamond Metadata
 
-This event is OPTIONAL.
+This event is OPTIONAL, except `upgradeDiamond` functions MUST emit it as specified in this standard.
 
 This event can be used to record versioning or other information about diamonds.
 
@@ -284,7 +286,7 @@ A facet-based diamond MUST implement the following:
    - Each facet MUST implement the `exportSelectors()` function, which returns a `bytes` array.
 
 
-### `receive()` function
+### `receive()` Function
 
 A diamond MAY have a `receive()` function.
 
@@ -305,14 +307,14 @@ The `upgradeDiamond` function works as follows:
 
 #### Replacing a Facet
 
-1. Call `exportSelectors()` on the old facet to obtain its packed selectors.
-2. Call `exportSelectors()` on the new facet to obtain its packed selectors.
+1. Call `exportSelectors()` on the old facet to obtain its function selectors.
+2. Call `exportSelectors()` on the new facet to obtain its function selectors.
 3. For selectors present in the new facet but not the old facet: add them.
 4. For selectors present in both: replace them to point to the new facet.
 5. For selectors present in the old facet but not the new facet: remove them.
 
 #### Removing a Facet
-1. Call `exportSelectors()` on the facet to obtain its packed selectors.
+1. Call `exportSelectors()` on the facet to obtain its function selectors.
 2. Remove each selector from the diamond.
 
 #### Errors and Types
@@ -389,7 +391,7 @@ function upgradeDiamond(
     bytes calldata _delegateCalldata,
     bytes32 _tag,
     bytes calldata _metadata
-);
+) external;
 ```
 The `upgradeDiamond` function MUST adhere to the following requirements:
 
@@ -494,15 +496,15 @@ The diamond can traverse the returned bytes and extract selectors efficiently.
 
 ### Diamond Upgrades
 
-This upgrade function specified by this standard is optional.
+The upgrade function specified by this standard is optional.
 
-This means a couple things:
+This means a couple of things:
 
 #### 1. Diamonds Can Be Immutable
 
 A Diamond does not have to have an upgrade function.
 
-- A diamond can be fully constructed within its constructor function without adding any upgrade function, making it immutable upon deployment.
+- A diamond can be fully constructed within its constructor without adding any upgrade function, making it immutable upon deployment.
 
 - A large immutable diamond can be built using well organized facets.
 
@@ -510,7 +512,7 @@ A Diamond does not have to have an upgrade function.
 
 #### 2. You Can Create Your Own Upgrade Functions
 
-You can design and create your own upgrade functions and remain compliant with this standard. All that is required is that you emit the appropriate add/replace/remove required events specified in the [Facet-Based Events section](#facet-based-events), that the introspection functions defined in the [Inspecting Diamonds section](#inspecting-diamonds) and the [Inspecting Facets section](#inspecting-facets) continue to exists and accurately return function and facet information.
+You can design and create your own upgrade functions and remain compliant with this standard. All that is required is that you emit the appropriate add/replace/remove events specified in the [Facet-Based Events section](#facet-based-events), and that the introspection functions defined in the [Inspecting Diamonds section](#inspecting-diamonds) and the [Inspecting Facets section](#inspecting-facets) continue to exist and accurately return function and facet information.
 
 ### Runtime Gas Considerations
 
@@ -528,7 +530,7 @@ Routing calls via `delegatecall` introduces a small amount of gas overhead. In p
 
 ### Storage Layout
 
-Diamonds and facets need to use a storage layout organizational pattern because Solidity's default storage layout doesn't support proxy contracts or diamonds. The storage layout technique or pattern to use is not specified in this ERC. However, examples of storage layout patterns that work with diamonds are [ERC-8042 Diamond Storage](./eip-8042) and [ERC-7201 Namespaced Storage Layout](./eip-7201).
+Diamonds and facets need to use a storage layout organizational pattern because Solidity's default storage layout doesn't support proxy contracts or diamonds. The storage layout technique or pattern to use is not specified in this ERC. However, examples of storage layout patterns that work with diamonds are [ERC-8042 Diamond Storage](./eip-8042.md) and [ERC-7201 Namespaced Storage Layout](./eip-7201.md).
 
 ### Facets Sharing Storage & Functionality
 
@@ -549,7 +551,11 @@ It is possible to implement facets in a way that makes them usable/composable/co
 
 ## Backwards Compatibility
 
-Diamonds implementing this ERC have the same introspection functions as ERC-2535 diamonds, so they are compatible with ERC-2535 tooling that rely on these functions.
+Diamonds implementing this ERC have the same introspection functions as ERC-2535 diamonds, so they are compatible with ERC-2535 tooling that relies on these functions.
+
+This ERC breaks compatibility with ERC-2535 events and upgrades.
+
+Facets deployed for ERC-2535 diamonds cannot be used with ERC-8153 diamonds if they do not have the `exportSelectors()` function.
 
 ## Security Considerations
 
@@ -572,7 +578,7 @@ The specified `upgradeDiamond` behavior prevents a number of upgrade mistakes. U
 - A facet is added that already exists in the diamond.
 - A facet is replaced or removed that does not exist in the diamond.
 - A selector is added that already exists in the diamond.
-- A selector is replaced that exists in the diamond but it is from a different facet than the facet being replaced.
+- A selector is replaced that exists in the diamond but is mapped to a different facet than the facet being replaced.
 - A facet address contains no bytecode.
 - A facet does not implement `exportSelectors()` successfully.
 - A facet provides zero selectors.

--- a/ERCS/erc-8153.md
+++ b/ERCS/erc-8153.md
@@ -4,7 +4,7 @@ title: Facet-Based Diamonds
 description: Simplifies diamond management, deployment and upgrades.
 author: Nick Mudge (@mudgen)
 discussions-to: https://ethereum-magicians.org/t/erc-8153-facet-based-diamonds/27685
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2026-02-07
@@ -154,7 +154,7 @@ Each facet MUST implement the following pure introspection function:
 function exportSelectors() external pure returns (bytes memory selectors)
 ```
 
-`exportSelectors()` returns a `bytes` array containing one or more 4-byte function selectors. The returned `bytes` array length is a multiple of 4, and each 4-byte chunk is a selector. The function MUST not return the same selector more than once.
+`exportSelectors()` returns a `bytes` array containing one or more 4-byte function selectors. The returned `bytes` array length is a multiple of 4, and each 4-byte chunk is a selector. The function MUST not return a specific selector more than once.
 
 The `bytes` array contains selectors of functions implemented by the facet that are intended to be added to a diamond.
 
@@ -393,7 +393,7 @@ function upgradeDiamond(
 ```
 The `upgradeDiamond` function MUST adhere to the following requirements:
 
-> The complete definitions of events and custom errors referenced below are given earlier in this standard.
+> Definitions of events and custom errors referenced below are given earlier in this standard.
 
 1. **Inputs**
    - `_addFacets` array of facet addresses to add.


### PR DESCRIPTION
Editorial pass on ERC-8153: fixed relative link extensions, made the exportSelectors() snippet a valid interface, tightened normative wording (MUST NOT, multiple-of-4 requirement), clarified when the optional events are required, expanded Backwards Compatibility, and fixed typos/grammar. No status change.