### PR TITLE
Update ERC-8217: Add 8004A nickname to ERC-8217

### DIFF
--- a/ERCS/erc-8217.md
+++ b/ERCS/erc-8217.md
@@ -15,6 +15,8 @@ requires: 8004
 
 This ERC defines a standard onchain metadata record and verification interface for expressing that an [ERC-8004](./eip-8004.md) agent identity is bound to an external NFT or tokenized asset contract. The metadata record stores only the binding contract address (20 bytes) under a reserved metadata key. The binding contract is expected to be deployed as a canonical per-chain singleton. Token standard, token contract, and token id are read from that contract via `bindingOf(agentId)` and are not duplicated in metadata.
 
+This ERC introduces the nickname **8004A**. An NFT registered as a master NFT under ERC-8217 can use the **8004A** label, regardless of the registration method used.
+
 ## Motivation
 
 [ERC-8004](./eip-8004.md) registrations are themselves NFTs. For an existing NFT to own an ERC-8004 registration, the two NFTs must be bound together. The owning NFT, called the master NFT, might be a project, character, or collection NFT. This ERC defines that binding. A canonical per-chain singleton binding contract records the link between an ERC-8004 agent id and its master NFT. The owner of the master NFT controls the bound ERC-8004 registration. When the master NFT is transferred, control follows automatically. The ERC-8004 record itself never changes.


### PR DESCRIPTION
Introduces **8004A** as a label for NFTs registered as master NFTs under ERC-8217, regardless of registration method.