### PR TITLE
Update ERC-8354: bind expiry as a public input in the reference circuit

### DIFF
--- a/assets/erc-8354/circuits/Prover.example.toml
+++ b/assets/erc-8354/circuits/Prover.example.toml
@@ -6,7 +6,9 @@ policy_root = "0x053d4542d140ad2350a0ee79fae4a522821274e428bd881e7e803ecd816635a
 action_commitment = [124, 203, 122, 78, 157, 81, 18, 139, 149, 28, 190, 221, 239, 174, 193, 20, 1, 128, 163, 209, 63, 110, 174, 111, 6, 89, 109, 196, 50, 5, 124, 250]
 nullifier = "0x041271fcaf479f6ab927df3a03f74d3809e9f49d880cd7a9595c8dc0a58a5e03"
 decision = "1"
+policy_kind = "0"   # 0 = ALLOWED (was missing from this example — required public input)
 executor = "0xE0"
+expiry = "1900000000"
 chain_id = "1"
 target = "0x1234"
 value = "0"

--- a/assets/erc-8354/circuits/src/main.nr
+++ b/assets/erc-8354/circuits/src/main.nr
@@ -38,6 +38,11 @@ fn main(
     decision: pub u8, // 1 = ALLOW
     policy_kind: pub u8, // 0 = ALLOWED
     executor: pub Field, // address permitted to consume; committed so the proof binds to it
+    // Every Verdict field MUST be a public input and MUST NOT sit in the private witness. `expiry`
+    // was omitted here while the Guard checks it on chain, which left the proof unbound to it: the
+    // same proof verified under any expiry the submitter chose. Appended last so no existing
+    // public-input index moves.
+    expiry: pub Field,
     // ---- private witness ----
     chain_id: Field,
     target: Field, // call target address as an integer
@@ -47,6 +52,13 @@ fn main(
     index: Field, // leaf index of `target` in the allowlist
     path: [Field; TREE_DEPTH], // sibling hashes bottom-to-top
 ) {
+    // `expiry` is deliberately not constrained here: the Guard performs the time check and the
+    // circuit has no notion of block time. It is public so the PROOF COMMITS TO IT, which is the
+    // whole requirement — proving at one expiry and verifying at another fails in the reduction
+    // step. Do not delete this binding to silence the unused warning; that is exactly the defect
+    // this line exists to close.
+    let _ = expiry;
+
     // 1. ALLOW only
     assert(decision == 1);
     // The kind is committed, so a relying party cannot be handed a taxonomy the proof never established.
@@ -154,10 +166,11 @@ fn test_allow_verdict() {
     let (chi, clo) = bytes32_to_two_fields(commit);
     let nullifier = std::hash::pedersen_hash([domain_id, agent_id, chi, clo, action_nonce]);
     let executor: Field = 0xE0; // matches ConsumeReal.t.sol executor address(0xE0)
+    let expiry: Field = 1900000000; // any value: main leaves expiry unconstrained on purpose
 
     main(
-        agent_id, domain_id, policy_root, commit, nullifier, 1, KIND_ALLOWED, executor, chain_id, target, value,
-        call_data_hash, action_nonce, index, path,
+        agent_id, domain_id, policy_root, commit, nullifier, 1, KIND_ALLOWED, executor, expiry, chain_id,
+        target, value, call_data_hash, action_nonce, index, path,
     );
 }
 


### PR DESCRIPTION
## What

Binds `expiry` as a public input in the ERC-8354 reference circuit (`assets/erc-8354/circuits`).

The reference circuit was still the pre-fix shape: `expiry` — a `Verdict` field the on-chain Guard checks — was **not** a public input, so a proof was not bound to it and the *same proof verified under any `expiry`* the submitter chose. The ERC's own Rationale requires every `Verdict` field to be a public input.

This mirrors the merged deployment-side fix in the reference implementation — `zexoverz/confidential-agent-policy-verdicts#4` ("bind expiry as a public input on all three programs"). Flagged by @zexoverz in the working group; this brings the ERC reference asset in line with it.

## Changes

- **`src/main.nr`** — add `expiry: pub Field`, appended last so no existing public-input index moves, plus `let _ = expiry;`. It is deliberately *not* constrained in-circuit: the Guard performs the time check and the circuit has no notion of block time. Making it public means the **proof commits to it** (bound by the verifier), which is the whole requirement — proving at one expiry and verifying at another fails in the reduction step. `test_allow_verdict` updated to pass it.
- **`Prover.example.toml`** — add `expiry`, and add the previously-missing `policy_kind` (a required public input the example omitted, so it did not execute as published).

## Verification (nargo 1.0.0-beta.26)

- Baseline (unmodified): `nargo check` clean, `test_allow_verdict` passes.
- Modified: `nargo check` clean, all 4 tests pass.
- Completed example: `nargo execute` → *"Circuit witness successfully solved."*

The binding is by construction — public inputs are bound by the verifier; the deployment repo's #4 additionally proves it at the verifier level (`ExpiryBinding.t.sol`).
