### PR TITLE
Update ERC-7656: Correct deployed bytecode size to 173 bytes

### DIFF
--- a/ERCS/erc-7656.md
+++ b/ERCS/erc-7656.md
@@ -132,7 +132,9 @@ ERC-1167 Footer               (15 bytes)
 <linkedId (uint256)>          (32 bytes)
 ```
 
-**Total bytecode size: 183 bytes**
+**Total deployed bytecode size: 173 bytes**
+
+The creation code is 183 bytes. The additional 10 bytes are the ERC-1167 constructor prefix, which returns the 173-byte runtime bytecode shown above and is not itself part of the deployed contract.
 
 Linked services SHOULD implement the `IERC7656Service` interface:
 


### PR DESCRIPTION
## Description

ERC-7656 is Final. This is an errata correction to a numeric value in the Specification section, plus a clarifying sentence. No normative requirement changes.

The Deployment Requirements section lists the structure of a linked service's deployed bytecode and then states "Total bytecode size: 183 bytes". The listed segments sum to 173 bytes:

```
10 + 20 + 15 + 32 + 32 + 12 + 20 + 32 = 173
```

183 is the size of the creation code, which includes a 10-byte ERC-1167 constructor prefix that is not part of the listed structure. A client validating a linked service by `extcodesize`, or deriving `extcodecopy` offsets from the stated total, would be off by 10 bytes.

## Change

- "Total bytecode size: 183 bytes" becomes "Total deployed bytecode size: 173 bytes". The word "deployed" is added because the confusion between creation code and runtime code is exactly what the original figure got wrong.
- A sentence is added stating that the creation code is 183 bytes and that the extra 10 bytes are the ERC-1167 constructor prefix. This keeps the 183 figure in the document with the correct meaning attached, rather than silently dropping a number an implementer may have relied on.

## Verification

Six checks, all against the ERC's own reference implementation in `assets/erc-7656/` unless noted.

1. The listed segments sum to 173.

2. `ERC7656Factory.create` deploys with `create2(0, 0x55, 0xb7, salt)`. The length argument `0xb7` is 183, so 183 is the creation code size.

3. The constructor prefix written by that same function is `3d60ad80600a3d3981f3`. The `60ad` is `PUSH1 0xad`, and `0xad` is 173. That is the runtime length the constructor returns, so the deployed contract is 173 bytes.

4. `ERC7656BytecodeLib.getCreationCode` ends with `mstore(result, 0xb7)`, setting the returned creation code length to 183. Its own offset comments run from `0x14` through `0xb7` plus a 32-byte `linkedId`, which is the same 183 bytes.

5. The example `LinkedService` in the ERC text reads its immutable data with `extcodecopy(service, add(encodedData, 0x20), 0x4d, 0x60)`. That is offset 77 for 96 bytes, ending at 173. Those offsets are only correct for a 173-byte deployed contract.

6. Deployed the reference factory under Foundry and measured the result:

```
creationLen: 183, deployedLen: 173
```

`creationLen` is the length of the array returned by `ERC7656BytecodeLib.getCreationCode`. `deployedLen` is `extcodesize` of the address returned by `create()`. The runtime bytecode splits exactly along the documented structure:

```
363d3d373d3d3d363d73                     ERC-1167 Header  (10)
2e234dae75c793f67a35089c9d99245e1c58470b implementation   (20)
5af43d82803e903d91602b57fd5bf3           ERC-1167 Footer  (15)
00...aaaa                                salt             (32)
00...7a69                                chainId          (32)
000000000000000000000001                 mode             (12)
00000000000000000000000000000000deadbeef linkedContract   (20)
00...002a                                linkedId         (32)
                                                          173
```

As corroboration: the reference implementation states it was mutated from the ERC-6551 reference. ERC-6551 documents the same layout, with a single 32-byte tokenContract slot where ERC-7656 has mode (12) plus linkedContract (20), and its worked example bytecode is 173 bytes.

## What this does not change

No interface, no behavior, no requirement. I re-checked the other computed values in the document while I was here and they are all correct: `IERC7656Service` interface ID `0x7e110a1d`, `IERC7656Factory` interface ID `0x9e23230a` (`create` `0xb4cb3cbb` XOR `compute` `0x2ae81fb1`), and the `Created` event topic `0x5d6f1b27222bf34d576ad575c1c8749e981db502da9cd2e96e6e525893809905`.
