### PR TITLE
Update ERC-5805: Move to Review

### DIFF
--- a/ERCS/erc-5805.md
+++ b/ERCS/erc-5805.md
@@ -4,7 +4,7 @@ title: Voting with delegation
 description: An interface for voting weight tracking, with delegation support
 author: Hadrien Croubois (@Amxx), Francisco Giordano (@frangio)
 discussions-to: https://ethereum-magicians.org/t/eip-5805-voting-with-delegation/11407
-status: Stagnant
+status: Review
 type: Standards Track
 category: ERC
 created: 2022-07-04

--- a/ERCS/erc-5805.md
+++ b/ERCS/erc-5805.md
@@ -36,7 +36,7 @@ Additionally, the existing (non-standardized) implementations are limited to `bl
 
 ## Specification
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
 
 Following pre-existing (but not-standardized) implementation, the EIP proposes the following mechanism.
 


### PR DESCRIPTION
Moves ERC-5805 from Stagnant back to Review.

The proposal is stable and implemented (OpenZeppelin `Votes`/`ERC20Votes`/`ERC721Votes`), and its only ERC dependency (ERC-6372) is already in Review.