### PR TITLE
Align uRWA721 canTransfer with ERC-7943 policy semantics

### DIFF
--- a/assets/erc-7943/contracts/uRWA721.sol
+++ b/assets/erc-7943/contracts/uRWA721.sol
@@ -59,8 +59,6 @@ contract uRWA721 is Context, ERC721, AccessControlEnumerable, IERC7943NonFungibl
 
     /// @inheritdoc IERC7943NonFungible
     function canTransfer(address from, address to, uint256 tokenId) public view virtual override returns (bool allowed) {
-        address owner = _ownerOf(tokenId);
-        if (owner != from || owner == address(0)) return allowed;
         if (getFrozenTokens(from, tokenId)) return allowed;
         if (!canSend(from) || !canReceive(to)) return allowed;
 

--- a/assets/erc-7943/test/uRWA721.t.sol
+++ b/assets/erc-7943/test/uRWA721.t.sol
@@ -329,6 +329,12 @@ contract uRWA721Test is Test {
         token.transferFrom(user1, user2, TOKEN_ID_1);
     }
 
+    function test_Revert_Transfer_FromIncorrectOwner() public {
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721IncorrectOwner.selector, user2, TOKEN_ID_1, user1));
+        token.transferFrom(user2, user1, TOKEN_ID_1);
+    }
+
     function test_Revert_Transfer_WhenFrozen() public {
         vm.prank(freezer);
         token.setFrozenTokens(user1, TOKEN_ID_1, true);
@@ -489,12 +495,12 @@ contract uRWA721Test is Test {
         assertTrue(token.canTransfer(user1, user2, TOKEN_ID_1));
     }
 
-    function test_CanTransfer_Fail_FromNotOwner() public view {
-        assertFalse(token.canTransfer(user2, user1, TOKEN_ID_1));
+    function test_CanTransfer_Success_FromNotOwnerWhenPolicyAllows() public view {
+        assertTrue(token.canTransfer(user2, user1, TOKEN_ID_1));
     }
 
-    function test_CanTransfer_Fail_NonExistentToken() public view {
-        assertFalse(token.canTransfer(user1, user2, NON_EXISTENT_TOKEN_ID));
+    function test_CanTransfer_Success_NonExistentTokenWhenPolicyAllows() public view {
+        assertTrue(token.canTransfer(user1, user2, NON_EXISTENT_TOKEN_ID));
     }
 
     function test_CanTransfer_Fail_FromCannotSend() public {


### PR DESCRIPTION
uRWA721.canTransfer currently returns false when from is not the token owner or when tokenId does not exist.

The final ERC-7943 specification defines canTransfer as a permissioned-policy check and requires it not to return false for token-specific, non-permissioned validations belonging to the underlying base token.

ERC-721 ownership and token existence are base-token feasibility checks. This patch removes only those two checks from canTransfer. Frozen-token, canSend(from), and canReceive(to) checks are unchanged.

Actual transfer execution is unchanged and continues to enforce token existence, ownership, caller authorization, and ERC-7943 restrictions.

The canonical tests update the policy-view expectations and confirm that incorrect ownership, nonexistent tokens, unauthorized callers, and frozen transfers remain blocked during execution.

This is a conformance fix, not a security vulnerability.