### PR TITLE
Update ERC-7730: Bind proxy descriptors to implementation addresses

### DIFF
--- a/ERCS/erc-7730.md
+++ b/ERCS/erc-7730.md
@@ -499,7 +499,7 @@ The `contract` sub-key is used to introduce an EVM smart contract binding contex
 
 An array of deployments options. Wallets MUST verify that the target chain and contract address of the containing transaction either:
   * Match one of these deployment options
-  * Is a *proxy* pointing to one of the deployment option (see [Proxy support](#proxy-support))
+  * Is a *proxy* whose resolved *implementation* address matches one of these deployment options (see [Proxy support](#proxy-support))
 
 A deployment option is an object with:
   * `chainId`: an [EIP-155 identifier](./eip-155.md) of the chain the described contract is deployed on.
@@ -551,7 +551,7 @@ When an `eip712.deployments` constraint is set, the wallet MUST verify that:
 * The message being displayed has both `domain.chainId` and `domain.verifyingContract` keys
 * The `chainId` and `verifyingContract` values in the domain either
   * Match ONE of the deployment option specified in `eip712.deployments`
-  * Is a *proxy* pointing to one of the deployment options (see [Proxy support](#proxy-support))
+  * Is a *proxy* whose resolved *implementation* address matches one of the deployment options specified in `eip712.deployments` (see [Proxy support](#proxy-support))
 
 A deployment option is an object with:
 * `chainId`: an EIP-155 identifier of the chain the described contract is deployed on.
@@ -1733,27 +1733,29 @@ The proxy pattern is widely use in Ethereum in multiple scenarios to provide fle
 
 These patterns are often used in conjunction. Supporting those patterns require some considerations from both smart contract developers and wallets.
 
+**Binding to the implementation address**
+
+For all proxy patterns, the ERC-7730 file SHOULD be bound to the *implementation* address, NOT to the *proxy* address.
+
+An ERC-7730 file describes the meaning of a specific piece of code, but the code behind a proxy address can change at any time. A file bound to the proxy address keeps matching after an upgrade and displays the intents reviewed for the *old* implementation while the *new* implementation executes. The displayed intent then silently diverges from the executed behavior, which is exactly the class of attack clear signing exists to prevent. Updating the file on every upgrade does not solve this, since previous reviews and attestations do not apply to the new code.
+
+Binding to the implementation address pins the ERC-7730 file to the exact code that was reviewed. Wallets detect that the target address is a proxy, resolve the implementation it points to, and look up the ERC-7730 file by this implementation address. After an upgrade, the previous file stops matching, and the author publishes a new ERC-7730 file bound to the new implementation address.
+
 **Upgradeable proxy contracts**
 
-Upgradeable proxy contracts (such as Transparent Proxies or UUPS proxies as defined in [ERC-1822](./eip-1822.md)) use a fixed proxy address that delegates calls to a replaceable implementation contract. For these contracts, the ERC-7730 file SHOULD be bound to the *proxy* address, since this is the stable address users interact with.
-
-When an upgrade introduces breaking ABI changes (new functions, modified signatures, or removed functions), developers SHOULD update the ERC-7730 file in the registry accordingly. Since the old implementation is no longer callable after the upgrade, the previous ERC-7730 definitions can be safely replaced.
-
-Wallets need to ensure they use the latest version of the registry and match the transaction target against the *proxy* address.
+Upgradeable proxy contracts (such as Transparent Proxies or UUPS proxies as defined in [ERC-1822](./eip-1822.md)) use a fixed proxy address that delegates calls to a replaceable implementation contract. For these contracts, the ERC-7730 file SHOULD be bound to the *implementation* address, for the reasons given above.
 
 **Composable contracts**
 
 Composable contracts, like Diamond proxies, aggregate through a single *proxy* address, multiple implementation facets. Each facet has its own ABI.
 
-A good pattern to support diamond proxies is to introduce an ERC-7730 file for each facet, without any context info, and use the composability of ERC-7730 files to create an overarching ERC-7730 file that includes all implemented facets of a proxy and bound to the final *proxy* address.
-
-Similarly wallets just need to ensure they have the latest version of the registry and that the target address is the *proxy* address.
+A good pattern to support diamond proxies is to introduce an ERC-7730 file for each facet, bound to the *facet* address. Wallets resolve the facet handling the selector of the call and match it against the deployments of the ERC-7730 file. When a facet is replaced, the new facet gets a new ERC-7730 file, as for upgradeable proxies.
 
 **Multi-instanciation**
 
 This pattern is typically used by smart wallet factories to efficiently deploy many smart wallets relying on a single, secure implementation.
 
-It is not efficient nor advisable to deploy an ERC-7730 for *each* smart wallet address. In this case, it is recommended to bind the ERC-7730 file to the *implementation* address of the smart wallet and rely on the user's wallet to detect that the target address is actually a proxy to a well known implementation address.
+It is not efficient nor advisable to deploy an ERC-7730 for *each* smart wallet address. In this case as well, the ERC-7730 file SHOULD be bound to the *implementation* address of the smart wallet and rely on the user's wallet to detect that the target address is actually a proxy to a well known implementation address.
 
 ### Interpolated intent security
 


### PR DESCRIPTION
This PR corrects the proxy guidance in ERC-7730. This change was discussed in an earlier Clear Signing Working group call but has been forgotten to implement.

The spec previously recommended binding ERC-7730 files to the *proxy* address for upgradeable and Diamond proxies, and to the *implementation* address only for multi-instantiation. A file bound to a proxy address keeps matching after an upgrade and displays intents reviewed for the old implementation while the new one executes. This is exactly the attack clear signing is meant to prevent.

Changes:
- Proxy support: ERC-7730 files SHOULD be bound to the implementation address for all proxy patterns, with an explanation why.
- Upgradeable proxies: bind to the implementation address. A new implementation gets a new file.
- Composable contracts: one file per facet, bound to the facet address.
- `contract.deployments` and `eip712.deployments`: a proxy matches when its resolved implementation address matches a deployment option.

Related: https://github.com/ethereum/clear-signing-erc7730-registry/issues/2960