### PR TITLE
Add ERC: Agent Wallet Execution Interface

### DIFF
--- a/ERCS/erc-8412.md
+++ b/ERCS/erc-8412.md
@@ -150,11 +150,16 @@ It takes two OPTIONAL parameters:
   approve anything, cannot widen the policy, and cannot make a denied plan
   sendable. A wallet MUST reject `mustReview` combined with `requestId`, whose
   bytes are already reviewed and signed.
-- `onSimulationFailure` — whether a failed simulation should be reported to the
-  client or queued for a human. Its default SHOULD be to queue.
+- `onSimulationFailure` — `"queue"` to put a plan whose simulation failed in
+  front of a human, or `"fail"` to report the failure to the client instead. The
+  default MUST be `"queue"`. Neither value affects a `rejected` outcome, which
+  fails regardless.
 
-The method MUST return one of: a submitted transaction; a `requestId` in the
-`approvalRequired` state; or a failure. It MUST NOT return a `requestId` for a
+The method MUST return either a failure or a `requestId` together with the
+request's current state, which on success is `submitted` when the policy allowed
+the plan and `approvalRequired` otherwise. Every accepted submission has a
+`requestId`, including one that signed automatically, so that the same status
+and wait methods apply to both. The method MUST NOT return a `requestId` for a
 `rejected` outcome — a denying rule produces a failure, never a queued request.
 
 `mustReview` exists for a specific and common situation: the user wants to look
@@ -180,6 +185,12 @@ A queued request MUST occupy exactly one of these states:
 | `cancellationPending` | A cancellation is racing the broadcast envelope |
 | `replaced` | The nonce was consumed elsewhere; these bytes can never mine |
 
+`rejected`, `timedOut`, `reverted`, `cancelled`, and `replaced` are terminal.
+`submitted` is terminal for the purposes of this interface once the wallet
+reports the receipt as final; before that, a wallet MAY still move it to
+`replaced`. The remaining states are transitional and a client MUST keep waiting
+on them.
+
 `approvalRequired` is a state, not an error. Wallets MUST expose it as such, and
 clients MUST treat it as a reason to wait.
 
@@ -198,6 +209,10 @@ under which a naive client would retry forever.
 call times out. `wallet_getExecutionStatus` returns the current state.
 `wallet_waitForExecution` blocks until a submitted transaction reaches a final
 chain state.
+
+A status result MUST carry the `requestId`, the chain, the plan digest, and the
+state, and once the transaction is broadcast MUST carry its hash; once mined it
+SHOULD carry the block, the confirmation depth, and the fee actually paid.
 
 These cover different phases and MUST NOT be substituted for one another.
 `wallet_waitForExecution` does not cover the approval phase; a client that calls

--- a/ERCS/erc-8412.md
+++ b/ERCS/erc-8412.md
@@ -1,0 +1,403 @@
+---
+eip: 8412
+title: Agent Wallet Execution Interface
+description: Wallet methods letting an autonomous client submit and track a transaction it can never approve, with waiting for a human as a state
+author: Moody Salem (@moodysalem)
+discussions-to: https://ethereum-magicians.org/t/erc-8412-agent-wallet-execution-interface/0
+status: Draft
+type: Standards Track
+category: ERC
+created: 2026-09-04
+---
+
+## Abstract
+
+This proposal defines the methods a wallet exposes to an autonomous client — an
+AI agent, a scheduled job, an automation runner — so that the client can ask for
+a transaction, watch what happens to it, and follow it to a final state, while
+being structurally unable to approve it.
+
+The centerpiece is a request lifecycle in which *waiting for a human* is an
+ordinary state the client polls, rather than an error it retries or a
+notification it hopes arrives. A client submits, learns that approval is
+required, waits, and is told the outcome. Approval happens in the wallet's own
+interface, on the wallet's own surface, out of the client's reach.
+
+The proposal also fixes the capability boundary: the exact set of things this
+interface does not do, regardless of what the client asks. It is
+transport-neutral; a binding to one agent transport is sketched, and the methods
+carry no assumption about it.
+
+## Motivation
+
+Wallet interfaces assume a human is present. The provider interface, and the
+batching interface built on it, are shaped around a person at a browser: a
+request goes out, a modal appears, an answer comes back within seconds, and if
+nobody answers, the promise rejects. Everything about that shape breaks when the
+requester is a process running unattended.
+
+The gap is not that agents need more power. It is that the honest arrangement —
+the agent asks, a human decides, possibly hours later — has no vocabulary:
+
+- **Approval is not a failure.** An unattended client that receives a rejected
+  promise learns nothing about whether the user said no, walked away, or has not
+  looked yet. It cannot distinguish "ask again" from "never ask again", so it
+  does the wrong one.
+- **There is no durable handle.** A request that outlives a connection needs an
+  identifier the client can return to. In-page interfaces have none, because
+  nothing was expected to outlive the page.
+- **Retry is dangerous without a state machine.** A client that does not know
+  whether its transaction was signed, broadcast, replaced, or is racing a
+  cancellation will resubmit, and resubmitting a transaction is not idempotent.
+- **The boundary is undocumented.** Which operations must remain unavailable to
+  a client is currently a matter of each wallet's judgment. Given that a client
+  may be acting on prompt-injected instructions from an untrusted source, the
+  set of things it cannot do is the whole security story, and it deserves to be
+  written down and identical across wallets.
+- **Simulation gets mistaken for permission.** A client that simulates
+  successfully will conclude it may send, and a wallet that lets a stored
+  simulation result stand in for a fresh policy evaluation has turned a
+  convenience into an authorization bypass.
+
+The economically useful thing an agent does is prepare and track work. The thing
+it must never do is decide. This proposal is the interface that keeps those
+separate while letting the first one be practical.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in RFC 2119 and RFC 8174.
+
+Method names are given in the `wallet_` convention of the existing wallet
+interfaces. The names are normative; the transport is not.
+
+This interface carries transactions as *execution plans* and refers to a
+*signing policy*; both are specified in companion proposals, and an
+implementation MAY substitute an equivalent call-sequence and authorization
+representation without changing the lifecycle defined here.
+
+### Capability boundary
+
+A wallet MUST NOT expose, through this interface, any operation that:
+
+- approves, rejects, or otherwise decides a pending request;
+- exports, derives, or reveals private key material;
+- signs arbitrary bytes outside the message and typed-data methods below;
+- installs or edits the signing policy;
+- accepts legal terms or agreements on the account holder's behalf;
+- mutates account-holder-only settings, or creates or deletes accounts.
+
+These are not defaults to be relaxed by configuration. A client that can reach
+any of them is a client for which the rest of this proposal provides no
+protection, because every other control assumes the decision stays with a
+person.
+
+Where a wallet attributes a request to a named client, that attribution is
+activity context and MUST NOT authorize anything.
+
+### Inventory
+
+`wallet_getAccounts` and `wallet_getNetworks` return the accounts and chains the
+client may address. Clients SHOULD call them before constructing a request
+rather than assuming an account or chain, and a wallet MUST reject a request
+naming an account or chain it did not offer.
+
+### Simulating
+
+`wallet_simulateExecutionPlan` takes a plan, or a reference to one, and
+simulates it against current chain state. It returns the simulated result, the
+authorization findings the policy produces, an overall outcome, and a
+short-lived `simulationId`.
+
+The outcome MUST be one of:
+
+- `allowed` — every call matched an allowing rule; this would sign without
+  asking.
+- `requiresApproval` — some call is not covered, or is covered by a rule that
+  requires review. This is a normal route to a human, not a failure.
+- `rejected` — a denying rule matched. This will never sign and will never be
+  queued.
+
+A wallet MUST make clear that `requiresApproval` is not a reason to stop. The
+common client error is to treat any non-`allowed` outcome as refusal and abandon
+work a human would have approved. `rejected` is the only outcome that a send
+cannot follow.
+
+`simulationId` is a short-lived handle to that exact plan. It MUST NOT be
+treated as authorization, as a reusable prepared envelope, or as a cached policy
+decision. Consuming one MUST re-run simulation, transaction preparation, and
+evaluation against the policy as it stands at that moment.
+
+Wallets MAY offer hypothetical execution against a temporary fork. A fork result
+MUST NOT create a pending request and MUST NOT authorize a send.
+
+### Sending
+
+`wallet_sendExecutionPlan` freshly simulates, prepares the exact transaction,
+evaluates the current policy, and then signs, persists, and broadcasts — or
+queues for approval. It accepts exactly one of:
+
+- a plan or a reference to one;
+- a `simulationId`, consumed as described above;
+- a `requestId`, to re-submit the exact already-signed bytes of a request that
+  remains signed after a failed submission attempt.
+
+It takes two OPTIONAL parameters:
+
+- `mustReview` — queue this submission for human review even where the policy
+  would have signed it automatically. It MUST only ever add a review: it cannot
+  approve anything, cannot widen the policy, and cannot make a denied plan
+  sendable. A wallet MUST reject `mustReview` combined with `requestId`, whose
+  bytes are already reviewed and signed.
+- `onSimulationFailure` — whether a failed simulation should be reported to the
+  client or queued for a human. Its default SHOULD be to queue.
+
+The method MUST return one of: a submitted transaction; a `requestId` in the
+`approvalRequired` state; or a failure. It MUST NOT return a `requestId` for a
+`rejected` outcome — a denying rule produces a failure, never a queued request.
+
+`mustReview` exists for a specific and common situation: the user wants to look
+at one particular transaction that their policy would otherwise have signed
+silently. Without it, the only way to see that transaction is to edit the
+policy, which changes the standing rules to answer a question about one
+transaction. Adding a review to a single submission is the proportionate act.
+
+### The request lifecycle
+
+A queued request MUST occupy exactly one of these states:
+
+| State | Meaning |
+| --- | --- |
+| `approvalRequired` | Waiting for a human |
+| `rejected` | A human declined |
+| `timedOut` | Expired before a human answered |
+| `approved` | A human approved; signing or submission is under way |
+| `submissionPending` | Signed; submission attempted and not yet confirmed |
+| `submitted` | Broadcast and accepted by the network |
+| `reverted` | Mined and reverted |
+| `cancelled` | Superseded by a cancellation at the same nonce |
+| `cancellationPending` | A cancellation is racing the broadcast envelope |
+| `replaced` | The nonce was consumed elsewhere; these bytes can never mine |
+
+`approvalRequired` is a state, not an error. Wallets MUST expose it as such, and
+clients MUST treat it as a reason to wait.
+
+Approval is itself an action: approving a request MUST attempt to submit the
+exact signed bytes. A client MUST NOT assume that approval leaves work for it to
+do, and MUST re-submit with `requestId` only when the request remains signed
+after that attempt.
+
+`replaced` is terminal and distinct from `cancelled`. It says the exact bytes
+can never mine because their nonce is gone, which is precisely the condition
+under which a naive client would retry forever.
+
+### Waiting and status
+
+`wallet_waitForApproval` blocks until a request leaves `approvalRequired` or the
+call times out. `wallet_getExecutionStatus` returns the current state.
+`wallet_waitForExecution` blocks until a submitted transaction reaches a final
+chain state.
+
+These cover different phases and MUST NOT be substituted for one another.
+`wallet_waitForExecution` does not cover the approval phase; a client that calls
+it on a queued request waits for something that cannot happen yet.
+
+A timeout from any wait method means the deadline passed, not that the request
+ended. Clients MUST continue calling until a final state is reached. A wallet
+SHOULD return, with each wait result, an explicit statement of the next action,
+so that a client following instructions literally follows the correct one.
+
+Wallets MUST direct the user to the request's review in the wallet's own
+interface, and clients MUST NOT ask a user to communicate approval back through
+the client. Approval given by telling an agent "yes" is approval the wallet
+never saw.
+
+A client MUST NOT return a request identifier to its user and stop. An
+unwatched queued request is the failure mode this lifecycle exists to prevent.
+
+### Cancelling
+
+`wallet_attemptCancel` requests cancellation of a specific submitted request by
+replacing it at the same nonce. It is an attempt: the outcome is decided by the
+network, and the request moves through `cancellationPending` to `cancelled` or
+to a completed state. Wallets MUST NOT present cancellation as certain.
+
+### Signatures
+
+`wallet_signMessage` and `wallet_signTypedData` request signatures over data
+that is not a transaction. Both MUST be review-only: a wallet MUST NOT sign
+either automatically on a client's request, regardless of policy. The policy
+vocabulary describes calls and envelopes; a bare signature has neither, so there
+is nothing for it to constrain, and an unconstrainable operation does not get an
+automatic path.
+
+Corresponding wait methods follow the same lifecycle discipline as approvals.
+
+### Reading the policy
+
+`wallet_getPolicy` returns the active policy and its revision.
+`wallet_proposePolicy` submits a complete replacement, bound to the revision it
+was computed against, with a stated purpose. A wallet MUST reject a proposal
+whose bound revision is no longer current, and MUST NOT install a proposal
+without the account holder's explicit act in the wallet's own interface.
+
+Proposing a policy MUST NOT be a precondition for sending a plan. A client that
+responds to `requiresApproval` by proposing a policy widening is answering "may
+I do this once" with "may I do this always", and wallets SHOULD document that
+the ordinary route is the approval it was just offered.
+
+### Transport bindings
+
+The methods above are transport-neutral. A binding MUST preserve the lifecycle,
+the capability boundary, and the requirement that approval occurs on the
+wallet's own surface.
+
+The reference implementation binds them to the Model Context Protocol, exposing
+each method as a tool over a local stdio bridge to a wallet process holding the
+keys. The binding adds no authority: the bridge is a transport, the session
+carries no capability of its own, and every restriction above is enforced by the
+wallet rather than by the transport. A binding over a different agent protocol,
+or over a local socket with a different framing, is expected to look the same.
+
+## Rationale
+
+### Why not extend the in-page provider interface
+
+The batching interface already carries a call sequence to a wallet, and it could
+be given a request identifier. What it cannot be given is a different assumption
+about time. Its whole contract is that a request is answered while the caller
+waits, and the changes needed — durable identifiers, a state machine spanning
+hours, wait methods with timeouts that are not failures, a capability boundary
+enforced against the caller rather than presented to a user — amount to a
+different interface wearing the same name. Keeping them separate lets a wallet
+implement both, which is what wallets actually do.
+
+### Why approval is a state rather than a callback
+
+Callbacks require the wallet to reach the client, which requires the client to
+be reachable, which is exactly what an unattended process spread across restarts
+and machines is not. Polling a state is worse in latency and better in every
+other respect: it survives client restarts, it is inspectable, and it produces
+the same answer whether asked once or a thousand times.
+
+### Why the capability boundary is normative
+
+A wallet could reasonably decide for itself what an agent may do, and every
+wallet deciding separately produces a market where the most permissive wallet
+sets the norm, and where a user cannot know what connecting an agent means. The
+list is short and consists entirely of things that, if reachable, make the rest
+of the interface decorative. Writing it down is what makes "this wallet
+implements this proposal" a statement worth relying on.
+
+### Why signatures are review-only
+
+Automatic signing is safe when there is something to constrain. A policy
+constrains targets, values, and decoded calldata. A typed-data signature has a
+domain and a payload whose consequences live in a contract the wallet did not
+call and may not know about; an off-chain order signed today can be executed
+against the account tomorrow. Rather than invent a second authorization
+vocabulary of unclear strength, this proposal declines to offer automation for
+signatures at all.
+
+### Why a client is told what to do next
+
+The clients here are frequently language models, which follow the most recent
+explicit instruction and are prone to plausible-looking wrong next steps:
+calling the wrong wait method, resubmitting a replaced request, or handing back
+an identifier and stopping. Returning the correct next action in-band, with each
+result, converts a class of client bugs into a wallet responsibility. This is
+unusual for an Ethereum interface and is the single highest-value affordance for
+this class of caller.
+
+## Backwards Compatibility
+
+This proposal adds methods and does not modify any existing interface. A wallet
+may implement it alongside the provider and batching interfaces; a wallet that
+does not implement it is unaffected.
+
+Clients MUST detect availability by attempting the methods rather than by
+inferring support from any other interface being present.
+
+## Reference Implementation
+
+Ekubo Wallet, a desktop wallet at `github.com/EkuboProtocol/wallet`, implements
+this interface for local agent clients. Its method surface is `src/mcp.rs`, the
+capability boundary is enforced by the restricted session type described in
+`docs/mcp-security-model.md`, and the transport is the stdio bridge in
+`crates/mcp-bridge`.
+
+The implementation exercises the parts of this proposal that are easy to state
+and hard to hold: the session receives no key store and no arbitrary signing
+operation, only two guarded execution paths; the client cannot approve, reject,
+export a key, accept terms, or install a policy; simulation handles re-run the
+full pipeline when consumed; denied plans fail without queuing; and each wait
+result carries the next action the client should take. Its documented threat
+model also states plainly where the platform's key storage does not isolate keys
+from other software running as the same user, which bounds what the interface
+can promise.
+
+## Security Considerations
+
+### The client is untrusted, including when it is honest
+
+An agent acting on text from a web page, an email, or a tool result may be
+carrying an attacker's instructions while its own code behaves correctly. Every
+control here assumes the client is adversarial: the wallet enforces the
+boundary, the wallet evaluates the policy, the wallet asks the human, and the
+wallet shows what will happen. Nothing may be delegated to the client's
+judgment, including its own claim about who it is.
+
+### Approval must happen on the wallet's surface
+
+The most direct attack on this interface is social: an agent tells the user that
+a transaction is safe, and the user approves without reading. The
+countermeasure is that the wallet renders what will actually execute, from its
+own preparation, and that approval is an act in the wallet's interface. Clients
+MUST NOT be able to supply or influence the text shown at approval, and a wallet
+SHOULD present decoded calls and the plan's digest rather than any
+requester-supplied description.
+
+### Simulation is neither authorization nor prediction
+
+A simulation handle is a pointer to a plan, not a decision about it, and a
+wallet that lets one skip re-evaluation has built a bypass with a convenient
+name. Separately, a clean simulation is not a promise: state moves, and a plan
+that simulated cleanly may revert or execute differently when mined.
+
+### Approval attempts submission
+
+Because approving submits, the window between a human's decision and the
+broadcast is short by construction, which is the point — a long window is a
+window in which the approved bytes become stale. Clients must not assume that a
+request they see as `approved` still needs them to act, or they will submit a
+second time.
+
+### Denied requests must not become prompts
+
+A denying rule means the account holder already answered. Surfacing such a
+request as an approval prompt converts a considered refusal into a moment of
+fatigue, and it lets a persistent client convert a rule it cannot change into a
+question it can keep asking.
+
+### The transport is not the boundary
+
+A local transport typically authenticates nothing beyond "same user". Any
+process running as the user may connect and present any client identifier. All
+authority therefore has to live in the wallet's enforcement, and wallets MUST
+NOT grant a capability on the basis of a client's self-description. Where the
+platform's key storage does not isolate keys to the wallet, an attacker with
+same-user code execution can bypass this interface entirely by using the keys
+directly; implementations MUST document that limitation rather than let this
+interface imply a boundary the platform does not provide.
+
+### Resource exhaustion
+
+Wait methods hold connections, and simulation and retrieval consume network and
+memory. Wallets MUST bound concurrent waits, simulations, and outbound fetches
+per session, and MUST expire queued requests rather than accumulating them
+indefinitely.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Adds ERC-8412, the wallet methods an autonomous client — an AI agent, a scheduled job, an automation runner — uses to submit and track a transaction it is structurally unable to approve.

Existing wallet interfaces assume a human is present: a request goes out, a modal appears, an answer comes back in seconds, and if nobody answers the promise rejects. Every part of that breaks when the requester runs unattended. The gap is not that agents need more power; it is that the honest arrangement — the agent asks, a human decides, possibly hours later — has no vocabulary.

**The centerpiece is that waiting for a human is a state, not an error.** A client submits, learns approval is required, polls, and is told the outcome. A rejected promise cannot distinguish "the user said no" from "the user has not looked yet", so a client receiving one does the wrong thing. Polling is worse in latency and better in everything else: it survives client restarts, it is inspectable, and it answers the same whether asked once or a thousand times.

**Two parts I would like editor input on**

1. **The capability boundary is normative rather than left to each wallet.** The spec lists exactly what this interface must never expose: deciding a pending request, exporting key material, installing or editing policy, accepting legal terms, mutating owner-only settings. Given a client may be relaying prompt-injected instructions, the set of things it *cannot* do is the whole security story. Leaving it to each implementation produces a market where the most permissive wallet sets the norm and a user cannot know what connecting an agent means.

2. **Signature methods are review-only, with no automatic path at all.** A policy can constrain targets, values, and decoded calldata. A typed-data signature has a domain and a payload whose consequences live in a contract the wallet never called; an order signed today executes against the account tomorrow. Rather than invent a second authorization vocabulary of unclear strength, the proposal declines to offer automation here.

**Framing.** This is written as transport-neutral `wallet_` methods plus a lifecycle state machine, not as a tool surface for any particular agent protocol. One binding (MCP over a local bridge) is described in a paragraph, and it adds no authority — every restriction is enforced by the wallet, not the transport.

One unusual affordance worth flagging: the spec asks wallets to return the correct next action in-band with each result. The clients here are frequently language models, which follow the most recent explicit instruction and are prone to plausible wrong next steps — calling the wrong wait method, resubmitting a request whose nonce is gone, or handing back a request id and stopping. This converts a class of client bugs into a wallet responsibility.

**Reference implementation.** Ekubo Wallet (`github.com/EkuboProtocol/wallet`), `src/mcp.rs`, where the session receives no key store and no arbitrary signing operation — only two guarded execution paths. Named in prose rather than linked, per the EIP-1 external-link rule.

**Notes for editors**
- `discussions-to` is a format-valid placeholder; the Ethereum Magicians thread is not yet created and I will update this before requesting review.
- The number was taken as the next free one across both repositories at the time of writing; happy to renumber.
- This proposal carries transactions as execution plans and refers to a signing policy, both specified in companion proposals open alongside it. They are referred to in prose rather than by number, since `markdown-refs` cannot resolve an unmerged sibling; I will add the numbers and `requires` entries once assigned.

CI checks run locally before opening: eipw (via the pinned `eipw-lint-js`, against the same merged EIP+ERC corpus the workflow builds), markdownlint, codespell, and markdown-link-check.