### PR TITLE
Add ERC: Declarative Wallet Signing Policy

### DIFF
--- a/ERCS/erc-8411.md
+++ b/ERCS/erc-8411.md
@@ -47,8 +47,8 @@ requesting software is honest. In that setting the only durable control is one
 the user wrote down beforehand and the wallet enforces regardless of what it is
 asked.
 
-Existing work does not cover it. [ERC-7715](./erc-7715.md) lets a dapp request
-permissions and [ERC-7710](./erc-7710.md) lets contracts redeem delegated
+Existing work does not cover it. [ERC-7715](./eip-7715.md) lets a dapp request
+permissions and [ERC-7710](./eip-7710.md) lets contracts redeem delegated
 authority; both grant scoped power to a *third party*, typically enforced
 onchain by a smart account. This proposal is about the signer itself: a local,
 offchain constraint on what the key will produce, applicable to an externally
@@ -356,7 +356,7 @@ This proposal introduces a new document format and no changes to the chain, to
 existing interfaces, or to deployed contracts. A wallet that does not implement
 it behaves as though it held the empty policy.
 
-It composes with [ERC-7715](./erc-7715.md) and [ERC-7710](./erc-7710.md) rather
+It composes with [ERC-7715](./eip-7715.md) and [ERC-7710](./eip-7710.md) rather
 than competing with them: those constrain what authority a third party holds,
 this constrains what this signer will produce, and a transaction may be subject
 to both. It composes with [EIP-7702](./eip-7702.md) through the `delegation`

--- a/ERCS/erc-8411.md
+++ b/ERCS/erc-8411.md
@@ -1,0 +1,449 @@
+---
+eip: 8411
+title: Declarative Wallet Signing Policy
+description: An ordered allow, review, or deny document a wallet evaluates against every call and prepared envelope before it will sign automatically
+author: Moody Salem (@moodysalem)
+discussions-to: https://ethereum-magicians.org/t/erc-8411-declarative-wallet-signing-policy/0
+status: Draft
+type: Standards Track
+category: ERC
+created: 2026-09-04
+requires: 7702
+---
+
+## Abstract
+
+This proposal defines a JSON document that states, in advance, which
+transactions a wallet may sign without asking a human.
+
+The document is an ordered list of rules. Each rule carries an effect —
+`allow`, `review`, or `deny` — and a set of matchers over one planned call, over
+the prepared transaction envelope that will carry it, and over the channel that
+delivered the request. Every call in a transaction is evaluated independently,
+the first matching rule decides each one, and the transaction takes the
+least-permissive result across its calls. A call that matches nothing needs a
+human.
+
+It also defines the *authority ordering* `deny < review < allow`, which makes
+"this change only ever removes permission" a mechanically checkable property of
+a proposed edit. That is what lets a wallet accept a tightening edit without an
+authentication challenge while requiring one to widen anything, and what lets an
+untrusted party propose a policy at all.
+
+## Motivation
+
+A wallet that signs only when a human clicks is safe and does not scale. A
+wallet that signs whatever it is asked scales and is not safe. Every system that
+has tried to sit between those — session keys, spending caps, allowlists,
+delegated signers — has invented a private encoding of "which transactions are
+fine", and none of them can be read by anything other than the system that wrote
+it.
+
+The gap has become urgent because of who is now asking wallets to sign.
+Autonomous agents submit transactions on a schedule, in response to text they
+read from untrusted sources, at hours when no human is available. Prompt
+injection makes the requesting party's *intent* untrustworthy even when the
+requesting software is honest. In that setting the only durable control is one
+the user wrote down beforehand and the wallet enforces regardless of what it is
+asked.
+
+Existing work does not cover it. [ERC-7715](./erc-7715.md) lets a dapp request
+permissions and [ERC-7710](./erc-7710.md) lets contracts redeem delegated
+authority; both grant scoped power to a *third party*, typically enforced
+onchain by a smart account. This proposal is about the signer itself: a local,
+offchain constraint on what the key will produce, applicable to an externally
+owned account, evaluated before a signature exists. The two compose — a
+delegation says who may act, a policy says what this wallet will put its name to
+— and neither substitutes for the other.
+
+Four things are missing today and are specified here:
+
+- **A vocabulary.** Enough to say "swaps on this router, up to this size, on
+  this chain" without saying so much that the document becomes a program whose
+  behavior nobody can predict.
+- **Three effects, not two.** `review` — sign only after a human says so — is
+  the effect that makes a policy adoptable, because it lets a user narrow the
+  set of things they are asked about without committing to automation.
+- **A safe editing rule.** An agent should be able to *propose* a policy. The
+  authority ordering makes it checkable whether a proposal only removes
+  permission, so proposals can be accepted at proportionate friction rather than
+  being refused outright or waved through.
+- **Honesty about provenance.** Rules keyed on "which dapp" or "which agent" are
+  everywhere, and most of those fields are self-asserted. A vocabulary that does
+  not say which of its inputs are proved invites users to build security
+  boundaries out of claims.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in RFC 2119 and RFC 8174.
+
+A machine-readable schema is provided in
+[the signing policy schema](../assets/eip-8411/policy.schema.json).
+
+### The document
+
+```json
+{ "version": 1, "rules": [] }
+```
+
+`version` MUST be `1` for this revision. `rules` is an ordered array of at most
+256 rules. A document with unknown members MUST be rejected.
+
+The empty rule list is the default and means every transaction is put to a
+human. It is the correct starting state: a policy that has never been edited
+should assert nothing.
+
+### Rules
+
+A rule is an object with a REQUIRED `effect`, an OPTIONAL human-readable
+`label`, and any number of matchers. `effect` MUST be one of:
+
+- `allow` — may be signed with no human interaction.
+- `review` — MUST NOT be signed until a human explicitly approves it.
+- `deny` — MUST NOT be signed, and MUST NOT be queued for approval.
+
+Matchers present on a rule are ANDed. An omitted matcher matches any value.
+
+Per-call matchers describe one planned call:
+
+| Matcher | Subject |
+| --- | --- |
+| `chain_id` | Chain the call executes on |
+| `to` | Call target |
+| `native_value` | Native value moved by this call |
+| `calldata` | Call input |
+
+Prepared-envelope matchers describe the transaction that will carry the calls:
+
+| Matcher | Subject |
+| --- | --- |
+| `transaction_type` | Envelope type |
+| `nonce` | Envelope nonce |
+| `gas_limit` | Envelope gas limit |
+| `max_fee_per_gas` | Envelope maximum fee per gas |
+| `max_priority_fee_per_gas` | Envelope maximum priority fee per gas |
+| `envelope_to` | Outer transaction target |
+| `envelope_native_value` | Native value moved by the outer transaction |
+| `delegation` | Signed [EIP-7702](./eip-7702.md) authorization target |
+
+`source` is a matcher of its own shape, described below.
+
+`native_value` is per call; `envelope_native_value` is the value on the outer
+transaction. Neither is a cumulative budget, and no matcher in this vocabulary
+accumulates across transactions. A policy is a stateless predicate over one
+transaction.
+
+`delegation` matches only a signed authorization target. A transaction carrying
+no authorization does not match a rule that names it, rather than matching it
+with an empty value.
+
+### Evaluation
+
+A wallet MUST evaluate a request as follows:
+
+1. For each planned call, walk `rules` in order and take the effect of the first
+   rule whose every present matcher matches. A call matching no rule takes
+   `review`.
+2. Combine the per-call effects by least authority under `deny < review <
+   allow`: if any call is `deny` the transaction is denied; otherwise if any
+   call is `review` the transaction requires approval; otherwise it is allowed.
+
+Order is authority. A wallet MUST NOT reorder rules, and SHOULD reject an
+installation in which a rule is provably shadowed by an earlier one — a rule
+that can never be reached is either a mistake about ordering or decoration, and
+both are worth surfacing before they are relied on.
+
+Prepared-envelope matchers can only be evaluated once the wallet has simulated
+the request and prepared the exact transaction. A rule containing one MUST NOT
+match a context in which no envelope has been prepared. Wallets MUST derive
+these values from their own preparation and MUST NOT accept them from the
+requester.
+
+`deny` is distinct from "not allowed". A denied transaction MUST NOT be offered
+to a human as an approval prompt. The user already answered; re-asking at the
+moment a request arrives is how a considered "no" becomes a tired "yes".
+
+### Predicates
+
+A matcher holds a predicate. The following are defined:
+
+| Predicate | Meaning |
+| --- | --- |
+| `"any_value"` | Matches anything |
+| `{"eq": v}` | Equal to `v` |
+| `{"in": [v, ...]}` | Equal to some member |
+| `{"lt"\|"lte"\|"gt"\|"gte": v}` | Integer comparison |
+| `{"any": [p, ...]}` | Some subpredicate matches |
+| `{"all": [p, ...]}` | Every subpredicate matches |
+| `{"not": p}` | The subpredicate does not match |
+| `{"length": p}` | `p` matches the subject's length |
+| `{"selector": {...}}` | Decoded calldata match |
+| `{"each": p}` | `p` matches every element of an array |
+| `{"tuple": [p\|null, ...]}` | Positional match on a tuple |
+
+All scalar values are JSON strings. Integers are canonical unsigned decimal
+strings; addresses are `0x`-prefixed and compared case-insensitively.
+
+A `selector` predicate names a full canonical ABI function signature in `abi`
+and constrains decoded arguments by name in `args`. The signature MUST name
+every top-level parameter. It matches when the call's selector matches and every
+named argument's predicate matches:
+
+```json
+{
+  "selector": {
+    "abi": "approve(address spender, uint256 amount)",
+    "args": {
+      "spender": { "eq": "0x1111111111111111111111111111111111111111" },
+      "amount": { "lte": "1000000" }
+    }
+  }
+}
+```
+
+Tuple components are constrained positionally, because Solidity selector types
+do not preserve component names. A `tuple` predicate MUST have exactly the
+arity of the ABI tuple it constrains; `null` leaves a position unconstrained.
+Tuple predicates nest, and an array of tuples is written
+`{"each": {"tuple": [...]}}`.
+
+The single variable `$self` MAY appear where an address literal is expected and
+resolves to the signing account.
+
+Implementations MUST reject a predicate whose form the subject cannot answer —
+an integer comparison against a chain-delivered boolean, a `length` against a
+number — at installation time rather than treating it as a non-match at
+evaluation time. A predicate that silently never matches is a rule that silently
+does nothing.
+
+### Source
+
+`source` names the channel that delivered the request. It is tagged by channel,
+so a channel and the fields that exist only within it cannot come apart:
+
+```json
+{ "source": { "walletconnect": { "domain": { "in": ["app.example.org"] } } } }
+{ "source": { "agent": { "client": { "eq": "some-harness" } } } }
+{ "source": { "agent": { "plan_host": { "eq": "plans.example.org" } } } }
+{ "source": { "automation": { "id": { "eq": "..." } } } }
+```
+
+Naming a field requires the request to carry it, so a `source` matcher never
+matches a request whose origin the wallet does not know. Adding one to a rule
+therefore only ever shrinks what that rule matches, which is why a `source`
+matcher can never widen authority and is permitted under any effect.
+
+Implementations MUST distinguish proved from claimed fields, and SHOULD say
+which is which wherever a policy is edited:
+
+- **Proved.** The channel itself, because the wallet is the thing being called.
+  An automation identifier, because nothing outside the wallet chooses it. And
+  `plan_host`, the host that served the request's bytes under transport
+  authentication. Because a payload supplied inline has no host, constraining
+  `plan_host` at all is also how a rule refuses an inline payload.
+- **Claimed.** A dapp's `domain` is the URL it typed about itself when it
+  proposed a session; a site served from anywhere may name any domain. An
+  agent's `client` is whatever identifier the local process passed when it
+  connected. Neither is attested.
+
+Claimed fields are useful for keeping one requester's rules off another's, which
+is a real problem. They are not a barrier against a hostile requester: a `deny`
+keyed on "not this client" is escaped by claiming to be that client, and an
+`allow` for a client is available to anything that says so. Implementations MUST
+NOT present them as an origin guarantee. Where request origin has to be a
+security boundary rather than a workflow convenience, the transaction belongs on
+`review`, or the other matchers must be narrow enough that every origin is safe.
+
+### Installing a policy
+
+A wallet MUST treat installation as a transition from the active document to the
+proposed one, and MUST classify it:
+
+- A transition is a **tightening** when it can be proved that no transaction
+  allowed by the proposed document was denied or reviewed by the active one, and
+  no transaction reviewed by the proposed one was denied by the active one.
+- Any other transition, including one whose direction cannot be decided, is a
+  **widening**.
+
+A widening MUST require explicit human authorization, and implementations
+SHOULD require an operating-system authentication challenge. A tightening MAY be
+installed from the wallet's own owner interface without an additional challenge.
+Implementations that cannot decide a transition MUST classify it as widening.
+
+Proposals MUST be bound to the revision of the document they were computed
+against and MUST be rejected if the active document has changed. Implementations
+SHOULD present a minimized difference in permission terms rather than a textual
+diff of the JSON.
+
+A party that is not the wallet owner — an agent, a dapp — MAY propose a policy
+and MUST NOT be able to install one. Installation is an act of the owner.
+
+### Interaction with stored authorizations
+
+Anything holding standing authority derived from a policy — a scheduled job, a
+queued request signed under an earlier revision — MUST be re-checked when the
+policy changes, and MUST NOT execute under the new document on the strength of
+the old one. Implementations SHOULD unlink such holders on a policy change and
+require the owner to re-establish them.
+
+## Rationale
+
+### Why three effects
+
+`allow`/`deny` alone forces every rule to be a decision about automation. Most
+users do not want to automate a category of transaction; they want to stop being
+asked about *everything else* so the prompts they do see mean something.
+`review` is what makes the document adoptable incrementally, and it is why a
+matcherless `review` rule at the top — review everything — is a coherent and
+useful policy rather than a no-op.
+
+The three effects also give the authority ordering its middle element, without
+which "this edit only tightens" would be a much coarser judgment.
+
+### Why first match wins
+
+The alternatives are most-specific-wins and deny-overrides. Both compute an
+answer the reader cannot see by reading top to bottom, and both make the effect
+of inserting a rule depend on rules elsewhere in the document. First match makes
+order explicit and local: the exception goes above the general rule, and where
+it sits is visible. The cost is that a badly ordered document can contain
+unreachable rules, which is why shadowed rules should be rejected rather than
+silently accepted.
+
+### Why the fee fields are matchers rather than settings
+
+An automatic `allow` that says nothing about `gas_limit` or `max_fee_per_gas`
+accepts whatever fee the wallet's endpoint named, and `gas_limit ×
+max_fee_per_gas` is the whole of what a dishonest or compromised endpoint can
+cost an account that signs without asking. Putting a ceiling in configuration
+would leave it unreviewed. Putting it in the policy — usually as a `deny` above
+the allow rules — puts it behind the same revision, difference, and
+authorization path as every other permission, which is where a control of that
+size belongs.
+
+### Why matchers are flat rather than a nested expression tree
+
+The vocabulary is deliberately not a programming language. A policy has to be
+readable by the person whose money it governs and mechanically comparable for
+the tightening check. Flat, ANDed matchers with a bounded predicate grammar keep
+both properties. A general expression language would make the tightening proof
+undecidable in the general case, which would collapse every edit into "requires
+full authorization" and destroy the reason for having the ordering at all.
+
+### Why decoded results and display metadata are excluded
+
+Token symbols, decimals, price estimates, and decoded transfer effects are
+useful at review and unusable for authorization. They are supplied by, or
+derived from, parties the policy exists to constrain, and a symbol is not a
+property of a contract. Restricting authorization inputs to values the wallet
+derives itself — the call's own fields and its own transaction preparation — is
+what keeps a policy from being steerable by the requester.
+
+### Why per-transaction rather than cumulative
+
+A cumulative budget requires durable state, and turns every evaluation into a
+question about history, which makes a policy impossible to reason about by
+reading it and impossible to compare two versions of. Per-transaction bounds are
+weaker, and they are honestly weaker rather than deceptively strong. A rate or
+budget control is better built as a separate mechanism than smuggled into a
+predicate language whose main virtue is that it is decidable.
+
+## Backwards Compatibility
+
+This proposal introduces a new document format and no changes to the chain, to
+existing interfaces, or to deployed contracts. A wallet that does not implement
+it behaves as though it held the empty policy.
+
+It composes with [ERC-7715](./erc-7715.md) and [ERC-7710](./erc-7710.md) rather
+than competing with them: those constrain what authority a third party holds,
+this constrains what this signer will produce, and a transaction may be subject
+to both. It composes with [EIP-7702](./eip-7702.md) through the `delegation`
+matcher, which is how a policy expresses a constraint on which implementation an
+account may be delegated to.
+
+`version` is a required integer so that a wallet encountering a later revision
+rejects it rather than enforcing a document it partly understands.
+
+## Reference Implementation
+
+Ekubo Wallet, a desktop wallet at `github.com/EkuboProtocol/wallet`, enforces
+this document on every transaction it signs, from any channel. Its policy
+evaluator is `crates/ekubo-wallet-core/src/core/policy.rs`, its schema is
+`schemas/policy.schema.json`, and the authoring guidance it ships to agents is
+`docs/policy-authoring.md`.
+
+The implementation covers the parts of this proposal that are easy to omit: the
+tightening proof that decides whether an installation needs an operating-system
+challenge, rejection of provably shadowed rules, the per-call evaluation with
+least-authority combination, prepared-envelope matchers evaluated only after the
+wallet's own transaction preparation, and the proved-versus-claimed distinction
+surfaced in the policy editor. Agents may propose a document and cannot install
+one. A policy revision change unlinks installed scheduled jobs before they can
+run under the new document.
+
+## Security Considerations
+
+### An `allow` rule is a signature you have already given
+
+The document is not a filter on a user's own intentions; it is a standing
+instruction to sign without asking. Every `allow` rule should be read as
+authorizing every transaction it matches, from every channel, at any hour,
+including transactions the user has not imagined. Implementations SHOULD present
+new `allow` rules in those terms.
+
+### Rules match whoever asks
+
+A policy belongs to the account, not to the party that proposed it. A rule with
+no `source` matcher matches a request from any channel, so allowing an operation
+for one agent also allows it for a connected dapp and for a scheduled job.
+Implementations MUST make this visible where rules are written, because the
+natural reading of "I allowed my agent to do this" is not what an unqualified
+rule says.
+
+### Claimed source fields are not an origin boundary
+
+This bears repeating as a security property rather than a design note. `domain`
+and `client` are asserted by the requester. Any local process may present any
+client identifier, and any site may name any domain. Rules built on them are
+worth exactly what the claim is worth, which is nothing against an adversary,
+and implementations MUST NOT let a user believe otherwise. `plan_host` and the
+automation identifier are the fields that survive an adversary.
+
+### The vocabulary bounds one transaction at a time
+
+There is no cumulative budget, no rate limit, and no cross-transaction state. An
+`allow` rule permitting a bounded transfer permits an unbounded number of them.
+Users and implementations MUST size individual bounds with that in mind, and a
+control that genuinely needs a budget needs a mechanism beyond this document.
+
+### Denied is not reviewable, by design
+
+Because a `deny` never produces a prompt, a user who denies too broadly will see
+requests fail with no offer to override. This is the intended trade: an
+overridable deny is a deny that will be overridden at the worst moment, and the
+remedy — editing the policy, which is a deliberate act at proportionate friction
+— is the right amount of work for reversing a considered refusal.
+
+### Policy changes are the highest-value target
+
+The most efficient attack on a wallet that enforces a policy is not to defeat
+enforcement but to widen the document. Implementations MUST require explicit
+human authorization for any widening, MUST classify undecidable transitions as
+widening, MUST bind proposals to the revision they were computed against, and
+MUST NOT allow any non-owner channel to install one. The difference presented to
+the owner MUST describe the change in permission terms; a user shown a JSON diff
+of a 200-rule document is a user who approves without reading.
+
+### Enforcement is only as good as its boundary
+
+A policy constrains a signer that respects it. It provides no protection against
+an adversary who can obtain the key material directly, and implementations
+SHOULD state plainly where their key storage does not isolate keys from other
+software running as the same user. A policy is a control on a wallet's own
+signing path, not a substitute for custody.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/ERCS/erc-8411.md
+++ b/ERCS/erc-8411.md
@@ -119,7 +119,7 @@ Prepared-envelope matchers describe the transaction that will carry the calls:
 
 | Matcher | Subject |
 | --- | --- |
-| `transaction_type` | Envelope type |
+| `transaction_type` | Envelope type, as a string: `eip1559` or `eip7702` |
 | `nonce` | Envelope nonce |
 | `gas_limit` | Envelope gas limit |
 | `max_fee_per_gas` | Envelope maximum fee per gas |
@@ -138,6 +138,11 @@ transaction.
 `delegation` matches only a signed authorization target. A transaction carrying
 no authorization does not match a rule that names it, rather than matching it
 with an empty value.
+
+`transaction_type` names the envelope kind the wallet prepared. Only
+[EIP-1559](./eip-1559.md) and [EIP-7702](./eip-7702.md) envelopes are defined by
+this revision; a wallet that prepares another kind MUST NOT match it against
+either value.
 
 ### Evaluation
 
@@ -213,7 +218,7 @@ The single variable `$self` MAY appear where an address literal is expected and
 resolves to the signing account.
 
 Implementations MUST reject a predicate whose form the subject cannot answer —
-an integer comparison against a chain-delivered boolean, a `length` against a
+an integer comparison against a boolean argument, a `length` against a
 number — at installation time rather than treating it as a non-match at
 evaluation time. A predicate that silently never matches is a rule that silently
 does nothing.

--- a/assets/erc-8411/policy.schema.json
+++ b/assets/erc-8411/policy.schema.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eips.ethereum.org/assets/erc-8411/policy.schema.json",
+  "title": "Wallet signing policy",
+  "description": "An ordered, stateless predicate over each planned call, the exact prepared transaction envelope, and the channel that delivered the request. The first matching rule decides each call: allow signs with no human interaction, review requires explicit approval, deny rejects without queuing, and matching no rule also requires review. Every call is evaluated before the transaction takes the least-permissive result under deny < review < allow. Omitted matchers match anything and present matchers are ANDed. Structural constraints only; the evaluation, installation, and tightening rules stated normatively in ERC-8411 MUST also be enforced.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "rules"],
+  "properties": {
+    "$schema": { "type": ["string", "null"] },
+    "version": {
+      "description": "Revision of this format. A wallet encountering a later revision rejects it rather than enforcing a document it partly understands.",
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1
+    },
+    "rules": {
+      "description": "Evaluated in order. Order is authority: an exception goes above the general rule it excepts. A rule provably shadowed by an earlier one SHOULD be rejected at installation.",
+      "type": "array",
+      "maxItems": 256,
+      "items": { "$ref": "#/$defs/Rule" }
+    }
+  },
+  "$defs": {
+    "Rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["effect"],
+      "properties": {
+        "effect": { "$ref": "#/$defs/Effect" },
+        "label": {
+          "description": "Human-readable note. Never an authorization input.",
+          "type": ["string", "null"]
+        },
+
+        "chain_id": { "$ref": "#/$defs/MaybePredicate" },
+        "to": { "$ref": "#/$defs/MaybePredicate" },
+        "native_value": { "$ref": "#/$defs/MaybePredicate" },
+        "calldata": { "$ref": "#/$defs/MaybePredicate" },
+
+        "transaction_type": { "$ref": "#/$defs/MaybePredicate" },
+        "nonce": { "$ref": "#/$defs/MaybePredicate" },
+        "gas_limit": { "$ref": "#/$defs/MaybePredicate" },
+        "max_fee_per_gas": { "$ref": "#/$defs/MaybePredicate" },
+        "max_priority_fee_per_gas": { "$ref": "#/$defs/MaybePredicate" },
+        "delegation": { "$ref": "#/$defs/MaybePredicate" },
+        "envelope_to": { "$ref": "#/$defs/MaybePredicate" },
+        "envelope_native_value": { "$ref": "#/$defs/MaybePredicate" },
+
+        "source": {
+          "anyOf": [{ "$ref": "#/$defs/SourceMatcher" }, { "type": "null" }]
+        }
+      }
+    },
+
+    "Effect": {
+      "description": "allow signs with no human interaction; review signs only after explicit human approval; deny rejects without offering an approval prompt at all.",
+      "type": "string",
+      "enum": ["allow", "review", "deny"]
+    },
+
+    "MaybePredicate": {
+      "anyOf": [{ "$ref": "#/$defs/Predicate" }, { "type": "null" }]
+    },
+
+    "Predicate": {
+      "description": "All scalar values are JSON strings: integers as canonical unsigned decimal, addresses 0x-prefixed and compared case-insensitively. The single variable $self may appear where an address literal is expected.",
+      "oneOf": [
+        { "type": "string", "const": "any_value" },
+        { "$ref": "#/$defs/Eq" },
+        { "$ref": "#/$defs/In" },
+        { "$ref": "#/$defs/Lt" },
+        { "$ref": "#/$defs/Lte" },
+        { "$ref": "#/$defs/Gt" },
+        { "$ref": "#/$defs/Gte" },
+        { "$ref": "#/$defs/Selector" },
+        { "$ref": "#/$defs/Each" },
+        { "$ref": "#/$defs/Tuple" },
+        { "$ref": "#/$defs/Any" },
+        { "$ref": "#/$defs/All" },
+        { "$ref": "#/$defs/Not" },
+        { "$ref": "#/$defs/Length" }
+      ]
+    },
+
+    "Eq": { "type": "object", "additionalProperties": false, "required": ["eq"], "properties": { "eq": { "type": "string" } } },
+    "In": { "type": "object", "additionalProperties": false, "required": ["in"], "properties": { "in": { "type": "array", "uniqueItems": true, "items": { "type": "string" } } } },
+    "Lt": { "type": "object", "additionalProperties": false, "required": ["lt"], "properties": { "lt": { "type": "string" } } },
+    "Lte": { "type": "object", "additionalProperties": false, "required": ["lte"], "properties": { "lte": { "type": "string" } } },
+    "Gt": { "type": "object", "additionalProperties": false, "required": ["gt"], "properties": { "gt": { "type": "string" } } },
+    "Gte": { "type": "object", "additionalProperties": false, "required": ["gte"], "properties": { "gte": { "type": "string" } } },
+
+    "Selector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["selector"],
+      "properties": { "selector": { "$ref": "#/$defs/SelectorPredicate" } }
+    },
+    "SelectorPredicate": {
+      "description": "Matches when the call's selector matches the signature and every named argument's predicate matches.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["abi"],
+      "properties": {
+        "abi": {
+          "description": "A full canonical ABI function signature naming every top-level parameter, for example \"approve(address spender, uint256 amount)\".",
+          "type": "string"
+        },
+        "args": {
+          "description": "Keyed by the parameter names given in abi.",
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/Predicate" }
+        }
+      }
+    },
+
+    "Each": { "type": "object", "additionalProperties": false, "required": ["each"], "properties": { "each": { "$ref": "#/$defs/Predicate" } } },
+    "Tuple": {
+      "description": "Positional, because Solidity selector types do not preserve tuple component names. Arity MUST equal the ABI tuple's; null leaves a position unconstrained.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tuple"],
+      "properties": {
+        "tuple": { "type": "array", "items": { "$ref": "#/$defs/MaybePredicate" } }
+      }
+    },
+    "Any": { "type": "object", "additionalProperties": false, "required": ["any"], "properties": { "any": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/Predicate" } } } },
+    "All": { "type": "object", "additionalProperties": false, "required": ["all"], "properties": { "all": { "type": "array", "items": { "$ref": "#/$defs/Predicate" } } } },
+    "Not": { "type": "object", "additionalProperties": false, "required": ["not"], "properties": { "not": { "$ref": "#/$defs/Predicate" } } },
+    "Length": { "type": "object", "additionalProperties": false, "required": ["length"], "properties": { "length": { "$ref": "#/$defs/NumberPredicate" } } },
+
+    "SourceMatcher": {
+      "description": "Which channel delivered the request, and what that channel is required to have known about who asked. Tagged by channel so the channel and its own fields cannot come apart. Naming a field requires the request to carry it, so this matcher never matches a request whose origin the wallet does not know, and adding one to a rule can only shrink what it matches.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["walletconnect"],
+          "properties": {
+            "walletconnect": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "domain": {
+                  "description": "Host of the URL the dapp gives for itself, lowercased, without scheme or port. CLAIMED by the dapp in its session proposal and attested by nothing: a site served from anywhere may name any domain. Separates connected dapps from one another; proves nothing about who is on the other end.",
+                  "anyOf": [{ "$ref": "#/$defs/StringPredicate" }, { "type": "null" }]
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agent"],
+          "properties": {
+            "agent": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "client": {
+                  "description": "The agent harness identifier. CLAIMED by whatever local process connected and attested by nothing; any local process may present any value. Useful for keeping one agent's rules off another agent's requests, not as a barrier against a hostile one.",
+                  "anyOf": [{ "$ref": "#/$defs/StringPredicate" }, { "type": "null" }]
+                },
+                "plan_host": {
+                  "description": "Host that served the request's bytes, PROVED by transport authentication. A payload supplied inline has no host, so constraining this at all is also how a rule refuses an inline payload.",
+                  "anyOf": [{ "$ref": "#/$defs/StringPredicate" }, { "type": "null" }]
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["automation"],
+          "properties": {
+            "automation": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": {
+                  "description": "The installed scheduled job's identifier. PROVED: nothing outside the wallet chooses it.",
+                  "anyOf": [{ "$ref": "#/$defs/StringPredicate" }, { "type": "null" }]
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "StringPredicate": {
+      "description": "The predicate language restricted to the forms a string-typed slot can answer. A wallet rejects the others where they are written rather than treating them as a silent non-match.",
+      "oneOf": [
+        { "type": "string", "const": "any_value" },
+        { "$ref": "#/$defs/Eq" },
+        { "$ref": "#/$defs/In" },
+        { "type": "object", "additionalProperties": false, "required": ["any"], "properties": { "any": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/StringPredicate" } } } },
+        { "type": "object", "additionalProperties": false, "required": ["all"], "properties": { "all": { "type": "array", "items": { "$ref": "#/$defs/StringPredicate" } } } },
+        { "type": "object", "additionalProperties": false, "required": ["not"], "properties": { "not": { "$ref": "#/$defs/StringPredicate" } } },
+        { "type": "object", "additionalProperties": false, "required": ["length"], "properties": { "length": { "$ref": "#/$defs/NumberPredicate" } } }
+      ]
+    },
+
+    "NumberPredicate": {
+      "description": "The predicate language restricted to the forms an unsigned-integer slot can answer. length is absent: its subject is an array, bytes, or a string, never a number.",
+      "oneOf": [
+        { "type": "string", "const": "any_value" },
+        { "$ref": "#/$defs/Eq" },
+        { "$ref": "#/$defs/In" },
+        { "$ref": "#/$defs/Lt" },
+        { "$ref": "#/$defs/Lte" },
+        { "$ref": "#/$defs/Gt" },
+        { "$ref": "#/$defs/Gte" },
+        { "type": "object", "additionalProperties": false, "required": ["any"], "properties": { "any": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/NumberPredicate" } } } },
+        { "type": "object", "additionalProperties": false, "required": ["all"], "properties": { "all": { "type": "array", "items": { "$ref": "#/$defs/NumberPredicate" } } } },
+        { "type": "object", "additionalProperties": false, "required": ["not"], "properties": { "not": { "$ref": "#/$defs/NumberPredicate" } } }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds ERC-8411, a document that states in advance which transactions a wallet may sign without asking a human: an ordered list of `allow` / `review` / `deny` rules over each planned call, the prepared transaction envelope, and the channel that delivered the request.

A wallet that signs only when a human clicks is safe and does not scale. A wallet that signs whatever it is asked scales and is not safe. Agents now submit transactions on a schedule, in response to text read from untrusted sources, at hours when nobody is available — and prompt injection makes the requester's *intent* untrustworthy even when its code is honest. The only durable control in that setting is one the user wrote down beforehand.

**Relationship to existing work.** ERC-7715 and ERC-7710 grant scoped authority to a *third party*, typically enforced onchain by a smart account. This constrains the signer itself: a local, offchain limit on what the key will produce, applicable to an EOA, evaluated before a signature exists. A delegation says who may act; a policy says what this wallet will put its name to.

**Three things I would particularly like editor eyes on**

1. **The authority ordering `deny < review < allow`.** It makes "this edit only removes permission" mechanically checkable, which is what lets an untrusted party propose a policy at all: a provable tightening installs at low friction, and anything else — including anything undecidable — requires explicit human authorization. This is also why the matcher vocabulary is deliberately flat rather than a general expression language; a richer grammar would make the tightening proof undecidable and collapse every edit into full authorization.

2. **`review` as a third effect.** Most users do not want to automate a category of transaction; they want to stop being asked about everything else so the prompts they do see mean something. `review` is what makes a policy adoptable incrementally.

3. **The proved/claimed distinction on `source`.** A dapp's `domain` and an agent's `client` are self-asserted and attested by nothing; the channel, an automation id, and the TLS-vetted `plan_host` are proved. The spec requires implementations to surface which is which, because a vocabulary that does not say this invites users to build security boundaries out of claims. I would rather this be normative than left to each wallet.

**Included.** `assets/erc-8411/policy.schema.json`, validated with ajv against a conforming policy.

**Reference implementation.** Ekubo Wallet (`github.com/EkuboProtocol/wallet`), `crates/ekubo-wallet-core/src/core/policy.rs`, which implements the parts that are easy to omit: the tightening proof, rejection of provably shadowed rules, envelope matchers evaluated only after the wallet's own transaction preparation, and agents that can propose but never install. Named in prose rather than linked, per the EIP-1 external-link rule.

**Notes for editors**
- `discussions-to` is a format-valid placeholder; the Ethereum Magicians thread is not yet created and I will update this before requesting review.
- The number was taken as the next free one across both repositories at the time of writing; happy to renumber.
- Companion proposals are open alongside this one and are referred to in prose rather than by number, since `markdown-refs` cannot resolve an unmerged sibling.

CI checks run locally before opening: eipw (via the pinned `eipw-lint-js`, against the same merged EIP+ERC corpus the workflow builds), markdownlint, codespell, and markdown-link-check.