### PR TITLE
Update ERC-7730: fix broken tokenTicker table rendering

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -1473,6 +1473,7 @@ Formats applicable to `address` solidity type.
 | `Sender`                | Field Value 0x0000000000000000000000000000000000000000 <br> `senderAddress` = ["0x0000000000000000000000000000000000000000"] <br> `types` = ["eoa"] |
 
 ---
+
 | **`tokenTicker`**          |                                                                                              |
 |----------------------------|----------------------------------------------------------------------------------------------|
 | *Description*              | Display address as an [ERC-20](./eip-20.md) token ticker                                     |


### PR DESCRIPTION
The `tokenTicker` table in the "Field formats" section renders as a plain paragraph on eips.ethereum.org ([live page](https://eips.ethereum.org/EIPS/eip-7730#field-formats)), because the table starts on the line directly after a `---` horizontal rule. Kramdown needs a blank line between the two, otherwise it absorbs the table rows into a paragraph.

This PR adds that blank line. No content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)