### PR TITLE
Add ERC: Integrity Verified Artifact References

### DIFF
--- a/ERCS/erc-8410.md
+++ b/ERCS/erc-8410.md
@@ -1,0 +1,343 @@
+---
+eip: 8410
+title: Integrity Verified Artifact References
+description: An envelope naming a wallet payload by URL and keccak256 digest, so a relaying party can pass it along without being trusted with its bytes
+author: Moody Salem (@moodysalem)
+discussions-to: https://ethereum-magicians.org/t/erc-8410-integrity-verified-artifact-references/0
+status: Draft
+type: Standards Track
+category: ERC
+created: 2026-09-04
+---
+
+## Abstract
+
+This proposal defines the *artifact reference*: a small JSON envelope that names
+a wallet-bound payload by its location and its keccak256 digest, rather than
+carrying the payload itself.
+
+A producer stores a document — an execution plan, a bundle of read calls, a
+curated token list — and returns an envelope holding an `https` URL or a bounded
+`data:` URI, the digest of the exact stored bytes, their exact count, and what
+kind of document they are. Any number of intermediaries may pass that envelope
+along verbatim. The consuming wallet retrieves the bytes itself, verifies the
+digest and the byte count, and only then parses.
+
+The result is that a relaying party carries authority over *which* document is
+used, and none at all over *what it says*. This proposal also fixes the network
+admission rules for the retrieval, because a wallet that fetches a
+caller-supplied URL is a wallet that can be aimed at things.
+
+## Motivation
+
+Payloads bound for a wallet are increasingly assembled by one party, relayed by a
+second, and executed by a third. The middle party is often the least trustworthy
+link in the chain — a browser extension, an automation runner, or an AI agent
+acting on text from an untrusted source — and it is exactly the link that
+currently gets handed the full bytes and asked to forward them faithfully.
+
+Passing payloads inline through that link has three costs:
+
+- **The relay can rewrite anything.** An agent asked to forward a swap plan can
+  forward a different one. Nothing downstream can tell, because the bytes it
+  receives are all it ever sees.
+- **The relay must reproduce kilobytes exactly.** Calldata and token lists are
+  large. A relay that re-serializes, pretty-prints, reorders, or truncates them
+  corrupts the payload without meaning to — a failure mode that is
+  disproportionately common when the relay is a language model reconstructing
+  JSON rather than copying it.
+- **Provenance is destroyed.** After an inline hop, the consumer cannot tell
+  whether a payload came from a vetted service or was invented one step earlier.
+
+Content addressing solves all three, and the wallet ecosystem has no agreed way
+to express it. Subresource Integrity solves the analogous problem for browsers,
+but it is an HTML attribute over a fixed set of SHA hashes with no notion of what
+kind of resource is being named and no inline form. This proposal is the
+equivalent for wallet payloads: keccak256 to match the rest of the ecosystem's
+tooling, a required type discriminator so a consumer can enforce size limits and
+refuse a substitution across kinds, and a `data:` form so the same envelope shape
+works when there is no server.
+
+The retrieval rules matter as much as the envelope. A wallet that will fetch a
+URL chosen by its caller has become a request forwarder positioned inside the
+user's network, and the interesting attacks — internal address probing, redirect
+chains, credential-bearing URLs, unbounded response bodies — are all in the
+fetch, not in the payload. Specifying the envelope without specifying admission
+would standardize the easy half.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in RFC 2119 and RFC 8174.
+
+A machine-readable schema is provided in
+[the artifact reference schema](../assets/eip-8410/artifact-reference.schema.json).
+
+### The envelope
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `kind` | string | yes | MUST be `"artifact_reference"` |
+| `artifact_type` | string | yes | What sort of document the bytes are |
+| `url` | string | yes | `https` URL or `data:` URI locating the bytes |
+| `integrity` | object | conditional | Digest over the exact stored bytes |
+| `bytes` | number | conditional | Exact byte length of the stored bytes |
+| `instruction` | string | no | Human-readable note from the producer |
+
+`integrity` and `bytes` are REQUIRED when `url` is an `https` URL, and OPTIONAL
+when it is a `data:` URI. Over the network the digest is the only thing making
+the reference meaningful; in a `data:` URI the bytes are the reference, so there
+is nothing for a digest to protect against that is not already true of the
+envelope itself. When either is supplied for a `data:` URI it MUST still be
+checked.
+
+Consumers MUST ignore members they do not recognize at the top level of the
+envelope, so that producers can enrich it without stranding deployed wallets.
+
+`integrity` is an object with:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `algorithm` | string | yes | Digest algorithm; `"keccak256"` for this revision |
+| `value` | string | yes | `0x` followed by 64 hexadecimal digits |
+
+Unlike the envelope, `integrity` is strict: a consumer MUST reject an `integrity`
+object carrying any member not listed above. An integrity block containing
+something the consumer does not understand is an integrity block it cannot claim
+to have verified, and quietly ignoring half of one produces exactly the false
+assurance the field exists to prevent. `algorithm` is a string rather than a
+fixed enumeration so that a rejection can name both what was offered and what is
+supported.
+
+`artifact_type` is an extension point. This proposal defines:
+
+- `execution_plan` — a plan document as specified in the companion proposal on
+  portable execution plans.
+- `read_calls` — a bundle of read-only calls to evaluate.
+- `token_list` — a curated list of token metadata.
+
+Consumers MUST reject an `artifact_type` they do not implement, and MUST reject a
+reference whose `artifact_type` differs from the type expected at the point of
+use. The discriminator is what stops an envelope prepared for one purpose from
+being redeemed for another, and it is what lets a consumer apply a size limit
+appropriate to the kind before it fetches anything.
+
+`instruction` is producer-supplied prose. It is display context and MUST NOT
+influence any authorization decision.
+
+### Retrieving the bytes
+
+Given an envelope, a consumer MUST:
+
+1. Reject the envelope if its serialized length exceeds the consumer's limit,
+   before parsing the URL.
+2. Reject the reference if `bytes` is present and exceeds the maximum body size
+   for `artifact_type`, before opening any connection. There is no reason to
+   fetch something a producer has already said is too large.
+3. Retrieve the bytes according to the transport rules below.
+4. Reject the result if `bytes` is present and the retrieved length differs.
+5. Reject the result if `integrity` is present and the digest of the retrieved
+   bytes differs.
+6. Parse and validate the bytes exactly as it would an equivalent payload
+   supplied inline.
+
+Steps 4 through 6 are ordered deliberately. Length is checked before the digest
+because it is the cheaper refutation, and both are checked before parsing because
+a parser is a larger attack surface than a comparison.
+
+The digest is computed over the exact bytes the consumer will parse. Where the
+transport applied a content encoding, the digest is over the decoded bytes.
+
+Verification says nothing about whether the bytes should be acted upon. A
+verified payload has been shown to be the payload the envelope named, and that is
+all; it earns no trust from having a URL. Consumers MUST apply the same
+validation and the same authorization rules they would apply to the identical
+payload handed to them inline.
+
+### The `https` transport
+
+A consumer that fetches an `https` URL MUST enforce all of the following, and
+MUST fail rather than degrade when any of them cannot be met:
+
+- The scheme is `https` on the default port. Ports are not a policy control, but
+  a caller who needs a non-default one is describing a service that was not
+  published for general retrieval.
+- The URL carries no userinfo component, and no fragment.
+- The host resolves, and every address it resolves to is a public unicast
+  address. Loopback, link-local, unique-local, and other private ranges MUST be
+  refused. This is the control that stops a wallet from being used to probe the
+  network it sits inside.
+- Redirects are not followed. A redirect moves the bytes to a location the
+  producer did not name and the admission checks did not examine.
+- No credentials, cookies, or ambient authorization are attached. The bytes are
+  public or the reference is not usable.
+- The response body is bounded by the maximum for `artifact_type`, enforced
+  during reading rather than after.
+- Connection and total timeouts are enforced.
+- The number of concurrent retrievals is bounded.
+
+Consumers SHOULD attach the bound as a limit on the decoded stream, so that a
+compressed response cannot expand past it.
+
+Error messages MUST NOT include any part of the response body. A consumer that
+reports what a refused endpoint returned has turned itself into a mechanism for
+reading its own network from outside it.
+
+### The `data:` transport
+
+A `data:` URI MUST have media type `application/json`, MAY use the `;base64`
+parameter, and MUST decode to at most the maximum body size for
+`artifact_type`. Consumers MUST bound the encoded length before decoding, and
+MUST NOT perform any network access for a `data:` reference.
+
+The encoded bound is derived from the decoded one: base64 packs three bytes into
+four characters and percent-encoding never contracts, so nothing longer than
+`⌊max ÷ 3⌋ × 4 + 4` characters can decode to an acceptable body.
+
+### Provenance
+
+A consumer that reports where verified bytes came from MUST distinguish:
+
+- **An `https` host**, which is a fact proved by the transport. The host is the
+  one the admission checks accepted and the certificate authenticated.
+- **An inline `data:` URI**, which has no host and no provenance beyond whoever
+  handed over the envelope.
+
+Consumers MUST NOT present any other origin claim as provenance. In particular, a
+local filesystem path is not provenance: a path is caller-chosen text describing
+where a file sat, not a statement about who published it.
+
+The distinction is worth surfacing because it is one of the few facts about a
+payload that is attested rather than asserted, and because it is a useful
+authorization input: a wallet can require that a payload arrive from a named host
+under transport authentication, and refusing an inline payload is expressible as
+requiring any host at all.
+
+## Rationale
+
+### Why not Subresource Integrity
+
+Subresource Integrity covers the same idea in the browser, and it is not
+reusable here. Its digests are SHA-256, SHA-384, and SHA-512, where the rest of
+the wallet ecosystem — plan digests, transaction hashes, ABI selectors — is
+keccak256, and mixing hash functions across a single trust boundary invites the
+mistake of verifying one and reporting the other. It has no type discriminator,
+so nothing prevents redeeming a reference in the wrong context. It has no inline
+form. And it is defined as an attribute of an HTML element rather than as a value
+that can be relayed through non-browser transports, which is the entire use case
+here.
+
+### Why the type discriminator is required
+
+Without it, a consumer is asked to fetch an unbounded number of bytes before it
+knows what limit applies, and an envelope obtained legitimately for one purpose
+can be presented for another. Making the kind part of the envelope, and requiring
+that it match the point of use, means a caller cannot use a token-list reference
+where a plan is expected, even if the caller obtained that reference honestly.
+
+### Why redirects are refused rather than followed with re-checking
+
+Re-running admission on each hop is possible, and it is more complexity for less
+assurance. Every hop is another chance for a check to be applied inconsistently,
+and the producer already knows where its own bytes are. Refusing redirects makes
+the URL in the envelope the URL that was fetched, which is also what makes the
+reported host meaningful.
+
+### Why `integrity` is strict when the envelope is not
+
+They protect different things. The envelope is a message that will grow, and a
+consumer that rejected an enriched envelope would break on a producer's routine
+improvement. The integrity block is an assertion the consumer either verified in
+full or did not verify at all; there is no partial credit, so tolerating unknown
+members inside it would let a producer believe it had constrained something the
+consumer never checked.
+
+### Why byte count as well as digest
+
+The digest subsumes it cryptographically, but not operationally. The count lets a
+consumer refuse an oversized body before it opens a connection, and lets it stop
+reading a response the moment it exceeds what was promised, rather than buffering
+an unbounded stream and discovering the mismatch at the end.
+
+## Backwards Compatibility
+
+This proposal introduces a new envelope format and no changes to the chain, to
+existing interfaces, or to deployed contracts. It composes with, and does not
+replace, inline delivery of the same payloads.
+
+`artifact_type` and `integrity.algorithm` are open string fields so that later
+proposals may register additional kinds and digest algorithms. A consumer MUST
+reject values it does not implement rather than proceeding without the check.
+
+## Reference Implementation
+
+Ekubo Wallet, a desktop wallet at `github.com/EkuboProtocol/wallet`, implements
+this envelope in `crates/ekubo-wallet-core/src/plan_fetch.rs`. It accepts
+references for all three artifact types defined here, enforces the admission
+rules above, verifies the byte count and keccak256 digest before parsing, and
+surfaces the transport-proved host or the inline origin at approval time. Its
+outbound retrievals are bounded by a semaphore and by per-type body caps, and its
+failures name the reason without echoing the response.
+
+The Ekubo protocol's plan producer at `mcp.ekubo.org` returns these envelopes for
+the payloads it stores, and the relaying agent between them passes each envelope
+through verbatim rather than reproducing its contents.
+
+## Security Considerations
+
+### The digest binds bytes, not intent
+
+A verified reference proves that the retrieved bytes are the bytes the envelope
+named. It proves nothing about whether the producer is honest, whether the
+payload does what its `instruction` claims, or whether it should be executed. A
+consumer that treats verification as approval has replaced a review with a
+checksum.
+
+### Server-side request forgery is the primary risk
+
+A consumer that fetches caller-supplied URLs is a request forwarder inside the
+user's trust boundary. The admission rules — public unicast addresses only, no
+redirects, no credentials, no non-default ports, no fragments — exist for this,
+and each of them is load-bearing.
+
+Consumers MUST re-check the resolved address rather than the hostname alone, and
+SHOULD connect to the address they checked, because a name that resolves publicly
+at check time and privately at connect time defeats a hostname-only check.
+
+Suppressing response bodies in errors is part of the same control: without it, a
+refused fetch still leaks what an internal endpoint returned.
+
+### Denial of service through the fetch primitive
+
+Every retrieval consumes a resolver query, a connection, a timeout window, and up
+to the type's body cap in memory. An unbounded caller is an amplifier for
+outbound traffic and an exhaustion vector for the consuming process. The
+concurrency bound, the timeouts, and the pre-fetch size refusal are all required,
+and belong to the retrieval primitive rather than to any one caller of it.
+
+### Compression
+
+A consumer that decodes a content encoding before hashing MUST bound the decoded
+stream as it decodes. Otherwise a small response expands past the cap before the
+size check runs.
+
+### `data:` references are not safer for being local
+
+A `data:` URI avoids the network, and that is its only security advantage. Its
+bytes came from whoever handed over the envelope and carry no provenance at all.
+A consumer that shows a fetched artifact's host and shows nothing for an inline
+one is reporting this correctly; a consumer that presents inline content as
+trusted because it did not touch the network has it backwards.
+
+### Stale references
+
+A digest mismatch means the bytes changed or the reference is stale, and the two
+are indistinguishable from the consumer's position. Consumers MUST treat both as
+failure and MUST NOT fall back to using the retrieved bytes. Producers SHOULD
+serve immutable bodies at each URL, so that a mismatch is unambiguously an
+integrity failure.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/assets/erc-8410/artifact-reference.schema.json
+++ b/assets/erc-8410/artifact-reference.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eips.ethereum.org/assets/erc-8410/artifact-reference.schema.json",
+  "title": "Artifact reference",
+  "description": "An envelope naming a wallet-bound payload by location and keccak256 digest instead of carrying it. Structural constraints only; the conditional and procedural rules stated normatively in ERC-8410 MUST also be enforced, in particular that integrity and bytes are required for an https url, that a data: URI is never fetched over the network, that the retrieved length and digest are checked before parsing, and the whole of the https admission policy.",
+  "type": "object",
+  "required": ["kind", "artifact_type", "url"],
+  "properties": {
+    "kind": {
+      "description": "Discriminates this envelope from a payload supplied inline.",
+      "type": "string",
+      "const": "artifact_reference"
+    },
+    "artifact_type": {
+      "description": "What sort of document the referenced bytes are. A consumer rejects a type it does not implement, and rejects a reference whose type differs from the one expected at the point of use. Open for extension by later proposals.",
+      "type": "string",
+      "examples": ["execution_plan", "read_calls", "token_list"]
+    },
+    "url": {
+      "description": "Where the bytes are. Either a public https URL on the default port, or a bounded data:application/json URI carrying them inline.",
+      "type": "string",
+      "anyOf": [
+        { "pattern": "^https://" },
+        { "pattern": "^data:application/json[;,]" }
+      ]
+    },
+    "integrity": { "$ref": "#/$defs/ArtifactIntegrity" },
+    "bytes": {
+      "description": "Exact byte length of the stored body. Lets a consumer refuse an oversized body before opening a connection, and stop reading the moment a response exceeds what was promised. Required alongside integrity for an https url.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "instruction": {
+      "description": "Producer-supplied prose. Display context only; it MUST NOT influence any authorization decision.",
+      "type": "string"
+    }
+  },
+  "$defs": {
+    "ArtifactIntegrity": {
+      "description": "Digest over the exact stored bytes. Strict, unlike the enclosing envelope: an integrity object carrying a member the consumer does not understand is one it cannot claim to have verified, so unknown members are rejected rather than ignored.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "value"],
+      "properties": {
+        "algorithm": {
+          "description": "Kept an open string rather than an enumeration so a rejection can name both what was offered and what is supported. Only keccak256 is defined by this revision.",
+          "type": "string",
+          "examples": ["keccak256"]
+        },
+        "value": {
+          "description": "0x followed by 64 hexadecimal digits.",
+          "type": "string",
+          "pattern": "^0x[0-9a-fA-F]{64}$"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds ERC-8410, an envelope that names a wallet-bound payload by location and keccak256 digest instead of carrying it, so that a relaying party holds authority over *which* document is used and none at all over *what it says*.

The motivating case is a payload assembled by one party, relayed by a second, and executed by a third, where the middle link is the least trustworthy — a browser extension, an automation runner, or an AI agent acting on text from an untrusted source. Today that link is handed the full bytes and asked to forward them faithfully. It can rewrite them, it can corrupt them by re-serializing rather than copying (a failure mode that is disproportionately common when the relay is a language model), and it destroys provenance.

**Why not Subresource Integrity.** SRI is SHA-2 where the rest of this ecosystem is keccak256, has no type discriminator, has no inline form, and is defined as an HTML attribute rather than a relayable value. Each of those gaps matters here.

**The retrieval rules are half the proposal.** A wallet that fetches a caller-supplied URL is a request forwarder positioned inside the user's network. The spec fixes admission — public unicast addresses only, no redirects, no credentials, no non-default ports, no fragments, bounded bodies enforced during read, bounded concurrency, and errors that never echo the response body — because specifying the envelope alone would standardize the easy half.

**Included**
- `assets/erc-8410/artifact-reference.schema.json`, validated with ajv.
- A deliberate asymmetry, explained in the Rationale: the envelope tolerates unknown members so producers can enrich it, while the `integrity` block rejects them, because an integrity object containing something unverified is not an integrity object.

**Reference implementation.** Ekubo Wallet (`github.com/EkuboProtocol/wallet`), `crates/ekubo-wallet-core/src/plan_fetch.rs`. Named in prose rather than linked, per the EIP-1 external-link rule.

**Notes for editors**
- `discussions-to` is a format-valid placeholder; the Ethereum Magicians thread is not yet created and I will update this before requesting review.
- The number was taken as the next free one across both repositories at the time of writing; happy to renumber.
- Companion proposals are open alongside this one and are referred to in prose rather than by number, since `markdown-refs` cannot resolve an unmerged sibling. Numbers and `requires` entries will follow once assigned.

CI checks run locally before opening: eipw (via the pinned `eipw-lint-js`, against the same merged EIP+ERC corpus the workflow builds), markdownlint, codespell, and markdown-link-check.