### PR TITLE
CI: lint changed ERC documents with markdownlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
-          gh pr diff ${{ github.event.number }} --name-only | grep -E -x '[^/]+\.md|EIPS/eip-[0-9]+\.md' >> $GITHUB_ENV
+          gh pr diff ${{ github.event.number }} --name-only | grep -E -x '[^/]+\.md|ERCS/erc-[0-9]+\.md' >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

## Description

Fix Markdown Linter changed-file detection for ERC documents.

## Problem

The Markdown Linter workflow currently filters changed files with:

```bash
grep -E -x '[^/]+\.md|EIPS/eip-[0-9]+\.md'
```

ERC proposals are stored under `ERCS/erc-*.md`, so ERC-only pull requests do not match this expression. The `grep` command then exits with status 1, causing the `Get Changed Files` step to fail and the Markdown Linter step to be skipped.

## Changes

Update the changed-file filter to include:

```text
ERCS/erc-[0-9]+.md
```

## Testing

Verified locally that:

- `ERCS/erc-20.md` does not match the previous expression.
- `ERCS/erc-20.md` matches the updated expression.
- The updated workflow YAML parses successfully.
- `git diff --check` passes.
