### PR TITLE
Update ERC-7730: update EIP712 deployment chainId

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -543,7 +543,7 @@ Note that `chainId` and `verifyingContract` can also be bound to their values th
 
 **`eip712.deployments`**
 
-An array of deployments options. 
+An array of deployment options. 
 
 When an `eip712.deployments` constraint is set, the wallet MUST verify that:
 * The message being displayed has both `domain.chainId` and `domain.verifyingContract` keys
@@ -552,8 +552,10 @@ When an `eip712.deployments` constraint is set, the wallet MUST verify that:
   * Is a *proxy* pointing to one of the deployment options (see [Proxy support](#proxy-support))
 
 A deployment option is an object with:
-* `chainId`: an EIP-155 identifier of the chain the described contract is deployed on.
-* `address`: the address of the deployed contract on specified `chainId` chain.
+* `chainId`: the EIP-155 identifier matched against the `chainId` field of the domain.
+* `address`: the contract address matched against the `verifyingContract` field of the domain.
+
+In most cases `chainId` is the chain the verifying contract is deployed on. Some protocols, however, bind the domain's `chainId` to the chain of the data being authorized rather than the chain hosting the verifying contract — for instance a verifier deployed on a dedicated coordination chain serving several host chains, where the host `chainId` provides cross-chain replay protection and matches the chain the user's wallet is connected to when signing. In such cases no code is deployed at `address` on the `chainId` chain; source verification of the verifying contract applies to the chain where it is actually deployed.
 
 **`eip712.domainSeparator`**
 


### PR DESCRIPTION
A suggestion following discussion from https://github.com/ethereum/clear-signing-erc7730-registry/pull/2595#issuecomment-5445830095

Although the `eip712.deployments` semantic now becomes a bit misleading. 