### PR TITLE
Update ERC-8167: no requirements outside specifications

### DIFF
--- a/ERCS/erc-8167.md
+++ b/ERCS/erc-8167.md
@@ -157,7 +157,7 @@ Access control designs are outside the scope of this standard.
 
 ### Avoid self-destruct
 
-Delegates MUST NOT self-destruct.
+Delegates should not self-destruct.
 If a delegate can self-destruct, it can break proxies that use it.
 
 ### Storage Layout
@@ -168,7 +168,7 @@ Delegates should be designed to minimize the risk of storage layout overlap betw
 There are two known approaches to protect storage layouts against such collisions.
 
 The first is to define a single shared proxy storage layout in a common superclass inherited by all of the proxy's delegates.
-Such subclasses SHOULD NOT declare additional storage.
+Such subclasses should not declare additional storage.
 
 The second is to use storage namespaces, such as [ERC-7201](./eip-7201.md) and [ERC-8042](./eip-8042.md).
 This approach is appropriate for shared libraries.


### PR DESCRIPTION

Requested by @SamWilsn [here](https://github.com/ethereum/ERCs/pull/1958#discussion_r3906184718)
#### Changes
* Disallow requirements outside of the Specification section by downgrading to prose.