### PR TITLE
Update ERC-7730: define wallet behavior for non-zero native value

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1682,6 +1682,14 @@ ERC-7730 creates a risk surface where malicious actors could abuse formatting to
 
 The binding `context` mitigates misuse by specifying exactly which structured data a given ERC-7730 file may format. app developers MUST set restrictive constraints; wallets MUST verify all constraints and ensure formatting is cryptographically bound to the reviewed data and not tamperable in transit (including on resource-constrained hardware wallets).
 
+### Native currency value (`@.value`)
+
+Wallets select a format specification by function selector. Since a selector does not encode payability, the same format applies whether or not the transaction carries native currency value. A format that omits `@.value` could therefore hide an unexpected native currency transfer.
+
+Wallets MUST display `@.value` to the user when it is non-zero, even when no field in the format specification references it.
+
+For each format describing a payable function, descriptor authors SHOULD either include `@.value` as a displayed field, or assert that it is zero when the described operation is not expected to carry native currency value.
+
 ### Registry poisoning
 
 Curation and registry of ERC-7730 files are out of scope for this specification, but any external registry or wallet ecosystem MUST assume it will be targeted. A secure registry should (a) require cryptographically verifiable provenance and attestations for each ERC-7730 file and its maintainer, (b) keep a public, tamper-evident history of submissions, approvals, and revocations, (c) implement a mechanism to credibly link contract ownership or authority to the submitted file, and (d) adopt a clear governance model with multi-party sign-off and automated monitoring to detect anomalies or mass poisoning attempts. These measures mitigate attacks on ERC-7730 files in transit and make registry compromise significantly harder without constraining this ERC itself.


### PR DESCRIPTION
Resolves https://github.com/ethereum/clear-signing-erc7730-registry/issues/2900.

## Motivation

Function selectors encode parameter types only, not payability, so the same format
specification applies whether or not a transaction carries native currency value. When a
format does not reference `@.value`, the standard currently says nothing about what the
wallet should display, which leaves the decision to each implementation. A transaction can
therefore carry arbitrary native value that some wallets never surface to the user.

## Change

Adds a `Native currency value (@.value)` subsection to Security Considerations, placed after
`Binding context`:

- Wallets MUST display `@.value` when it is non-zero, even when no field in the format
  specification references it.
- For formats describing a payable function, authors SHOULD either include `@.value` as a
  displayed field, or assert that it is zero when the described operation is not expected to
  carry native currency value.

The author-side recommendation is intentionally mechanism-agnostic. The schema already
provides ways to constrain a field's value, and ongoing proposals would change how such
constraints are expressed, so naming a specific key here would date the text.

Protocols that charge a mandatory fee in native value would surface dust on every legitimate
call, which is presumably why some implementations suppress it. Future spec or schema changes
may introduce better ways to encode an expected range for a value, which would partially
address this. Any such mechanism is opt-in, though, so the default wallet behavior still needs
to be defined for the case where nothing is declared.
